### PR TITLE
feat: evm

### DIFF
--- a/crates/evm2/Cargo.toml
+++ b/crates/evm2/Cargo.toml
@@ -16,6 +16,7 @@ workspace = true
 [dependencies]
 evm2-macros.workspace = true
 
+alloy-eips = { version = "2.0.4", default-features = false }
 alloy-primitives.workspace = true
 thiserror.workspace = true
 
@@ -28,7 +29,6 @@ serde = { workspace = true, features = ["derive", "alloc"], optional = true }
 
 [dev-dependencies]
 alloy-consensus = "2.0.4"
-alloy-eips = "2.0.4"
 serde_json.workspace = true
 
 [[example]]

--- a/crates/evm2/src/env.rs
+++ b/crates/evm2/src/env.rs
@@ -1,23 +1,15 @@
 //! EVM environment types.
 
 use alloc::{vec, vec::Vec};
-use alloy_primitives::{Address, Bytes, U256};
+use alloy_primitives::{Address, U256};
 
-/// Transaction environment values visible to opcodes.
+/// Transaction-global environment values visible to opcodes.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TxEnv {
-    /// Current contract address.
-    pub address: Address,
     /// Transaction origin.
     pub origin: Address,
-    /// Immediate caller.
-    pub caller: Address,
     /// Effective gas price.
     pub gas_price: U256,
-    /// Call value.
-    pub call_value: U256,
-    /// Call input data.
-    pub calldata: Bytes,
     /// Chain ID.
     pub chain_id: U256,
     /// Transaction blob versioned hashes.
@@ -28,12 +20,8 @@ impl Default for TxEnv {
     #[inline]
     fn default() -> Self {
         Self {
-            address: Address::ZERO,
             origin: Address::ZERO,
-            caller: Address::ZERO,
             gas_price: U256::ZERO,
-            call_value: U256::ZERO,
-            calldata: Bytes::new(),
             chain_id: U256::ONE,
             blob_hashes: vec![],
         }

--- a/crates/evm2/src/evm.rs
+++ b/crates/evm2/src/evm.rs
@@ -1,0 +1,207 @@
+//! EVM execution host.
+
+use crate::{
+    bytecode::Bytecode,
+    env::{BlockEnv, TxEnv},
+    interpreter::{
+        Host, InstrStop, Interpreter, Message, SpecId, Table, Word,
+        table::{DEFAULT_TABLE, new_gas_table},
+    },
+    registry::{HandlerResult, TxRegistry},
+};
+use alloy_eips::eip2718::Typed2718;
+use alloy_primitives::{B256, Log};
+
+/// Result of executing a transaction.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub struct TxResult {
+    /// Whether execution succeeded.
+    pub status: bool,
+    /// Gas used by execution.
+    pub gas_used: u64,
+}
+
+/// EVM host and transaction dispatcher.
+#[derive(Debug)]
+pub struct Evm<Tx> {
+    block: BlockEnv,
+    registry: TxRegistry<Tx, TxResult>,
+    spec_id: SpecId,
+}
+
+impl<Tx> Evm<Tx> {
+    /// Creates an EVM with the provided transaction handler registry and hard fork specification.
+    pub const fn new(block: BlockEnv, registry: TxRegistry<Tx, TxResult>, spec_id: SpecId) -> Self {
+        Self { block, registry, spec_id }
+    }
+
+    /// Returns the transaction handler registry.
+    pub const fn registry(&self) -> &TxRegistry<Tx, TxResult> {
+        &self.registry
+    }
+
+    /// Returns the active hard fork specification.
+    pub const fn spec_id(&self) -> SpecId {
+        self.spec_id
+    }
+}
+
+impl<Tx> Evm<Tx>
+where
+    Tx: Typed2718,
+{
+    /// Dispatches the transaction to the handler registered for its EIP-2718 type byte.
+    pub fn transact(&self, tx: &Tx) -> HandlerResult<TxResult> {
+        self.registry.try_get_by_type(tx.ty())?.call(tx)
+    }
+
+    /// Dispatches each transaction to its registered EIP-2718 handler.
+    pub fn transact_iter<'a, I>(
+        &'a self,
+        txs: I,
+    ) -> impl Iterator<Item = HandlerResult<TxResult>> + 'a
+    where
+        I: IntoIterator<Item = &'a Tx>,
+        I::IntoIter: 'a,
+        Tx: 'a,
+        Self: 'a,
+    {
+        txs.into_iter().map(move |tx| self.transact(tx))
+    }
+}
+
+impl<Tx> Host for Evm<Tx> {
+    fn block_env(&mut self) -> &BlockEnv {
+        &self.block
+    }
+
+    fn balance(&mut self, _address: Word) -> Word {
+        Word::ZERO
+    }
+
+    fn get_code_size(&mut self, _address: Word) -> usize {
+        0
+    }
+
+    fn get_code_hash(&mut self, _address: Word) -> B256 {
+        B256::ZERO
+    }
+
+    fn block_hash(&mut self, _number: u64) -> Option<B256> {
+        None
+    }
+
+    fn sload(&mut self, _index: Word) -> Word {
+        Word::ZERO
+    }
+
+    fn sstore(&mut self, _index: Word, _value: Word) {}
+
+    fn tload(&mut self, _index: Word) -> Word {
+        Word::ZERO
+    }
+
+    fn tstore(&mut self, _index: Word, _value: Word) {}
+
+    fn log(&mut self, _log: Log) {}
+
+    fn run_interpreter(
+        &mut self,
+        tx_env: TxEnv,
+        bytecode: Bytecode,
+        message: Message,
+    ) -> InstrStop {
+        run_interpreter_with_host(self, bytecode, self.spec_id, tx_env, message)
+    }
+}
+
+fn run_interpreter_with_host<H>(
+    host: &mut H,
+    bytecode: Bytecode,
+    spec_id: SpecId,
+    tx_env: TxEnv,
+    message: Message,
+) -> InstrStop
+where
+    H: Host,
+{
+    let gas_table = new_gas_table(spec_id);
+    let mut interpreter = Interpreter::new(bytecode, spec_id, tx_env, message);
+    interpreter.run_with_table(Table::Normal(&DEFAULT_TABLE), &gas_table, host)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        bytecode::Bytecode,
+        interpreter::{MessageKind, op},
+        registry::TxRequest,
+    };
+    use alloy_primitives::{Address, Bytes, U256};
+
+    const TEST_TX_TYPE: u8 = 0x7f;
+
+    #[derive(Debug)]
+    struct TestTx {
+        value: u64,
+    }
+
+    impl Typed2718 for TestTx {
+        fn ty(&self) -> u8 {
+            TEST_TX_TYPE
+        }
+    }
+
+    fn extract_test_tx(tx: &TestTx) -> Option<&TestTx> {
+        Some(tx)
+    }
+
+    fn handle_test_tx(req: TxRequest<'_, TestTx>) -> HandlerResult<TxResult> {
+        Ok(TxResult { status: true, gas_used: req.tx.value + 1 })
+    }
+
+    #[test]
+    fn dispatches_transaction_by_typed_2718_type() {
+        let registry =
+            TxRegistry::new().with_handler(TEST_TX_TYPE, extract_test_tx, handle_test_tx);
+        let evm = Evm::new(BlockEnv::default(), registry, SpecId::OSAKA);
+        let tx = TestTx { value: 41 };
+
+        assert_eq!(evm.transact(&tx).map(|result| result.gas_used), Ok(42));
+    }
+
+    #[test]
+    fn dispatches_transaction_iter() {
+        let registry =
+            TxRegistry::new().with_handler(TEST_TX_TYPE, extract_test_tx, handle_test_tx);
+        let evm = Evm::new(BlockEnv::default(), registry, SpecId::OSAKA);
+        let txs = [TestTx { value: 1 }, TestTx { value: 2 }];
+        let gas_used = evm
+            .transact_iter(&txs)
+            .map(|result| result.map(|result| result.gas_used))
+            .collect::<HandlerResult<Vec<_>>>();
+
+        assert_eq!(gas_used, Ok(vec![2, 3]));
+    }
+
+    #[test]
+    fn runs_interpreter_with_message() {
+        let mut evm =
+            Evm::new(BlockEnv::default(), TxRegistry::<TestTx, TxResult>::new(), SpecId::OSAKA);
+        let bytecode = Bytecode::new_legacy(Bytes::from_static(&[op::ADDRESS, op::STOP]));
+        let destination = Address::from([0x11; 20]);
+        let message = Message {
+            kind: MessageKind::Call,
+            gas_limit: 10_000,
+            destination,
+            code_address: destination,
+            value: U256::ZERO,
+            ..Message::default()
+        };
+
+        let stop = Host::run_interpreter(&mut evm, TxEnv::default(), bytecode, message);
+
+        assert!(matches!(stop, InstrStop::Stop));
+    }
+}

