### PR TITLE
feat(state): expose transaction state changes

### DIFF
--- a/crates/evm2-statetest/Cargo.toml
+++ b/crates/evm2-statetest/Cargo.toml
@@ -19,6 +19,7 @@ evm2 = { path = "../evm2", features = ["std", "serde"] }
 
 alloy-consensus = { workspace = true, features = ["std"] }
 alloy-primitives = { workspace = true, features = ["std", "serde", "rlp"] }
+alloy-rlp = { workspace = true, features = ["std"] }
 alloy-trie = { workspace = true, features = ["ethereum"] }
 k256 = { workspace = true, features = ["ecdsa", "std"] }
 libtest-mimic.workspace = true

--- a/crates/evm2-statetest/src/execute.rs
+++ b/crates/evm2-statetest/src/execute.rs
@@ -3,7 +3,7 @@ use crate::{
     types::{AccountInfo, Env, Test, TestSuite, TestUnit, TransactionParts, TxPartIndices},
 };
 use alloy_consensus::{TxLegacy, transaction::Recovered};
-use alloy_primitives::{Address, B256, Bytes, TxKind, U256};
+use alloy_primitives::{Address, B256, Bytes, Log, TxKind, U256, keccak256};
 use alloy_trie::{
     TrieAccount,
     root::{state_root_unhashed, storage_root_unhashed},
@@ -13,7 +13,7 @@ use evm2::{
     bytecode::Bytecode,
     env::BlockEnv,
     ethereum::{RecoveredTxEnvelope, ethereum_tx_registry},
-    evm::{AccountInfo as EvmAccountInfo, InMemoryDB, StateChanges, logs_hash},
+    evm::{AccountInfo as EvmAccountInfo, InMemoryDB, StateChanges},
     registry::HandlerError,
 };
 use k256::ecdsa::SigningKey;
@@ -249,6 +249,12 @@ fn spec_outcome<T: EvmTypes<Database = InMemoryDB>>(
     }
 }
 
