### PR TITLE
refactor: rename stop halt helpers

### DIFF
--- a/crates/evm2/src/ethereum.rs
+++ b/crates/evm2/src/ethereum.rs
@@ -163,7 +163,7 @@ fn handle_legacy<T: EvmTypes<Host = Evm<T>>>(
     let mut result = req.host.execute_message(tx_env, bytecode, message, false);
     if !result.stop.is_success() {
         req.host.state.rollback(execution_checkpoint);
-        if result.stop.is_error() {
+        if result.stop.is_halt() {
             result.gas_remaining = 0;
         }
     }

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -330,7 +330,7 @@ impl<T: EvmTypes<Host = Self>> Host for Evm<T> {
 
                 if let Some(stop) = stop {
                     self.state.rollback(checkpoint);
-                    gas_remaining = if stop.is_error() { 0 } else { gas.remaining() };
+                    gas_remaining = if stop.is_halt() { 0 } else { gas.remaining() };
                     return MessageResult { stop, gas_remaining, output, created_address: None };
                 }
 
@@ -339,7 +339,7 @@ impl<T: EvmTypes<Host = Self>> Host for Evm<T> {
                 self.state.set_code(address, Bytecode::new_legacy(output.clone()));
             } else {
                 self.state.rollback(checkpoint);
-                if stop.is_error() {
+                if stop.is_halt() {
                     gas_remaining = 0;
                 }
             }
@@ -370,7 +370,7 @@ impl<T: EvmTypes<Host = Self>> Host for Evm<T> {
                 }
                 Ok(_) => (InstrStop::PrecompileOOG, 0, Bytes::new()),
                 Err(stop) => {
-                    let gas_remaining = if stop.is_error() { 0 } else { message.gas_limit };
+                    let gas_remaining = if stop.is_halt() { 0 } else { message.gas_limit };
                     (stop, gas_remaining, Bytes::new())
                 }
             };
@@ -392,7 +392,7 @@ impl<T: EvmTypes<Host = Self>> Host for Evm<T> {
 
         if !stop.is_success() {
             self.state.rollback(checkpoint);
-            if stop.is_error() {
+            if stop.is_halt() {
                 gas_remaining = 0;
             }
         }

--- a/crates/evm2/src/interpreter/mod.rs
+++ b/crates/evm2/src/interpreter/mod.rs
@@ -45,8 +45,6 @@ pub enum InstrStop {
     Return,
     /// Self-destruct the current contract.
     SelfDestruct,
-    /// Temporarily suspended, for CALL/CREATE.
-    Suspend,
 
     // Revert Codes
     /// Revert the transaction.
@@ -62,7 +60,7 @@ pub enum InstrStop {
     /// `ExtDelegateCall` calling a non EOF contract.
     InvalidExtDelegateCallTarget,
 
-    // Error Codes
+    // Halt Codes
     /// Out of gas error.
     OutOfGas = 0x20,
     /// Out of gas error encountered during memory expansion.
@@ -135,21 +133,9 @@ impl InstrStop {
         )
     }
 
-    /// Returns whether execution reverted without an exceptional halt.
+    /// Returns whether execution halted exceptionally.
     #[inline]
-    pub const fn is_reverted(self) -> bool {
-        self.is_revert()
-    }
-
-    /// Returns whether execution completed successfully or reverted.
-    #[inline]
-    pub const fn is_ok_or_revert(self) -> bool {
-        self.is_success() || self.is_revert()
-    }
-
-    /// Returns whether execution halted with an exceptional error.
-    #[inline]
-    pub const fn is_error(self) -> bool {
-        !self.is_ok_or_revert() && !matches!(self, Self::Suspend)
+    pub const fn is_halt(self) -> bool {
+        !self.is_success() && !self.is_revert()
     }
 }


### PR DESCRIPTION
This updates the `InstrStop` category helpers to use success, revert, and halt terminology consistently.

It removes the unused suspend stop variant, drops the old reverted/ok-or-revert aliases, and updates gas handling call sites to use `is_halt()` for exceptional halts.