--- a/crates/evm2/src/interpreter/instructions/block.rs
+++ b/crates/evm2/src/interpreter/instructions/block.rs
@@ -6,7 +6,7 @@ const BLOCK_HASH_HISTORY: u64 = 256;
 
 #[instruction]
 pub(in crate::interpreter) fn blockhash(cx: _, [number]: [Word]) -> Result<out> {
-    *out = if let Some(diff) = cx.state.block.number.checked_sub(number) {
+    *out = if let Some(diff) = cx.state.host.block_env().number.checked_sub(number) {
         let diff = u64::try_from(diff).unwrap_or(u64::MAX);
         if diff == 0 || diff > BLOCK_HASH_HISTORY {
             Word::ZERO
@@ -25,31 +25,31 @@ pub(in crate::interpreter) fn blockhash(cx: _, [number]: [Word]) -> Result<out> 
 
 #[instruction]
 pub(in crate::interpreter) fn coinbase(cx: _) -> out {
-    *out = address_to_word(cx.state.block.beneficiary);
+    *out = address_to_word(cx.state.host.block_env().beneficiary);
 }
 
 #[instruction]
 pub(in crate::interpreter) fn timestamp(cx: _) -> out {
-    *out = cx.state.block.timestamp;
+    *out = cx.state.host.block_env().timestamp;
 }
 
 #[instruction]
 pub(in crate::interpreter) fn block_number(cx: _) -> out {
-    *out = cx.state.block.number;
+    *out = cx.state.host.block_env().number;
 }
 
 #[instruction]
 pub(in crate::interpreter) fn difficulty(cx: _) -> out {
     *out = if cx.state.spec.enables(SpecId::MERGE) {
-        cx.state.block.prevrandao
+        cx.state.host.block_env().prevrandao
     } else {
-        cx.state.block.difficulty
+        cx.state.host.block_env().difficulty
     };
 }
 
 #[instruction]
 pub(in crate::interpreter) fn gaslimit(cx: _) -> out {
-    *out = cx.state.block.gas_limit;
+    *out = cx.state.host.block_env().gas_limit;
 }
 
 #[instruction]
@@ -60,13 +60,13 @@ pub(in crate::interpreter) fn chainid(cx: _) -> Result<out> {
 
 #[instruction]
 pub(in crate::interpreter) fn selfbalance(cx: _) -> out {
-    *out = cx.state.host.balance(address_to_word(cx.state.tx.address));
+    *out = cx.state.host.balance(address_to_word(cx.state.message.destination));
 }
 
 #[instruction]
 pub(in crate::interpreter) fn basefee(cx: _) -> Result<out> {
     check_spec(cx.state.spec, SpecId::LONDON)?;
-    *out = cx.state.block.basefee;
+    *out = cx.state.host.block_env().basefee;
 }
 
 #[instruction]
@@ -79,13 +79,13 @@ pub(in crate::interpreter) fn blobhash(cx: _, [index]: [Word]) -> Result<out> {
 #[instruction]
 pub(in crate::interpreter) fn blobbasefee(cx: _) -> Result<out> {
     check_spec(cx.state.spec, SpecId::CANCUN)?;
-    *out = cx.state.block.blob_basefee;
+    *out = cx.state.host.block_env().blob_basefee;
 }
 
 #[instruction]
 pub(in crate::interpreter) fn slotnum(cx: _) -> Result<out> {
     check_spec(cx.state.spec, SpecId::AMSTERDAM)?;
-    *out = cx.state.block.slot_num;
+    *out = cx.state.host.block_env().slot_num;
 }
 
 #[cfg(test)]
@@ -95,7 +95,10 @@ mod tests {
         interpreter::{
             InstrStop, SpecId, Word,
             instructions::{
-                tests::{TestHost, push, run_with_host, run_with_host_and_spec},
+                tests::{
+                    TestHost, push, run_with_host, run_with_host_and_spec, run_with_host_message,
+                    run_with_host_tx_env_and_spec,
+                },
                 utils::{address_to_word, b256_to_word},
             },
             op,
@@ -182,12 +185,14 @@ mod tests {
 
     #[test]
     fn chainid_opcode() {
-        let mut host = TestHost {
-            tx: TxEnv { chain_id: Word::from(1), ..TxEnv::default() },
-            ..TestHost::default()
-        };
-        let interpreter =
-            run_with_host_and_spec([op::CHAINID, op::STOP], &mut host, SpecId::ISTANBUL);
+        let mut host = TestHost::default();
+        let tx_env = TxEnv { chain_id: Word::from(1), ..TxEnv::default() };
+        let interpreter = run_with_host_tx_env_and_spec(
+            [op::CHAINID, op::STOP],
+            &mut host,
+            tx_env,
+            SpecId::ISTANBUL,
+        );
         core::assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [Word::from(1)]);
     }
@@ -195,9 +200,13 @@ mod tests {
     #[test]
     fn selfbalance_opcode() {
         let address = Address::from([0x66; 20]);
-        let mut host =
-            TestHost { tx: TxEnv { address, ..TxEnv::default() }, ..TestHost::default() };
-        let interpreter = run_with_host([op::SELFBALANCE, op::STOP], &mut host);
+        let mut host = TestHost::default();
+        let message = crate::interpreter::Message {
+            destination: address,
+            gas_limit: 10_000,
+            ..Default::default()
+        };
+        let interpreter = run_with_host_message([op::SELFBALANCE, op::STOP], &mut host, message);
         core::assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [address_to_word(address)]);
     }
@@ -214,19 +223,22 @@ mod tests {
     #[test]
     fn blobhash_opcode() {
         let hash = B256::with_last_byte(0x42);
-        let mut host = TestHost {
-            tx: TxEnv { blob_hashes: Vec::from([b256_to_word(hash)]), ..TxEnv::default() },
-            ..TestHost::default()
-        };
+        let mut host = TestHost::default();
+        let tx_env = TxEnv { blob_hashes: Vec::from([b256_to_word(hash)]), ..TxEnv::default() };
 
-        let interpreter =
-            run_with_host_and_spec([op::PUSH0, op::BLOBHASH, op::STOP], &mut host, SpecId::CANCUN);
+        let interpreter = run_with_host_tx_env_and_spec(
+            [op::PUSH0, op::BLOBHASH, op::STOP],
+            &mut host,
+            tx_env.clone(),
+            SpecId::CANCUN,
+        );
         core::assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [b256_to_word(hash)]);
 
-        let interpreter = run_with_host_and_spec(
+        let interpreter = run_with_host_tx_env_and_spec(
             [op::PUSH1, 0x01, op::BLOBHASH, op::STOP],
             &mut host,
+            tx_env,
             SpecId::CANCUN,
         );
         core::assert_matches!(interpreter.err, InstrStop::Stop);

--- a/crates/evm2/src/interpreter/instructions/env.rs
+++ b/crates/evm2/src/interpreter/instructions/env.rs
@@ -210,6 +210,27 @@ mod tests {
     }
 
     #[test]
+    fn balance_cold_account_cost() {
+        let mut host = TestHost { is_cold: true, ..TestHost::default() };
+        let interpreter = run(RunConfig::new([op::PUSH1, 0xbe, op::BALANCE, op::STOP])
+            .host(&mut host)
+            .spec(SpecId::BERLIN));
+        core::assert_matches!(interpreter.err, InstrStop::Stop);
+        assert_eq!(interpreter.stack(), [Word::from(0xbe)]);
+        assert_eq!(interpreter.gas_remaining(), 7_397);
+    }
+
+    #[test]
+    fn balance_cold_account_skip_oog() {
+        let mut host = TestHost { is_cold: true, ..TestHost::default() };
+        let interpreter = run(RunConfig::new([op::PUSH1, 0xbe, op::BALANCE, op::STOP])
+            .host(&mut host)
+            .spec(SpecId::BERLIN)
+            .gas_limit(103));
+        core::assert_matches!(interpreter.err, InstrStop::OutOfGas);
+    }
+
+    #[test]
     fn origin_opcode() {
         let origin = Address::from([0x22; 20]);
         let mut host = TestHost::default();

--- a/crates/evm2/src/interpreter/instructions/env.rs
+++ b/crates/evm2/src/interpreter/instructions/env.rs
@@ -5,7 +5,7 @@ use evm2_macros::instruction;
 
 #[instruction]
 pub(in crate::interpreter) fn address(cx: _) -> out {
-    *out = address_to_word(cx.state.tx.address);
+    *out = address_to_word(cx.state.message.destination);
 }
 
 #[instruction]
@@ -20,18 +20,18 @@ pub(in crate::interpreter) fn origin(cx: _) -> out {
 
 #[instruction]
 pub(in crate::interpreter) fn caller(cx: _) -> out {
-    *out = address_to_word(cx.state.tx.caller);
+    *out = address_to_word(cx.state.message.caller);
 }
 
 #[instruction]
 pub(in crate::interpreter) fn callvalue(cx: _) -> out {
-    *out = cx.state.tx.call_value;
+    *out = cx.state.message.value;
 }
 
 #[instruction]
 pub(in crate::interpreter) fn calldataload(cx: _, [offset]: [Word]) -> out {
     let offset = as_usize_saturated(offset);
-    let input = cx.state.tx.calldata.as_ref();
+    let input = cx.state.message.input.as_ref();
     let mut word = B256::ZERO;
     if offset < input.len() {
         let len = 32.min(input.len() - offset);
@@ -42,7 +42,7 @@ pub(in crate::interpreter) fn calldataload(cx: _, [offset]: [Word]) -> out {
 
 #[instruction]
 pub(in crate::interpreter) fn calldatasize(cx: _) -> out {
-    *out = Word::from(cx.state.tx.calldata.len());
+    *out = Word::from(cx.state.message.input.len());
 }
 
 #[instruction]
@@ -57,7 +57,7 @@ pub(in crate::interpreter) fn calldatacopy(
     let memory_offset = as_usize(memory_offset)?;
     let data_offset = as_usize_saturated(data_offset);
     resize_memory(cx.gas, cx.state.memory, memory_offset, len)?;
-    cx.state.memory.set_data(memory_offset, data_offset, len, &cx.state.tx.calldata)
+    cx.state.memory.set_data(memory_offset, data_offset, len, &cx.state.message.input)
 }
 
 #[instruction]
@@ -98,11 +98,11 @@ mod tests {
     use crate::{
         env::TxEnv,
         interpreter::{
-            InstrStop, SpecId, Word,
+            InstrStop, Message, SpecId, Word,
             instructions::{
                 tests::{
                     TestHost, assert_stack, push, run, run_stack, run_with_host,
-                    run_with_host_and_spec,
+                    run_with_host_and_spec, run_with_host_message, run_with_host_tx_env,
                 },
                 utils::{address_to_word, b256_to_word},
             },
@@ -116,8 +116,8 @@ mod tests {
         Word::from(0).wrapping_sub(Word::from(value))
     }
 
-    fn test_host(tx: TxEnv) -> TestHost {
-        TestHost { tx, ..TestHost::default() }
+    fn test_message() -> Message {
+        Message { gas_limit: 10_000, ..Message::default() }
     }
 
     fn stack_code<const N: usize>(inputs: [Word; N], opcode: u8) -> Vec<u8> {
@@ -132,8 +132,9 @@ mod tests {
     #[test]
     fn address_opcode() {
         let address = Address::from([0x11; 20]);
-        let mut host = test_host(TxEnv { address, ..TxEnv::default() });
-        let interpreter = run_with_host([op::ADDRESS, op::STOP], &mut host);
+        let mut host = TestHost::default();
+        let message = Message { destination: address, ..test_message() };
+        let interpreter = run_with_host_message([op::ADDRESS, op::STOP], &mut host, message);
         core::assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [address_to_word(address)]);
     }
@@ -148,8 +149,9 @@ mod tests {
     #[test]
     fn origin_opcode() {
         let origin = Address::from([0x22; 20]);
-        let mut host = test_host(TxEnv { origin, ..TxEnv::default() });
-        let interpreter = run_with_host([op::ORIGIN, op::STOP], &mut host);
+        let mut host = TestHost::default();
+        let tx_env = TxEnv { origin, ..TxEnv::default() };
+        let interpreter = run_with_host_tx_env([op::ORIGIN, op::STOP], &mut host, tx_env);
         core::assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [address_to_word(origin)]);
     }
@@ -157,49 +159,62 @@ mod tests {
     #[test]
     fn caller_opcode() {
         let caller = Address::from([0x33; 20]);
-        let mut host = test_host(TxEnv { caller, ..TxEnv::default() });
-        let interpreter = run_with_host([op::CALLER, op::STOP], &mut host);
+        let mut host = TestHost::default();
+        let message = Message { caller, ..test_message() };
+        let interpreter = run_with_host_message([op::CALLER, op::STOP], &mut host, message);
         core::assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [address_to_word(caller)]);
     }
 
     #[test]
     fn callvalue_opcode() {
-        let mut host = test_host(TxEnv { call_value: Word::from(0xbeef), ..TxEnv::default() });
-        let interpreter = run_with_host([op::CALLVALUE, op::STOP], &mut host);
+        let mut host = TestHost::default();
+        let message = Message { value: Word::from(0xbeef), ..test_message() };
+        let interpreter = run_with_host_message([op::CALLVALUE, op::STOP], &mut host, message);
         core::assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [Word::from(0xbeef)]);
     }
 
     #[test]
     fn calldataload_opcode() {
-        let calldata = Bytes::from(Vec::from([1_u8, 2, 3]));
-        let mut host = test_host(TxEnv { calldata, ..TxEnv::default() });
+        let input = Bytes::from(Vec::from([1_u8, 2, 3]));
+        let mut host = TestHost::default();
+        let message = Message { input, ..test_message() };
 
-        let interpreter = run_with_host([op::PUSH0, op::CALLDATALOAD, op::STOP], &mut host);
+        let interpreter = run_with_host_message(
+            [op::PUSH0, op::CALLDATALOAD, op::STOP],
+            &mut host,
+            message.clone(),
+        );
         let mut expected = [0_u8; 32];
         expected[..3].copy_from_slice(&[1, 2, 3]);
         core::assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [Word::from_be_bytes(expected)]);
 
-        let interpreter = run_with_host([op::PUSH1, 0x20, op::CALLDATALOAD, op::STOP], &mut host);
+        let interpreter = run_with_host_message(
+            [op::PUSH1, 0x20, op::CALLDATALOAD, op::STOP],
+            &mut host,
+            message,
+        );
         core::assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [0]);
     }
 
     #[test]
     fn calldatasize_opcode() {
-        let calldata = Bytes::from(Vec::from([1_u8, 2, 3, 4]));
-        let mut host = test_host(TxEnv { calldata, ..TxEnv::default() });
-        let interpreter = run_with_host([op::CALLDATASIZE, op::STOP], &mut host);
+        let input = Bytes::from(Vec::from([1_u8, 2, 3, 4]));
+        let mut host = TestHost::default();
+        let message = Message { input, ..test_message() };
+        let interpreter = run_with_host_message([op::CALLDATASIZE, op::STOP], &mut host, message);
         core::assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [Word::from(4)]);
     }
 
     #[test]
     fn calldatacopy_opcode() {
-        let calldata = Bytes::from(Vec::from([0xaa_u8, 0xbb, 0xcc]));
-        let mut host = test_host(TxEnv { calldata, ..TxEnv::default() });
+        let input = Bytes::from(Vec::from([0xaa_u8, 0xbb, 0xcc]));
+        let mut host = TestHost::default();
+        let message = Message { input, ..test_message() };
         let mut code = Vec::new();
         push(&mut code, 2);
         push(&mut code, 1);
@@ -209,15 +224,16 @@ mod tests {
         code.push(op::MLOAD);
         code.push(op::STOP);
 
-        let interpreter = run_with_host(code, &mut host);
+        let interpreter = run_with_host_message(code, &mut host, message.clone());
         let mut expected = [0_u8; 32];
         expected[..2].copy_from_slice(&[0xbb, 0xcc]);
         core::assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [Word::from_be_bytes(expected)]);
 
-        let interpreter = run_with_host(
+        let interpreter = run_with_host_message(
             stack_code([Word::MAX, Word::MAX, Word::from(0)], op::CALLDATACOPY),
             &mut host,
+            message,
         );
         core::assert_matches!(interpreter.err, InstrStop::Stop);
     }
@@ -271,8 +287,9 @@ mod tests {
 
     #[test]
     fn gasprice_opcode() {
-        let mut host = test_host(TxEnv { gas_price: Word::from(0x1234), ..TxEnv::default() });
-        let interpreter = run_with_host([op::GASPRICE, op::STOP], &mut host);
+        let mut host = TestHost::default();
+        let tx_env = TxEnv { gas_price: Word::from(0x1234), ..TxEnv::default() };
+        let interpreter = run_with_host_tx_env([op::GASPRICE, op::STOP], &mut host, tx_env);
         core::assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [Word::from(0x1234)]);
     }

--- a/crates/evm2/src/interpreter/instructions/host.rs
+++ b/crates/evm2/src/interpreter/instructions/host.rs
@@ -68,7 +68,7 @@ pub(in crate::interpreter) fn log<const N: usize>(cx: _) -> Result {
     let topics =
         stack.popn::<N>()?.into_iter().map(|topic| B256::from(topic.to_be_bytes::<32>())).collect();
     cx.state.host.log(Log {
-        address: cx.state.tx.address,
+        address: cx.state.message.destination,
         data: LogData::new(topics, data).expect("LOG opcodes cannot emit more than 4 topics"),
     });
     Ok(())
@@ -80,6 +80,7 @@ mod tests {
         InstrStop, SpecId, Word,
         instructions::tests::{
             TestHost, push, run_with_host, run_with_host_and_spec, run_with_host_and_spec_config,
+            run_with_host_message,
         },
         op,
     };
@@ -234,15 +235,18 @@ mod tests {
 
     #[test]
     fn log0_opcode() {
-        let mut host = TestHost {
-            tx: crate::env::TxEnv { address: Address::from([0x11; 20]), ..Default::default() },
+        let mut host = TestHost::default();
+        let address = Address::from([0x11; 20]);
+        let message = crate::interpreter::Message {
+            destination: address,
+            gas_limit: 10_000,
             ..Default::default()
         };
-        let interpreter = run_with_host(log_code(30, 2, []), &mut host);
+        let interpreter = run_with_host_message(log_code(30, 2, []), &mut host, message);
         core::assert_matches!(interpreter.err, InstrStop::Stop);
         assert!(interpreter.stack().is_empty());
         assert_eq!(host.logs.len(), 1);
-        assert_eq!(host.logs[0].address, Address::from([0x11; 20]));
+        assert_eq!(host.logs[0].address, address);
         assert!(host.logs[0].topics().is_empty());
         assert_eq!(host.logs[0].data.data, Bytes::from_static(&[0xbe, 0xef]));
     }

--- a/crates/evm2/src/interpreter/instructions/host.rs
+++ b/crates/evm2/src/interpreter/instructions/host.rs
@@ -6,7 +6,7 @@ use alloy_primitives::{B256, Bytes, Log, LogData};
 use evm2_macros::instruction;
 
 const fn require_non_staticcall(cx: &InstructionCx<'_, '_, '_>) -> Result {
-    if cx.state.is_static {
+    if cx.state.message.is_static() {
         return Err(InstrStop::StateChangeDuringStaticCall);
     }
     Ok(())

--- a/crates/evm2/src/interpreter/instructions/host.rs
+++ b/crates/evm2/src/interpreter/instructions/host.rs
@@ -77,7 +77,7 @@ pub(in crate::interpreter) fn log<const N: usize>(cx: _) -> Result {
 #[cfg(test)]
 mod tests {
     use crate::interpreter::{
-        InstrStop, SpecId, Word,
+        InstrStop, Message, MessageKind, SpecId, Word,
         instructions::tests::{
             TestHost, push, run_with_host, run_with_host_and_spec, run_with_host_and_spec_config,
             run_with_host_message,
@@ -133,6 +133,23 @@ mod tests {
 
         let interpreter =
             run_with_host_and_spec_config(code, &mut host, SpecId::HOMESTEAD, true, 10_000);
+        core::assert_matches!(interpreter.err, InstrStop::StateChangeDuringStaticCall);
+        assert_eq!(interpreter.stack(), [Word::from(0xbeef), Word::from(1)]);
+        assert_eq!(host.storage.get(&Word::from(1)), None);
+    }
+
+    #[test]
+    fn sstore_staticcall_message_kind_check() {
+        let mut host = TestHost::default();
+        let mut code = Vec::new();
+        push(&mut code, 0xbeef);
+        push(&mut code, 1);
+        code.extend([op::SSTORE, op::STOP]);
+        let message =
+            Message { kind: MessageKind::StaticCall, gas_limit: 10_000, ..Default::default() };
+
+        let interpreter = run_with_host_message(code, &mut host, message);
+
         core::assert_matches!(interpreter.err, InstrStop::StateChangeDuringStaticCall);
         assert_eq!(interpreter.stack(), [Word::from(0xbeef), Word::from(1)]);
         assert_eq!(host.storage.get(&Word::from(1)), None);

--- a/crates/evm2/src/interpreter/instructions/mod.rs
+++ b/crates/evm2/src/interpreter/instructions/mod.rs
@@ -28,7 +28,7 @@ pub(super) use stack::*;
 mod system;
 
 mod i256;
-pub(in crate::interpreter) mod table;
+pub(crate) mod table;
 mod utils;
 
 #[cfg(test)]

--- a/crates/evm2/src/interpreter/instructions/table.rs
+++ b/crates/evm2/src/interpreter/instructions/table.rs
@@ -11,19 +11,19 @@ use crate::interpreter::{
 use core::hint::cold_path;
 
 /// Normal instruction return value.
-pub(in crate::interpreter) type InstrFnRet = (usize, Result);
+pub(crate) type InstrFnRet = (usize, Result);
 /// Normal instruction function pointer.
-pub(in crate::interpreter) type InstrFn = extern_table!(
+pub(crate) type InstrFn = extern_table!(
     fn(stack: Stack<'_>, pc: PcMut<'_>, gas: &mut Gas, state: &mut State<'_>) -> InstrFnRet
 );
 /// Normal instruction dispatch table.
-pub(in crate::interpreter) type InstrTable = [InstrFn; 256];
+pub(crate) type InstrTable = [InstrFn; 256];
 
 // TODO: consider splitting remaining gas into a separate struct passed by value.
 /// Tail instruction return value.
-pub(in crate::interpreter) type TailInstrFnRet = InstrStop;
+pub(crate) type TailInstrFnRet = InstrStop;
 /// Tail instruction function pointer.
-pub(in crate::interpreter) type TailInstrFn = extern_table!(
+pub(crate) type TailInstrFn = extern_table!(
     fn(
         stack: Stack<'_>,
         pc: Pc<'_>,
@@ -34,14 +34,14 @@ pub(in crate::interpreter) type TailInstrFn = extern_table!(
     ) -> TailInstrFnRet
 );
 /// Tail instruction dispatch table.
-pub(in crate::interpreter) type TailInstrTable = [TailInstrFn; 256];
+pub(crate) type TailInstrTable = [TailInstrFn; 256];
 
 /// Opcode gas table.
-pub(in crate::interpreter) type GasTable = [u16; 256];
+pub(crate) type GasTable = [u16; 256];
 
 /// Instruction execution context.
 #[derive(Debug)]
-pub(in crate::interpreter) struct InstructionCx<'a, 'ctrl, 'state> {
+pub(crate) struct InstructionCx<'a, 'ctrl, 'state> {
     /// Program counter state.
     pub pc: PcMut<'ctrl>,
     /// Gas state.
@@ -51,9 +51,9 @@ pub(in crate::interpreter) struct InstructionCx<'a, 'ctrl, 'state> {
 }
 
 /// Default normal dispatch table.
-pub(in crate::interpreter) static DEFAULT_TABLE: InstrTable = make_table();
+pub(crate) static DEFAULT_TABLE: InstrTable = make_table();
 /// Default tail dispatch table.
-pub(in crate::interpreter) static DEFAULT_TAIL_TABLE: TailInstrTable = make_tail_table();
+pub(crate) static DEFAULT_TAIL_TABLE: TailInstrTable = make_tail_table();
 
 pub(crate) trait Instruction {
     fn execute(
@@ -66,7 +66,7 @@ pub(crate) trait Instruction {
 
 /// Creates a gas table for `spec`.
 #[inline]
-pub(in crate::interpreter) const fn new_gas_table(spec: SpecId) -> GasTable {
+pub(crate) const fn new_gas_table(spec: SpecId) -> GasTable {
     let mut table = make_gas_table();
 
     if spec.enables(SpecId::TANGERINE) {
@@ -293,13 +293,13 @@ macro_rules! make_table_m {
 }
 
 /// Creates the normal instruction dispatch table.
-pub(in crate::interpreter) const fn make_table() -> InstrTable {
+pub(crate) const fn make_table() -> InstrTable {
     use crate::interpreter::instructions::*;
     make_table_m!(dispatch, InstrTable, InstrFn)
 }
 
 /// Creates the tail instruction dispatch table.
-pub(in crate::interpreter) const fn make_tail_table() -> TailInstrTable {
+pub(crate) const fn make_tail_table() -> TailInstrTable {
     use crate::interpreter::instructions::*;
     make_table_m!(tail_dispatch, TailInstrTable, TailInstrFn)
 }

--- a/crates/evm2/src/interpreter/instructions/tests.rs
+++ b/crates/evm2/src/interpreter/instructions/tests.rs
@@ -159,7 +159,7 @@ pub(super) fn run_with_host_and_spec_config(
     let bytecode = Bytecode::new_legacy(Bytes::from(code.into()));
     let message = Message { gas_limit, ..Message::default() };
     let mut inner = Interpreter::new(bytecode, spec_id, TxEnv::default(), message);
-    inner.is_static = is_static;
+    inner.is_static |= is_static;
     inner.gas = Gas::new(gas_limit);
     let err = inner.run(host);
     TestInterpreter { inner, err }

--- a/crates/evm2/src/interpreter/instructions/tests.rs
+++ b/crates/evm2/src/interpreter/instructions/tests.rs
@@ -1,7 +1,7 @@
 use crate::{
     bytecode::Bytecode,
     env::{BlockEnv, TxEnv},
-    interpreter::{Gas, Host, InstrStop, Interpreter, SpecId, Word, op},
+    interpreter::{Gas, Host, InstrStop, Interpreter, Message, SpecId, Word, op},
 };
 use alloc::vec::Vec;
 use alloy_primitives::{B256, Bytes, Log};
@@ -9,7 +9,6 @@ use std::collections::HashMap;
 
 #[derive(Debug, Default)]
 pub(in crate::interpreter) struct TestHost {
-    pub(super) tx: TxEnv,
     pub(super) block: BlockEnv,
     pub(super) code_size: usize,
     pub(super) code_hash: B256,
@@ -19,10 +18,6 @@ pub(in crate::interpreter) struct TestHost {
 }
 
 impl Host for TestHost {
-    fn tx_env(&mut self) -> &TxEnv {
-        &self.tx
-    }
-
     fn block_env(&mut self) -> &BlockEnv {
         &self.block
     }
@@ -100,6 +95,60 @@ pub(super) fn run_with_host_and_spec(
     run_with_host_and_spec_config(code, host, spec_id, false, 10_000)
 }
 
+pub(super) fn run_with_host_tx_env(
+    code: impl Into<Vec<u8>>,
+    host: &mut dyn Host,
+    tx_env: TxEnv,
+) -> TestInterpreter {
+    run_with_host_tx_env_and_spec(code, host, tx_env, SpecId::HOMESTEAD)
+}
+
+pub(super) fn run_with_host_tx_env_and_spec(
+    code: impl Into<Vec<u8>>,
+    host: &mut dyn Host,
+    tx_env: TxEnv,
+    spec_id: SpecId,
+) -> TestInterpreter {
+    run_with_host_message_tx_env_and_spec_config(
+        code,
+        host,
+        Message { gas_limit: 10_000, ..Message::default() },
+        tx_env,
+        spec_id,
+        false,
+    )
+}
+
+pub(super) fn run_with_host_message(
+    code: impl Into<Vec<u8>>,
+    host: &mut dyn Host,
+    message: Message,
+) -> TestInterpreter {
+    run_with_host_message_tx_env_and_spec_config(
+        code,
+        host,
+        message,
+        TxEnv::default(),
+        SpecId::HOMESTEAD,
+        false,
+    )
+}
+
+pub(super) fn run_with_host_message_tx_env_and_spec_config(
+    code: impl Into<Vec<u8>>,
+    host: &mut dyn Host,
+    message: Message,
+    tx_env: TxEnv,
+    spec_id: SpecId,
+    is_static: bool,
+) -> TestInterpreter {
+    let bytecode = Bytecode::new_legacy(Bytes::from(code.into()));
+    let mut inner = Interpreter::new(bytecode, spec_id, tx_env, message);
+    inner.is_static |= is_static;
+    let err = inner.run(host);
+    TestInterpreter { inner, err }
+}
+
 pub(super) fn run_with_host_and_spec_config(
     code: impl Into<Vec<u8>>,
     host: &mut dyn Host,
@@ -108,7 +157,8 @@ pub(super) fn run_with_host_and_spec_config(
     gas_limit: u64,
 ) -> TestInterpreter {
     let bytecode = Bytecode::new_legacy(Bytes::from(code.into()));
-    let mut inner = Interpreter::new(bytecode, spec_id);
+    let message = Message { gas_limit, ..Message::default() };
+    let mut inner = Interpreter::new(bytecode, spec_id, TxEnv::default(), message);
     inner.is_static = is_static;
     inner.gas = Gas::new(gas_limit);
     let err = inner.run(host);

--- a/crates/evm2/src/interpreter/instructions/tests.rs
+++ b/crates/evm2/src/interpreter/instructions/tests.rs
@@ -93,7 +93,6 @@ pub(super) struct RunConfig<'a> {
     pub(super) spec_id: SpecId,
     pub(super) tx_env: TxEnv,
     pub(super) message: Message,
-    pub(super) is_static: bool,
     pub(super) gas_limit: u64,
     pub(super) return_data: Bytes,
 }
@@ -123,8 +122,8 @@ impl<'a> RunConfig<'a> {
         self
     }
 
-    pub(super) const fn staticcall(mut self) -> Self {
-        self.is_static = true;
+    pub(super) fn staticcall(mut self) -> Self {
+        self.message.kind = MessageKind::StaticCall;
         self
     }
 
@@ -147,7 +146,6 @@ impl Default for RunConfig<'_> {
             spec_id: SpecId::HOMESTEAD,
             tx_env: TxEnv::default(),
             message: Message { gas_limit: 10_000, ..Message::default() },
-            is_static: false,
             gas_limit: 10_000,
             return_data: Bytes::new(),
         }
@@ -155,13 +153,9 @@ impl Default for RunConfig<'_> {
 }
 
 pub(super) fn run(config: RunConfig<'_>) -> TestInterpreter {
-    let RunConfig { code, host, spec_id, tx_env, mut message, is_static, gas_limit, return_data } =
-        config;
+    let RunConfig { code, host, spec_id, tx_env, mut message, gas_limit, return_data } = config;
     let bytecode = Bytecode::new_legacy(Bytes::from(code));
     message.gas_limit = gas_limit;
-    if is_static {
-        message.kind = MessageKind::StaticCall;
-    }
     let mut inner = Interpreter::new(bytecode, spec_id, tx_env, message);
     inner.return_data = return_data;
     let mut default_host = TestHost::default();

--- a/crates/evm2/src/interpreter/message.rs
+++ b/crates/evm2/src/interpreter/message.rs
@@ -44,6 +44,12 @@ pub struct Message {
 impl Message {
     /// EVM call depth limit.
     pub const CALL_DEPTH_LIMIT: u16 = 1024;
+
+    /// Returns whether this message forbids state-changing operations.
+    #[inline]
+    pub const fn is_static(&self) -> bool {
+        matches!(self.kind, MessageKind::StaticCall)
+    }
 }
 
 impl Default for Message {

--- a/crates/evm2/src/interpreter/message.rs
+++ b/crates/evm2/src/interpreter/message.rs
@@ -1,0 +1,63 @@
+use alloy_primitives::{Address, Bytes, U256};
+
+/// EVM message kind.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum MessageKind {
+    /// Regular `CALL` message.
+    #[default]
+    Call,
+    /// `DELEGATECALL` message.
+    DelegateCall,
+    /// `CALLCODE` message.
+    CallCode,
+    /// `CREATE` message.
+    Create,
+    /// `CREATE2` message.
+    Create2,
+    /// `STATICCALL` message.
+    StaticCall,
+}
+
+/// Frame-local EVM call/create message executed by the interpreter.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Message {
+    /// Message kind.
+    pub kind: MessageKind,
+    /// Current call depth.
+    pub depth: u16,
+    /// Gas available to this message.
+    pub gas_limit: u64,
+    /// Account whose context is being executed.
+    pub destination: Address,
+    /// Immediate caller.
+    pub caller: Address,
+    /// Call input data, or initcode for create messages.
+    pub input: Bytes,
+    /// Value transferred with the message.
+    pub value: U256,
+    /// Address whose code is being executed. This can differ from `destination` for `CALLCODE`
+    /// and `DELEGATECALL`.
+    pub code_address: Address,
+}
+
+impl Message {
+    /// EVM call depth limit.
+    pub const CALL_DEPTH_LIMIT: u16 = 1024;
+}
+
+impl Default for Message {
+    #[inline]
+    fn default() -> Self {
+        Self {
+            kind: MessageKind::Call,
+            depth: 0,
+            gas_limit: 0,
+            destination: Address::ZERO,
+            caller: Address::ZERO,
+            input: Bytes::new(),
+            value: U256::ZERO,
+            code_address: Address::ZERO,
+        }
+    }
+}

--- a/crates/evm2/src/interpreter/mod.rs
+++ b/crates/evm2/src/interpreter/mod.rs
@@ -9,7 +9,7 @@ pub use gas::{
 mod utils;
 
 mod instructions;
-pub(in crate::interpreter) use instructions::table;
+pub(crate) use instructions::table;
 
 mod opcode;
 pub use opcode::op;
@@ -23,11 +23,15 @@ pub use stack::{Stack, Word};
 mod memory;
 pub use memory::Memory;
 
+mod message;
+pub use message::{Message, MessageKind};
+
 mod state;
 pub use state::{Host, State};
 
 mod runtime;
 pub use runtime::Interpreter;
+pub(crate) use runtime::Table;
 
 pub(crate) type Result<T = (), E = InstrStop> = core::result::Result<T, E>;
 
@@ -257,7 +261,12 @@ mod tests {
 
         let gas_table = new_gas_table(spec_id);
         let bytecode = Bytecode::new_legacy(Bytes::copy_from_slice(bytecode));
-        let mut interpreter = Interpreter::new(bytecode, spec_id);
+        let mut interpreter = Interpreter::new(
+            bytecode,
+            spec_id,
+            crate::env::TxEnv::default(),
+            Message { gas_limit: 10_000, ..Message::default() },
+        );
         let mut host = TestHost::default();
         interpreter.run_with_table(instruction_table, &gas_table, &mut host);
     }
@@ -273,7 +282,12 @@ mod tests {
                 ("tail", Table::Tail(&DEFAULT_TAIL_TABLE)),
             ] {
                 let bytecode = Bytecode::new_legacy(Bytes::from_static(BASIC));
-                let mut interpreter = Interpreter::new(bytecode, spec);
+                let mut interpreter = Interpreter::new(
+                    bytecode,
+                    spec,
+                    crate::env::TxEnv::default(),
+                    Message { gas_limit: 10_000, ..Message::default() },
+                );
                 let mut host = TestHost::default();
                 interpreter.run_with_table(table, &gas_table, &mut host);
                 assert!(interpreter.gas.remaining() > 0);

--- a/crates/evm2/src/interpreter/runtime.rs
+++ b/crates/evm2/src/interpreter/runtime.rs
@@ -54,7 +54,7 @@ impl Interpreter {
             tx_env,
             message,
             spec_id,
-            is_static: false,
+            is_static,
         }
     }
 

--- a/crates/evm2/src/interpreter/runtime.rs
+++ b/crates/evm2/src/interpreter/runtime.rs
@@ -1,6 +1,6 @@
 use super::{
-    BytecodeRef, Gas, GasParams, Host, InstrStop, Memory, Message, MessageKind, Pc, PcMut, Result,
-    SpecId, Stack, State, Word,
+    BytecodeRef, Gas, GasParams, Host, InstrStop, Memory, Message, Pc, PcMut, Result, SpecId,
+    Stack, State, Word,
     instructions::table::{
         DEFAULT_TABLE, DEFAULT_TAIL_TABLE, GasTable, InstrTable, Instruction, TailInstrTable,
         new_gas_table,
@@ -37,7 +37,6 @@ pub struct Interpreter {
     pub(crate) message: Message,
     pub(crate) return_data: Bytes,
     spec_id: SpecId,
-    pub(crate) is_static: bool,
 }
 
 impl Interpreter {
@@ -45,7 +44,6 @@ impl Interpreter {
     /// environment, and a frame-local message.
     pub fn new(bytecode: Bytecode, spec_id: SpecId, tx_env: TxEnv, message: Message) -> Self {
         let gas_limit = message.gas_limit;
-        let is_static = matches!(message.kind, MessageKind::StaticCall);
         Self {
             bytecode,
             pc: 0,
@@ -59,7 +57,6 @@ impl Interpreter {
             message,
             return_data: Bytes::new(),
             spec_id,
-            is_static,
         }
     }
 
@@ -134,7 +131,6 @@ impl Interpreter {
             return_data: &self.return_data,
             spec: self.spec_id,
             gas_params: &self.gas_params,
-            is_static: self.is_static,
             raw_interp: core::ptr::null_mut(),
         };
 
@@ -206,7 +202,6 @@ impl Interpreter {
                 return_data: &self.return_data,
                 spec: self.spec_id,
                 gas_params: &self.gas_params,
-                is_static: self.is_static,
                 raw_interp: core::ptr::null_mut(),
             },
         );
@@ -240,7 +235,6 @@ impl Interpreter {
                 return_data: &self.return_data,
                 spec: self.spec_id,
                 gas_params: &self.gas_params,
-                is_static: self.is_static,
                 raw_interp: raw,
             },
             gas_table,

--- a/crates/evm2/src/interpreter/runtime.rs
+++ b/crates/evm2/src/interpreter/runtime.rs
@@ -1,5 +1,6 @@
 use super::{
-    BytecodeRef, Gas, Host, InstrStop, Memory, Pc, PcMut, Result, SpecId, Stack, State, Word,
+    BytecodeRef, Gas, Host, InstrStop, Memory, Message, MessageKind, Pc, PcMut, Result, SpecId,
+    Stack, State, Word,
     instructions::table::{
         DEFAULT_TABLE, DEFAULT_TAIL_TABLE, GasTable, InstrTable, Instruction, TailInstrTable,
         new_gas_table,
@@ -7,14 +8,14 @@ use super::{
     op,
     opcode::for_each_opcode,
 };
-use crate::bytecode::Bytecode;
+use crate::{bytecode::Bytecode, env::TxEnv};
 use alloc::boxed::Box;
 use core::hint::cold_path;
 
 /// Interpreter dispatch table mode.
 #[derive(Clone, Copy, Debug)]
 #[non_exhaustive]
-pub(in crate::interpreter) enum Table<'a> {
+pub(crate) enum Table<'a> {
     /// Normal dispatch loop.
     Normal(&'a InstrTable),
     /// Tail-call dispatch loop.
@@ -30,21 +31,28 @@ pub struct Interpreter {
     pub(crate) stack_len: usize,
     pub(crate) gas: Gas,
     pub(crate) memory: Memory,
+    tx_env: TxEnv,
+    pub(crate) message: Message,
     spec_id: SpecId,
     pub(crate) is_static: bool,
 }
 
 impl Interpreter {
-    /// Creates an interpreter from analyzed bytecode and a spec identifier.
-    pub fn new(bytecode: Bytecode, spec_id: SpecId) -> Self {
+    /// Creates an interpreter from analyzed bytecode, a spec identifier, a transaction-global
+    /// environment, and a frame-local message.
+    pub fn new(bytecode: Bytecode, spec_id: SpecId, tx_env: TxEnv, message: Message) -> Self {
+        let gas_limit = message.gas_limit;
+        let is_static = matches!(message.kind, MessageKind::StaticCall);
         Self {
             bytecode,
             pc: 0,
             // SAFETY: `Word` is valid at any bitpattern. It's not read before init anyway.
             stack: unsafe { Box::new_uninit().assume_init() },
             stack_len: 0,
-            gas: Gas::new(10_000),
+            gas: Gas::new(gas_limit),
             memory: Memory::new(),
+            tx_env,
+            message,
             spec_id,
             is_static: false,
         }
@@ -62,7 +70,7 @@ impl Interpreter {
         self.run_with_table(Table::Tail(&DEFAULT_TAIL_TABLE), &gas_table, host)
     }
 
-    pub(in crate::interpreter) fn run_with_table(
+    pub(crate) fn run_with_table(
         &mut self,
         table: Table<'_>,
         gas_table: &GasTable,
@@ -109,17 +117,14 @@ impl Interpreter {
         use super::instructions::*;
 
         let bytecode = BytecodeRef::new(&self.bytecode);
-        let host_ptr = host as *mut dyn Host;
-        let tx = unsafe { (&mut *host_ptr).tx_env() };
-        let block = unsafe { (&mut *host_ptr).block_env() };
         let stack = &mut Stack::new(&mut self.stack, self.stack_len);
         let gas_ref = &mut self.gas;
         let pc_field = &mut self.pc;
         let state = &mut State {
             bytecode,
-            host: unsafe { &mut *host_ptr },
-            tx,
-            block,
+            host,
+            tx: &self.tx_env,
+            message: &self.message,
             memory: &mut self.memory,
             spec: self.spec_id,
             is_static: self.is_static,
@@ -180,9 +185,6 @@ impl Interpreter {
         let bytecode = BytecodeRef::new(&self.bytecode);
         let mut pc = PcMut::new(bytecode, &mut self.pc);
         let op = Self::pre_step(pc.reborrow(), &mut self.gas, gas_table)?;
-        let host_ptr = host as *mut dyn Host;
-        let tx = unsafe { (&mut *host_ptr).tx_env() };
-        let block = unsafe { (&mut *host_ptr).block_env() };
         let r;
         (self.stack_len, r) = table[op as usize](
             Stack::new(&mut self.stack, self.stack_len),
@@ -190,9 +192,9 @@ impl Interpreter {
             &mut self.gas,
             &mut State {
                 bytecode,
-                host: unsafe { &mut *host_ptr },
-                tx,
-                block,
+                host,
+                tx: &self.tx_env,
+                message: &self.message,
                 memory: &mut self.memory,
                 spec: self.spec_id,
                 is_static: self.is_static,
@@ -211,9 +213,6 @@ impl Interpreter {
     ) -> Result {
         let raw = self as *mut _;
         let bytecode = BytecodeRef::new(&self.bytecode);
-        let host_ptr = host as *mut dyn Host;
-        let tx = unsafe { (&mut *host_ptr).tx_env() };
-        let block = unsafe { (&mut *host_ptr).block_env() };
         let (op, pc) = {
             let mut pc_mut = PcMut::new(bytecode, &mut self.pc);
             let op = Self::pre_step(pc_mut.reborrow(), &mut self.gas, gas_table)?;
@@ -225,9 +224,9 @@ impl Interpreter {
             &mut self.gas,
             &mut State {
                 bytecode,
-                host: unsafe { &mut *host_ptr },
-                tx,
-                block,
+                host,
+                tx: &self.tx_env,
+                message: &self.message,
                 memory: &mut self.memory,
                 spec: self.spec_id,
                 is_static: self.is_static,

--- a/crates/evm2/src/interpreter/state.rs
+++ b/crates/evm2/src/interpreter/state.rs
@@ -25,8 +25,6 @@ pub struct State<'a> {
     pub spec: SpecId,
     /// Dynamic gas parameters for the active spec.
     pub gas_params: &'a GasParams,
-    /// Whether state-changing opcodes are forbidden.
-    pub is_static: bool,
     pub(crate) raw_interp: *mut Interpreter,
 }
 
@@ -40,7 +38,6 @@ impl fmt::Debug for State<'_> {
             .field("return_data", &self.return_data)
             .field("spec", &self.spec)
             .field("gas_params", &self.gas_params)
-            .field("is_static", &self.is_static)
             .field("raw_interp", &self.raw_interp)
             .finish_non_exhaustive()
     }

--- a/crates/evm2/src/interpreter/state.rs
+++ b/crates/evm2/src/interpreter/state.rs
@@ -1,5 +1,8 @@
-use super::{BytecodeRef, Interpreter, Memory, SpecId, Word};
-use crate::env::{BlockEnv, TxEnv};
+use super::{BytecodeRef, InstrStop, Interpreter, Memory, Message, SpecId, Word};
+use crate::{
+    bytecode::Bytecode,
+    env::{BlockEnv, TxEnv},
+};
 use alloy_primitives::{B256, Log};
 use core::fmt;
 
@@ -9,10 +12,10 @@ pub struct State<'a> {
     pub bytecode: BytecodeRef<'a>,
     /// Host implementation.
     pub host: &'a mut (dyn Host + 'a),
-    /// Cached transaction environment.
+    /// Cached transaction-global environment.
     pub tx: &'a TxEnv,
-    /// Cached block environment.
-    pub block: &'a BlockEnv,
+    /// Active frame-local call/create message.
+    pub message: &'a Message,
     /// Linear memory.
     pub memory: &'a mut Memory,
     /// Active spec identifier.
@@ -27,7 +30,7 @@ impl fmt::Debug for State<'_> {
         f.debug_struct("State")
             .field("bytecode", &self.bytecode)
             .field("tx", &self.tx)
-            .field("block", &self.block)
+            .field("message", &self.message)
             .field("memory", &self.memory)
             .field("spec", &self.spec)
             .field("is_static", &self.is_static)
@@ -38,9 +41,6 @@ impl fmt::Debug for State<'_> {
 
 /// External host operations.
 pub trait Host {
-    /// Returns the transaction environment.
-    fn tx_env(&mut self) -> &TxEnv;
-
     /// Returns the block environment.
     fn block_env(&mut self) -> &BlockEnv;
 
@@ -70,4 +70,14 @@ pub trait Host {
 
     /// Records an emitted log.
     fn log(&mut self, log: Log);
+
+    /// Runs an interpreter frame inside this host.
+    fn run_interpreter(
+        &mut self,
+        _tx_env: TxEnv,
+        _bytecode: Bytecode,
+        _message: Message,
+    ) -> InstrStop {
+        InstrStop::FatalExternalError
+    }
 }

--- a/crates/evm2/src/lib.rs
+++ b/crates/evm2/src/lib.rs
@@ -12,6 +12,8 @@ extern crate alloc;
 
 pub mod bytecode;
 pub mod env;
+/// EVM host and transaction dispatcher.
+pub mod evm;
 pub mod interpreter;
 pub mod registry;
 


### PR DESCRIPTION
Adds a frame-local `Message` type and a basic `evm` execution host.

`TxEnv` is now transaction-global only (`origin`, gas price, chain id, blob hashes), while per-frame values moved into `Message` (`kind`, depth, gas limit, destination, caller, input, value, code address).

Also adds `Evm` with block/spec context, transaction handler registry dispatch by EIP-2718 type, and host-based interpreter recursion using explicit `TxEnv` + `Message`.
