### PR TITLE
fix(interpreter): correct dynamic gas and return copy

### DIFF
--- a/crates/evm2/src/interpreter/instructions/crypto.rs
+++ b/crates/evm2/src/interpreter/instructions/crypto.rs
@@ -6,6 +6,7 @@ use evm2_macros::instruction;
 #[instruction]
 pub(in crate::interpreter) fn keccak256(cx: _, [offset, len]: [Word]) -> Result<out> {
     let len = as_usize(len)?;
+    cx.gas.spend(cx.gas_params.keccak256_word_cost(len))?;
     let hash = if len == 0 {
         keccak256_hash([])
     } else {

--- a/crates/evm2/src/interpreter/instructions/env.rs
+++ b/crates/evm2/src/interpreter/instructions/env.rs
@@ -68,6 +68,7 @@ pub(in crate::interpreter) fn calldatacopy(
     [memory_offset, data_offset, len]: [Word],
 ) -> Result {
     let len = as_usize(len)?;
+    cx.gas.spend(cx.gas_params.copy_cost(len))?;
     if len == 0 {
         return Ok(());
     }
@@ -87,6 +88,7 @@ pub(in crate::interpreter) fn codesize(cx: _) -> out {
 #[instruction]
 pub(in crate::interpreter) fn codecopy(cx: _, [memory_offset, code_offset, len]: [Word]) -> Result {
     let len = as_usize(len)?;
+    cx.gas.spend(cx.gas_params.copy_cost(len))?;
     if len == 0 {
         return Ok(());
     }

--- a/crates/evm2/src/interpreter/instructions/system.rs
+++ b/crates/evm2/src/interpreter/instructions/system.rs
@@ -164,12 +164,8 @@ fn call_inner<C: EvmConfig>(
     let bytecode = crate::bytecode::Bytecode::new_legacy(code);
     let result = cx.state.host.execute_message(cx.state.tx().clone(), bytecode, message);
     cx.gas.erase_cost(result.gas_remaining);
-    cx.state.memory().set_data(
-        return_memory_range.start,
-        0,
-        return_memory_range.len(),
-        &result.output,
-    );
+    let copy_len = min(return_memory_range.len(), result.output.len());
+    cx.state.memory().set(return_memory_range.start, &result.output[..copy_len]);
     cx.state.set_return_data(result.output);
     let success = if success(result.stop) { Word::from(1) } else { Word::ZERO };
     stack.push(success)


### PR DESCRIPTION
- `calldatacopy`, `codecopy` & `keccak` did not charge per input byte
- in `call` we used `set_data` which performs a zero-fill, which is wrong for EVM semantics; returndata is not zerofilled. The EVM only copies: `min(ret_len, returndata.len())`