### PR TITLE
fix(interpreter): propagate static execution flag

### DIFF
--- a/crates/evm2/src/ethereum.rs
+++ b/crates/evm2/src/ethereum.rs
@@ -163,7 +163,7 @@ where
         }
     };
 
-    let mut result = req.host.execute_message(tx_env, bytecode, message);
+    let mut result = req.host.execute_message(tx_env, bytecode, message, false);
     if !result.stop.is_success() {
         req.host.state.rollback(execution_checkpoint);
         req.host.logs.truncate(log_checkpoint);

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -189,6 +189,7 @@ impl<C: EvmConfig<Host = Self>> Host for Evm<C> {
         tx_env: TxEnv,
         bytecode: Bytecode,
         message: Message,
+        caller_is_static: bool,
     ) -> MessageResult {
         if message.depth >= Message::CALL_DEPTH_LIMIT {
             return MessageResult {
@@ -242,7 +243,8 @@ impl<C: EvmConfig<Host = Self>> Host for Evm<C> {
             create_message.destination = address;
             create_message.code_address = address;
             create_message.input = Bytes::new();
-            let mut interpreter = Interpreter::new(bytecode, tx_env, create_message);
+            let mut interpreter =
+                Interpreter::new(bytecode, tx_env, create_message, caller_is_static);
             let stop = interpreter.run::<C>(self);
             let mut gas = interpreter.gas();
             if stop.is_success() || stop.is_revert() {
@@ -300,7 +302,7 @@ impl<C: EvmConfig<Host = Self>> Host for Evm<C> {
             return MessageResult { stop, gas_remaining, output, created_address: None };
         }
 
-        let mut interpreter = Interpreter::new(bytecode, tx_env, message);
+        let mut interpreter = Interpreter::new(bytecode, tx_env, message, caller_is_static);
         let stop = interpreter.run::<C>(self);
         let mut gas = interpreter.gas();
         if stop.is_success() || stop.is_revert() {
@@ -443,7 +445,7 @@ mod tests {
             ..Message::default()
         };
 
-        let result = Host::execute_message(&mut evm, TxEnv::default(), bytecode, message);
+        let result = Host::execute_message(&mut evm, TxEnv::default(), bytecode, message, false);
         assert!(result.stop.is_success());
     }
 

--- a/crates/evm2/src/interpreter/instructions/host.rs
+++ b/crates/evm2/src/interpreter/instructions/host.rs
@@ -11,7 +11,7 @@ use evm2_macros::instruction;
 
 #[inline]
 fn require_non_staticcall<C: EvmConfig>(cx: &InstructionCx<'_, '_, C>) -> Result {
-    if cx.state.message().is_static() {
+    if cx.state.is_static() {
         return Err(InstrStop::StateChangeDuringStaticCall);
     }
     Ok(())

--- a/crates/evm2/src/interpreter/instructions/system.rs
+++ b/crates/evm2/src/interpreter/instructions/system.rs
@@ -14,7 +14,7 @@ use evm2_macros::instruction;
 
 #[inline]
 fn require_non_staticcall<C: EvmConfig>(cx: &InstructionCx<'_, '_, C>) -> Result {
-    if cx.state.message().is_static() {
+    if cx.state.is_static() {
         return Err(InstrStop::StateChangeDuringStaticCall);
     }
     Ok(())
@@ -117,7 +117,7 @@ fn call_inner<C: EvmConfig>(
     let [input_offset, input_len, return_offset, return_len] = stack.popn::<4>()?;
     let to = word_to_address(to);
     let has_transfer = !value.is_zero();
-    if cx.state.message().is_static() && has_transfer {
+    if cx.state.is_static() && kind == MessageKind::Call && has_transfer {
         return Err(InstrStop::CallNotAllowedInsideStatic);
     }
     if cx.state.message().depth.saturating_add(1) >= Message::CALL_DEPTH_LIMIT {
@@ -161,8 +161,10 @@ fn call_inner<C: EvmConfig>(
         code_address,
         salt: B256::ZERO,
     };
+    let caller_is_static = cx.state.is_static();
     let bytecode = crate::bytecode::Bytecode::new_legacy(code);
-    let result = cx.state.host.execute_message(cx.state.tx().clone(), bytecode, message);
+    let result =
+        cx.state.host.execute_message(cx.state.tx().clone(), bytecode, message, caller_is_static);
     cx.gas.erase_cost(result.gas_remaining);
     let copy_len = min(return_memory_range.len(), result.output.len());
     cx.state.memory().set(return_memory_range.start, &result.output[..copy_len]);
@@ -240,7 +242,7 @@ fn create_inner<C: EvmConfig>(
         salt: salt.map(|salt| B256::from(salt.to_be_bytes())).unwrap_or_default(),
     };
     let bytecode = crate::bytecode::Bytecode::new_legacy(input);
-    let result = cx.state.host.execute_message(cx.state.tx().clone(), bytecode, message);
+    let result = cx.state.host.execute_message(cx.state.tx().clone(), bytecode, message, false);
     cx.gas.erase_cost(result.gas_remaining);
     cx.state.set_return_data(result.output);
     let address = result
@@ -319,6 +321,59 @@ mod tests {
         assert_eq!(host.calls[0].kind, MessageKind::Call);
         assert_eq!(host.calls[0].destination, target);
         assert_eq!(host.calls[0].caller, caller);
+    }
+
+    #[test]
+    fn call_propagates_static_flag() {
+        let target = Address::from([0x22; 20]);
+        let mut host = TestHost::default();
+        let mut code = Vec::new();
+        push_all(
+            &mut code,
+            [
+                Word::from(0),
+                Word::from(0),
+                Word::from(0),
+                Word::from(0),
+                Word::ZERO,
+                address_to_word(target),
+                Word::from(1000),
+            ],
+        );
+        code.extend([op::CALL, op::STOP]);
+
+        let interpreter = run(RunConfig::new(code).host(&mut host).staticcall());
+        core::assert_matches!(interpreter.err, InstrStop::Stop);
+        assert_eq!(host.calls.len(), 1);
+        assert_eq!(host.calls[0].kind, MessageKind::Call);
+        assert!(host.call_static_flags[0]);
+    }
+
+    #[test]
+    fn callcode_propagates_static_flag_and_allows_apparent_value() {
+        let code_address = Address::from([0x33; 20]);
+        let mut host = TestHost::default();
+        let mut code = Vec::new();
+        push_all(
+            &mut code,
+            [
+                Word::from(0),
+                Word::from(0),
+                Word::from(0),
+                Word::from(0),
+                Word::from(7),
+                address_to_word(code_address),
+                Word::from(1000),
+            ],
+        );
+        code.extend([op::CALLCODE, op::STOP]);
+
+        let interpreter = run(RunConfig::new(code).host(&mut host).staticcall().gas_limit(20_000));
+        core::assert_matches!(interpreter.err, InstrStop::Stop);
+        assert_eq!(host.calls.len(), 1);
+        assert_eq!(host.calls[0].kind, MessageKind::CallCode);
+        assert_eq!(host.calls[0].value, Word::from(7));
+        assert!(host.call_static_flags[0]);
     }
 
     #[test]
@@ -426,7 +481,7 @@ mod tests {
         core::assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [Word::from(1)]);
         assert_eq!(host.calls[0].kind, MessageKind::StaticCall);
-        assert!(host.calls[0].is_static());
+        assert!(host.call_static_flags[0]);
 
         let interpreter = run(RunConfig::new([
             op::PUSH1,

--- a/crates/evm2/src/interpreter/instructions/table.rs
+++ b/crates/evm2/src/interpreter/instructions/table.rs
@@ -714,6 +714,7 @@ mod tests {
             bytecode,
             TxEnv::default(),
             Message { gas_limit: 10_000, ..Message::default() },
+            false,
         );
         let mut host = TestHost::default();
 

--- a/crates/evm2/src/interpreter/instructions/tests.rs
+++ b/crates/evm2/src/interpreter/instructions/tests.rs
@@ -38,6 +38,7 @@ pub(in crate::interpreter) struct TestHost {
     pub(super) execute_result: MessageResult,
     pub(super) selfdestruct_result: SelfDestructResult,
     pub(super) calls: Vec<Message>,
+    pub(super) call_static_flags: Vec<bool>,
     pub(super) selfdestructs: Vec<(Address, Address, bool)>,
 }
 
@@ -55,6 +56,7 @@ impl Default for TestHost {
             execute_result: MessageResult { stop: InstrStop::Return, ..MessageResult::default() },
             selfdestruct_result: SelfDestructResult::default(),
             calls: Vec::new(),
+            call_static_flags: Vec::new(),
             selfdestructs: Vec::new(),
         }
     }
@@ -115,7 +117,9 @@ impl Host for TestHost {
         _tx_env: TxEnv,
         _bytecode: Bytecode,
         message: Message,
+        caller_is_static: bool,
     ) -> MessageResult {
+        self.call_static_flags.push(caller_is_static || message.kind == MessageKind::StaticCall);
         self.calls.push(message);
         self.execute_result.clone()
     }
@@ -269,7 +273,7 @@ fn run_with_config<C: EvmConfig<Tx = (), Host = TestHost>>(
     let RunConfig { code, host, spec_id: _, tx_env, mut message, gas_limit, return_data } = config;
     let bytecode = Bytecode::new_legacy(Bytes::from(code));
     message.gas_limit = gas_limit;
-    let mut inner = Interpreter::new(bytecode, tx_env, message);
+    let mut inner = Interpreter::new(bytecode, tx_env, message, false);
     inner.return_data = return_data;
     let mut default_host = TestHost::default();
     let host = host.unwrap_or(&mut default_host);

--- a/crates/evm2/src/interpreter/message.rs
+++ b/crates/evm2/src/interpreter/message.rs
@@ -46,12 +46,6 @@ pub struct Message {
 impl Message {
     /// EVM call depth limit.
     pub const CALL_DEPTH_LIMIT: u16 = 1024;
-
-    /// Returns whether this message forbids state-changing operations.
-    #[inline]
-    pub const fn is_static(&self) -> bool {
-        matches!(self.kind, MessageKind::StaticCall)
-    }
 }
 
 impl Default for Message {

--- a/crates/evm2/src/interpreter/mod.rs
+++ b/crates/evm2/src/interpreter/mod.rs
@@ -301,6 +301,7 @@ mod tests {
             bytecode,
             crate::env::TxEnv::default(),
             Message { gas_limit: 10_000, ..Message::default() },
+            false,
         );
         let mut host = TestHost::default();
         interpreter.run::<Config>(&mut host);
@@ -318,6 +319,7 @@ mod tests {
                     bytecode,
                     crate::env::TxEnv::default(),
                     Message { gas_limit: 10_000, ..Message::default() },
+                    false,
                 );
                 let mut host = TestHost::default();
                 interpreter.run::<Config>(&mut host);

--- a/crates/evm2/src/interpreter/runtime.rs
+++ b/crates/evm2/src/interpreter/runtime.rs
@@ -1,5 +1,5 @@
 use super::{
-    BytecodeRef, Gas, InstrStop, Memory, Message, Pc, Result, Stack, State, Word,
+    BytecodeRef, Gas, InstrStop, Memory, Message, MessageKind, Pc, Result, Stack, State, Word,
     table::InstructionTables,
 };
 use crate::{EvmConfig, bytecode::Bytecode, env::TxEnv};
@@ -24,14 +24,21 @@ pub struct Interpreter {
     pub(crate) output: *const [u8],
     tx_env: TxEnv,
     pub(crate) message: Message,
+    pub(crate) is_static: bool,
     pub(crate) return_data: Bytes,
 }
 
 impl Interpreter {
     /// Creates an interpreter from analyzed bytecode, a transaction-global environment, and a
     /// frame-local message.
-    pub fn new(bytecode: Bytecode, tx_env: TxEnv, message: Message) -> Self {
+    pub fn new(
+        bytecode: Bytecode,
+        tx_env: TxEnv,
+        message: Message,
+        caller_is_static: bool,
+    ) -> Self {
         let gas_limit = message.gas_limit;
+        let is_static = caller_is_static || matches!(message.kind, MessageKind::StaticCall);
         Self {
             pc: bytecode.original_byte_slice().as_ptr(),
             bytecode,
@@ -44,6 +51,7 @@ impl Interpreter {
             output: &[],
             tx_env,
             message,
+            is_static,
             return_data: Bytes::new(),
         }
     }
@@ -61,6 +69,11 @@ impl Interpreter {
     #[inline]
     pub(crate) const fn message(&self) -> &Message {
         &self.message
+    }
+
+    #[inline]
+    pub(crate) const fn is_static(&self) -> bool {
+        self.is_static
     }
 
     #[inline]

--- a/crates/evm2/src/interpreter/state.rs
+++ b/crates/evm2/src/interpreter/state.rs
@@ -47,6 +47,12 @@ impl<H: Host + ?Sized> State<'_, H> {
         self.interp().message()
     }
 
+    /// Returns whether the active frame forbids state-changing operations.
+    #[inline]
+    pub(crate) fn is_static(&self) -> bool {
+        self.interp().is_static()
+    }
+
     /// Returns linear memory.
     #[inline]
     pub(crate) fn memory(&mut self) -> &mut Memory {
@@ -78,6 +84,7 @@ impl<H: Host + ?Sized> fmt::Debug for State<'_, H> {
             .field("bytecode", &self.bytecode)
             .field("tx", &self.tx())
             .field("message", &self.message())
+            .field("is_static", &self.is_static())
             .field("memory", &self.interp().memory)
             .field("return_data", &self.return_data())
             .field("spec", &self.spec)
@@ -144,6 +151,7 @@ pub trait Host {
         tx_env: TxEnv,
         bytecode: Bytecode,
         message: Message,
+        caller_is_static: bool,
     ) -> MessageResult;
 
     /// Registers the current contract for self-destruction.

--- a/crates/evm2/src/lib.rs
+++ b/crates/evm2/src/lib.rs
@@ -77,6 +77,11 @@ pub fn _get_asm() -> impl Sized {
         Default::default(),
         Default::default(),
     );
-    crate::interpreter::Interpreter::new(Default::default(), Default::default(), Default::default())
-        .run::<EvmVersion<()>>(&mut evm)
+    crate::interpreter::Interpreter::new(
+        Default::default(),
+        Default::default(),
+        Default::default(),
+        false,
+    )
+    .run::<EvmVersion<()>>(&mut evm)
 }

--- a/crates/evm2/src/tests.rs
+++ b/crates/evm2/src/tests.rs
@@ -22,6 +22,7 @@ fn run_tx(evm: &mut TestEvm, destination: Address, code: impl Into<Vec<u8>>) {
         TxEnv::default(),
         Bytecode::new_legacy(Bytes::from(code.into())),
         message,
+        false,
     );
     assert!(result.stop.is_success());
 }
@@ -96,6 +97,7 @@ fn evm_reports_invalid_transaction_execution() {
         TxEnv::default(),
         Bytecode::new_legacy(Bytes::from_static(&[op::PUSH1, 0x01, op::SSTORE])),
         message,
+        false,
     );
 
     assert_eq!(result.stop, InstrStop::StackUnderflow);


### PR DESCRIPTION
- Tracks inherited static context on interpreter frames.
- Propagates static execution through nested CALL/CALLCODE/DELEGATECALL.

Instructions should use `State::is_static` or `Interpreter::is_static` and not rely on the message kind for staticness.