### PR TITLE
feat: tx handlers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,18 @@ jobs:
       - name: cargo hack
         run: cargo hack check --workspace --feature-powerset --skip nightly ${{ matrix.flags }}
 
+  examples:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+      - name: Check examples
+        run: cargo check --workspace --examples
+
   typos:
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -143,6 +155,7 @@ jobs:
       - test
       - wasm
       - feature-checks
+      - examples
       - typos
       - clippy
       - docs

--- a/crates/evm2/Cargo.toml
+++ b/crates/evm2/Cargo.toml
@@ -27,7 +27,19 @@ paste.workspace = true
 serde = { workspace = true, features = ["derive", "alloc"], optional = true }
 
 [dev-dependencies]
+alloy-consensus = "2.0.4"
+alloy-eips = "2.0.4"
 serde_json.workspace = true
+
+[[example]]
+name = "registry_tx_handler"
+path = "examples/registry/tx_handler.rs"
+doc-scrape-examples = true
+
+[[example]]
+name = "registry_custom_handler"
+path = "examples/registry/custom_handler.rs"
+doc-scrape-examples = true
 
 [features]
 default = ["std"]

--- a/crates/evm2/examples/registry/custom_handler.rs
+++ b/crates/evm2/examples/registry/custom_handler.rs
@@ -1,0 +1,90 @@
+//! Custom transaction handler object with a custom envelope.
+
+use evm2::registry::{HandlerResult, TxHandler, TxRegistry, TxRequest};
+
+const CUSTOM_TX_TYPE: u8 = 0x42;
+
+/// A simple custom EIP-2718-style transaction.
+#[derive(Debug)]
+struct CustomTx {
+    gas_limit: u64,
+    nonce: u64,
+}
+
+impl CustomTx {
+    const fn ty(&self) -> u8 {
+        CUSTOM_TX_TYPE
+    }
+}
+
+/// A minimal custom envelope that can grow more variants later.
+#[derive(Debug)]
+enum CustomEnvelope {
+    Custom(CustomTx),
+}
+
+impl CustomEnvelope {
+    const fn as_custom_tx(&self) -> Option<&CustomTx> {
+        match self {
+            Self::Custom(tx) => Some(tx),
+        }
+    }
+
+    const fn ty(&self) -> u8 {
+        match self {
+            Self::Custom(tx) => tx.ty(),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct Receipt {
+    success: bool,
+    cumulative_gas_used: u64,
+    logs: Vec<String>,
+}
+
+const fn dummy_receipt(cumulative_gas_used: u64) -> Receipt {
+    Receipt { success: true, cumulative_gas_used, logs: Vec::new() }
+}
+
+/// A concrete handler object instead of a bare function.
+///
+/// This is useful when a handler needs configuration, dependencies, caches, or
+/// policy objects. The registry accepts it because it implements `TxHandler<Tx, Output>`.
+struct CustomTxHandler {
+    intrinsic_gas: u64,
+}
+
+impl TxHandler<CustomTx, Receipt> for CustomTxHandler {
+    fn call(&self, req: TxRequest<'_, CustomTx>) -> HandlerResult<Receipt> {
+        let gas_used = self.intrinsic_gas + req.tx.gas_limit / 10 + req.tx.nonce;
+        Ok(dummy_receipt(gas_used))
+    }
+}
+
+fn build_registry() -> TxRegistry<CustomEnvelope, Receipt> {
+    TxRegistry::<CustomEnvelope, Receipt>::new().with_handler(
+        CUSTOM_TX_TYPE,
+        CustomEnvelope::as_custom_tx,
+        CustomTxHandler { intrinsic_gas: 21_000 },
+    )
+}
+
+fn main() -> HandlerResult<()> {
+    let registry = build_registry();
+
+    let tx = CustomEnvelope::Custom(CustomTx { gas_limit: 100_000, nonce: 7 });
+
+    let receipt = registry.try_get_by_type(tx.ty())?.call(&tx)?;
+
+    println!(
+        "custom tx type=0x{:02x}: success={}, cumulative_gas_used={}, logs={}",
+        tx.ty(),
+        receipt.success,
+        receipt.cumulative_gas_used,
+        receipt.logs.len()
+    );
+
+    Ok(())
+}

--- a/crates/evm2/examples/registry/tx_handler.rs
+++ b/crates/evm2/examples/registry/tx_handler.rs
@@ -1,0 +1,96 @@
+//! Transaction handler registry with Alloy transaction envelopes.
+
+use alloy_consensus::{Receipt, Signed, TxEip1559, TxEip7702, TxEnvelope, TxLegacy, TxType};
+use alloy_eips::eip2718::Typed2718;
+use alloy_primitives::Signature;
+use evm2::registry::{HandlerResult, TxRegistry, TxRequest};
+
+const fn dummy_receipt(cumulative_gas_used: u64) -> Receipt {
+    Receipt {
+        status: alloy_consensus::Eip658Value::success(),
+        cumulative_gas_used,
+        logs: Vec::new(),
+    }
+}
+
+const fn handle_legacy(req: TxRequest<'_, Signed<TxLegacy>>) -> HandlerResult<Receipt> {
+    // A dummy receipt. A real handler would validate, run the interpreter, settle gas,
+    // collect logs, and then build the receipt from the execution result.
+    Ok(dummy_receipt(req.tx.tx().gas_limit))
+}
+
+const fn handle_eip1559(req: TxRequest<'_, Signed<TxEip1559>>) -> HandlerResult<Receipt> {
+    let tx = req.tx.tx();
+
+    Ok(dummy_receipt(tx.gas_limit))
+}
+
+const fn handle_eip7702(req: TxRequest<'_, Signed<TxEip7702>>) -> HandlerResult<Receipt> {
+    let tx = req.tx.tx();
+
+    Ok(dummy_receipt(tx.gas_limit))
+}
+
+fn build_registry() -> TxRegistry<TxEnvelope, Receipt> {
+    // Each registration has three parts:
+    //
+    // 1. The runtime dispatch key. Here we use the EIP-2718 transaction type byte.
+    // 2. A typed extractor from the erased envelope (`TxEnvelope`) to the concrete tx.
+    // 3. A typed handler that receives that concrete tx type.
+    //
+    // After registration the registry is type-erased, but `handle_legacy` still sees
+    // `Signed<TxLegacy>`, not `dyn Any` or a generic transaction view.
+    //
+    // Functions automatically implement `TxHandler<Tx, Output>`, so no explicit adapter is needed.
+    TxRegistry::<TxEnvelope, Receipt>::new()
+        .with_handler(TxType::Legacy.ty(), TxEnvelope::as_legacy, handle_legacy)
+        // The EIP-1559 handler is a different concrete function type. It can access
+        // EIP-1559 fields directly after the extractor succeeds.
+        .with_handler(TxType::Eip1559.ty(), TxEnvelope::as_eip1559, handle_eip1559)
+        // The same function-handler registration works for EIP-7702. A real EVM
+        // handler would validate, apply authorizations, enter the interpreter, and
+        // settle gas before returning a receipt.
+        .with_handler(TxType::Eip7702.ty(), TxEnvelope::as_eip7702, handle_eip7702)
+}
+
+fn sample_transactions() -> [TxEnvelope; 3] {
+    let legacy = TxEnvelope::Legacy(Signed::new_unhashed(
+        TxLegacy { gas_limit: 21_000, ..Default::default() },
+        Signature::test_signature(),
+    ));
+
+    let eip1559 = TxEnvelope::Eip1559(Signed::new_unhashed(
+        TxEip1559 {
+            gas_limit: 21_000,
+            max_fee_per_gas: 10,
+            max_priority_fee_per_gas: 2,
+            ..Default::default()
+        },
+        Signature::test_signature(),
+    ));
+
+    let eip7702 = TxEnvelope::Eip7702(Signed::new_unhashed(
+        TxEip7702 { gas_limit: 21_000, authorization_list: Vec::new(), ..Default::default() },
+        Signature::test_signature(),
+    ));
+
+    [legacy, eip1559, eip7702]
+}
+
+fn main() -> HandlerResult<()> {
+    let registry = build_registry();
+    let transactions = sample_transactions();
+
+    for tx in &transactions {
+        let receipt = registry.try_get_by_type(tx.ty())?.call(tx)?;
+        println!(
+            "{:?}: success={}, cumulative_gas_used={}, logs={}",
+            tx.tx_type(),
+            receipt.status.coerce_status(),
+            receipt.cumulative_gas_used,
+            receipt.logs.len()
+        );
+    }
+
+    Ok(())
+}

--- a/crates/evm2/src/lib.rs
+++ b/crates/evm2/src/lib.rs
@@ -11,5 +11,6 @@ extern crate alloc;
 
 pub mod bytecode;
 pub mod interpreter;
+pub mod registry;
 
 mod once_lock;

--- a/crates/evm2/src/registry.rs
+++ b/crates/evm2/src/registry.rs
@@ -1,0 +1,324 @@
+//! Type-erased transaction handler registry with typed handlers.
+//!
+//! Handlers are written against concrete transaction types. The registry stores
+//! them behind an object-safe boundary and dispatches by transaction type byte.
+//!
+//! The registry is generic over the envelope type and the handler output, so it
+//! does not force a particular transaction or receipt representation onto the
+//! rest of the crate.
+//!
+//! # Example
+//!
+//! ```
+//! use evm2::registry::{HandlerError, HandlerResult, TxRegistry, TxRequest};
+//!
+//! const TRANSFER: u8 = 0x01;
+//!
+//! struct TransferTx {
+//!     amount: u64,
+//! }
+//!
+//! enum Envelope {
+//!     Transfer(TransferTx),
+//! }
+//!
+//! impl Envelope {
+//!     fn as_transfer(&self) -> Option<&TransferTx> {
+//!         match self {
+//!             Self::Transfer(tx) => Some(tx),
+//!         }
+//!     }
+//! }
+//!
+//! #[derive(Debug, PartialEq, Eq)]
+//! struct Receipt {
+//!     gas_used: u64,
+//! }
+//!
+//! fn handle_transfer(req: TxRequest<'_, TransferTx>) -> HandlerResult<Receipt> {
+//!     Ok(Receipt { gas_used: 21_000 + req.tx.amount })
+//! }
+//!
+//! let registry = TxRegistry::<Envelope, Receipt>::new().with_handler(
+//!     TRANSFER,
+//!     Envelope::as_transfer,
+//!     handle_transfer,
+//! );
+//!
+//! let tx = Envelope::Transfer(TransferTx { amount: 7 });
+//! let receipt = registry.try_get_by_type(TRANSFER)?.call(&tx)?;
+//!
+//! assert_eq!(receipt, Receipt { gas_used: 21_007 });
+//! # Ok::<(), HandlerError>(())
+//! ```
+
+use alloc::boxed::Box;
+use core::{array, fmt, marker::PhantomData};
+
+/// Convenience result type used by the registry and handlers.
+pub type HandlerResult<T> = core::result::Result<T, HandlerError>;
+
+/// Registry and handler errors.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum HandlerError {
+    /// No handler is registered for the transaction type byte.
+    UnsupportedTransactionType(u8),
+    /// A registered handler's extractor did not match the provided envelope.
+    WrongTransactionType {
+        /// Expected transaction type byte.
+        expected: u8,
+    },
+}
+
+impl fmt::Display for HandlerError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnsupportedTransactionType(ty) => {
+                write!(f, "unsupported transaction type 0x{ty:02x}")
+            }
+            Self::WrongTransactionType { expected } => {
+                write!(f, "envelope did not contain expected transaction type 0x{expected:02x}")
+            }
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for HandlerError {}
+
+/// Request passed to a typed transaction handler.
+#[derive(Clone, Copy, Debug)]
+#[non_exhaustive]
+pub struct TxRequest<'a, Tx> {
+    /// Concrete transaction extracted from the envelope.
+    pub tx: &'a Tx,
+}
+
+/// A typed transaction handler.
+///
+/// `Tx` remains concrete. This is what gives handlers strong type guarantees
+/// even though the registry itself is type-erased.
+pub trait TxHandler<Tx, Output> {
+    /// Executes the handler.
+    fn call(&self, req: TxRequest<'_, Tx>) -> HandlerResult<Output>;
+}
+
+impl<Tx, Output, F> TxHandler<Tx, Output> for F
+where
+    F: for<'a> Fn(TxRequest<'a, Tx>) -> HandlerResult<Output>,
+{
+    fn call(&self, req: TxRequest<'_, Tx>) -> HandlerResult<Output> {
+        self(req)
+    }
+}
+
+/// An erased transaction handler returned by [`TxRegistry`].
+#[derive(Clone, Copy)]
+pub struct AnyTxHandler<'a, Env, Output> {
+    inner: &'a dyn ErasedTxHandler<Env, Output>,
+}
+
+impl<Env, Output> fmt::Debug for AnyTxHandler<'_, Env, Output> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("AnyTxHandler").finish_non_exhaustive()
+    }
+}
+
+impl<Env, Output> AnyTxHandler<'_, Env, Output> {
+    /// Executes the erased handler against an envelope.
+    pub fn call(&self, env: &Env) -> HandlerResult<Output> {
+        self.inner.call(env)
+    }
+}
+
+trait ErasedTxHandler<Env, Output> {
+    fn call(&self, env: &Env) -> HandlerResult<Output>;
+}
+
+struct HandlerAdapter<Tx, H, F> {
+    type_id: u8,
+    handler: H,
+    extract: F,
+    _tx: PhantomData<fn() -> Tx>,
+}
+
+impl<Tx, H, F> HandlerAdapter<Tx, H, F> {
+    const fn new(type_id: u8, extract: F, handler: H) -> Self {
+        Self { type_id, handler, extract, _tx: PhantomData }
+    }
+}
+
+impl<Env, Tx, Output, H, F> ErasedTxHandler<Env, Output> for HandlerAdapter<Tx, H, F>
+where
+    H: TxHandler<Tx, Output>,
+    F: for<'a> Fn(&'a Env) -> Option<&'a Tx>,
+{
+    fn call(&self, env: &Env) -> HandlerResult<Output> {
+        let tx = (self.extract)(env)
+            .ok_or(HandlerError::WrongTransactionType { expected: self.type_id })?;
+        self.handler.call(TxRequest { tx })
+    }
+}
+
+/// A type-erased transaction handler registry keyed by transaction type byte.
+pub struct TxRegistry<Env, Output = ()> {
+    handlers: [Option<Box<dyn ErasedTxHandler<Env, Output>>>; 256],
+}
+
+impl<Env, Output> fmt::Debug for TxRegistry<Env, Output> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let len = self.handlers.iter().filter(|handler| handler.is_some()).count();
+        f.debug_struct("TxRegistry").field("len", &len).finish_non_exhaustive()
+    }
+}
+
+impl<Env, Output> Default for TxRegistry<Env, Output> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<Env, Output> TxRegistry<Env, Output> {
+    /// Creates an empty registry.
+    pub fn new() -> Self {
+        Self { handlers: array::from_fn(|_| None) }
+    }
+
+    /// Registers a typed handler for a transaction type byte.
+    ///
+    /// `extract` projects `Tx` out of the envelope. The handler remains typed
+    /// as `TxHandler<Tx, Output>`; only this registry boundary is erased.
+    pub fn register<Tx, H, F>(&mut self, type_id: u8, extract: F, handler: H) -> &mut Self
+    where
+        Tx: 'static,
+        H: TxHandler<Tx, Output> + 'static,
+        F: for<'a> Fn(&'a Env) -> Option<&'a Tx> + 'static,
+    {
+        self.handlers[type_id as usize] =
+            Some(Box::new(HandlerAdapter::new(type_id, extract, handler)));
+        self
+    }
+
+    /// Adds a typed handler and returns the registry.
+    #[must_use]
+    pub fn with_handler<Tx, H, F>(mut self, type_id: u8, extract: F, handler: H) -> Self
+    where
+        Tx: 'static,
+        H: TxHandler<Tx, Output> + 'static,
+        F: for<'a> Fn(&'a Env) -> Option<&'a Tx> + 'static,
+    {
+        self.register(type_id, extract, handler);
+        self
+    }
+
+    /// Returns true if a handler is registered for `type_id`.
+    pub fn contains(&self, type_id: u8) -> bool {
+        self.handlers[type_id as usize].is_some()
+    }
+
+    /// Returns the erased handler registered for `type_id`, if any.
+    pub fn get_by_type(&self, type_id: u8) -> Option<AnyTxHandler<'_, Env, Output>> {
+        self.handlers[type_id as usize].as_deref().map(|inner| AnyTxHandler { inner })
+    }
+
+    /// Returns the erased handler registered for `type_id`.
+    pub fn try_get_by_type(&self, type_id: u8) -> HandlerResult<AnyTxHandler<'_, Env, Output>> {
+        self.get_by_type(type_id).ok_or(HandlerError::UnsupportedTransactionType(type_id))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec::Vec;
+
+    #[derive(Debug)]
+    struct TransferTx {
+        amount: u64,
+    }
+
+    #[derive(Debug)]
+    struct CreateTx {
+        initcode: Vec<u8>,
+    }
+
+    #[derive(Debug)]
+    enum Envelope {
+        Transfer(TransferTx),
+        Create(CreateTx),
+    }
+
+    #[derive(Debug, PartialEq, Eq)]
+    struct Receipt {
+        success: bool,
+        cumulative_gas_used: u64,
+    }
+
+    fn transfer(env: &Envelope) -> Option<&TransferTx> {
+        match env {
+            Envelope::Transfer(tx) => Some(tx),
+            Envelope::Create(_) => None,
+        }
+    }
+
+    fn create(env: &Envelope) -> Option<&CreateTx> {
+        match env {
+            Envelope::Create(tx) => Some(tx),
+            Envelope::Transfer(_) => None,
+        }
+    }
+
+    fn receipt(cumulative_gas_used: u64) -> Receipt {
+        Receipt { success: true, cumulative_gas_used }
+    }
+
+    fn handle_transfer(req: TxRequest<'_, TransferTx>) -> HandlerResult<Receipt> {
+        let gas_used = 21_000 + req.tx.amount;
+        Ok(receipt(gas_used))
+    }
+
+    fn handle_create(req: TxRequest<'_, CreateTx>) -> HandlerResult<Receipt> {
+        let gas_used = 53_000 + req.tx.initcode.len() as u64;
+        Ok(receipt(gas_used))
+    }
+
+    fn call_registered(
+        registry: &TxRegistry<Envelope, Receipt>,
+        type_id: u8,
+        env: &Envelope,
+    ) -> HandlerResult<Receipt> {
+        registry.try_get_by_type(type_id)?.call(env)
+    }
+
+    #[test]
+    fn dispatches_to_typed_handlers_from_erased_registry() {
+        let mut registry = TxRegistry::<Envelope, Receipt>::new();
+        registry.register(0x01, transfer, handle_transfer);
+        registry.register(0x02, create, handle_create);
+
+        let transfer_receipt =
+            call_registered(&registry, 0x01, &Envelope::Transfer(TransferTx { amount: 7 }))
+                .expect("transfer handler is registered");
+        assert_eq!(transfer_receipt, receipt(21_007));
+
+        let create_receipt =
+            call_registered(&registry, 0x02, &Envelope::Create(CreateTx { initcode: Vec::new() }))
+                .expect("create handler is registered");
+        assert_eq!(create_receipt, receipt(53_000));
+    }
+
+    #[test]
+    fn reports_unsupported_and_mismatched_types() {
+        let mut registry = TxRegistry::<Envelope, Receipt>::new();
+        registry.register(0x01, transfer, handle_transfer);
+
+        assert_eq!(
+            call_registered(&registry, 0xff, &Envelope::Transfer(TransferTx { amount: 7 })),
+            Err(HandlerError::UnsupportedTransactionType(0xff))
+        );
+        assert_eq!(
+            call_registered(&registry, 0x01, &Envelope::Create(CreateTx { initcode: Vec::new() })),
+            Err(HandlerError::WrongTransactionType { expected: 0x01 })
+        );
+    }
+}

--- a/crates/evm2/src/registry.rs
+++ b/crates/evm2/src/registry.rs
@@ -160,9 +160,11 @@ where
     }
 }
 
+type HandlerTable<Env, Output> = [Option<Box<dyn ErasedTxHandler<Env, Output>>>; 256];
+
 /// A type-erased transaction handler registry keyed by transaction type byte.
 pub struct TxRegistry<Env, Output = ()> {
-    handlers: [Option<Box<dyn ErasedTxHandler<Env, Output>>>; 256],
+    handlers: Box<HandlerTable<Env, Output>>,
 }
 
 impl<Env, Output> fmt::Debug for TxRegistry<Env, Output> {
@@ -181,7 +183,7 @@ impl<Env, Output> Default for TxRegistry<Env, Output> {
 impl<Env, Output> TxRegistry<Env, Output> {
     /// Creates an empty registry.
     pub fn new() -> Self {
-        Self { handlers: array::from_fn(|_| None) }
+        Self { handlers: Box::new(array::from_fn(|_| None)) }
     }
 
     /// Registers a typed handler for a transaction type byte.


### PR DESCRIPTION
Adds a typed transaction handler registry that keeps handlers strongly typed while storing them behind an erased dispatch table keyed by transaction type byte. 