+fn logs_hash(logs: &[Log]) -> B256 {
+    let mut out = Vec::with_capacity(alloy_rlp::list_length(logs));
+    alloy_rlp::encode_list(logs, &mut out);
+    keccak256(out)
+}
+
 fn state_root(pre: &InMemoryDB, changes: &StateChanges) -> B256 {
     let post = apply_state_changes(pre, changes);
     let accounts = post.accounts.iter().map(|(&address, info)| {
@@ -397,6 +403,22 @@ fn recover_address(private_key: &[u8]) -> Option<Address> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloy_primitives::LogData;
+
+    #[test]
+    fn logs_hash_matches_empty_logs() {
+        assert_eq!(logs_hash(&[]), keccak256([alloy_rlp::EMPTY_LIST_CODE]));
+    }
+
+    #[test]
+    fn logs_hash_hashes_logs() {
+        let log = Log {
+            address: Address::from([0x22; 20]),
+            data: LogData::new_unchecked(vec![B256::with_last_byte(1)], Bytes::from_static(&[2])),
+        };
+
+        assert_ne!(logs_hash(&[log]), B256::ZERO);
+    }
 
     #[test]
     fn effective_gas_price_uses_legacy_gas_price() {

--- a/crates/evm2-statetest/src/execute.rs
+++ b/crates/evm2-statetest/src/execute.rs
@@ -13,7 +13,7 @@ use evm2::{
     bytecode::Bytecode,
     env::BlockEnv,
     ethereum::{RecoveredTxEnvelope, ethereum_tx_registry},
-    evm::{AccountInfo as EvmAccountInfo, InMemoryDB, State, logs_hash},
+    evm::{AccountInfo as EvmAccountInfo, InMemoryDB, StateChanges, logs_hash},
     registry::HandlerError,
 };
 use k256::ecdsa::SigningKey;
@@ -238,10 +238,10 @@ fn execute_spec(
 fn spec_outcome<T: EvmTypes<Database = InMemoryDB>>(
     evm: &Evm<T>,
     result: TxResult,
-    spec: SpecId,
+    _spec: SpecId,
 ) -> SpecOutcome {
     SpecOutcome {
-        state_root: state_root(evm.state(), spec),
+        state_root: state_root(evm.state().initial(), &result.state_changes),
         logs_root: logs_hash(evm.logs()),
         output: result.output,
         gas_used: result.gas_used,
@@ -249,20 +249,11 @@ fn spec_outcome<T: EvmTypes<Database = InMemoryDB>>(
     }
 }
 
-fn state_root(state: &State<InMemoryDB>, spec: SpecId) -> B256 {
-    let mut addresses = Vec::from_iter(state.initial.accounts.keys().copied());
-    addresses.extend(state.modified.keys().copied());
-    addresses.sort_unstable();
-    addresses.dedup();
-
-    let accounts = addresses.into_iter().filter_map(|address| {
-        let info = state.account_info(address)?;
-        let storage = storage_for_root(state, address);
-        if !include_account_in_root(state, address, &info, &storage, spec) {
-            return None;
-        }
-
-        Some((
+fn state_root(pre: &InMemoryDB, changes: &StateChanges) -> B256 {
+    let post = apply_state_changes(pre, changes);
+    let accounts = post.accounts.iter().map(|(&address, info)| {
+        let storage = storage_for_root(&post, address);
+        (
             address,
             TrieAccount {
                 nonce: info.nonce,
@@ -270,56 +261,50 @@ fn state_root(state: &State<InMemoryDB>, spec: SpecId) -> B256 {
                 storage_root: storage_root_unhashed(storage),
                 code_hash: info.code_hash,
             },
-        ))
+        )
     });
 
     state_root_unhashed(accounts)
 }
 
-fn include_account_in_root(
-    state: &State<InMemoryDB>,
-    address: Address,
-    info: &EvmAccountInfo,
-    storage: &[(B256, U256)],
-    spec: SpecId,
-) -> bool {
-    if !spec.enables(SpecId::SPURIOUS_DRAGON) {
-        return state.initial.accounts.contains_key(&address)
-            || state.modified.contains_key(&address);
+fn apply_state_changes(pre: &InMemoryDB, changes: &StateChanges) -> InMemoryDB {
+    let mut post = pre.clone();
+    for (&code_hash, code) in &changes.code {
+        post.contracts.insert(code_hash, code.clone());
     }
-
-    if !info.is_empty() || !storage.is_empty() {
-        return true;
-    }
-
-    // Approximate revm's `AccountState::None` case without tracking account state locally:
-    // untouched empty accounts that existed before execution remain in the state trie.
-    state.initial.accounts.contains_key(&address) && !state.modified.contains_key(&address)
-}
-
-fn storage_for_root(state: &State<InMemoryDB>, address: Address) -> Vec<(B256, U256)> {
-    let mut storage = Vec::new();
-    for ((storage_address, key), value) in &state.initial.storage {
-        if *storage_address == address && !value.is_zero() {
-            storage.push((B256::from(key.to_be_bytes()), *value));
+    for (&address, storage) in &changes.storage {
+        if storage.wipe {
+            post.storage.retain(|(storage_address, _), _| *storage_address != address);
         }
-    }
-
-    if let Some(account) = state.modified.get(&address) {
-        for (key, value) in &account.storage {
-            let key = B256::from(key.to_be_bytes());
-            if let Some(existing) =
-                storage.iter_mut().find(|(existing_key, _)| *existing_key == key)
-            {
-                existing.1 = value.current;
-            } else if !value.current.is_zero() {
-                storage.push((key, value.current));
+        for (&key, change) in &storage.slots {
+            if change.current.is_zero() {
+                post.storage.remove(&(address, key));
+            } else {
+                post.storage.insert((address, key), change.current);
             }
         }
     }
+    for (&address, change) in &changes.accounts {
+        match &change.current {
+            Some(info) => post.insert_account_info(address, info.clone()),
+            None => {
+                post.accounts.remove(&address);
+                post.storage.retain(|(storage_address, _), _| *storage_address != address);
+            }
+        }
+    }
+    post
+}
 
-    storage.retain(|(_, value)| !value.is_zero());
-    storage
+fn storage_for_root(state: &InMemoryDB, address: Address) -> Vec<(B256, U256)> {
+    state
+        .storage
+        .iter()
+        .filter_map(|(&(storage_address, key), &value)| {
+            (storage_address == address && !value.is_zero())
+                .then_some((B256::from(key.to_be_bytes()), value))
+        })
+        .collect()
 }
 
 fn parse_state(pre: &BTreeMap<Address, AccountInfo>) -> Result<InMemoryDB, TestErrorKind> {

--- a/crates/evm2-statetest/src/execute.rs
+++ b/crates/evm2-statetest/src/execute.rs
@@ -242,7 +242,7 @@ fn spec_outcome<T: EvmTypes<Database = InMemoryDB>>(
 ) -> SpecOutcome {
     SpecOutcome {
         state_root: state_root(evm.state().initial(), &result.state_changes),
-        logs_root: logs_hash(evm.logs()),
+        logs_root: logs_hash(&result.state_changes.logs),
         output: result.output,
         gas_used: result.gas_used,
         evm_result: format!("{:?}", result.stop),

--- a/crates/evm2/examples/custom_evm.rs
+++ b/crates/evm2/examples/custom_evm.rs
@@ -153,6 +153,7 @@ fn handle_custom_tx(
         gas_used: GAS_LIMIT - result.gas_remaining,
         stop: result.stop,
         output: result.output,
+        ..Default::default()
     })
 }
 
@@ -199,9 +200,7 @@ fn main() {
     assert!(result.status);
     assert_eq!(result.gas_used, expected_custom_gas);
     assert_eq!(
-        evm.state().account_ref(custom_target).expect("custom target should exist").storage
-            [&Word::from(1)]
-            .current,
+        result.state_changes.storage[&custom_target].slots[&Word::from(1)].current,
         Word::from(0xdead_u64),
     );
 

--- a/crates/evm2/examples/e2e_transfer_sstore.rs
+++ b/crates/evm2/examples/e2e_transfer_sstore.rs
@@ -53,8 +53,6 @@ fn main() {
         "status={} gas_used={} storage[1]={}",
         result.status,
         result.gas_used,
-        evm.state().account_ref(contract).expect("sample contract account should exist").storage
-            [&U256::from(1)]
-            .current
+        result.state_changes.storage[&contract].slots[&U256::from(1)].current
     );
 }

--- a/crates/evm2/src/ethereum.rs
+++ b/crates/evm2/src/ethereum.rs
@@ -118,7 +118,6 @@ fn handle_legacy<T: EvmTypes<Host = Evm<T>>>(
     req.host.state.add_balance(caller, Word::ZERO.wrapping_sub(max_gas_cost));
     req.host.state.increment_nonce(caller);
     let execution_checkpoint = req.host.state.checkpoint();
-    let log_checkpoint = req.host.logs.len();
 
     let gas_limit = tx.gas_limit - intrinsic;
     let tx_env = TxEnv {
@@ -164,7 +163,6 @@ fn handle_legacy<T: EvmTypes<Host = Evm<T>>>(
     let mut result = req.host.execute_message(tx_env, bytecode, message, false);
     if !result.stop.is_success() {
         req.host.state.rollback(execution_checkpoint);
-        req.host.logs.truncate(log_checkpoint);
         if result.stop.is_error() {
             result.gas_remaining = 0;
         }

--- a/crates/evm2/src/ethereum.rs
+++ b/crates/evm2/src/ethereum.rs
@@ -180,13 +180,12 @@ fn handle_legacy<T: EvmTypes<Host = Evm<T>>>(
     req.host
         .state
         .add_balance(req.host.block.beneficiary, U256::from(gas_used) * beneficiary_gas_price);
-    req.host.state.prune_empty_accounts();
-
     Ok(TxResult {
         status: result.stop.is_success(),
         gas_used,
         stop: result.stop,
         output: result.output,
+        ..TxResult::default()
     })
 }
 

--- a/crates/evm2/src/evm/db.rs
+++ b/crates/evm2/src/evm/db.rs
@@ -1,0 +1,131 @@
+//! In-memory database helpers for the EVM state overlay.
+
+use super::state::AccountInfo;
+use crate::{KECCAK_EMPTY, bytecode::Bytecode, interpreter::Word};
+use alloc::string::ToString;
+use alloy_primitives::{Address, B256, keccak256, map};
+
+/// Backing database view used to initialize mutable [`super::State`].
+pub trait Database {
+    /// Loads account information.
+    fn get_account(&self, address: Address) -> Option<AccountInfo>;
+
+    /// Loads account code.
+    fn get_account_code(&self, address: Address) -> Bytecode;
+
+    /// Loads a persistent storage slot.
+    fn get_storage(&self, address: Address, key: Word) -> Word;
+
+    /// Loads a historical block hash.
+    fn get_block_hash(&self, number: u64) -> Option<B256>;
+}
+
+/// A simple in-memory database view.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct CacheDB {
+    /// Accounts keyed by address.
+    pub accounts: map::HashMap<Address, AccountInfo>,
+    /// Contracts keyed by code hash.
+    pub contracts: map::HashMap<B256, Bytecode>,
+    /// Persistent storage keyed by account and slot.
+    pub storage: map::HashMap<(Address, Word), Word>,
+    /// Cached block hashes keyed by block number.
+    pub block_hashes: map::HashMap<u64, B256>,
+}
+
+impl Default for CacheDB {
+    #[inline]
+    fn default() -> Self {
+        let mut contracts = map::HashMap::default();
+        contracts.insert(KECCAK_EMPTY, Bytecode::default());
+        contracts.insert(B256::ZERO, Bytecode::default());
+
+        Self {
+            accounts: map::HashMap::default(),
+            contracts,
+            storage: map::HashMap::default(),
+            block_hashes: map::HashMap::default(),
+        }
+    }
+}
+
+impl CacheDB {
+    /// Inserts account code into the contract cache.
+    #[inline]
+    pub fn insert_contract(&mut self, info: &mut AccountInfo) {
+        if let Some(code) = &info.code
+            && !code.is_empty()
+        {
+            if info.code_hash == KECCAK_EMPTY {
+                info.code_hash = code.hash_slow();
+            }
+            self.contracts.entry(info.code_hash).or_insert_with(|| code.clone());
+        }
+        if info.code_hash.is_zero() {
+            info.code_hash = KECCAK_EMPTY;
+        }
+    }
+
+    /// Inserts account info.
+    #[inline]
+    pub fn insert_account_info(&mut self, address: Address, mut info: AccountInfo) {
+        self.insert_contract(&mut info);
+        self.accounts.insert(address, info);
+    }
+
+    /// Returns account info if the account exists.
+    #[inline]
+    pub fn account_info(&self, address: Address) -> Option<&AccountInfo> {
+        self.accounts.get(&address)
+    }
+
+    /// Inserts persistent storage.
+    #[inline]
+    pub fn insert_account_storage(&mut self, address: Address, key: Word, value: Word) {
+        self.accounts.entry(address).or_default();
+        self.storage.insert((address, key), value);
+    }
+
+    /// Sets a historical block hash.
+    #[inline]
+    pub fn insert_block_hash(&mut self, number: u64, hash: B256) {
+        self.block_hashes.insert(number, hash);
+    }
+}
+
+impl Database for CacheDB {
+    #[inline]
+    fn get_account(&self, address: Address) -> Option<AccountInfo> {
+        self.accounts.get(&address).cloned()
+    }
+
+    #[inline]
+    fn get_account_code(&self, address: Address) -> Bytecode {
+        self.accounts
+            .get(&address)
+            .and_then(|info| info.code.clone())
+            .or_else(|| {
+                self.accounts
+                    .get(&address)
+                    .and_then(|info| self.contracts.get(&info.code_hash).cloned())
+            })
+            .unwrap_or_default()
+    }
+
+    #[inline]
+    fn get_storage(&self, address: Address, key: Word) -> Word {
+        self.storage.get(&(address, key)).copied().unwrap_or_default()
+    }
+
+    #[inline]
+    fn get_block_hash(&self, number: u64) -> Option<B256> {
+        self.block_hashes
+            .get(&number)
+            .copied()
+            .or_else(|| Some(keccak256(number.to_string().as_bytes())))
+    }
+}
+
+/// A database implementation that stores initial state in memory.
+pub type InMemoryDB = CacheDB;

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -22,8 +22,9 @@ pub mod registry;
 
 mod state;
 pub use state::{
-    Account, AccountInfo, CacheDB, Database, InMemoryDB, JournalEntry, KECCAK_EMPTY, State,
-    StorageValue, logs_hash,
+    Account, AccountChange, AccountInfo, CacheDB, Database, InMemoryDB, JournalEntry, KECCAK_EMPTY,
+    State, StateChanges, StorageChange, StorageChangeSet, StorageOverlay, StorageValue, Tracked,
+    logs_hash,
 };
 
 const MAX_CODE_SIZE: usize = 0x6000;
@@ -39,6 +40,8 @@ pub struct TxResult {
     pub stop: InstrStop,
     /// Return or revert output.
     pub output: Bytes,
+    /// Database-visible state transition produced by this transaction.
+    pub state_changes: StateChanges,
 }
 
 /// EVM host and transaction dispatcher.
@@ -157,8 +160,15 @@ impl<T: EvmTypes<Tx: Typed2718>> Evm<T> {
     /// Dispatches the transaction to the handler registered for its EIP-2718 type byte.
     pub fn transact(&mut self, tx: &T::Tx) -> HandlerResult<TxResult> {
         let handler = self.registry.try_get_by_type(tx.ty())?;
-        let result = handler.call(tx, self);
-        self.state.clear_accesses();
+        let spec_id = self.spec_id();
+        let result = handler.call(tx, self).map(|mut result| {
+            result.state_changes = self.state.build_state_changes(spec_id);
+            self.state.accept_transaction(spec_id);
+            result
+        });
+        if result.is_err() {
+            self.state.clear_transaction_state();
+        }
         result
     }
 
@@ -414,17 +424,14 @@ impl<T: EvmTypes<Host = Self>> Host for Evm<T> {
         }
         self.state.warm_account(target);
         let target_exists = self.state.account_info(target).is_some_and(|info| !info.is_empty());
-        let previously_destroyed =
-            self.state.account_ref(contract).is_some_and(|account| account.destructed);
+        let previously_destroyed = self.state.is_selfdestructed(contract);
         let balance = self.state.account_info(contract).map_or(Word::ZERO, |info| info.balance);
 
         if contract != target && !balance.is_zero() {
             self.state.transfer(contract, target, balance);
+        } else if !balance.is_zero() {
+            self.state.add_balance(contract, Word::ZERO.wrapping_sub(balance));
         }
-
-        let previous = self.state.get_or_insert(contract).balance;
-        self.state.journal.push(JournalEntry::BalanceChange { address: contract, previous });
-        self.state.get_or_insert(contract).balance = Word::ZERO;
         self.state.mark_destructed(contract);
 
         Ok(SelfDestructResult {

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -10,7 +10,6 @@ use crate::{
     registry::{HandlerResult, TxRegistry},
     version::GasId,
 };
-use alloc::vec::Vec;
 use alloy_eips::eip2718::Typed2718;
 use alloy_primitives::{Address, B256, Bytes, Log};
 use core::cmp::min;
@@ -39,7 +38,7 @@ pub struct TxResult {
     pub stop: InstrStop,
     /// Return or revert output.
     pub output: Bytes,
-    /// Database-visible state transition produced by this transaction.
+    /// State transition and logs produced by this transaction.
     pub state_changes: StateChanges,
 }
 
@@ -54,7 +53,6 @@ pub struct Evm<T: EvmTypes> {
     registry: TxRegistry<T::Tx, TxResult, Self>,
     pub(crate) state: State<T::Database>,
     precompiles: T::Precompiles,
-    pub(crate) logs: Vec<Log>,
 }
 
 impl<T: EvmTypes> Evm<T> {
@@ -88,15 +86,7 @@ impl<T: EvmTypes> Evm<T> {
         database: T::Database,
         precompiles: T::Precompiles,
     ) -> Self {
-        Self {
-            spec_id,
-            execution_config,
-            block,
-            registry,
-            state: State::new(database),
-            precompiles,
-            logs: Vec::new(),
-        }
+        Self { spec_id, execution_config, block, registry, state: State::new(database), precompiles }
     }
 
     #[inline]
@@ -124,9 +114,9 @@ impl<T: EvmTypes> Evm<T> {
         &self.state
     }
 
-    /// Returns emitted logs.
+    /// Returns logs emitted by the current in-flight transaction.
     pub fn logs(&self) -> &[Log] {
-        &self.logs
+        self.state.logs()
     }
 
     /// Returns the precompile provider.
@@ -244,7 +234,7 @@ impl<T: EvmTypes<Host = Self>> Host for Evm<T> {
     }
 
     fn log(&mut self, log: Log) {
-        self.logs.push(log);
+        self.state.log(log);
     }
 
     fn execute_message(
@@ -289,12 +279,10 @@ impl<T: EvmTypes<Host = Self>> Host for Evm<T> {
             }
 
             let checkpoint = self.state.checkpoint();
-            let log_checkpoint = self.logs.len();
             if let Err(stop) =
                 self.state.create_account(message.caller, address, message.value, self.spec_id())
             {
                 self.state.rollback(checkpoint);
-                self.logs.truncate(log_checkpoint);
                 return MessageResult {
                     stop,
                     gas_remaining: message.gas_limit,
@@ -335,7 +323,6 @@ impl<T: EvmTypes<Host = Self>> Host for Evm<T> {
 
                 if let Some(stop) = stop {
                     self.state.rollback(checkpoint);
-                    self.logs.truncate(log_checkpoint);
                     gas_remaining = if stop.is_error() { 0 } else { gas.remaining() };
                     return MessageResult { stop, gas_remaining, output, created_address: None };
                 }
@@ -345,7 +332,6 @@ impl<T: EvmTypes<Host = Self>> Host for Evm<T> {
                 self.state.set_code(address, Bytecode::new_legacy(output.clone()));
             } else {
                 self.state.rollback(checkpoint);
-                self.logs.truncate(log_checkpoint);
                 if stop.is_error() {
                     gas_remaining = 0;
                 }
@@ -360,7 +346,6 @@ impl<T: EvmTypes<Host = Self>> Host for Evm<T> {
         }
 
         let checkpoint = self.state.checkpoint();
-        let log_checkpoint = self.logs.len();
         if matches!(message.kind, MessageKind::Call)
             && !self.state.transfer(message.caller, message.destination, message.value)
         {
@@ -384,7 +369,6 @@ impl<T: EvmTypes<Host = Self>> Host for Evm<T> {
             };
             if !stop.is_success() {
                 self.state.rollback(checkpoint);
-                self.logs.truncate(log_checkpoint);
             }
             return MessageResult { stop, gas_remaining, output, created_address: None };
         }
@@ -401,7 +385,6 @@ impl<T: EvmTypes<Host = Self>> Host for Evm<T> {
 
         if !stop.is_success() {
             self.state.rollback(checkpoint);
-            self.logs.truncate(log_checkpoint);
             if stop.is_error() {
                 gas_remaining = 0;
             }

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -19,10 +19,12 @@ pub mod env;
 pub mod precompile;
 pub mod registry;
 
+mod db;
 mod state;
+pub use db::{CacheDB, Database, InMemoryDB};
 pub use state::{
-    Account, AccountChange, AccountInfo, CacheDB, Database, InMemoryDB, JournalEntry, KECCAK_EMPTY,
-    State, StateChanges, StorageChange, StorageChangeSet, StorageOverlay, Tracked, logs_hash,
+    Account, AccountInfo, JournalEntry, State, StateChanges, StorageChangeSet, StorageOverlay,
+    Tracked,
 };
 
 const MAX_CODE_SIZE: usize = 0x6000;
@@ -86,7 +88,14 @@ impl<T: EvmTypes> Evm<T> {
         database: T::Database,
         precompiles: T::Precompiles,
     ) -> Self {
-        Self { spec_id, execution_config, block, registry, state: State::new(database), precompiles }
+        Self {
+            spec_id,
+            execution_config,
+            block,
+            registry,
+            state: State::new(database),
+            precompiles,
+        }
     }
 
     #[inline]
@@ -149,15 +158,13 @@ impl<T: EvmTypes<Tx: Typed2718>> Evm<T> {
     /// Dispatches the transaction to the handler registered for its EIP-2718 type byte.
     pub fn transact(&mut self, tx: &T::Tx) -> HandlerResult<TxResult> {
         let handler = self.registry.try_get_by_type(tx.ty())?;
-        let spec_id = self.spec_id();
-        let result = handler.call(tx, self).map(|mut result| {
-            result.state_changes = self.state.build_state_changes(spec_id);
-            self.state.accept_transaction(spec_id);
-            result
-        });
-        if result.is_err() {
-            self.state.clear_transaction_state();
-        }
+        let mut result = handler.call(tx, self);
+        if let Ok(result) = &mut result {
+            self.state.finalize_transaction(self.spec_id());
+            result.state_changes = self.state.build_state_changes();
+            self.state.commit_transaction_overlay();
+        };
+        self.state.clear_transaction_state();
         result
     }
 
@@ -408,13 +415,17 @@ impl<T: EvmTypes<Host = Self>> Host for Evm<T> {
         let target_exists = self.state.account_info(target).is_some_and(|info| !info.is_empty());
         let previously_destroyed = self.state.is_selfdestructed(contract);
         let balance = self.state.account_info(contract).map_or(Word::ZERO, |info| info.balance);
+        let should_destroy = !self.spec_id().enables(SpecId::CANCUN)
+            || self.state.is_created_in_transaction(contract);
 
-        if contract != target && !balance.is_zero() {
+        if contract != target {
             self.state.transfer(contract, target, balance);
-        } else if !balance.is_zero() {
+        } else if should_destroy && !balance.is_zero() {
             self.state.add_balance(contract, Word::ZERO.wrapping_sub(balance));
         }
-        self.state.mark_destructed(contract);
+        if should_destroy {
+            self.state.mark_destructed(contract);
+        }
 
         Ok(SelfDestructResult {
             had_value: !balance.is_zero(),
@@ -434,7 +445,7 @@ mod tests {
         interpreter::{MessageKind, op},
         registry::TxRequest,
     };
-    use alloy_primitives::{Address, B256, Bytes, Log, LogData, U256, keccak256};
+    use alloy_primitives::{Address, Bytes, U256};
 
     const TEST_TX_TYPE: u8 = 0x7f;
 
@@ -539,21 +550,6 @@ mod tests {
 
         let result = Host::execute_message(&mut evm, TxEnv::default(), bytecode, message, false);
         assert!(result.stop.is_success());
-    }
-
-    #[test]
-    fn logs_hash_matches_empty_logs() {
-        assert_eq!(logs_hash(&[]), keccak256([alloy_rlp::EMPTY_LIST_CODE]));
-    }
-
-    #[test]
-    fn logs_hash_hashes_logs() {
-        let log = Log {
-            address: Address::from([0x22; 20]),
-            data: LogData::new_unchecked(vec![B256::with_last_byte(1)], Bytes::from_static(&[2])),
-        };
-
-        assert_ne!(logs_hash(&[log]), B256::ZERO);
     }
 
     #[test]

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -23,8 +23,7 @@ pub mod registry;
 mod state;
 pub use state::{
     Account, AccountChange, AccountInfo, CacheDB, Database, InMemoryDB, JournalEntry, KECCAK_EMPTY,
-    State, StateChanges, StorageChange, StorageChangeSet, StorageOverlay, StorageValue, Tracked,
-    logs_hash,
+    State, StateChanges, StorageChange, StorageChangeSet, StorageOverlay, Tracked, logs_hash,
 };
 
 const MAX_CODE_SIZE: usize = 0x6000;

--- a/crates/evm2/src/evm/state.rs
+++ b/crates/evm2/src/evm/state.rs
@@ -892,11 +892,16 @@ impl<D: Database> State<D> {
         changes
     }
 
-    /// Advances the in-memory overlay to the next transaction boundary.
+    /// Marks the current transaction's overlay values as the new baseline.
     ///
-    /// This accepts the already-computed transition in the overlay only. It does
-    /// not write to or mutate the backing database.
-    pub fn accept_transaction(&mut self, spec: crate::SpecId) {
+    /// After [`Self::build_state_changes`] has emitted the transaction write-set,
+    /// the overlay must stop treating those writes as pending changes. This rolls
+    /// the current account and storage values forward into their `original` slots,
+    /// applies local deletion/wipe bookkeeping, and clears transaction-local journal,
+    /// touch, selfdestruct, and access-list state. It only advances the in-memory
+    /// overlay; callers are still responsible for applying the emitted write-set to
+    /// their backing database.
+    pub(super) fn accept_transaction(&mut self, spec: crate::SpecId) {
         let changes = self.build_state_changes(spec);
         for (&address, change) in &changes.accounts {
             self.ensure_account_overlay(address);

--- a/crates/evm2/src/evm/state.rs
+++ b/crates/evm2/src/evm/state.rs
@@ -3,7 +3,7 @@
 use crate::{bytecode::Bytecode, interpreter::Word};
 use alloc::{collections::BTreeMap, string::ToString, vec::Vec};
 use alloy_primitives::{
-    Address, B256, U256, keccak256,
+    Address, B256, Log, U256, keccak256,
     map::{self, HashMap, HashSet, hash_map},
 };
 
@@ -174,14 +174,14 @@ pub struct StorageOverlay {
     pub(crate) slots: HashMap<Word, StorageValue>,
 }
 
-/// Complete state transition produced by a transaction.
+/// Complete state transition and emitted logs produced by a transaction.
 ///
 /// `StateChanges` is the public write-set returned in [`crate::TxResult`]. It
 /// is intentionally explicit so embedding clients can update their own database
 /// and compute post-state roots without reimplementing EVM account-lifetime
-/// rules.
+/// rules. It also carries the logs emitted by the transaction.
 ///
-/// Consumers should apply changes in this order:
+/// Consumers should apply database changes in this order:
 ///
 /// 1. write bytecode from [`Self::code`] for every non-empty code hash they do not already have;
 /// 2. for each [`StorageChangeSet`] whose [`StorageChangeSet::wipe`] flag is true, delete all
@@ -201,13 +201,18 @@ pub struct StateChanges {
     pub storage: BTreeMap<Address, StorageChangeSet>,
     /// Newly created or modified bytecode keyed by code hash.
     pub code: BTreeMap<B256, Bytecode>,
+    /// Logs emitted by the transaction.
+    pub logs: Vec<Log>,
 }
 
 impl StateChanges {
-    /// Returns whether this transition contains no database-visible changes.
+    /// Returns whether this transition contains no changes or logs.
     #[inline]
     pub fn is_empty(&self) -> bool {
-        self.accounts.is_empty() && self.storage.is_empty() && self.code.is_empty()
+        self.accounts.is_empty()
+            && self.storage.is_empty()
+            && self.code.is_empty()
+            && self.logs.is_empty()
     }
 }
 
@@ -333,6 +338,11 @@ pub enum JournalEntry {
         /// Storage key.
         key: Word,
     },
+    /// Log was emitted.
+    Log {
+        /// Log index before emission.
+        index: usize,
+    },
 }
 
 /// Mutable EVM state with an overlay and reversible journal.
@@ -352,6 +362,8 @@ pub struct State<D> {
     pub storage: HashMap<Address, StorageOverlay>,
     /// Revert journal.
     pub journal: Vec<JournalEntry>,
+    /// Logs emitted by the current transaction.
+    pub logs: Vec<Log>,
     /// Accounts touched for transaction-finalization account-lifetime rules.
     ///
     /// This is separate from the account overlay and the EIP-2929 warm set. A
@@ -380,6 +392,7 @@ impl<D> State<D> {
             accounts: map::HashMap::default(),
             storage: map::HashMap::default(),
             journal: Vec::new(),
+            logs: Vec::new(),
             touched: map::HashSet::default(),
             selfdestructs: map::HashSet::default(),
             accessed_accounts: map::HashSet::default(),
@@ -404,6 +417,20 @@ impl<D> State<D> {
     #[inline]
     pub const fn initial_mut(&mut self) -> &mut D {
         &mut self.initial
+    }
+
+    /// Returns logs emitted by the current in-flight transaction.
+    #[inline]
+    pub fn logs(&self) -> &[Log] {
+        &self.logs
+    }
+
+    /// Records a transaction log and journals it for rollback.
+    #[inline]
+    pub fn log(&mut self, log: Log) {
+        let index = self.logs.len();
+        self.journal.push(JournalEntry::Log { index });
+        self.logs.push(log);
     }
 
     /// Returns the current account overlay if present and not deleted.
@@ -449,6 +476,7 @@ impl<D> State<D> {
         self.accessed_accounts.clear();
         self.accessed_storage.clear();
         self.transient_storage.clear();
+        self.logs.clear();
     }
 
     /// Clears all transaction-scoped warm accesses.
@@ -793,6 +821,9 @@ impl<D: Database> State<D> {
                 JournalEntry::StorageWarmed { address, key } => {
                     self.accessed_storage.remove(&(address, key));
                 }
+                JournalEntry::Log { index } => {
+                    self.logs.truncate(index);
+                }
             }
         }
     }
@@ -815,14 +846,14 @@ impl<D: Database> State<D> {
             && account.is_none_or(Account::is_empty)
     }
 
-    /// Builds the database-visible state transition for the current transaction.
+    /// Builds the state transition and emitted logs for the current transaction.
     ///
     /// This method is pure: it does not apply changes to the backing database and
     /// does not advance the overlay to the next transaction. Callers normally use
     /// the [`StateChanges`] attached to [`crate::TxResult`] instead of invoking
     /// this directly.
     pub fn build_state_changes(&self, spec: crate::SpecId) -> StateChanges {
-        let mut changes = StateChanges::default();
+        let mut changes = StateChanges { logs: self.logs.clone(), ..StateChanges::default() };
 
         for (&address, tracked) in &self.accounts {
             let deleted = self.account_deleted_by_rules(address, tracked.current.as_ref(), spec);
@@ -947,7 +978,7 @@ impl<D: Database> State<D> {
 }
 
 /// Returns the state-test logs hash.
-pub fn logs_hash(logs: &[alloy_primitives::Log]) -> B256 {
+pub fn logs_hash(logs: &[Log]) -> B256 {
     let mut out = Vec::with_capacity(alloy_rlp::list_length(logs));
     alloy_rlp::encode_list(logs, &mut out);
     keccak256(out)
@@ -1109,6 +1140,56 @@ mod tests {
         assert!(state.is_selfdestructed(address));
         state.rollback(checkpoint);
         assert!(!state.is_selfdestructed(address));
+    }
+
+    #[test]
+    fn log_rolls_back_to_checkpoint() {
+        use alloy_primitives::{Bytes, LogData};
+
+        let mut state = State::new(CacheDB::default());
+        let kept = Log {
+            address: Address::from([0x44; 20]),
+            data: LogData::new_unchecked(Vec::new(), Bytes::from_static(&[0x01])),
+        };
+        let reverted = Log {
+            address: Address::from([0x55; 20]),
+            data: LogData::new_unchecked(Vec::new(), Bytes::from_static(&[0x02])),
+        };
+
+        state.log(kept.clone());
+        let checkpoint = state.checkpoint();
+        state.log(reverted);
+
+        assert_eq!(
+            state.logs(),
+            &[
+                kept.clone(),
+                Log {
+                    address: Address::from([0x55; 20]),
+                    data: LogData::new_unchecked(Vec::new(), Bytes::from_static(&[0x02])),
+                }
+            ]
+        );
+        state.rollback(checkpoint);
+        assert_eq!(state.logs(), &[kept]);
+    }
+
+    #[test]
+    fn state_changes_include_logs_and_accept_clears_them() {
+        use alloy_primitives::{Bytes, LogData};
+
+        let mut state = State::new(CacheDB::default());
+        let log = Log {
+            address: Address::from([0x66; 20]),
+            data: LogData::new_unchecked(Vec::new(), Bytes::from_static(&[0x03])),
+        };
+
+        state.log(log.clone());
+        let changes = state.build_state_changes(crate::SpecId::SPURIOUS_DRAGON);
+        assert_eq!(changes.logs, [log]);
+
+        state.accept_transaction(crate::SpecId::SPURIOUS_DRAGON);
+        assert!(state.logs().is_empty());
     }
 
     #[test]

--- a/crates/evm2/src/evm/state.rs
+++ b/crates/evm2/src/evm/state.rs
@@ -112,8 +112,7 @@ impl AccountInfo {
     }
 }
 
-/// Persistent storage value cached by [`State`].
-pub type StorageValue = Tracked<Word>;
+type StorageValue = Tracked<Word>;
 
 /// Mutable account state cached by [`State`].
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
@@ -174,7 +173,7 @@ pub struct StorageOverlay {
     /// before applying individual slot changes.
     pub wiped: bool,
     /// Loaded or changed storage slots.
-    pub slots: HashMap<Word, StorageValue>,
+    pub(crate) slots: HashMap<Word, StorageValue>,
 }
 
 /// Complete state transition produced by a transaction.
@@ -547,9 +546,8 @@ impl<D: Database> State<D> {
         }
     }
 
-    /// Gets a persistent storage value.
     #[inline]
-    pub fn get_storage_value(&mut self, address: Address, key: Word) -> &mut StorageValue {
+    fn get_storage_value(&mut self, address: Address, key: Word) -> &mut StorageValue {
         self.ensure_storage_slot(address, key, false);
         self.storage
             .get_mut(&address)

--- a/crates/evm2/src/evm/state.rs
+++ b/crates/evm2/src/evm/state.rs
@@ -343,17 +343,29 @@ pub enum JournalEntry {
 pub struct State<D> {
     /// Read-only initial database.
     pub initial: D,
-    /// Account overlay keyed by address.
+    /// Account data overlay keyed by address.
+    ///
+    /// Entries are created when account state is loaded or mutated. The tracked
+    /// `original`/`current` pair is used to execute against the in-memory overlay
+    /// and later derive account-level [`StateChanges`]. Presence here does not by
+    /// itself mean the account was touched or warmed.
     pub accounts: HashMap<Address, Tracked<Option<Account>>>,
     /// Persistent storage overlay keyed by account address.
     pub storage: HashMap<Address, StorageOverlay>,
     /// Revert journal.
     pub journal: Vec<JournalEntry>,
-    /// Accounts touched in the current transaction.
+    /// Accounts touched for transaction-finalization account-lifetime rules.
+    ///
+    /// This is separate from the account overlay and the EIP-2929 warm set. A
+    /// touched account may have no field changes, but can still matter for empty
+    /// account deletion/materialization rules across forks.
     pub touched: HashSet<Address>,
     /// Accounts self-destructed in the current transaction.
     pub selfdestructs: HashSet<Address>,
-    /// Transaction-scoped warm account set.
+    /// Transaction-scoped warm account set for EIP-2929 gas accounting.
+    ///
+    /// This tracks whether account access is warm or cold. It does not imply the
+    /// account was touched, changed, or should be emitted in [`StateChanges`].
     pub accessed_accounts: HashSet<Address>,
     /// Transaction-scoped warm storage slot set.
     pub accessed_storage: HashSet<(Address, Word)>,

--- a/crates/evm2/src/evm/state.rs
+++ b/crates/evm2/src/evm/state.rs
@@ -1,22 +1,22 @@
 //! Basic in-memory EVM host state.
 
-use crate::{bytecode::Bytecode, interpreter::Word};
-use alloc::{collections::BTreeMap, string::ToString, vec::Vec};
+use super::db::Database;
+use crate::{KECCAK_EMPTY, bytecode::Bytecode, interpreter::Word};
+use alloc::{collections::BTreeMap, vec::Vec};
 use alloy_primitives::{
-    Address, B256, Log, U256, keccak256,
+    Address, B256, Log, U256,
     map::{self, HashMap, HashSet, hash_map},
 };
-
-pub use alloy_primitives::KECCAK256_EMPTY as KECCAK_EMPTY;
 
 /// A value tracked together with the value it had at the start of the current
 /// transaction.
 ///
-/// `Tracked` is used internally by [`State`] to keep an overlay over the
-/// backing database. `original` is the value at the current transaction
-/// boundary, while `current` is the value after all in-flight EVM mutations.
-/// When a transaction is accepted, `current` becomes the next transaction's
-/// `original` without writing anything to the backing database.
+/// `Tracked` is used by [`State`] to keep an overlay over the backing database
+/// and by [`StateChanges`] to describe account and storage transitions.
+/// `original` is the value at the current transaction boundary, while `current`
+/// is the value after all in-flight EVM mutations. When a transaction is
+/// accepted, `current` becomes the next transaction's `original` without writing
+/// anything to the backing database.
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct Tracked<T> {
     /// Value at the start of the current transaction.
@@ -112,8 +112,6 @@ impl AccountInfo {
     }
 }
 
-type StorageValue = Tracked<Word>;
-
 /// Mutable account state cached by [`State`].
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 #[non_exhaustive]
@@ -171,7 +169,7 @@ pub struct StorageOverlay {
     /// before applying individual slot changes.
     pub wiped: bool,
     /// Loaded or changed storage slots.
-    pub(crate) slots: HashMap<Word, StorageValue>,
+    pub(crate) slots: HashMap<Word, Tracked<Word>>,
 }
 
 /// Complete state transition and emitted logs produced by a transaction.
@@ -186,8 +184,8 @@ pub struct StorageOverlay {
 /// 1. write bytecode from [`Self::code`] for every non-empty code hash they do not already have;
 /// 2. for each [`StorageChangeSet`] whose [`StorageChangeSet::wipe`] flag is true, delete all
 ///    storage for that account;
-/// 3. apply each storage slot change: a zero [`StorageChange::current`] means delete the slot,
-///    otherwise write the slot value;
+/// 3. apply each storage slot change: a zero [`Tracked::current`] means delete the slot, otherwise
+///    write the slot value;
 /// 4. apply account changes: `current = Some(..)` means upsert the account, `current = None` means
 ///    delete the account.
 ///
@@ -196,8 +194,17 @@ pub struct StorageOverlay {
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct StateChanges {
     /// Account changes keyed by address.
-    pub accounts: BTreeMap<Address, AccountChange>,
+    ///
+    /// [`Tracked::original`] is the account at the beginning of the transaction.
+    /// [`Tracked::current`] is the account after transaction execution and EVM
+    /// account-lifetime rules have been evaluated. `current = None` is an explicit account
+    /// deletion.
+    pub accounts: BTreeMap<Address, Tracked<Option<AccountInfo>>>,
     /// Persistent storage changes keyed by account address.
+    ///
+    /// Each slot change's [`Tracked::original`] value is the slot value at the beginning of the
+    /// transaction, after any storage wipe/re-incarnation semantics that occurred before the slot
+    /// was loaded. `current = 0` means the consumer should delete the slot.
     pub storage: BTreeMap<Address, StorageChangeSet>,
     /// Newly created or modified bytecode keyed by code hash.
     pub code: BTreeMap<B256, Bytecode>,
@@ -216,19 +223,6 @@ impl StateChanges {
     }
 }
 
-/// Account transition for a single address.
-///
-/// `original` is the account at the beginning of the transaction. `current` is
-/// the account after transaction execution and EVM account-lifetime rules have
-/// been evaluated. `current = None` is an explicit account deletion.
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct AccountChange {
-    /// Account at the beginning of the transaction.
-    pub original: Option<AccountInfo>,
-    /// Account after the transaction, or `None` to delete it.
-    pub current: Option<AccountInfo>,
-}
-
 /// Storage transition for a single account.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct StorageChangeSet {
@@ -237,35 +231,7 @@ pub struct StorageChangeSet {
     /// re-incarnation semantics using an explicit storage wipe marker.
     pub wipe: bool,
     /// Changed storage slots keyed by slot.
-    pub slots: BTreeMap<Word, StorageChange>,
-}
-
-/// Storage transition for a single slot.
-///
-/// `original` is the slot value at the beginning of the transaction, after any
-/// storage wipe/re-incarnation semantics that occurred before the slot was
-/// loaded. `current = 0` means the consumer should delete the slot.
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-pub struct StorageChange {
-    /// Slot value at the beginning of the transaction.
-    pub original: Word,
-    /// Slot value after the transaction. Zero means delete the slot.
-    pub current: Word,
-}
-
-/// Backing database view used to initialize mutable [`State`].
-pub trait Database {
-    /// Loads account information.
-    fn get_account(&self, address: Address) -> Option<AccountInfo>;
-
-    /// Loads account code.
-    fn get_account_code(&self, address: Address) -> Bytecode;
-
-    /// Loads a persistent storage slot.
-    fn get_storage(&self, address: Address, key: Word) -> Word;
-
-    /// Loads a historical block hash.
-    fn get_block_hash(&self, number: u64) -> Option<B256>;
+    pub slots: BTreeMap<Word, Tracked<Word>>,
 }
 
 /// Compact journal entry for reverting state changes.
@@ -478,13 +444,6 @@ impl<D> State<D> {
         self.transient_storage.clear();
         self.logs.clear();
     }
-
-    /// Clears all transaction-scoped warm accesses.
-    #[inline]
-    pub fn clear_accesses(&mut self) {
-        self.accessed_accounts.clear();
-        self.accessed_storage.clear();
-    }
 }
 
 impl<D: Database> State<D> {
@@ -581,7 +540,7 @@ impl<D: Database> State<D> {
         let initial = self.storage_initial(address, key);
         let storage = self.storage.entry(address).or_default();
         if let hash_map::Entry::Vacant(entry) = storage.slots.entry(key) {
-            entry.insert(StorageValue::new(initial));
+            entry.insert(Tracked::new(initial));
             if journal_insert {
                 self.journal.push(JournalEntry::StorageInserted { address, key });
             }
@@ -589,7 +548,7 @@ impl<D: Database> State<D> {
     }
 
     #[inline]
-    fn get_storage_value(&mut self, address: Address, key: Word) -> &mut StorageValue {
+    fn get_storage_value(&mut self, address: Address, key: Word) -> &mut Tracked<Word> {
         self.ensure_storage_slot(address, key, false);
         self.storage
             .get_mut(&address)
@@ -707,7 +666,6 @@ impl<D: Database> State<D> {
             code: Bytecode::default(),
             just_created: true,
             code_changed: true,
-            ..Account::default()
         });
         self.touch(address);
         Ok(())
@@ -756,6 +714,7 @@ impl<D: Database> State<D> {
     /// Marks an account as self-destructed in the current transaction.
     #[inline]
     pub fn mark_destructed(&mut self, address: Address) {
+        self.ensure_account_overlay(address);
         if self.selfdestructs.insert(address) {
             self.journal.push(JournalEntry::SelfDestruct { address });
         }
@@ -766,6 +725,15 @@ impl<D: Database> State<D> {
     #[inline]
     pub fn is_selfdestructed(&self, address: Address) -> bool {
         self.selfdestructs.contains(&address)
+    }
+
+    /// Returns whether an account was created in the current transaction.
+    #[inline]
+    pub(super) fn is_created_in_transaction(&self, address: Address) -> bool {
+        self.accounts
+            .get(&address)
+            .and_then(|tracked| tracked.current.as_ref())
+            .is_some_and(|account| account.just_created)
     }
 
     /// Reverts state changes after the checkpoint.
@@ -828,42 +796,90 @@ impl<D: Database> State<D> {
         }
     }
 
-    fn final_account_info(account: &Account, deleted: bool) -> Option<AccountInfo> {
-        if deleted { None } else { Some(account.info()) }
-    }
-
-    fn account_deleted_by_rules(
-        &self,
-        address: Address,
-        account: Option<&Account>,
-        spec: crate::SpecId,
-    ) -> bool {
-        if self.selfdestructs.contains(&address) {
-            return true;
-        }
-        spec.enables(crate::SpecId::SPURIOUS_DRAGON)
-            && self.touched.contains(&address)
-            && account.is_none_or(Account::is_empty)
-    }
-
-    /// Builds the state transition and emitted logs for the current transaction.
+    /// Returns whether an existing account is dead by the EIP-161 definition.
     ///
-    /// This method is pure: it does not apply changes to the backing database and
-    /// does not advance the overlay to the next transaction. Callers normally use
-    /// the [`StateChanges`] attached to [`crate::TxResult`] instead of invoking
-    /// this directly.
-    pub fn build_state_changes(&self, spec: crate::SpecId) -> StateChanges {
-        let mut changes = StateChanges { logs: self.logs.clone(), ..StateChanges::default() };
+    /// Accounts with zero nonce, zero balance, and empty code are dead. Starting
+    /// in Spurious Dragon, touched dead accounts that exist in the pre/final
+    /// overlay state are deleted during transaction finalization. Non-existent
+    /// touched accounts stay non-existent.
+    fn is_existing_dead(&self, address: Address) -> bool {
+        if let Some(account) = self.accounts.get(&address) {
+            return account.current.as_ref().is_some_and(Account::is_empty)
+                || (account.current.is_none() && account.original.is_some());
+        }
+        self.initial.get_account(address).is_some_and(|account| account.is_empty())
+    }
+
+    fn delete_account_for_finalization(&mut self, address: Address) {
+        self.accounts
+            .get_mut(&address)
+            .expect("finalized account is loaded into the overlay")
+            .current = None;
+        self.storage
+            .insert(address, StorageOverlay { wiped: true, slots: map::HashMap::default() });
+    }
+
+    fn materialize_empty_account_for_finalization(&mut self, address: Address) {
+        self.ensure_account_overlay(address);
+        if let Some(account) = self.accounts.get_mut(&address)
+            && account.original.is_none()
+            && account.current.is_none()
+        {
+            account.current = Some(Account {
+                code_hash: KECCAK_EMPTY,
+                code: Bytecode::default(),
+                ..Account::default()
+            });
+        }
+    }
+
+    /// Applies transaction-finalization account-lifetime rules to the overlay.
+    ///
+    /// This mutates the in-memory post-transaction state before it is serialized
+    /// by [`Self::build_state_changes`]. Runtime records
+    /// transaction substate such as touches and selfdestructs, while finalization
+    /// turns that substate into account deletions, storage wipes, or pre-EIP-161
+    /// empty-account materialization.
+    pub(super) fn finalize_transaction(&mut self, spec: crate::SpecId) {
+        let selfdestructs = core::mem::take(&mut self.selfdestructs);
+        for address in selfdestructs.iter().copied() {
+            self.delete_account_for_finalization(address);
+        }
+
+        let touched = core::mem::take(&mut self.touched);
+        if spec.enables(crate::SpecId::SPURIOUS_DRAGON) {
+            for address in touched {
+                // EIP-161 deletes touched dead accounts at transaction finalization.
+                if self.is_existing_dead(address) {
+                    self.ensure_account_overlay(address);
+                    self.delete_account_for_finalization(address);
+                }
+            }
+        } else {
+            for address in touched {
+                // Before EIP-161, touching a non-existent account materializes it as empty.
+                if !selfdestructs.contains(&address) && self.account_info(address).is_none() {
+                    self.materialize_empty_account_for_finalization(address);
+                }
+            }
+        }
+    }
+
+    /// Builds the state transition and takes emitted logs for the current transaction.
+    ///
+    /// This does not apply changes to the backing database, apply transaction-finalization rules,
+    /// or advance the overlay to the next transaction. It does move transaction-local logs into the
+    /// returned [`StateChanges`], since callers clear transaction-local state immediately after
+    /// accepting or discarding the transaction.
+    pub(crate) fn build_state_changes(&mut self) -> StateChanges {
+        let mut changes =
+            StateChanges { logs: core::mem::take(&mut self.logs), ..StateChanges::default() };
 
         for (&address, tracked) in &self.accounts {
-            let deleted = self.account_deleted_by_rules(address, tracked.current.as_ref(), spec);
             let original = tracked.original.as_ref().map(Account::info);
-            let current = tracked
-                .current
-                .as_ref()
-                .and_then(|account| Self::final_account_info(account, deleted));
+            let current = tracked.current.as_ref().map(Account::info);
             if original != current {
-                changes.accounts.insert(address, AccountChange { original, current });
+                changes.accounts.insert(address, Tracked { original, current });
             }
             if let Some(account) = tracked.current.as_ref()
                 && account.code_changed
@@ -875,62 +891,16 @@ impl<D: Database> State<D> {
             }
         }
 
-        for &address in &self.touched {
-            if self.accounts.contains_key(&address) {
-                continue;
-            }
-            let original = self.initial.get_account(address);
-            if spec.enables(crate::SpecId::SPURIOUS_DRAGON) {
-                if original.as_ref().is_some_and(AccountInfo::is_empty) {
-                    changes.accounts.insert(address, AccountChange { original, current: None });
-                }
-                continue;
-            }
-            if original.is_none() {
-                let empty = Account {
-                    code_hash: KECCAK_EMPTY,
-                    code: Bytecode::default(),
-                    ..Account::default()
-                };
-                changes
-                    .accounts
-                    .insert(address, AccountChange { original: None, current: Some(empty.info()) });
-            }
-        }
-
-        for &address in &self.selfdestructs {
-            let original = self
-                .accounts
-                .get(&address)
-                .and_then(|tracked| tracked.original.as_ref())
-                .map(Account::info)
-                .or_else(|| self.initial.get_account(address));
-            changes.accounts.entry(address).or_insert(AccountChange { original, current: None });
-        }
-
         for (&address, storage) in &self.storage {
-            let account_deleted =
-                changes.accounts.get(&address).is_some_and(|change| change.current.is_none());
-            let mut set =
-                StorageChangeSet { wipe: storage.wiped || account_deleted, slots: BTreeMap::new() };
-            if !account_deleted {
-                for (&key, slot) in &storage.slots {
-                    if slot.original != slot.current && (!set.wipe || !slot.current.is_zero()) {
-                        set.slots.insert(
-                            key,
-                            StorageChange { original: slot.original, current: slot.current },
-                        );
-                    }
+            let mut set = StorageChangeSet { wipe: storage.wiped, slots: BTreeMap::new() };
+            for (&key, slot) in &storage.slots {
+                if slot.original != slot.current && (!set.wipe || !slot.current.is_zero()) {
+                    set.slots
+                        .insert(key, Tracked { original: slot.original, current: slot.current });
                 }
             }
             if set.wipe || !set.slots.is_empty() {
                 changes.storage.insert(address, set);
-            }
-        }
-
-        for (&address, change) in &changes.accounts {
-            if change.current.is_none() {
-                changes.storage.entry(address).or_default().wipe = true;
             }
         }
 
@@ -939,164 +909,39 @@ impl<D: Database> State<D> {
 
     /// Marks the current transaction's overlay values as the new baseline.
     ///
-    /// After [`Self::build_state_changes`] has emitted the transaction write-set,
-    /// the overlay must stop treating those writes as pending changes. This rolls
-    /// the current account and storage values forward into their `original` slots,
-    /// applies local deletion/wipe bookkeeping, and clears transaction-local journal,
-    /// touch, selfdestruct, and access-list state. It only advances the in-memory
-    /// overlay; callers are still responsible for applying the emitted write-set to
-    /// their backing database.
-    pub(super) fn accept_transaction(&mut self, spec: crate::SpecId) {
-        let changes = self.build_state_changes(spec);
-        for (&address, change) in &changes.accounts {
-            self.ensure_account_overlay(address);
-            let current = change.current.clone().map(Account::from_info);
-            if let Some(account) = self.accounts.get_mut(&address) {
-                account.original = current.clone();
-                account.current = current;
+    /// After [`Self::finalize_transaction`] and [`Self::build_state_changes`] have
+    /// produced the transaction write-set, the overlay must stop treating those
+    /// writes as pending changes. This rolls the current account and storage
+    /// values forward into their `original` slots and applies local deletion/wipe
+    /// bookkeeping. It only advances the in-memory overlay; callers are still
+    /// responsible for applying the emitted write-set to their backing database
+    /// and clearing transaction-local state.
+    pub(super) fn commit_transaction_overlay(&mut self) {
+        for account in self.accounts.values_mut() {
+            if let Some(current) = &mut account.current {
+                current.just_created = false;
+                current.code_changed = false;
             }
+            account.original.clone_from(&account.current);
         }
-        for (&address, change) in &changes.storage {
-            if change.wipe {
-                self.storage.remove(&address);
+
+        self.storage.retain(|_, storage| {
+            if storage.wiped {
+                storage.slots.retain(|_, slot| !slot.current.is_zero());
             }
-            if !change.slots.is_empty() {
-                let storage = self.storage.entry(address).or_default();
-                for (&key, slot_change) in &change.slots {
-                    storage.slots.insert(key, StorageValue::new(slot_change.current));
-                }
-            }
-        }
-        for storage in self.storage.values_mut() {
             for slot in storage.slots.values_mut() {
                 slot.original = slot.current;
             }
             storage.wiped = false;
-        }
-        self.clear_transaction_state();
+            !storage.slots.is_empty()
+        });
     }
 }
-
-/// Returns the state-test logs hash.
-pub fn logs_hash(logs: &[Log]) -> B256 {
-    let mut out = Vec::with_capacity(alloy_rlp::list_length(logs));
-    alloy_rlp::encode_list(logs, &mut out);
-    keccak256(out)
-}
-
-/// A simple in-memory database view.
-#[derive(Clone, Debug, PartialEq, Eq)]
-#[non_exhaustive]
-pub struct CacheDB {
-    /// Accounts keyed by address.
-    pub accounts: HashMap<Address, AccountInfo>,
-    /// Contracts keyed by code hash.
-    pub contracts: HashMap<B256, Bytecode>,
-    /// Persistent storage keyed by account and slot.
-    pub storage: HashMap<(Address, Word), Word>,
-    /// Cached block hashes keyed by block number.
-    pub block_hashes: HashMap<u64, B256>,
-}
-
-impl Default for CacheDB {
-    #[inline]
-    fn default() -> Self {
-        let mut contracts = map::HashMap::default();
-        contracts.insert(KECCAK_EMPTY, Bytecode::default());
-        contracts.insert(B256::ZERO, Bytecode::default());
-
-        Self {
-            accounts: map::HashMap::default(),
-            contracts,
-            storage: map::HashMap::default(),
-            block_hashes: map::HashMap::default(),
-        }
-    }
-}
-
-impl CacheDB {
-    /// Inserts account code into the contract cache.
-    #[inline]
-    pub fn insert_contract(&mut self, info: &mut AccountInfo) {
-        if let Some(code) = &info.code
-            && !code.is_empty()
-        {
-            if info.code_hash == KECCAK_EMPTY {
-                info.code_hash = code.hash_slow();
-            }
-            self.contracts.entry(info.code_hash).or_insert_with(|| code.clone());
-        }
-        if info.code_hash.is_zero() {
-            info.code_hash = KECCAK_EMPTY;
-        }
-    }
-
-    /// Inserts account info.
-    #[inline]
-    pub fn insert_account_info(&mut self, address: Address, mut info: AccountInfo) {
-        self.insert_contract(&mut info);
-        self.accounts.insert(address, info);
-    }
-
-    /// Returns account info if the account exists.
-    #[inline]
-    pub fn account_info(&self, address: Address) -> Option<&AccountInfo> {
-        self.accounts.get(&address)
-    }
-
-    /// Inserts persistent storage.
-    #[inline]
-    pub fn insert_account_storage(&mut self, address: Address, key: Word, value: Word) {
-        self.accounts.entry(address).or_default();
-        self.storage.insert((address, key), value);
-    }
-
-    /// Sets a historical block hash.
-    #[inline]
-    pub fn insert_block_hash(&mut self, number: u64, hash: B256) {
-        self.block_hashes.insert(number, hash);
-    }
-}
-
-impl Database for CacheDB {
-    #[inline]
-    fn get_account(&self, address: Address) -> Option<AccountInfo> {
-        self.accounts.get(&address).cloned()
-    }
-
-    #[inline]
-    fn get_account_code(&self, address: Address) -> Bytecode {
-        self.accounts
-            .get(&address)
-            .and_then(|info| info.code.clone())
-            .or_else(|| {
-                self.accounts
-                    .get(&address)
-                    .and_then(|info| self.contracts.get(&info.code_hash).cloned())
-            })
-            .unwrap_or_default()
-    }
-
-    #[inline]
-    fn get_storage(&self, address: Address, key: Word) -> Word {
-        self.storage.get(&(address, key)).copied().unwrap_or_default()
-    }
-
-    #[inline]
-    fn get_block_hash(&self, number: u64) -> Option<B256> {
-        self.block_hashes
-            .get(&number)
-            .copied()
-            .or_else(|| Some(keccak256(number.to_string().as_bytes())))
-    }
-}
-
-/// A database implementation that stores initial state in memory.
-pub type InMemoryDB = CacheDB;
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::evm::CacheDB;
 
     #[test]
     fn storage_change_rolls_back_to_checkpoint() {
@@ -1175,7 +1020,7 @@ mod tests {
     }
 
     #[test]
-    fn state_changes_include_logs_and_accept_clears_them() {
+    fn state_changes_take_logs_from_transaction_state() {
         use alloy_primitives::{Bytes, LogData};
 
         let mut state = State::new(CacheDB::default());
@@ -1185,10 +1030,13 @@ mod tests {
         };
 
         state.log(log.clone());
-        let changes = state.build_state_changes(crate::SpecId::SPURIOUS_DRAGON);
-        assert_eq!(changes.logs, [log]);
+        state.finalize_transaction(crate::SpecId::SPURIOUS_DRAGON);
+        let changes = state.build_state_changes();
+        assert_eq!(changes.logs.as_slice(), core::slice::from_ref(&log));
+        assert!(state.logs().is_empty());
 
-        state.accept_transaction(crate::SpecId::SPURIOUS_DRAGON);
+        state.commit_transaction_overlay();
+        state.clear_transaction_state();
         assert!(state.logs().is_empty());
     }
 
@@ -1201,7 +1049,8 @@ mod tests {
         let mut state = State::new(database);
 
         state.touch(address);
-        let changes = state.build_state_changes(crate::SpecId::SPURIOUS_DRAGON);
+        state.finalize_transaction(crate::SpecId::SPURIOUS_DRAGON);
+        let changes = state.build_state_changes();
 
         let change = changes.accounts.get(&address).expect("touched empty account is deleted");
         assert_eq!(change.original, Some(empty));
@@ -1217,7 +1066,8 @@ mod tests {
         let mut state = State::new(database);
 
         state.touch(address);
-        let changes = state.build_state_changes(crate::SpecId::HOMESTEAD);
+        state.finalize_transaction(crate::SpecId::HOMESTEAD);
+        let changes = state.build_state_changes();
 
         assert!(!changes.accounts.contains_key(&address));
         assert!(!changes.storage.contains_key(&address));
@@ -1229,7 +1079,8 @@ mod tests {
         let mut state = State::new(CacheDB::default());
 
         state.touch(address);
-        let changes = state.build_state_changes(crate::SpecId::HOMESTEAD);
+        state.finalize_transaction(crate::SpecId::HOMESTEAD);
+        let changes = state.build_state_changes();
 
         let change =
             changes.accounts.get(&address).expect("pre-spurious empty touch creates account");
@@ -1244,7 +1095,8 @@ mod tests {
         let mut state = State::new(CacheDB::default());
 
         state.touch(address);
-        let changes = state.build_state_changes(crate::SpecId::SPURIOUS_DRAGON);
+        state.finalize_transaction(crate::SpecId::SPURIOUS_DRAGON);
+        let changes = state.build_state_changes();
 
         assert!(!changes.accounts.contains_key(&address));
         assert!(!changes.storage.contains_key(&address));
@@ -1259,7 +1111,8 @@ mod tests {
         let mut state = State::new(database);
 
         state.mark_destructed(address);
-        let changes = state.build_state_changes(crate::SpecId::SPURIOUS_DRAGON);
+        state.finalize_transaction(crate::SpecId::SPURIOUS_DRAGON);
+        let changes = state.build_state_changes();
 
         let change = changes.accounts.get(&address).expect("selfdestruct deletes account");
         assert!(change.original.is_some());

--- a/crates/evm2/src/evm/state.rs
+++ b/crates/evm2/src/evm/state.rs
@@ -124,8 +124,6 @@ pub struct Account {
     pub balance: Word,
     /// Account code hash.
     pub code_hash: B256,
-    /// EIP-1153 transient storage.
-    pub transient_storage: HashMap<Word, Word>,
     /// Cached account bytecode.
     pub code: Bytecode,
     /// Whether the account was created in the current transaction.
@@ -369,6 +367,8 @@ pub struct State<D> {
     pub accessed_accounts: HashSet<Address>,
     /// Transaction-scoped warm storage slot set.
     pub accessed_storage: HashSet<(Address, Word)>,
+    /// Transaction-scoped EIP-1153 transient storage keyed by account address and slot.
+    pub transient_storage: HashMap<(Address, Word), Word>,
 }
 
 impl<D> State<D> {
@@ -384,6 +384,7 @@ impl<D> State<D> {
             selfdestructs: map::HashSet::default(),
             accessed_accounts: map::HashSet::default(),
             accessed_storage: map::HashSet::default(),
+            transient_storage: map::HashMap::default(),
         }
     }
 
@@ -447,6 +448,7 @@ impl<D> State<D> {
         self.selfdestructs.clear();
         self.accessed_accounts.clear();
         self.accessed_storage.clear();
+        self.transient_storage.clear();
     }
 
     /// Clears all transaction-scoped warm accesses.
@@ -705,17 +707,22 @@ impl<D: Database> State<D> {
     /// Loads transient storage.
     #[inline]
     pub fn transient_storage(&mut self, address: Address, key: Word) -> Word {
-        self.account_ref(address)
-            .and_then(|account| account.transient_storage.get(&key).copied())
-            .unwrap_or_default()
+        self.transient_storage.get(&(address, key)).copied().unwrap_or_default()
     }
 
     /// Stores transient storage.
     #[inline]
     pub fn set_transient_storage(&mut self, address: Address, key: Word, value: Word) {
-        let previous = self.account_mut(address).transient_storage.get(&key).copied();
+        let previous = self.transient_storage.get(&(address, key)).copied();
+        if previous.unwrap_or_default() == value {
+            return;
+        }
         self.journal.push(JournalEntry::TransientStorageChange { address, key, previous });
-        self.account_mut(address).transient_storage.insert(key, value);
+        if value.is_zero() {
+            self.transient_storage.remove(&(address, key));
+        } else {
+            self.transient_storage.insert((address, key), value);
+        }
     }
 
     /// Marks an account as self-destructed in the current transaction.
@@ -772,17 +779,14 @@ impl<D: Database> State<D> {
                         self.storage.remove(&address);
                     }
                 },
-                JournalEntry::TransientStorageChange { address, key, previous } => {
-                    let storage = &mut self.account_mut(address).transient_storage;
-                    match previous {
-                        Some(previous) => {
-                            storage.insert(key, previous);
-                        }
-                        None => {
-                            storage.remove(&key);
-                        }
+                JournalEntry::TransientStorageChange { address, key, previous } => match previous {
+                    Some(previous) if !previous.is_zero() => {
+                        self.transient_storage.insert((address, key), previous);
                     }
-                }
+                    _ => {
+                        self.transient_storage.remove(&(address, key));
+                    }
+                },
                 JournalEntry::AccountWarmed { address } => {
                     self.accessed_accounts.remove(&address);
                 }

--- a/crates/evm2/src/evm/state.rs
+++ b/crates/evm2/src/evm/state.rs
@@ -1,15 +1,51 @@
 //! Basic in-memory EVM host state.
 
 use crate::{bytecode::Bytecode, interpreter::Word};
-use alloc::{string::ToString, vec::Vec};
+use alloc::{collections::BTreeMap, string::ToString, vec::Vec};
 use alloy_primitives::{
     Address, B256, U256, keccak256,
-    map::{self, HashMap, HashSet},
+    map::{self, HashMap, HashSet, hash_map},
 };
 
 pub use alloy_primitives::KECCAK256_EMPTY as KECCAK_EMPTY;
 
-/// Account information loaded from the backing database.
+/// A value tracked together with the value it had at the start of the current
+/// transaction.
+///
+/// `Tracked` is used internally by [`State`] to keep an overlay over the
+/// backing database. `original` is the value at the current transaction
+/// boundary, while `current` is the value after all in-flight EVM mutations.
+/// When a transaction is accepted, `current` becomes the next transaction's
+/// `original` without writing anything to the backing database.
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
+pub struct Tracked<T> {
+    /// Value at the start of the current transaction.
+    pub original: T,
+    /// Current overlay value.
+    pub current: T,
+}
+
+impl<T> Tracked<T> {
+    /// Creates a tracked value whose original and current values are equal.
+    #[inline]
+    pub fn new(value: T) -> Self
+    where
+        T: Clone,
+    {
+        Self { original: value.clone(), current: value }
+    }
+}
+
+impl<T: PartialEq> Tracked<T> {
+    /// Returns whether the current value differs from the original value.
+    #[inline]
+    pub fn is_changed(&self) -> bool {
+        self.original != self.current
+    }
+}
+
+/// Account information loaded from the backing database or emitted in a state
+/// transition.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 #[non_exhaustive]
 pub struct AccountInfo {
@@ -21,8 +57,6 @@ pub struct AccountInfo {
     pub code_hash: B256,
     /// Bytecode associated with this account.
     pub code: Option<Bytecode>,
-    /// Whether the account has initial persistent storage.
-    pub has_storage: bool,
 }
 
 impl Default for AccountInfo {
@@ -33,7 +67,6 @@ impl Default for AccountInfo {
             nonce: 0,
             code_hash: KECCAK_EMPTY,
             code: Some(Bytecode::default()),
-            has_storage: false,
         }
     }
 }
@@ -42,7 +75,7 @@ impl AccountInfo {
     /// Creates a new [`AccountInfo`] with the given fields.
     #[inline]
     pub const fn new(balance: Word, nonce: u64, code_hash: B256, code: Bytecode) -> Self {
-        Self { balance, nonce, code_hash, code: Some(code), has_storage: false }
+        Self { balance, nonce, code_hash, code: Some(code) }
     }
 
     /// Creates a new [`AccountInfo`] with the given code.
@@ -80,28 +113,7 @@ impl AccountInfo {
 }
 
 /// Persistent storage value cached by [`State`].
-#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
-#[non_exhaustive]
-pub struct StorageValue {
-    /// Current value.
-    pub current: Word,
-    /// Original value loaded from the backing database.
-    pub original: Word,
-}
-
-impl StorageValue {
-    /// Creates a new unchanged storage value.
-    #[inline]
-    pub const fn new(value: Word) -> Self {
-        Self { current: value, original: value }
-    }
-
-    /// Returns whether the value changed from its original value.
-    #[inline]
-    pub fn is_changed(&self) -> bool {
-        self.current != self.original
-    }
-}
+pub type StorageValue = Tracked<Word>;
 
 /// Mutable account state cached by [`State`].
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
@@ -113,18 +125,10 @@ pub struct Account {
     pub balance: Word,
     /// Account code hash.
     pub code_hash: B256,
-    /// Whether the account has initial persistent storage.
-    pub has_initial_storage: bool,
-    /// Cached and modified persistent storage entries.
-    pub storage: HashMap<Word, StorageValue>,
     /// EIP-1153 transient storage.
     pub transient_storage: HashMap<Word, Word>,
     /// Cached account bytecode.
     pub code: Bytecode,
-    /// Whether the account has been self-destructed.
-    pub destructed: bool,
-    /// Whether the account should be deleted if empty.
-    pub erase_if_empty: bool,
     /// Whether the account was created in the current transaction.
     pub just_created: bool,
     /// Whether the account code has been modified.
@@ -139,7 +143,6 @@ impl Account {
             nonce: info.nonce,
             balance: info.balance,
             code_hash: info.code_hash,
-            has_initial_storage: info.has_storage,
             code: info.code.unwrap_or_default(),
             ..Self::default()
         }
@@ -153,8 +156,6 @@ impl Account {
             nonce: self.nonce,
             code_hash: self.code_hash,
             code: Some(self.code.clone()),
-            has_storage: self.has_initial_storage
-                || self.storage.values().any(StorageValue::is_changed),
         }
     }
 
@@ -163,6 +164,91 @@ impl Account {
     pub fn is_empty(&self) -> bool {
         self.nonce == 0 && self.balance.is_zero() && self.code_hash == KECCAK_EMPTY
     }
+}
+
+/// Persistent storage overlay for one account.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+#[non_exhaustive]
+pub struct StorageOverlay {
+    /// Whether consumers must delete all pre-existing storage for the account
+    /// before applying individual slot changes.
+    pub wiped: bool,
+    /// Loaded or changed storage slots.
+    pub slots: HashMap<Word, StorageValue>,
+}
+
+/// Complete state transition produced by a transaction.
+///
+/// `StateChanges` is the public write-set returned in [`crate::TxResult`]. It
+/// is intentionally explicit so embedding clients can update their own database
+/// and compute post-state roots without reimplementing EVM account-lifetime
+/// rules.
+///
+/// Consumers should apply changes in this order:
+///
+/// 1. write bytecode from [`Self::code`] for every non-empty code hash they do not already have;
+/// 2. for each [`StorageChangeSet`] whose [`StorageChangeSet::wipe`] flag is true, delete all
+///    storage for that account;
+/// 3. apply each storage slot change: a zero [`StorageChange::current`] means delete the slot,
+///    otherwise write the slot value;
+/// 4. apply account changes: `current = Some(..)` means upsert the account, `current = None` means
+///    delete the account.
+///
+/// `evm2` does not write to the backing database. These changes describe what
+/// happened; applying them is the responsibility of the caller.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct StateChanges {
+    /// Account changes keyed by address.
+    pub accounts: BTreeMap<Address, AccountChange>,
+    /// Persistent storage changes keyed by account address.
+    pub storage: BTreeMap<Address, StorageChangeSet>,
+    /// Newly created or modified bytecode keyed by code hash.
+    pub code: BTreeMap<B256, Bytecode>,
+}
+
+impl StateChanges {
+    /// Returns whether this transition contains no database-visible changes.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.accounts.is_empty() && self.storage.is_empty() && self.code.is_empty()
+    }
+}
+
+/// Account transition for a single address.
+///
+/// `original` is the account at the beginning of the transaction. `current` is
+/// the account after transaction execution and EVM account-lifetime rules have
+/// been evaluated. `current = None` is an explicit account deletion.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AccountChange {
+    /// Account at the beginning of the transaction.
+    pub original: Option<AccountInfo>,
+    /// Account after the transaction, or `None` to delete it.
+    pub current: Option<AccountInfo>,
+}
+
+/// Storage transition for a single account.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct StorageChangeSet {
+    /// If true, delete all pre-existing storage for this account before applying
+    /// [`Self::slots`]. This is used for selfdestruct and contract
+    /// re-incarnation semantics using an explicit storage wipe marker.
+    pub wipe: bool,
+    /// Changed storage slots keyed by slot.
+    pub slots: BTreeMap<Word, StorageChange>,
+}
+
+/// Storage transition for a single slot.
+///
+/// `original` is the slot value at the beginning of the transaction, after any
+/// storage wipe/re-incarnation semantics that occurred before the slot was
+/// loaded. `current = 0` means the consumer should delete the slot.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct StorageChange {
+    /// Slot value at the beginning of the transaction.
+    pub original: Word,
+    /// Slot value after the transaction. Zero means delete the slot.
+    pub current: Word,
 }
 
 /// Backing database view used to initialize mutable [`State`].
@@ -184,15 +270,25 @@ pub trait Database {
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum JournalEntry {
-    /// Account balance changed.
-    BalanceChange {
+    /// Account current value changed.
+    AccountChange {
         /// Account address.
         address: Address,
-        /// Previous balance.
-        previous: Word,
+        /// Previous current account value.
+        previous: Option<Account>,
+    },
+    /// Account overlay entry was inserted.
+    AccountInserted {
+        /// Account address.
+        address: Address,
     },
     /// Account was touched.
-    Touched {
+    Touch {
+        /// Account address.
+        address: Address,
+    },
+    /// Account was self-destructed.
+    SelfDestruct {
         /// Account address.
         address: Address,
     },
@@ -202,8 +298,22 @@ pub enum JournalEntry {
         address: Address,
         /// Storage key.
         key: Word,
-        /// Previous storage value.
+        /// Previous current storage value.
         previous: Word,
+    },
+    /// Persistent storage slot overlay was inserted.
+    StorageInserted {
+        /// Account address.
+        address: Address,
+        /// Storage key.
+        key: Word,
+    },
+    /// Account storage wipe flag changed.
+    StorageWipe {
+        /// Account address.
+        address: Address,
+        /// Previous storage overlay.
+        previous: Option<StorageOverlay>,
     },
     /// Transient storage changed.
     TransientStorageChange {
@@ -212,12 +322,7 @@ pub enum JournalEntry {
         /// Storage key.
         key: Word,
         /// Previous transient storage value.
-        previous: Word,
-    },
-    /// Account nonce was incremented.
-    NonceBump {
-        /// Account address.
-        address: Address,
+        previous: Option<Word>,
     },
     /// Account was warmed by EIP-2929 access tracking.
     AccountWarmed {
@@ -231,30 +336,24 @@ pub enum JournalEntry {
         /// Storage key.
         key: Word,
     },
-    /// Account was created.
-    Create {
-        /// Account address.
-        address: Address,
-        /// Whether the account existed before creation.
-        existed: bool,
-    },
-    /// Account was self-destructed.
-    Destruct {
-        /// Account address.
-        address: Address,
-    },
 }
 
-/// Mutable EVM state with evmone-style journaling.
+/// Mutable EVM state with an overlay and reversible journal.
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub struct State<D> {
     /// Read-only initial database.
     pub initial: D,
-    /// Accounts loaded from the initial database and potentially modified.
-    pub modified: HashMap<Address, Account>,
+    /// Account overlay keyed by address.
+    pub accounts: HashMap<Address, Tracked<Option<Account>>>,
+    /// Persistent storage overlay keyed by account address.
+    pub storage: HashMap<Address, StorageOverlay>,
     /// Revert journal.
     pub journal: Vec<JournalEntry>,
+    /// Accounts touched in the current transaction.
+    pub touched: HashSet<Address>,
+    /// Accounts self-destructed in the current transaction.
+    pub selfdestructs: HashSet<Address>,
     /// Transaction-scoped warm account set.
     pub accessed_accounts: HashSet<Address>,
     /// Transaction-scoped warm storage slot set.
@@ -267,8 +366,11 @@ impl<D> State<D> {
     pub fn new(initial: D) -> Self {
         Self {
             initial,
-            modified: map::HashMap::default(),
+            accounts: map::HashMap::default(),
+            storage: map::HashMap::default(),
             journal: Vec::new(),
+            touched: map::HashSet::default(),
+            selfdestructs: map::HashSet::default(),
             accessed_accounts: map::HashSet::default(),
             accessed_storage: map::HashSet::default(),
         }
@@ -292,10 +394,10 @@ impl<D> State<D> {
         &mut self.initial
     }
 
-    /// Returns the modified account if present.
+    /// Returns the current account overlay if present and not deleted.
     #[inline]
     pub fn account_ref(&self, address: Address) -> Option<&Account> {
-        self.modified.get(&address)
+        self.accounts.get(&address).and_then(|account| account.current.as_ref())
     }
 
     /// Returns whether an account is warm in the current transaction.
@@ -326,6 +428,16 @@ impl<D> State<D> {
         }
     }
 
+    /// Clears transaction-scoped substate.
+    #[inline]
+    pub fn clear_transaction_state(&mut self) {
+        self.journal.clear();
+        self.touched.clear();
+        self.selfdestructs.clear();
+        self.accessed_accounts.clear();
+        self.accessed_storage.clear();
+    }
+
     /// Clears all transaction-scoped warm accesses.
     #[inline]
     pub fn clear_accesses(&mut self) {
@@ -335,38 +447,68 @@ impl<D> State<D> {
 }
 
 impl<D: Database> State<D> {
+    fn load_account(&mut self, address: Address) -> Option<&Tracked<Option<Account>>> {
+        if !self.accounts.contains_key(&address)
+            && let Some(info) = self.initial.get_account(address)
+        {
+            let account = Account::from_info(info);
+            self.accounts.insert(address, Tracked::new(Some(account)));
+        }
+        self.accounts.get(&address)
+    }
+
+    fn ensure_account_overlay(&mut self, address: Address) {
+        if !self.accounts.contains_key(&address) {
+            let original = self.initial.get_account(address).map(Account::from_info);
+            self.accounts
+                .insert(address, Tracked { original: original.clone(), current: original });
+            self.journal.push(JournalEntry::AccountInserted { address });
+        }
+    }
+
+    fn account_mut(&mut self, address: Address) -> &mut Account {
+        self.ensure_account_overlay(address);
+        if self.accounts[&address].current.is_none() {
+            self.journal.push(JournalEntry::AccountChange { address, previous: None });
+            self.accounts.get_mut(&address).expect("account overlay exists").current =
+                Some(Account {
+                    code_hash: KECCAK_EMPTY,
+                    code: Bytecode::default(),
+                    ..Account::default()
+                });
+        }
+        self.accounts
+            .get_mut(&address)
+            .and_then(|account| account.current.as_mut())
+            .expect("current account exists")
+    }
+
+    fn journal_account_change(&mut self, address: Address) {
+        self.ensure_account_overlay(address);
+        let previous = self.accounts[&address].current.clone();
+        self.journal.push(JournalEntry::AccountChange { address, previous });
+    }
+
     /// Returns account info.
     #[inline]
     pub fn account_info(&self, address: Address) -> Option<AccountInfo> {
-        self.modified.get(&address).map(Account::info).or_else(|| self.initial.get_account(address))
+        if let Some(account) = self.accounts.get(&address) {
+            return account.current.as_ref().map(Account::info);
+        }
+        self.initial.get_account(address)
     }
 
     /// Returns an account if it exists.
     #[inline]
     pub fn find(&mut self, address: Address) -> Option<&Account> {
-        if !self.modified.contains_key(&address)
-            && let Some(info) = self.initial.get_account(address)
-        {
-            self.modified.insert(address, Account::from_info(info));
-        }
-        self.modified.get(&address)
+        self.load_account(address);
+        self.account_ref(address)
     }
 
     /// Gets an existing account or inserts a new empty account.
     #[inline]
     pub fn get_or_insert(&mut self, address: Address) -> &mut Account {
-        if !self.modified.contains_key(&address) {
-            let account =
-                self.initial.get_account(address).map(Account::from_info).unwrap_or_else(|| {
-                    Account {
-                        code_hash: KECCAK_EMPTY,
-                        code: Bytecode::default(),
-                        ..Account::default()
-                    }
-                });
-            self.modified.insert(address, account);
-        }
-        self.modified.get_mut(&address).expect("account was just inserted")
+        self.account_mut(address)
     }
 
     /// Gets account code.
@@ -384,47 +526,90 @@ impl<D: Database> State<D> {
         self.initial.get_account_code(address)
     }
 
+    fn storage_initial(&self, address: Address, key: Word) -> Word {
+        if self.storage.get(&address).is_some_and(|storage| storage.wiped)
+            || self.accounts.get(&address).is_some_and(|account| account.original.is_none())
+        {
+            Word::ZERO
+        } else {
+            self.initial.get_storage(address, key)
+        }
+    }
+
+    fn ensure_storage_slot(&mut self, address: Address, key: Word, journal_insert: bool) {
+        let initial = self.storage_initial(address, key);
+        let storage = self.storage.entry(address).or_default();
+        if let hash_map::Entry::Vacant(entry) = storage.slots.entry(key) {
+            entry.insert(StorageValue::new(initial));
+            if journal_insert {
+                self.journal.push(JournalEntry::StorageInserted { address, key });
+            }
+        }
+    }
+
     /// Gets a persistent storage value.
     #[inline]
     pub fn get_storage_value(&mut self, address: Address, key: Word) -> &mut StorageValue {
-        if !self.get_or_insert(address).storage.contains_key(&key) {
-            let initial = self.initial.get_storage(address, key);
-            self.get_or_insert(address).storage.insert(key, StorageValue::new(initial));
-        }
-        self.get_or_insert(address).storage.get_mut(&key).expect("storage was just inserted")
+        self.ensure_storage_slot(address, key, false);
+        self.storage
+            .get_mut(&address)
+            .and_then(|storage| storage.slots.get_mut(&key))
+            .expect("storage slot was just inserted")
     }
 
     /// Loads persistent storage.
     #[inline]
     pub fn storage(&mut self, address: Address, key: Word) -> Word {
+        if self.account_info(address).is_none() {
+            return Word::ZERO;
+        }
         self.get_storage_value(address, key).current
     }
 
     /// Stores persistent storage.
     #[inline]
     pub fn set_storage(&mut self, address: Address, key: Word, value: Word) {
-        let previous = self.get_storage_value(address, key).current;
+        self.account_mut(address);
+        let inserted =
+            !self.storage.get(&address).is_some_and(|storage| storage.slots.contains_key(&key));
+        self.ensure_storage_slot(address, key, inserted);
+        let previous = self.storage[&address].slots[&key].current;
         self.journal.push(JournalEntry::StorageChange { address, key, previous });
-        self.get_storage_value(address, key).current = value;
+        self.storage
+            .get_mut(&address)
+            .expect("storage overlay exists")
+            .slots
+            .get_mut(&key)
+            .expect("storage slot exists")
+            .current = value;
+    }
+
+    /// Marks an account as touched by the current transaction.
+    #[inline]
+    pub fn touch(&mut self, address: Address) {
+        if self.touched.insert(address) {
+            self.journal.push(JournalEntry::Touch { address });
+        }
     }
 
     /// Adds a signed balance delta by wrapping two's-complement values.
     #[inline]
     pub fn add_balance(&mut self, address: Address, delta: Word) {
         if delta.is_zero() {
-            self.get_or_insert(address).erase_if_empty = true;
+            self.touch(address);
             return;
         }
-        let previous = self.get_or_insert(address).balance;
-        self.journal.push(JournalEntry::BalanceChange { address, previous });
-        self.get_or_insert(address).balance = previous.wrapping_add(delta);
+        self.journal_account_change(address);
+        let account = self.account_mut(address);
+        account.balance = account.balance.wrapping_add(delta);
+        self.touch(address);
     }
 
     /// Transfers value between accounts.
     #[inline]
     pub fn transfer(&mut self, from: Address, to: Address, value: Word) -> bool {
         if value.is_zero() || from == to {
-            self.get_or_insert(to).erase_if_empty = true;
+            self.touch(to);
             return true;
         }
 
@@ -433,21 +618,24 @@ impl<D: Database> State<D> {
             return false;
         };
 
-        let from_previous = self.get_or_insert(from).balance;
-        self.journal.push(JournalEntry::BalanceChange { address: from, previous: from_previous });
-        self.get_or_insert(from).balance = new_from_balance;
+        self.journal_account_change(from);
+        self.account_mut(from).balance = new_from_balance;
+        self.touch(from);
 
-        let to_previous = self.get_or_insert(to).balance;
-        self.journal.push(JournalEntry::BalanceChange { address: to, previous: to_previous });
-        self.get_or_insert(to).balance = to_previous.saturating_add(value);
+        self.journal_account_change(to);
+        let to_balance = self.account_mut(to).balance;
+        self.account_mut(to).balance = to_balance.saturating_add(value);
+        self.touch(to);
         true
     }
 
     /// Increments account nonce.
     #[inline]
     pub fn increment_nonce(&mut self, address: Address) {
-        self.journal.push(JournalEntry::NonceBump { address });
-        self.get_or_insert(address).nonce = self.get_or_insert(address).nonce.saturating_add(1);
+        self.journal_account_change(address);
+        let account = self.account_mut(address);
+        account.nonce = account.nonce.saturating_add(1);
+        self.touch(address);
     }
 
     /// Creates a contract account and transfers endowment from the caller.
@@ -459,66 +647,80 @@ impl<D: Database> State<D> {
         value: Word,
         spec: crate::SpecId,
     ) -> Result<(), crate::interpreter::InstrStop> {
-        let existed = self.account_info(address).is_some();
         if let Some(info) = self.account_info(address)
             && (info.nonce != 0 || info.code_hash != KECCAK_EMPTY)
         {
             return Err(crate::interpreter::InstrStop::CreateCollision);
         }
 
-        self.journal.push(JournalEntry::Create { address, existed });
         if !self.transfer(caller, address, value) {
             return Err(crate::interpreter::InstrStop::OutOfFunds);
         }
 
-        let account = self.get_or_insert(address);
-        account.nonce = u64::from(spec.enables(crate::SpecId::SPURIOUS_DRAGON));
-        account.code_hash = KECCAK_EMPTY;
-        account.code = Bytecode::default();
-        account.storage.clear();
-        account.transient_storage.clear();
-        account.destructed = false;
-        account.just_created = true;
-        account.code_changed = true;
+        let balance = self.account_mut(address).balance;
+        self.wipe_storage(address);
+        self.journal_account_change(address);
+        self.accounts.get_mut(&address).expect("account overlay exists").current = Some(Account {
+            nonce: u64::from(spec.enables(crate::SpecId::SPURIOUS_DRAGON)),
+            balance,
+            code_hash: KECCAK_EMPTY,
+            code: Bytecode::default(),
+            just_created: true,
+            code_changed: true,
+            ..Account::default()
+        });
+        self.touch(address);
         Ok(())
     }
 
     /// Sets account bytecode.
     #[inline]
     pub fn set_code(&mut self, address: Address, code: Bytecode) {
-        let account = self.get_or_insert(address);
+        self.journal_account_change(address);
+        let account = self.account_mut(address);
         account.code_hash = code.hash_slow();
         account.code = code;
         account.code_changed = true;
     }
 
-    /// Removes modified accounts that should be erased and are empty.
+    /// Marks all prior persistent storage for `address` as deleted.
     #[inline]
-    pub fn prune_empty_accounts(&mut self) {
-        self.modified.retain(|_, account| {
-            !(account.erase_if_empty && account.is_empty() && !account.has_initial_storage)
-        });
+    pub fn wipe_storage(&mut self, address: Address) {
+        let previous = self.storage.get(&address).cloned();
+        self.journal.push(JournalEntry::StorageWipe { address, previous });
+        self.storage
+            .insert(address, StorageOverlay { wiped: true, slots: map::HashMap::default() });
     }
 
     /// Loads transient storage.
     #[inline]
     pub fn transient_storage(&mut self, address: Address, key: Word) -> Word {
-        self.get_or_insert(address).transient_storage.get(&key).copied().unwrap_or_default()
+        self.account_ref(address)
+            .and_then(|account| account.transient_storage.get(&key).copied())
+            .unwrap_or_default()
     }
 
     /// Stores transient storage.
     #[inline]
     pub fn set_transient_storage(&mut self, address: Address, key: Word, value: Word) {
-        let previous = self.transient_storage(address, key);
+        let previous = self.account_mut(address).transient_storage.get(&key).copied();
         self.journal.push(JournalEntry::TransientStorageChange { address, key, previous });
-        self.get_or_insert(address).transient_storage.insert(key, value);
+        self.account_mut(address).transient_storage.insert(key, value);
     }
 
-    /// Marks an account as self-destructed.
+    /// Marks an account as self-destructed in the current transaction.
     #[inline]
     pub fn mark_destructed(&mut self, address: Address) {
-        self.journal.push(JournalEntry::Destruct { address });
-        self.get_or_insert(address).destructed = true;
+        if self.selfdestructs.insert(address) {
+            self.journal.push(JournalEntry::SelfDestruct { address });
+        }
+        self.touch(address);
+    }
+
+    /// Returns whether an account has been marked self-destructed in the current transaction.
+    #[inline]
+    pub fn is_selfdestructed(&self, address: Address) -> bool {
+        self.selfdestructs.contains(&address)
     }
 
     /// Reverts state changes after the checkpoint.
@@ -526,20 +728,50 @@ impl<D: Database> State<D> {
     pub fn rollback(&mut self, checkpoint: usize) {
         while self.journal.len() != checkpoint {
             match self.journal.pop().expect("journal length checked above") {
-                JournalEntry::BalanceChange { address, previous } => {
-                    self.get_or_insert(address).balance = previous;
+                JournalEntry::AccountChange { address, previous } => {
+                    if let Some(account) = self.accounts.get_mut(&address) {
+                        account.current = previous;
+                    }
                 }
-                JournalEntry::Touched { address } => {
-                    self.get_or_insert(address).erase_if_empty = false;
+                JournalEntry::AccountInserted { address } => {
+                    self.accounts.remove(&address);
+                }
+                JournalEntry::Touch { address } => {
+                    self.touched.remove(&address);
+                }
+                JournalEntry::SelfDestruct { address } => {
+                    self.selfdestructs.remove(&address);
                 }
                 JournalEntry::StorageChange { address, key, previous } => {
-                    self.get_storage_value(address, key).current = previous;
+                    if let Some(storage) = self.storage.get_mut(&address)
+                        && let Some(slot) = storage.slots.get_mut(&key)
+                    {
+                        slot.current = previous;
+                    }
                 }
+                JournalEntry::StorageInserted { address, key } => {
+                    if let Some(storage) = self.storage.get_mut(&address) {
+                        storage.slots.remove(&key);
+                    }
+                }
+                JournalEntry::StorageWipe { address, previous } => match previous {
+                    Some(storage) => {
+                        self.storage.insert(address, storage);
+                    }
+                    None => {
+                        self.storage.remove(&address);
+                    }
+                },
                 JournalEntry::TransientStorageChange { address, key, previous } => {
-                    self.get_or_insert(address).transient_storage.insert(key, previous);
-                }
-                JournalEntry::NonceBump { address } => {
-                    self.get_or_insert(address).nonce -= 1;
+                    let storage = &mut self.account_mut(address).transient_storage;
+                    match previous {
+                        Some(previous) => {
+                            storage.insert(key, previous);
+                        }
+                        None => {
+                            storage.remove(&key);
+                        }
+                    }
                 }
                 JournalEntry::AccountWarmed { address } => {
                     self.accessed_accounts.remove(&address);
@@ -547,21 +779,151 @@ impl<D: Database> State<D> {
                 JournalEntry::StorageWarmed { address, key } => {
                     self.accessed_storage.remove(&(address, key));
                 }
-                JournalEntry::Create { address, existed } => {
-                    if existed {
-                        let account = self.get_or_insert(address);
-                        account.nonce = 0;
-                        account.code_hash = KECCAK_EMPTY;
-                        account.code = Bytecode::default();
-                    } else {
-                        self.modified.remove(&address);
+            }
+        }
+    }
+
+    fn final_account_info(account: &Account, deleted: bool) -> Option<AccountInfo> {
+        if deleted { None } else { Some(account.info()) }
+    }
+
+    fn account_deleted_by_rules(
+        &self,
+        address: Address,
+        account: Option<&Account>,
+        spec: crate::SpecId,
+    ) -> bool {
+        if self.selfdestructs.contains(&address) {
+            return true;
+        }
+        spec.enables(crate::SpecId::SPURIOUS_DRAGON)
+            && self.touched.contains(&address)
+            && account.is_none_or(Account::is_empty)
+    }
+
+    /// Builds the database-visible state transition for the current transaction.
+    ///
+    /// This method is pure: it does not apply changes to the backing database and
+    /// does not advance the overlay to the next transaction. Callers normally use
+    /// the [`StateChanges`] attached to [`crate::TxResult`] instead of invoking
+    /// this directly.
+    pub fn build_state_changes(&self, spec: crate::SpecId) -> StateChanges {
+        let mut changes = StateChanges::default();
+
+        for (&address, tracked) in &self.accounts {
+            let deleted = self.account_deleted_by_rules(address, tracked.current.as_ref(), spec);
+            let original = tracked.original.as_ref().map(Account::info);
+            let current = tracked
+                .current
+                .as_ref()
+                .and_then(|account| Self::final_account_info(account, deleted));
+            if original != current {
+                changes.accounts.insert(address, AccountChange { original, current });
+            }
+            if let Some(account) = tracked.current.as_ref()
+                && account.code_changed
+                && !account.code.is_empty()
+                && !account.code_hash.is_zero()
+                && account.code_hash != KECCAK_EMPTY
+            {
+                changes.code.insert(account.code_hash, account.code.clone());
+            }
+        }
+
+        for &address in &self.touched {
+            if self.accounts.contains_key(&address) {
+                continue;
+            }
+            let original = self.initial.get_account(address);
+            if spec.enables(crate::SpecId::SPURIOUS_DRAGON) {
+                if original.as_ref().is_some_and(AccountInfo::is_empty) {
+                    changes.accounts.insert(address, AccountChange { original, current: None });
+                }
+                continue;
+            }
+            if original.is_none() {
+                let empty = Account {
+                    code_hash: KECCAK_EMPTY,
+                    code: Bytecode::default(),
+                    ..Account::default()
+                };
+                changes
+                    .accounts
+                    .insert(address, AccountChange { original: None, current: Some(empty.info()) });
+            }
+        }
+
+        for &address in &self.selfdestructs {
+            let original = self
+                .accounts
+                .get(&address)
+                .and_then(|tracked| tracked.original.as_ref())
+                .map(Account::info)
+                .or_else(|| self.initial.get_account(address));
+            changes.accounts.entry(address).or_insert(AccountChange { original, current: None });
+        }
+
+        for (&address, storage) in &self.storage {
+            let account_deleted =
+                changes.accounts.get(&address).is_some_and(|change| change.current.is_none());
+            let mut set =
+                StorageChangeSet { wipe: storage.wiped || account_deleted, slots: BTreeMap::new() };
+            if !account_deleted {
+                for (&key, slot) in &storage.slots {
+                    if slot.original != slot.current && (!set.wipe || !slot.current.is_zero()) {
+                        set.slots.insert(
+                            key,
+                            StorageChange { original: slot.original, current: slot.current },
+                        );
                     }
                 }
-                JournalEntry::Destruct { address } => {
-                    self.get_or_insert(address).destructed = false;
+            }
+            if set.wipe || !set.slots.is_empty() {
+                changes.storage.insert(address, set);
+            }
+        }
+
+        for (&address, change) in &changes.accounts {
+            if change.current.is_none() {
+                changes.storage.entry(address).or_default().wipe = true;
+            }
+        }
+
+        changes
+    }
+
+    /// Advances the in-memory overlay to the next transaction boundary.
+    ///
+    /// This accepts the already-computed transition in the overlay only. It does
+    /// not write to or mutate the backing database.
+    pub fn accept_transaction(&mut self, spec: crate::SpecId) {
+        let changes = self.build_state_changes(spec);
+        for (&address, change) in &changes.accounts {
+            self.ensure_account_overlay(address);
+            let current = change.current.clone().map(Account::from_info);
+            if let Some(account) = self.accounts.get_mut(&address) {
+                account.original = current.clone();
+                account.current = current;
+            }
+        }
+        for (&address, change) in &changes.storage {
+            if change.wipe {
+                self.storage.remove(&address);
+            }
+            if !change.slots.is_empty() {
+                let storage = self.storage.entry(address).or_default();
+                for (&key, slot_change) in &change.slots {
+                    storage.slots.insert(key, StorageValue::new(slot_change.current));
                 }
             }
         }
+        for storage in self.storage.values_mut() {
+            for slot in storage.slots.values_mut() {
+                slot.original = slot.current;
+            }
+            storage.wiped = false;
+        }
+        self.clear_transaction_state();
     }
 }
 
@@ -635,7 +997,7 @@ impl CacheDB {
     /// Inserts persistent storage.
     #[inline]
     pub fn insert_account_storage(&mut self, address: Address, key: Word, value: Word) {
-        self.accounts.entry(address).or_default().has_storage = true;
+        self.accounts.entry(address).or_default();
         self.storage.insert((address, key), value);
     }
 
@@ -690,6 +1052,7 @@ mod tests {
     fn storage_change_rolls_back_to_checkpoint() {
         let address = Address::from([0x11; 20]);
         let mut database = CacheDB::default();
+        database.insert_account_info(address, AccountInfo::default());
         database.insert_account_storage(address, Word::from(1), Word::from(10));
         let mut state = State::new(database);
 
@@ -724,8 +1087,83 @@ mod tests {
         let checkpoint = state.checkpoint();
         state.mark_destructed(address);
 
-        assert!(state.account_ref(address).unwrap().destructed);
+        assert!(state.is_selfdestructed(address));
         state.rollback(checkpoint);
-        assert!(!state.account_ref(address).unwrap().destructed);
+        assert!(!state.is_selfdestructed(address));
+    }
+
+    #[test]
+    fn spurious_dragon_deletes_touched_empty_existing_account() {
+        let address = Address::from([0x44; 20]);
+        let empty = AccountInfo::default();
+        let mut database = CacheDB::default();
+        database.insert_account_info(address, empty.clone());
+        let mut state = State::new(database);
+
+        state.touch(address);
+        let changes = state.build_state_changes(crate::SpecId::SPURIOUS_DRAGON);
+
+        let change = changes.accounts.get(&address).expect("touched empty account is deleted");
+        assert_eq!(change.original, Some(empty));
+        assert_eq!(change.current, None);
+        assert!(changes.storage.get(&address).is_some_and(|storage| storage.wipe));
+    }
+
+    #[test]
+    fn homestead_preserves_touched_empty_existing_account() {
+        let address = Address::from([0x45; 20]);
+        let mut database = CacheDB::default();
+        database.insert_account_info(address, AccountInfo::default());
+        let mut state = State::new(database);
+
+        state.touch(address);
+        let changes = state.build_state_changes(crate::SpecId::HOMESTEAD);
+
+        assert!(!changes.accounts.contains_key(&address));
+        assert!(!changes.storage.contains_key(&address));
+    }
+
+    #[test]
+    fn homestead_materializes_touched_empty_new_account() {
+        let address = Address::from([0x46; 20]);
+        let mut state = State::new(CacheDB::default());
+
+        state.touch(address);
+        let changes = state.build_state_changes(crate::SpecId::HOMESTEAD);
+
+        let change =
+            changes.accounts.get(&address).expect("pre-spurious empty touch creates account");
+        assert_eq!(change.original, None);
+        let current = change.current.as_ref().expect("created empty account");
+        assert!(current.is_empty());
+    }
+
+    #[test]
+    fn spurious_dragon_ignores_touched_empty_new_account() {
+        let address = Address::from([0x47; 20]);
+        let mut state = State::new(CacheDB::default());
+
+        state.touch(address);
+        let changes = state.build_state_changes(crate::SpecId::SPURIOUS_DRAGON);
+
+        assert!(!changes.accounts.contains_key(&address));
+        assert!(!changes.storage.contains_key(&address));
+    }
+
+    #[test]
+    fn selfdestruct_deletes_account_and_wipes_storage() {
+        let address = Address::from([0x48; 20]);
+        let mut database = CacheDB::default();
+        database.insert_account_info(address, AccountInfo::default().with_balance(Word::from(1)));
+        database.insert_account_storage(address, Word::from(1), Word::from(2));
+        let mut state = State::new(database);
+
+        state.mark_destructed(address);
+        let changes = state.build_state_changes(crate::SpecId::SPURIOUS_DRAGON);
+
+        let change = changes.accounts.get(&address).expect("selfdestruct deletes account");
+        assert!(change.original.is_some());
+        assert_eq!(change.current, None);
+        assert!(changes.storage.get(&address).is_some_and(|storage| storage.wipe));
     }
 }

--- a/crates/evm2/src/lib.rs
+++ b/crates/evm2/src/lib.rs
@@ -12,6 +12,8 @@ extern crate alloc;
 
 use alloy_primitives::{B256, Bytes};
 
+pub use alloy_primitives::KECCAK256_EMPTY as KECCAK_EMPTY;
+
 /// Loaded account information.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
 pub struct AccountLoad {

--- a/crates/evm2/src/tests.rs
+++ b/crates/evm2/src/tests.rs
@@ -40,10 +40,7 @@ fn evm_executes_storage_transaction() {
 
     run_tx(&mut evm, contract, [op::PUSH1, 0x2a, op::PUSH1, 0x01, op::SSTORE, op::STOP]);
 
-    assert_eq!(
-        evm.state().account_ref(contract).unwrap().storage.get(&Word::from(1)).unwrap().current,
-        Word::from(0x2a)
-    );
+    assert_eq!(evm.state().storage[&contract].slots[&Word::from(1)].current, Word::from(0x2a));
 }
 
 #[test]
@@ -78,9 +75,9 @@ fn evm_runs_transactions_against_initial_state() {
     );
     run_tx(&mut evm, contract, [op::PUSH1, 0x07, op::PUSH1, 0x01, op::SSTORE, op::STOP]);
 
-    let account = evm.state().account_ref(contract).unwrap();
-    assert_eq!(account.storage.get(&Word::from(1)).unwrap().current, Word::from(7));
-    assert_eq!(account.storage.get(&Word::from(2)).unwrap().current, Word::from(42));
+    assert!(evm.state().account_ref(contract).is_some());
+    assert_eq!(evm.state().storage[&contract].slots[&Word::from(1)].current, Word::from(7));
+    assert_eq!(evm.state().storage[&contract].slots[&Word::from(2)].current, Word::from(42));
 }
 
 #[test]


### PR DESCRIPTION
rewrites the journal+overlay state to track touched state and generate a complete set of state changes. Handles pre and post spurious dragon correctly, moves log and transient storage tracking into the state overlay.