### PR TITLE
refactor: clean up state and cache db

### DIFF
--- a/crates/evm2-statetest/src/execute.rs
+++ b/crates/evm2-statetest/src/execute.rs
@@ -257,7 +257,7 @@ fn logs_hash(logs: &[Log]) -> B256 {
 
 fn state_root(pre: &InMemoryDB, changes: &StateChanges) -> B256 {
     let post = apply_state_changes(pre, changes);
-    let accounts = post.accounts.iter().map(|(&address, info)| {
+    let accounts = post.cache.accounts.iter().map(|(&address, info)| {
         let storage = storage_for_root(&post, address);
         (
             address,
@@ -276,17 +276,17 @@ fn state_root(pre: &InMemoryDB, changes: &StateChanges) -> B256 {
 fn apply_state_changes(pre: &InMemoryDB, changes: &StateChanges) -> InMemoryDB {
     let mut post = pre.clone();
     for (&code_hash, code) in &changes.code {
-        post.contracts.insert(code_hash, code.clone());
+        post.cache.contracts.insert(code_hash, code.clone());
     }
     for (&address, storage) in &changes.storage {
         if storage.wipe {
-            post.storage.retain(|(storage_address, _), _| *storage_address != address);
+            post.cache.storage.retain(|(storage_address, _), _| *storage_address != address);
         }
         for (&key, change) in &storage.slots {
             if change.current.is_zero() {
-                post.storage.remove(&(address, key));
+                post.cache.storage.remove(&(address, key));
             } else {
-                post.storage.insert((address, key), change.current);
+                post.cache.storage.insert((address, key), change.current);
             }
         }
     }
@@ -294,8 +294,8 @@ fn apply_state_changes(pre: &InMemoryDB, changes: &StateChanges) -> InMemoryDB {
         match &change.current {
             Some(info) => post.insert_account_info(address, info.clone()),
             None => {
-                post.accounts.remove(&address);
-                post.storage.retain(|(storage_address, _), _| *storage_address != address);
+                post.cache.accounts.remove(&address);
+                post.cache.storage.retain(|(storage_address, _), _| *storage_address != address);
             }
         }
     }
@@ -304,6 +304,7 @@ fn apply_state_changes(pre: &InMemoryDB, changes: &StateChanges) -> InMemoryDB {
 
 fn storage_for_root(state: &InMemoryDB, address: Address) -> Vec<(B256, U256)> {
     state
+        .cache
         .storage
         .iter()
         .filter_map(|(&(storage_address, key), &value)| {

--- a/crates/evm2/src/bytecode/jump_table.rs
+++ b/crates/evm2/src/bytecode/jump_table.rs
@@ -77,8 +77,12 @@ impl JumpTable {
 
     #[inline]
     pub(crate) fn set(&mut self, pc: usize) {
-        debug_assert!(pc < self.bit_len);
-        self.table.to_mut()[pc >> 3] |= 1 << (pc & 7);
+        if pc >= self.bit_len {
+            cold_path();
+            return;
+        }
+        let (byte, bit) = (pc / 8, pc % 8);
+        self.table.to_mut()[byte] |= 1 << bit;
     }
 
     /// Constructs a jump map from raw bytes and length.

--- a/crates/evm2/src/bytecode/mod.rs
+++ b/crates/evm2/src/bytecode/mod.rs
@@ -1,6 +1,6 @@
 //! EVM bytecode.
 
-use crate::once_lock::OnceLock;
+use crate::{interpreter::op, once_lock::OnceLock};
 use alloc::sync::Arc;
 use alloy_primitives::{Address, B256, Bytes, KECCAK256_EMPTY, keccak256};
 use analysis::analyze_legacy;
@@ -138,7 +138,7 @@ impl Bytecode {
         DEFAULT.get_or_init(|| {
             Self(Arc::new(BytecodeInner {
                 kind: BytecodeKind::Legacy,
-                bytecode: Bytes::from_static(&[crate::interpreter::op::STOP]),
+                bytecode: Bytes::from_static(&[op::STOP]),
                 original_len: 0,
                 jump_table: JumpTable::default(),
                 hash: {
@@ -305,9 +305,6 @@ impl Bytecode {
     /// Calculates or returns cached hash of the bytecode.
     #[inline]
     pub fn hash_slow(&self) -> B256 {
-        if let Some(hash) = self.0.hash.get() {
-            return *hash;
-        }
         *self.0.hash.get_or_init(|| keccak256(self.original_byte_slice()))
     }
 

--- a/crates/evm2/src/ethereum.rs
+++ b/crates/evm2/src/ethereum.rs
@@ -108,16 +108,14 @@ fn handle_legacy<T: EvmTypes<Host = Evm<T>>>(
         return Err(HandlerError::InsufficientFunds);
     }
 
-    let _ = req.host.state.warm_account(caller);
+    req.host.state.warm_account(caller);
     if spec_id.enables(SpecId::SHANGHAI) {
-        let _ = req.host.state.warm_account(req.host.block.beneficiary);
+        req.host.state.warm_account(req.host.block.beneficiary);
     }
     if let TxKind::Call(to) = tx.to {
-        let _ = req.host.state.warm_account(to);
+        req.host.state.warm_account(to);
     }
-    for address in req.host.precompiles().warm_addresses() {
-        let _ = req.host.state.warm_account(address);
-    }
+    req.host.state.warm_accounts(req.host.precompiles().warm_addresses());
 
     req.host.state.add_balance(caller, Word::ZERO.wrapping_sub(max_gas_cost));
     req.host.state.increment_nonce(caller);

--- a/crates/evm2/src/ethereum.rs
+++ b/crates/evm2/src/ethereum.rs
@@ -107,12 +107,12 @@ fn handle_legacy<T: EvmTypes<Host = Evm<T>>>(
         return Err(HandlerError::InsufficientFunds);
     }
 
-    req.host.state.warm_account(caller);
+    let _ = req.host.state.warm_account(caller);
     if spec_id.enables(SpecId::SHANGHAI) {
-        req.host.state.warm_account(req.host.block.beneficiary);
+        let _ = req.host.state.warm_account(req.host.block.beneficiary);
     }
     if let TxKind::Call(to) = tx.to {
-        req.host.state.warm_account(to);
+        let _ = req.host.state.warm_account(to);
     }
 
     req.host.state.add_balance(caller, Word::ZERO.wrapping_sub(max_gas_cost));

--- a/crates/evm2/src/evm/config.rs
+++ b/crates/evm2/src/evm/config.rs
@@ -3,7 +3,10 @@
 use crate::{
     SpecId, VersionTables,
     evm::{InMemoryDB, precompile::PrecompileProvider},
-    interpreter::instructions::table::{InstructionTable, InstructionTables},
+    interpreter::{
+        Host,
+        instructions::table::{InstructionTable, InstructionTables},
+    },
     spec_to_generic,
     version::Version,
 };
@@ -26,7 +29,7 @@ pub trait EvmTypes: Sized + 'static {
     type Tx;
 
     /// Host type used by this EVM.
-    type Host: crate::interpreter::Host + ?Sized;
+    type Host: Host + ?Sized;
 
     /// Database type used by this EVM.
     type Database: crate::evm::Database;

--- a/crates/evm2/src/evm/db.rs
+++ b/crates/evm2/src/evm/db.rs
@@ -15,36 +15,36 @@ pub struct EmptyDB(());
 /// Backing database view used to initialize mutable [`super::State`].
 pub trait Database {
     /// Loads account information.
-    fn get_account(&self, address: Address) -> Option<AccountInfo>;
+    fn get_account(&mut self, address: Address) -> Option<AccountInfo>;
 
     /// Loads account code.
-    fn get_account_code(&self, address: Address) -> Bytecode;
+    fn get_account_code(&mut self, address: Address) -> Bytecode;
 
     /// Loads a persistent storage slot.
-    fn get_storage(&self, address: Address, key: Word) -> Word;
+    fn get_storage(&mut self, address: Address, key: Word) -> Word;
 
     /// Loads a historical block hash.
-    fn get_block_hash(&self, number: Word) -> Option<B256>;
+    fn get_block_hash(&mut self, number: Word) -> Option<B256>;
 }
 
 impl Database for EmptyDB {
     #[inline]
-    fn get_account(&self, _address: Address) -> Option<AccountInfo> {
+    fn get_account(&mut self, _address: Address) -> Option<AccountInfo> {
         None
     }
 
     #[inline]
-    fn get_account_code(&self, _address: Address) -> Bytecode {
+    fn get_account_code(&mut self, _address: Address) -> Bytecode {
         Bytecode::default()
     }
 
     #[inline]
-    fn get_storage(&self, _address: Address, _key: Word) -> Word {
+    fn get_storage(&mut self, _address: Address, _key: Word) -> Word {
         Word::ZERO
     }
 
     #[inline]
-    fn get_block_hash(&self, number: Word) -> Option<B256> {
+    fn get_block_hash(&mut self, number: Word) -> Option<B256> {
         Some(keccak256(number.to_string().as_bytes()))
     }
 }

--- a/crates/evm2/src/evm/db.rs
+++ b/crates/evm2/src/evm/db.rs
@@ -1,9 +1,16 @@
-//! In-memory database helpers for the EVM state overlay.
+//! Database helpers for the EVM state overlay.
 
 use super::state::AccountInfo;
-use crate::{KECCAK_EMPTY, bytecode::Bytecode, interpreter::Word};
+use crate::{bytecode::Bytecode, interpreter::Word};
 use alloc::string::ToString;
-use alloy_primitives::{Address, B256, keccak256, map};
+use alloy_primitives::{Address, B256, keccak256};
+
+mod cache;
+pub use cache::{Cache, CacheDB, InMemoryDB};
+
+/// Empty backing database.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct EmptyDB(());
 
 /// Backing database view used to initialize mutable [`super::State`].
 pub trait Database {
@@ -17,115 +24,27 @@ pub trait Database {
     fn get_storage(&self, address: Address, key: Word) -> Word;
 
     /// Loads a historical block hash.
-    fn get_block_hash(&self, number: u64) -> Option<B256>;
+    fn get_block_hash(&self, number: Word) -> Option<B256>;
 }
 
-/// A simple in-memory database view.
-#[derive(Clone, Debug, PartialEq, Eq)]
-#[non_exhaustive]
-pub struct CacheDB {
-    /// Accounts keyed by address.
-    pub accounts: map::HashMap<Address, AccountInfo>,
-    /// Contracts keyed by code hash.
-    pub contracts: map::HashMap<B256, Bytecode>,
-    /// Persistent storage keyed by account and slot.
-    pub storage: map::HashMap<(Address, Word), Word>,
-    /// Cached block hashes keyed by block number.
-    pub block_hashes: map::HashMap<u64, B256>,
-}
-
-impl Default for CacheDB {
+impl Database for EmptyDB {
     #[inline]
-    fn default() -> Self {
-        let mut contracts = map::HashMap::default();
-        contracts.insert(KECCAK_EMPTY, Bytecode::default());
-        contracts.insert(B256::ZERO, Bytecode::default());
+    fn get_account(&self, _address: Address) -> Option<AccountInfo> {
+        None
+    }
 
-        Self {
-            accounts: map::HashMap::default(),
-            contracts,
-            storage: map::HashMap::default(),
-            block_hashes: map::HashMap::default(),
-        }
+    #[inline]
+    fn get_account_code(&self, _address: Address) -> Bytecode {
+        Bytecode::default()
+    }
+
+    #[inline]
+    fn get_storage(&self, _address: Address, _key: Word) -> Word {
+        Word::ZERO
+    }
+
+    #[inline]
+    fn get_block_hash(&self, number: Word) -> Option<B256> {
+        Some(keccak256(number.to_string().as_bytes()))
     }
 }
-
-impl CacheDB {
-    /// Inserts account code into the contract cache.
-    #[inline]
-    pub fn insert_contract(&mut self, info: &mut AccountInfo) {
-        if let Some(code) = &info.code
-            && !code.is_empty()
-        {
-            if info.code_hash == KECCAK_EMPTY {
-                info.code_hash = code.hash_slow();
-            }
-            self.contracts.entry(info.code_hash).or_insert_with(|| code.clone());
-        }
-        if info.code_hash.is_zero() {
-            info.code_hash = KECCAK_EMPTY;
-        }
-    }
-
-    /// Inserts account info.
-    #[inline]
-    pub fn insert_account_info(&mut self, address: Address, mut info: AccountInfo) {
-        self.insert_contract(&mut info);
-        self.accounts.insert(address, info);
-    }
-
-    /// Returns account info if the account exists.
-    #[inline]
-    pub fn account_info(&self, address: Address) -> Option<&AccountInfo> {
-        self.accounts.get(&address)
-    }
-
-    /// Inserts persistent storage.
-    #[inline]
-    pub fn insert_account_storage(&mut self, address: Address, key: Word, value: Word) {
-        self.accounts.entry(address).or_default();
-        self.storage.insert((address, key), value);
-    }
-
-    /// Sets a historical block hash.
-    #[inline]
-    pub fn insert_block_hash(&mut self, number: u64, hash: B256) {
-        self.block_hashes.insert(number, hash);
-    }
-}
-
-impl Database for CacheDB {
-    #[inline]
-    fn get_account(&self, address: Address) -> Option<AccountInfo> {
-        self.accounts.get(&address).cloned()
-    }
-
-    #[inline]
-    fn get_account_code(&self, address: Address) -> Bytecode {
-        self.accounts
-            .get(&address)
-            .and_then(|info| info.code.clone())
-            .or_else(|| {
-                self.accounts
-                    .get(&address)
-                    .and_then(|info| self.contracts.get(&info.code_hash).cloned())
-            })
-            .unwrap_or_default()
-    }
-
-    #[inline]
-    fn get_storage(&self, address: Address, key: Word) -> Word {
-        self.storage.get(&(address, key)).copied().unwrap_or_default()
-    }
-
-    #[inline]
-    fn get_block_hash(&self, number: u64) -> Option<B256> {
-        self.block_hashes
-            .get(&number)
-            .copied()
-            .or_else(|| Some(keccak256(number.to_string().as_bytes())))
-    }
-}
-
-/// A database implementation that stores initial state in memory.
-pub type InMemoryDB = CacheDB;

--- a/crates/evm2/src/evm/db.rs
+++ b/crates/evm2/src/evm/db.rs
@@ -8,10 +8,6 @@ use alloy_primitives::{Address, B256, keccak256};
 mod cache;
 pub use cache::{Cache, CacheDB, InMemoryDB};
 
-/// Empty backing database.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub struct EmptyDB(());
-
 /// Backing database view used to initialize mutable [`super::State`].
 pub trait Database {
     /// Loads account information.
@@ -26,6 +22,10 @@ pub trait Database {
     /// Loads a historical block hash.
     fn get_block_hash(&mut self, number: Word) -> Option<B256>;
 }
+
+/// Empty backing database.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct EmptyDB(());
 
 impl Database for EmptyDB {
     #[inline]

--- a/crates/evm2/src/evm/db/cache.rs
+++ b/crates/evm2/src/evm/db/cache.rs
@@ -1,0 +1,149 @@
+//! In-memory cache database.
+
+use super::{Database, EmptyDB};
+use crate::{KECCAK_EMPTY, bytecode::Bytecode, evm::state::AccountInfo, interpreter::Word};
+use alloy_primitives::{
+    Address, B256,
+    map::{AddressMap, B256Map, HashMap, U256Map},
+};
+
+/// A database implementation that stores initial state in memory.
+pub type InMemoryDB = CacheDB<EmptyDB>;
+
+/// Cache used by [`CacheDB`].
+///
+/// Accounts and code are stored separately: accounts carry the code hash, and
+/// bytecode is keyed by that hash in [`Self::contracts`].
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct Cache {
+    /// Accounts keyed by address.
+    pub accounts: AddressMap<AccountInfo>,
+    /// Contracts keyed by code hash.
+    pub contracts: B256Map<Bytecode>,
+    /// Persistent storage keyed by account and slot.
+    pub storage: HashMap<(Address, Word), Word>,
+    /// Cached block hashes keyed by block number.
+    pub block_hashes: U256Map<B256>,
+}
+
+impl Default for Cache {
+    #[inline]
+    fn default() -> Self {
+        let mut contracts = B256Map::default();
+        contracts.insert(KECCAK_EMPTY, Bytecode::default());
+        contracts.insert(B256::ZERO, Bytecode::default());
+        Self {
+            accounts: AddressMap::default(),
+            contracts,
+            storage: HashMap::default(),
+            block_hashes: U256Map::default(),
+        }
+    }
+}
+
+/// A cache database over another backing database.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct CacheDB<ExtDB = EmptyDB> {
+    /// The cache that stores all local state.
+    pub cache: Cache,
+    /// Wrapped backing database.
+    pub db: ExtDB,
+}
+
+impl Default for CacheDB<EmptyDB> {
+    #[inline]
+    fn default() -> Self {
+        Self::new(EmptyDB::default())
+    }
+}
+
+impl<ExtDB> CacheDB<ExtDB> {
+    /// Creates a new cache over a backing database.
+    #[inline]
+    pub fn new(db: ExtDB) -> Self {
+        Self { cache: Cache::default(), db }
+    }
+
+    /// Inserts account code into the contract cache.
+    #[inline]
+    pub fn insert_contract(&mut self, info: &AccountInfo) {
+        if let Some(code) = &info.code
+            && !code.is_empty()
+        {
+            self.cache.contracts.entry(info.code_hash).or_insert_with(|| code.clone());
+        }
+    }
+
+    /// Inserts account info.
+    #[inline]
+    pub fn insert_account_info(&mut self, address: Address, mut info: AccountInfo) {
+        if let Some(code) = &info.code
+            && !code.is_empty()
+            && info.code_hash == KECCAK_EMPTY
+        {
+            info.code_hash = code.hash_slow();
+        }
+        if info.code_hash.is_zero() {
+            info.code_hash = KECCAK_EMPTY;
+        }
+        self.insert_contract(&info);
+        self.cache.accounts.insert(address, info);
+    }
+
+    /// Returns cached account info if the account exists in the cache.
+    #[inline]
+    pub fn account_info(&self, address: Address) -> Option<&AccountInfo> {
+        self.cache.accounts.get(&address)
+    }
+
+    /// Inserts persistent storage.
+    #[inline]
+    pub fn insert_account_storage(&mut self, address: Address, key: Word, value: Word) {
+        self.cache.accounts.entry(address).or_default();
+        self.cache.storage.insert((address, key), value);
+    }
+
+    /// Sets a historical block hash.
+    #[inline]
+    pub fn insert_block_hash(&mut self, number: Word, hash: B256) {
+        self.cache.block_hashes.insert(number, hash);
+    }
+}
+
+impl<ExtDB: Database> Database for CacheDB<ExtDB> {
+    #[inline]
+    fn get_account(&self, address: Address) -> Option<AccountInfo> {
+        self.cache.accounts.get(&address).cloned().or_else(|| self.db.get_account(address))
+    }
+
+    #[inline]
+    fn get_account_code(&self, address: Address) -> Bytecode {
+        self.cache
+            .accounts
+            .get(&address)
+            .and_then(|info| info.code.clone())
+            .or_else(|| {
+                self.cache
+                    .accounts
+                    .get(&address)
+                    .and_then(|info| self.cache.contracts.get(&info.code_hash).cloned())
+            })
+            .unwrap_or_else(|| self.db.get_account_code(address))
+    }
+
+    #[inline]
+    fn get_storage(&self, address: Address, key: Word) -> Word {
+        self.cache
+            .storage
+            .get(&(address, key))
+            .copied()
+            .unwrap_or_else(|| self.db.get_storage(address, key))
+    }
+
+    #[inline]
+    fn get_block_hash(&self, number: Word) -> Option<B256> {
+        self.cache.block_hashes.get(&number).copied().or_else(|| self.db.get_block_hash(number))
+    }
+}

--- a/crates/evm2/src/evm/db/cache.rs
+++ b/crates/evm2/src/evm/db/cache.rs
@@ -4,7 +4,7 @@ use super::{Database, EmptyDB};
 use crate::{KECCAK_EMPTY, bytecode::Bytecode, evm::state::AccountInfo, interpreter::Word};
 use alloy_primitives::{
     Address, B256,
-    map::{AddressMap, B256Map, HashMap, U256Map},
+    map::{AddressMap, B256Map, HashMap, U256Map, hash_map::Entry},
 };
 
 /// A database implementation that stores initial state in memory.
@@ -68,27 +68,30 @@ impl<ExtDB> CacheDB<ExtDB> {
 
     /// Inserts account code into the contract cache.
     #[inline]
-    pub fn insert_contract(&mut self, info: &AccountInfo) {
+    pub fn insert_contract(&mut self, info: &mut AccountInfo) {
+        Self::insert_contract_inner(&mut self.cache.contracts, info);
+    }
+
+    #[inline]
+    fn insert_contract_inner(contracts: &mut B256Map<Bytecode>, info: &mut AccountInfo) {
         if let Some(code) = &info.code
             && !code.is_empty()
         {
-            self.cache.contracts.entry(info.code_hash).or_insert_with(|| code.clone());
+            if info.code_hash == KECCAK_EMPTY {
+                info.code_hash = code.hash_slow();
+            }
+            contracts.entry(info.code_hash).or_insert_with(|| code.clone());
+        }
+        if info.code_hash.is_zero() {
+            info.code_hash = KECCAK_EMPTY;
         }
     }
 
     /// Inserts account info.
     #[inline]
     pub fn insert_account_info(&mut self, address: Address, mut info: AccountInfo) {
-        if let Some(code) = &info.code
-            && !code.is_empty()
-            && info.code_hash == KECCAK_EMPTY
-        {
-            info.code_hash = code.hash_slow();
-        }
-        if info.code_hash.is_zero() {
-            info.code_hash = KECCAK_EMPTY;
-        }
-        self.insert_contract(&info);
+        self.insert_contract(&mut info);
+        info.code = None;
         self.cache.accounts.insert(address, info);
     }
 
@@ -114,36 +117,123 @@ impl<ExtDB> CacheDB<ExtDB> {
 
 impl<ExtDB: Database> Database for CacheDB<ExtDB> {
     #[inline]
-    fn get_account(&self, address: Address) -> Option<AccountInfo> {
-        self.cache.accounts.get(&address).cloned().or_else(|| self.db.get_account(address))
+    fn get_account(&mut self, address: Address) -> Option<AccountInfo> {
+        let Cache { accounts, contracts, .. } = &mut self.cache;
+        match accounts.entry(address) {
+            Entry::Occupied(entry) => Some(entry.get().clone()),
+            Entry::Vacant(entry) => {
+                let mut info = self.db.get_account(address)?;
+                Self::insert_contract_inner(contracts, &mut info);
+                info.code = None;
+                Some(entry.insert(info).clone())
+            }
+        }
     }
 
     #[inline]
-    fn get_account_code(&self, address: Address) -> Bytecode {
-        self.cache
-            .accounts
-            .get(&address)
-            .and_then(|info| info.code.clone())
-            .or_else(|| {
-                self.cache
-                    .accounts
-                    .get(&address)
-                    .and_then(|info| self.cache.contracts.get(&info.code_hash).cloned())
-            })
-            .unwrap_or_else(|| self.db.get_account_code(address))
+    fn get_account_code(&mut self, address: Address) -> Bytecode {
+        let code_hash = self.get_account(address).map(|info| info.code_hash);
+        if let Some(code_hash) = code_hash
+            && let Some(code) = self.cache.contracts.get(&code_hash)
+        {
+            return code.clone();
+        }
+
+        let code = self.db.get_account_code(address);
+        if !code.is_empty() {
+            let code_hash = code_hash.unwrap_or_else(|| code.hash_slow());
+            self.cache.contracts.entry(code_hash).or_insert_with(|| code.clone());
+        }
+        code
     }
 
     #[inline]
-    fn get_storage(&self, address: Address, key: Word) -> Word {
-        self.cache
-            .storage
-            .get(&(address, key))
-            .copied()
-            .unwrap_or_else(|| self.db.get_storage(address, key))
+    fn get_storage(&mut self, address: Address, key: Word) -> Word {
+        match self.cache.storage.entry((address, key)) {
+            Entry::Occupied(entry) => *entry.get(),
+            Entry::Vacant(entry) => {
+                let value = self.db.get_storage(address, key);
+                *entry.insert(value)
+            }
+        }
     }
 
     #[inline]
-    fn get_block_hash(&self, number: Word) -> Option<B256> {
-        self.cache.block_hashes.get(&number).copied().or_else(|| self.db.get_block_hash(number))
+    fn get_block_hash(&mut self, number: Word) -> Option<B256> {
+        match self.cache.block_hashes.entry(number) {
+            Entry::Occupied(entry) => Some(*entry.get()),
+            Entry::Vacant(entry) => {
+                let hash = self.db.get_block_hash(number)?;
+                Some(*entry.insert(hash))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::interpreter::op;
+    use alloy_primitives::Bytes;
+
+    #[derive(Debug, Default)]
+    struct CountingDB {
+        account: Option<AccountInfo>,
+        storage: Word,
+        block_hash: Option<B256>,
+        account_loads: usize,
+        code_loads: usize,
+        storage_loads: usize,
+        block_hash_loads: usize,
+    }
+
+    impl Database for CountingDB {
+        fn get_account(&mut self, _address: Address) -> Option<AccountInfo> {
+            self.account_loads += 1;
+            self.account.clone()
+        }
+
+        fn get_account_code(&mut self, _address: Address) -> Bytecode {
+            self.code_loads += 1;
+            self.account.as_ref().and_then(|info| info.code.clone()).unwrap_or_default()
+        }
+
+        fn get_storage(&mut self, _address: Address, _key: Word) -> Word {
+            self.storage_loads += 1;
+            self.storage
+        }
+
+        fn get_block_hash(&mut self, _number: Word) -> Option<B256> {
+            self.block_hash_loads += 1;
+            self.block_hash
+        }
+    }
+
+    #[test]
+    fn cache_db_caches_wrapped_db_reads() {
+        let address = Address::with_last_byte(1);
+        let key = Word::from(2);
+        let code = Bytecode::new_legacy(Bytes::from_static(&[op::STOP]));
+        let block_hash = B256::with_last_byte(3);
+        let db = CountingDB {
+            account: Some(AccountInfo::default().with_code(code.clone())),
+            storage: Word::from(4),
+            block_hash: Some(block_hash),
+            ..CountingDB::default()
+        };
+        let mut cache = CacheDB::new(db);
+
+        assert_eq!(cache.get_account_code(address), code);
+        assert_eq!(cache.get_account_code(address), code);
+        assert_eq!(cache.db.account_loads, 1);
+        assert_eq!(cache.db.code_loads, 0);
+
+        assert_eq!(cache.get_storage(address, key), Word::from(4));
+        assert_eq!(cache.get_storage(address, key), Word::from(4));
+        assert_eq!(cache.db.storage_loads, 1);
+
+        assert_eq!(cache.get_block_hash(Word::from(5)), Some(block_hash));
+        assert_eq!(cache.get_block_hash(Word::from(5)), Some(block_hash));
+        assert_eq!(cache.db.block_hash_loads, 1);
     }
 }

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -21,7 +21,7 @@ pub mod registry;
 
 mod db;
 mod state;
-pub use db::{CacheDB, Database, InMemoryDB};
+pub use db::{Cache, CacheDB, Database, EmptyDB, InMemoryDB};
 pub use state::{
     Account, AccountInfo, JournalEntry, State, StateChanges, StorageChangeSet, StorageOverlay,
     Tracked,
@@ -203,7 +203,7 @@ impl<T: EvmTypes<Host = Self>> Host for Evm<T> {
         if skip_cold_load && is_cold {
             return Err(InstrStop::OutOfGas);
         }
-        self.state.warm_account(address);
+        let _ = self.state.warm_account(address);
         let info = self.state.account_info(address).unwrap_or_default();
         Ok(AccountLoad {
             balance: info.balance,
@@ -218,7 +218,7 @@ impl<T: EvmTypes<Host = Self>> Host for Evm<T> {
         })
     }
 
-    fn block_hash(&mut self, number: u64) -> Option<B256> {
+    fn block_hash(&mut self, number: Word) -> Option<B256> {
         self.state.initial().get_block_hash(number)
     }
 
@@ -279,7 +279,7 @@ impl<T: EvmTypes<Host = Self>> Host for Evm<T> {
                 _ => unreachable!("invalid create message kind"),
             };
 
-            self.state.warm_account(address);
+            let _ = self.state.warm_account(address);
 
             if message.depth > 0 {
                 self.state.increment_nonce(message.caller);
@@ -411,7 +411,7 @@ impl<T: EvmTypes<Host = Self>> Host for Evm<T> {
         if skip_cold_load && is_cold {
             return Err(InstrStop::OutOfGas);
         }
-        self.state.warm_account(target);
+        let _ = self.state.warm_account(target);
         let target_exists = self.state.account_info(target).is_some_and(|info| !info.is_empty());
         let previously_destroyed = self.state.is_selfdestructed(contract);
         let balance = self.state.account_info(contract).map_or(Word::ZERO, |info| info.balance);
@@ -419,7 +419,7 @@ impl<T: EvmTypes<Host = Self>> Host for Evm<T> {
             || self.state.is_created_in_transaction(contract);
 
         if contract != target {
-            self.state.transfer(contract, target, balance);
+            let _ = self.state.transfer(contract, target, balance);
         } else if should_destroy && !balance.is_zero() {
             self.state.add_balance(contract, Word::ZERO.wrapping_sub(balance));
         }

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -219,7 +219,7 @@ impl<T: EvmTypes<Host = Self>> Host for Evm<T> {
     }
 
     fn block_hash(&mut self, number: Word) -> Option<B256> {
-        self.state.initial().get_block_hash(number)
+        self.state.initial_mut().get_block_hash(number)
     }
 
     fn sload(&mut self, address: Address, key: Word) -> StorageLoad {

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -241,7 +241,7 @@ impl<T: EvmTypes<Host = Self>> Host for Evm<T> {
         if skip_cold_load && is_cold {
             return Err(InstrStop::OutOfGas);
         }
-        let _ = self.state.warm_account(address);
+        self.state.warm_account(address);
         let info = self.state.account_info(address).unwrap_or_default();
         Ok(AccountLoad {
             balance: info.balance,
@@ -317,7 +317,7 @@ impl<T: EvmTypes<Host = Self>> Host for Evm<T> {
                 _ => unreachable!("invalid create message kind"),
             };
 
-            let _ = self.state.warm_account(address);
+            self.state.warm_account(address);
 
             if message.depth > 0 {
                 self.state.increment_nonce(message.caller);
@@ -454,7 +454,7 @@ impl<T: EvmTypes<Host = Self>> Host for Evm<T> {
         if skip_cold_load && is_cold {
             return Err(InstrStop::OutOfGas);
         }
-        let _ = self.state.warm_account(target);
+        self.state.warm_account(target);
         let target_exists = self.state.account_info(target).is_some_and(|info| !info.is_empty());
         let previously_destroyed = self.state.is_selfdestructed(contract);
         let balance = self.state.account_info(contract).map_or(Word::ZERO, |info| info.balance);

--- a/crates/evm2/src/evm/registry.rs
+++ b/crates/evm2/src/evm/registry.rs
@@ -52,9 +52,9 @@
 //! # Ok::<(), HandlerError>(())
 //! ```
 
-use alloc::{boxed::Box, rc::Rc};
-use alloy_primitives::{Address, U256};
-use core::{array, fmt, marker::PhantomData};
+use alloc::rc::Rc;
+use alloy_primitives::{Address, U256, map::HashMap};
+use core::{fmt, marker::PhantomData};
 use thiserror::Error;
 
 /// Convenience result type used by the registry and handlers.
@@ -186,17 +186,14 @@ where
     }
 }
 
-type HandlerTable<Env, Output, Host> = [Option<Rc<dyn ErasedTxHandler<Env, Output, Host>>>; 256];
-
 /// A type-erased transaction handler registry keyed by transaction type byte.
 pub struct TxRegistry<Env, Output = (), Host = ()> {
-    handlers: Box<HandlerTable<Env, Output, Host>>,
+    handlers: HashMap<u8, Rc<dyn ErasedTxHandler<Env, Output, Host>>>,
 }
 
 impl<Env, Output, Host> fmt::Debug for TxRegistry<Env, Output, Host> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let len = self.handlers.iter().filter(|handler| handler.is_some()).count();
-        f.debug_struct("TxRegistry").field("len", &len).finish_non_exhaustive()
+        f.debug_struct("TxRegistry").field("len", &self.handlers.len()).finish_non_exhaustive()
     }
 }
 
@@ -209,7 +206,7 @@ impl<Env, Output, Host> Default for TxRegistry<Env, Output, Host> {
 impl<Env, Output, Host> TxRegistry<Env, Output, Host> {
     /// Creates an empty registry.
     pub fn new() -> Self {
-        Self { handlers: Box::new(array::from_fn(|_| None)) }
+        Self { handlers: HashMap::default() }
     }
 
     /// Registers a typed handler for a transaction type byte.
@@ -222,8 +219,7 @@ impl<Env, Output, Host> TxRegistry<Env, Output, Host> {
         H: TxHandler<Tx, Output, Host> + 'static,
         F: for<'a> Fn(&'a Env) -> Option<&'a Tx> + 'static,
     {
-        self.handlers[type_id as usize] =
-            Some(Rc::new(HandlerAdapter::new(type_id, extract, handler)));
+        self.handlers.insert(type_id, Rc::new(HandlerAdapter::new(type_id, extract, handler)));
         self
     }
 
@@ -241,14 +237,12 @@ impl<Env, Output, Host> TxRegistry<Env, Output, Host> {
 
     /// Returns true if a handler is registered for `type_id`.
     pub fn contains(&self, type_id: u8) -> bool {
-        self.handlers[type_id as usize].is_some()
+        self.handlers.contains_key(&type_id)
     }
 
     /// Returns the erased handler registered for `type_id`, if any.
     pub fn get_by_type(&self, type_id: u8) -> Option<AnyTxHandler<Env, Output, Host>> {
-        self.handlers[type_id as usize]
-            .as_ref()
-            .map(|inner| AnyTxHandler { inner: Rc::clone(inner) })
+        self.handlers.get(&type_id).map(|inner| AnyTxHandler { inner: Rc::clone(inner) })
     }
 
     /// Returns the erased handler registered for `type_id`.

--- a/crates/evm2/src/evm/state.rs
+++ b/crates/evm2/src/evm/state.rs
@@ -468,7 +468,7 @@ impl<D: Database> State<D> {
 
     #[must_use]
     fn ensure_account_overlay<'a>(
-        initial: &D,
+        initial: &mut D,
         accounts: &'a mut AddressMap<Tracked<Option<Account>>>,
         journal: &mut Vec<JournalEntry>,
         address: Address,
@@ -486,7 +486,7 @@ impl<D: Database> State<D> {
     #[must_use]
     fn account_mut(&mut self, address: Address) -> &mut Account {
         let tracked = Self::ensure_account_overlay(
-            &self.initial,
+            &mut self.initial,
             &mut self.accounts,
             &mut self.journal,
             address,
@@ -504,7 +504,7 @@ impl<D: Database> State<D> {
     #[must_use]
     fn journal_account_change(&mut self, address: Address) -> &mut Account {
         let tracked = Self::ensure_account_overlay(
-            &self.initial,
+            &mut self.initial,
             &mut self.accounts,
             &mut self.journal,
             address,
@@ -521,7 +521,7 @@ impl<D: Database> State<D> {
     /// Returns account info.
     #[inline]
     #[must_use]
-    pub fn account_info(&self, address: Address) -> Option<AccountInfo> {
+    pub fn account_info(&mut self, address: Address) -> Option<AccountInfo> {
         if let Some(account) = self.accounts.get(&address) {
             return account.current.as_ref().map(Account::info);
         }
@@ -558,7 +558,7 @@ impl<D: Database> State<D> {
     }
 
     #[must_use]
-    fn storage_initial(&self, address: Address, key: Word) -> Word {
+    fn storage_initial(&mut self, address: Address, key: Word) -> Word {
         if self.storage.get(&address).is_some_and(|storage| storage.wiped)
             || self.accounts.get(&address).is_some_and(|account| account.original.is_none())
         {
@@ -758,7 +758,7 @@ impl<D: Database> State<D> {
     #[inline]
     pub fn mark_destructed(&mut self, address: Address) {
         let _ = Self::ensure_account_overlay(
-            &self.initial,
+            &mut self.initial,
             &mut self.accounts,
             &mut self.journal,
             address,
@@ -854,7 +854,7 @@ impl<D: Database> State<D> {
     /// overlay state are deleted during transaction finalization. Non-existent
     /// touched accounts stay non-existent.
     #[must_use]
-    fn is_existing_dead(&self, address: Address) -> bool {
+    fn is_existing_dead(&mut self, address: Address) -> bool {
         if let Some(account) = self.accounts.get(&address) {
             return account.current.as_ref().is_some_and(Account::is_empty)
                 || (account.current.is_none() && account.original.is_some());
@@ -864,7 +864,7 @@ impl<D: Database> State<D> {
 
     fn delete_account_for_finalization(&mut self, address: Address) {
         let account = Self::ensure_account_overlay(
-            &self.initial,
+            &mut self.initial,
             &mut self.accounts,
             &mut self.journal,
             address,
@@ -875,7 +875,7 @@ impl<D: Database> State<D> {
 
     fn materialize_empty_account_for_finalization(&mut self, address: Address) {
         let account = Self::ensure_account_overlay(
-            &self.initial,
+            &mut self.initial,
             &mut self.accounts,
             &mut self.journal,
             address,

--- a/crates/evm2/src/evm/state.rs
+++ b/crates/evm2/src/evm/state.rs
@@ -1,11 +1,15 @@
 //! Basic in-memory EVM host state.
 
 use super::db::Database;
-use crate::{KECCAK_EMPTY, bytecode::Bytecode, interpreter::Word};
+use crate::{
+    KECCAK_EMPTY, SpecId,
+    bytecode::Bytecode,
+    interpreter::{InstrStop, Word},
+};
 use alloc::{collections::BTreeMap, vec::Vec};
 use alloy_primitives::{
     Address, B256, Log, U256,
-    map::{self, HashMap, HashSet, hash_map},
+    map::{AddressMap, AddressSet, HashMap, HashSet, U256Map, hash_map},
 };
 
 /// A value tracked together with the value it had at the start of the current
@@ -169,7 +173,7 @@ pub struct StorageOverlay {
     /// before applying individual slot changes.
     pub wiped: bool,
     /// Loaded or changed storage slots.
-    pub(crate) slots: HashMap<Word, Tracked<Word>>,
+    pub(crate) slots: U256Map<Tracked<Word>>,
 }
 
 /// Complete state transition and emitted logs produced by a transaction.
@@ -323,9 +327,9 @@ pub struct State<D> {
     /// `original`/`current` pair is used to execute against the in-memory overlay
     /// and later derive account-level [`StateChanges`]. Presence here does not by
     /// itself mean the account was touched or warmed.
-    pub accounts: HashMap<Address, Tracked<Option<Account>>>,
+    pub accounts: AddressMap<Tracked<Option<Account>>>,
     /// Persistent storage overlay keyed by account address.
-    pub storage: HashMap<Address, StorageOverlay>,
+    pub storage: AddressMap<StorageOverlay>,
     /// Revert journal.
     pub journal: Vec<JournalEntry>,
     /// Logs emitted by the current transaction.
@@ -335,14 +339,14 @@ pub struct State<D> {
     /// This is separate from the account overlay and the EIP-2929 warm set. A
     /// touched account may have no field changes, but can still matter for empty
     /// account deletion/materialization rules across forks.
-    pub touched: HashSet<Address>,
+    pub touched: AddressSet,
     /// Accounts self-destructed in the current transaction.
-    pub selfdestructs: HashSet<Address>,
+    pub selfdestructs: AddressSet,
     /// Transaction-scoped warm account set for EIP-2929 gas accounting.
     ///
     /// This tracks whether account access is warm or cold. It does not imply the
     /// account was touched, changed, or should be emitted in [`StateChanges`].
-    pub accessed_accounts: HashSet<Address>,
+    pub accessed_accounts: AddressSet,
     /// Transaction-scoped warm storage slot set.
     pub accessed_storage: HashSet<(Address, Word)>,
     /// Transaction-scoped EIP-1153 transient storage keyed by account address and slot.
@@ -355,15 +359,15 @@ impl<D> State<D> {
     pub fn new(initial: D) -> Self {
         Self {
             initial,
-            accounts: map::HashMap::default(),
-            storage: map::HashMap::default(),
+            accounts: AddressMap::default(),
+            storage: AddressMap::default(),
             journal: Vec::new(),
             logs: Vec::new(),
-            touched: map::HashSet::default(),
-            selfdestructs: map::HashSet::default(),
-            accessed_accounts: map::HashSet::default(),
-            accessed_storage: map::HashSet::default(),
-            transient_storage: map::HashMap::default(),
+            touched: AddressSet::default(),
+            selfdestructs: AddressSet::default(),
+            accessed_accounts: AddressSet::default(),
+            accessed_storage: HashSet::default(),
+            transient_storage: HashMap::default(),
         }
     }
 
@@ -401,18 +405,21 @@ impl<D> State<D> {
 
     /// Returns the current account overlay if present and not deleted.
     #[inline]
+    #[must_use]
     pub fn account_ref(&self, address: Address) -> Option<&Account> {
-        self.accounts.get(&address).and_then(|account| account.current.as_ref())
+        self.accounts.get(&address)?.current.as_ref()
     }
 
     /// Returns whether an account is warm in the current transaction.
     #[inline]
+    #[must_use]
     pub fn is_account_warm(&self, address: Address) -> bool {
         self.accessed_accounts.contains(&address)
     }
 
     /// Marks an account as warm and returns whether it was cold before this access.
     #[inline]
+    #[must_use]
     pub fn warm_account(&mut self, address: Address) -> bool {
         if self.accessed_accounts.insert(address) {
             self.journal.push(JournalEntry::AccountWarmed { address });
@@ -424,6 +431,7 @@ impl<D> State<D> {
 
     /// Marks a storage slot as warm and returns whether it was cold before this access.
     #[inline]
+    #[must_use]
     pub fn warm_storage(&mut self, address: Address, key: Word) -> bool {
         if self.accessed_storage.insert((address, key)) {
             self.journal.push(JournalEntry::StorageWarmed { address, key });
@@ -447,50 +455,72 @@ impl<D> State<D> {
 }
 
 impl<D: Database> State<D> {
-    fn load_account(&mut self, address: Address) -> Option<&Tracked<Option<Account>>> {
-        if !self.accounts.contains_key(&address)
-            && let Some(info) = self.initial.get_account(address)
-        {
-            let account = Account::from_info(info);
-            self.accounts.insert(address, Tracked::new(Some(account)));
-        }
-        self.accounts.get(&address)
-    }
-
-    fn ensure_account_overlay(&mut self, address: Address) {
-        if !self.accounts.contains_key(&address) {
-            let original = self.initial.get_account(address).map(Account::from_info);
-            self.accounts
-                .insert(address, Tracked { original: original.clone(), current: original });
-            self.journal.push(JournalEntry::AccountInserted { address });
+    #[must_use]
+    fn load_account(&mut self, address: Address) -> Option<&mut Tracked<Option<Account>>> {
+        match self.accounts.entry(address) {
+            hash_map::Entry::Occupied(entry) => Some(entry.into_mut()),
+            hash_map::Entry::Vacant(entry) => {
+                let info = self.initial.get_account(address)?;
+                Some(entry.insert(Tracked::new(Some(Account::from_info(info)))))
+            }
         }
     }
 
+    #[must_use]
+    fn ensure_account_overlay<'a>(
+        initial: &D,
+        accounts: &'a mut AddressMap<Tracked<Option<Account>>>,
+        journal: &mut Vec<JournalEntry>,
+        address: Address,
+    ) -> &'a mut Tracked<Option<Account>> {
+        match accounts.entry(address) {
+            hash_map::Entry::Occupied(entry) => entry.into_mut(),
+            hash_map::Entry::Vacant(entry) => {
+                let original = initial.get_account(address).map(Account::from_info);
+                journal.push(JournalEntry::AccountInserted { address });
+                entry.insert(Tracked { original: original.clone(), current: original })
+            }
+        }
+    }
+
+    #[must_use]
     fn account_mut(&mut self, address: Address) -> &mut Account {
-        self.ensure_account_overlay(address);
-        if self.accounts[&address].current.is_none() {
+        let tracked = Self::ensure_account_overlay(
+            &self.initial,
+            &mut self.accounts,
+            &mut self.journal,
+            address,
+        );
+        if tracked.current.is_none() {
             self.journal.push(JournalEntry::AccountChange { address, previous: None });
-            self.accounts.get_mut(&address).expect("account overlay exists").current =
-                Some(Account {
-                    code_hash: KECCAK_EMPTY,
-                    code: Bytecode::default(),
-                    ..Account::default()
-                });
         }
-        self.accounts
-            .get_mut(&address)
-            .and_then(|account| account.current.as_mut())
-            .expect("current account exists")
+        tracked.current.get_or_insert_with(|| Account {
+            code_hash: KECCAK_EMPTY,
+            code: Bytecode::default(),
+            ..Account::default()
+        })
     }
 
-    fn journal_account_change(&mut self, address: Address) {
-        self.ensure_account_overlay(address);
-        let previous = self.accounts[&address].current.clone();
+    #[must_use]
+    fn journal_account_change(&mut self, address: Address) -> &mut Account {
+        let tracked = Self::ensure_account_overlay(
+            &self.initial,
+            &mut self.accounts,
+            &mut self.journal,
+            address,
+        );
+        let previous = tracked.current.clone();
         self.journal.push(JournalEntry::AccountChange { address, previous });
+        tracked.current.get_or_insert_with(|| Account {
+            code_hash: KECCAK_EMPTY,
+            code: Bytecode::default(),
+            ..Account::default()
+        })
     }
 
     /// Returns account info.
     #[inline]
+    #[must_use]
     pub fn account_info(&self, address: Address) -> Option<AccountInfo> {
         if let Some(account) = self.accounts.get(&address) {
             return account.current.as_ref().map(Account::info);
@@ -500,9 +530,9 @@ impl<D: Database> State<D> {
 
     /// Returns an account if it exists.
     #[inline]
+    #[must_use]
     pub fn find(&mut self, address: Address) -> Option<&Account> {
-        self.load_account(address);
-        self.account_ref(address)
+        self.load_account(address)?.current.as_ref()
     }
 
     /// Gets an existing account or inserts a new empty account.
@@ -513,6 +543,7 @@ impl<D: Database> State<D> {
 
     /// Gets account code.
     #[inline]
+    #[must_use]
     pub fn get_code(&mut self, address: Address) -> Bytecode {
         let Some(account) = self.find(address) else {
             return Bytecode::default();
@@ -526,6 +557,7 @@ impl<D: Database> State<D> {
         self.initial.get_account_code(address)
     }
 
+    #[must_use]
     fn storage_initial(&self, address: Address, key: Word) -> Word {
         if self.storage.get(&address).is_some_and(|storage| storage.wiped)
             || self.accounts.get(&address).is_some_and(|account| account.original.is_none())
@@ -536,51 +568,47 @@ impl<D: Database> State<D> {
         }
     }
 
-    fn ensure_storage_slot(&mut self, address: Address, key: Word, journal_insert: bool) {
+    #[must_use]
+    fn storage_slot_mut(
+        &mut self,
+        address: Address,
+        key: Word,
+        journal_insert: bool,
+    ) -> &mut Tracked<Word> {
         let initial = self.storage_initial(address, key);
         let storage = self.storage.entry(address).or_default();
-        if let hash_map::Entry::Vacant(entry) = storage.slots.entry(key) {
-            entry.insert(Tracked::new(initial));
-            if journal_insert {
-                self.journal.push(JournalEntry::StorageInserted { address, key });
+        match storage.slots.entry(key) {
+            hash_map::Entry::Occupied(entry) => entry.into_mut(),
+            hash_map::Entry::Vacant(entry) => {
+                if journal_insert {
+                    self.journal.push(JournalEntry::StorageInserted { address, key });
+                }
+                entry.insert(Tracked::new(initial))
             }
         }
     }
 
-    #[inline]
-    fn get_storage_value(&mut self, address: Address, key: Word) -> &mut Tracked<Word> {
-        self.ensure_storage_slot(address, key, false);
-        self.storage
-            .get_mut(&address)
-            .and_then(|storage| storage.slots.get_mut(&key))
-            .expect("storage slot was just inserted")
-    }
-
     /// Loads persistent storage.
     #[inline]
+    #[must_use]
     pub fn storage(&mut self, address: Address, key: Word) -> Word {
-        if self.account_info(address).is_none() {
+        let Some(_) = self.account_info(address) else {
             return Word::ZERO;
-        }
-        self.get_storage_value(address, key).current
+        };
+        self.storage_slot_mut(address, key, false).current
     }
 
     /// Stores persistent storage.
     #[inline]
     pub fn set_storage(&mut self, address: Address, key: Word, value: Word) {
-        self.account_mut(address);
-        let inserted =
-            !self.storage.get(&address).is_some_and(|storage| storage.slots.contains_key(&key));
-        self.ensure_storage_slot(address, key, inserted);
-        let previous = self.storage[&address].slots[&key].current;
+        let _ = self.account_mut(address);
+        let previous = {
+            let slot = self.storage_slot_mut(address, key, true);
+            let previous = slot.current;
+            slot.current = value;
+            previous
+        };
         self.journal.push(JournalEntry::StorageChange { address, key, previous });
-        self.storage
-            .get_mut(&address)
-            .expect("storage overlay exists")
-            .slots
-            .get_mut(&key)
-            .expect("storage slot exists")
-            .current = value;
     }
 
     /// Marks an account as touched by the current transaction.
@@ -598,14 +626,14 @@ impl<D: Database> State<D> {
             self.touch(address);
             return;
         }
-        self.journal_account_change(address);
-        let account = self.account_mut(address);
+        let account = self.journal_account_change(address);
         account.balance = account.balance.wrapping_add(delta);
         self.touch(address);
     }
 
     /// Transfers value between accounts.
     #[inline]
+    #[must_use]
     pub fn transfer(&mut self, from: Address, to: Address, value: Word) -> bool {
         if value.is_zero() || from == to {
             self.touch(to);
@@ -617,13 +645,11 @@ impl<D: Database> State<D> {
             return false;
         };
 
-        self.journal_account_change(from);
-        self.account_mut(from).balance = new_from_balance;
+        self.journal_account_change(from).balance = new_from_balance;
         self.touch(from);
 
-        self.journal_account_change(to);
-        let to_balance = self.account_mut(to).balance;
-        self.account_mut(to).balance = to_balance.saturating_add(value);
+        let account = self.journal_account_change(to);
+        account.balance = account.balance.saturating_add(value);
         self.touch(to);
         true
     }
@@ -631,8 +657,7 @@ impl<D: Database> State<D> {
     /// Increments account nonce.
     #[inline]
     pub fn increment_nonce(&mut self, address: Address) {
-        self.journal_account_change(address);
-        let account = self.account_mut(address);
+        let account = self.journal_account_change(address);
         account.nonce = account.nonce.saturating_add(1);
         self.touch(address);
     }
@@ -644,29 +669,29 @@ impl<D: Database> State<D> {
         caller: Address,
         address: Address,
         value: Word,
-        spec: crate::SpecId,
-    ) -> Result<(), crate::interpreter::InstrStop> {
+        spec: SpecId,
+    ) -> Result<(), InstrStop> {
         if let Some(info) = self.account_info(address)
             && (info.nonce != 0 || info.code_hash != KECCAK_EMPTY)
         {
-            return Err(crate::interpreter::InstrStop::CreateCollision);
+            return Err(InstrStop::CreateCollision);
         }
 
         if !self.transfer(caller, address, value) {
-            return Err(crate::interpreter::InstrStop::OutOfFunds);
+            return Err(InstrStop::OutOfFunds);
         }
 
         let balance = self.account_mut(address).balance;
         self.wipe_storage(address);
-        self.journal_account_change(address);
-        self.accounts.get_mut(&address).expect("account overlay exists").current = Some(Account {
-            nonce: u64::from(spec.enables(crate::SpecId::SPURIOUS_DRAGON)),
+        let account = self.journal_account_change(address);
+        *account = Account {
+            nonce: u64::from(spec.enables(SpecId::SPURIOUS_DRAGON)),
             balance,
             code_hash: KECCAK_EMPTY,
             code: Bytecode::default(),
             just_created: true,
             code_changed: true,
-        });
+        };
         self.touch(address);
         Ok(())
     }
@@ -674,8 +699,7 @@ impl<D: Database> State<D> {
     /// Sets account bytecode.
     #[inline]
     pub fn set_code(&mut self, address: Address, code: Bytecode) {
-        self.journal_account_change(address);
-        let account = self.account_mut(address);
+        let account = self.journal_account_change(address);
         account.code_hash = code.hash_slow();
         account.code = code;
         account.code_changed = true;
@@ -686,12 +710,12 @@ impl<D: Database> State<D> {
     pub fn wipe_storage(&mut self, address: Address) {
         let previous = self.storage.get(&address).cloned();
         self.journal.push(JournalEntry::StorageWipe { address, previous });
-        self.storage
-            .insert(address, StorageOverlay { wiped: true, slots: map::HashMap::default() });
+        self.storage.insert(address, StorageOverlay { wiped: true, slots: U256Map::default() });
     }
 
     /// Loads transient storage.
     #[inline]
+    #[must_use]
     pub fn transient_storage(&mut self, address: Address, key: Word) -> Word {
         self.transient_storage.get(&(address, key)).copied().unwrap_or_default()
     }
@@ -699,22 +723,46 @@ impl<D: Database> State<D> {
     /// Stores transient storage.
     #[inline]
     pub fn set_transient_storage(&mut self, address: Address, key: Word, value: Word) {
-        let previous = self.transient_storage.get(&(address, key)).copied();
-        if previous.unwrap_or_default() == value {
-            return;
-        }
-        self.journal.push(JournalEntry::TransientStorageChange { address, key, previous });
-        if value.is_zero() {
-            self.transient_storage.remove(&(address, key));
-        } else {
-            self.transient_storage.insert((address, key), value);
+        match self.transient_storage.entry((address, key)) {
+            hash_map::Entry::Occupied(mut entry) => {
+                let previous = *entry.get();
+                if previous == value {
+                    return;
+                }
+                self.journal.push(JournalEntry::TransientStorageChange {
+                    address,
+                    key,
+                    previous: Some(previous),
+                });
+                if value.is_zero() {
+                    entry.remove();
+                } else {
+                    *entry.get_mut() = value;
+                }
+            }
+            hash_map::Entry::Vacant(entry) => {
+                if value.is_zero() {
+                    return;
+                }
+                self.journal.push(JournalEntry::TransientStorageChange {
+                    address,
+                    key,
+                    previous: None,
+                });
+                entry.insert(value);
+            }
         }
     }
 
     /// Marks an account as self-destructed in the current transaction.
     #[inline]
     pub fn mark_destructed(&mut self, address: Address) {
-        self.ensure_account_overlay(address);
+        let _ = Self::ensure_account_overlay(
+            &self.initial,
+            &mut self.accounts,
+            &mut self.journal,
+            address,
+        );
         if self.selfdestructs.insert(address) {
             self.journal.push(JournalEntry::SelfDestruct { address });
         }
@@ -723,24 +771,27 @@ impl<D: Database> State<D> {
 
     /// Returns whether an account has been marked self-destructed in the current transaction.
     #[inline]
+    #[must_use]
     pub fn is_selfdestructed(&self, address: Address) -> bool {
         self.selfdestructs.contains(&address)
     }
 
     /// Returns whether an account was created in the current transaction.
     #[inline]
+    #[must_use]
     pub(super) fn is_created_in_transaction(&self, address: Address) -> bool {
-        self.accounts
-            .get(&address)
-            .and_then(|tracked| tracked.current.as_ref())
-            .is_some_and(|account| account.just_created)
+        self.account_ref(address).is_some_and(|account| account.just_created)
     }
 
     /// Reverts state changes after the checkpoint.
     #[inline]
     pub fn rollback(&mut self, checkpoint: usize) {
+        assert!(checkpoint <= self.journal.len(), "checkpoint is past journal length");
         while self.journal.len() != checkpoint {
-            match self.journal.pop().expect("journal length checked above") {
+            let Some(entry) = self.journal.pop() else {
+                unreachable!("checkpoint is checked above")
+            };
+            match entry {
                 JournalEntry::AccountChange { address, previous } => {
                     if let Some(account) = self.accounts.get_mut(&address) {
                         account.current = previous;
@@ -802,6 +853,7 @@ impl<D: Database> State<D> {
     /// in Spurious Dragon, touched dead accounts that exist in the pre/final
     /// overlay state are deleted during transaction finalization. Non-existent
     /// touched accounts stay non-existent.
+    #[must_use]
     fn is_existing_dead(&self, address: Address) -> bool {
         if let Some(account) = self.accounts.get(&address) {
             return account.current.as_ref().is_some_and(Account::is_empty)
@@ -811,21 +863,25 @@ impl<D: Database> State<D> {
     }
 
     fn delete_account_for_finalization(&mut self, address: Address) {
-        self.accounts
-            .get_mut(&address)
-            .expect("finalized account is loaded into the overlay")
-            .current = None;
-        self.storage
-            .insert(address, StorageOverlay { wiped: true, slots: map::HashMap::default() });
+        let account = Self::ensure_account_overlay(
+            &self.initial,
+            &mut self.accounts,
+            &mut self.journal,
+            address,
+        );
+        account.current = None;
+        self.storage.insert(address, StorageOverlay { wiped: true, slots: U256Map::default() });
     }
 
     fn materialize_empty_account_for_finalization(&mut self, address: Address) {
-        self.ensure_account_overlay(address);
-        if let Some(account) = self.accounts.get_mut(&address)
-            && account.original.is_none()
-            && account.current.is_none()
-        {
-            account.current = Some(Account {
+        let account = Self::ensure_account_overlay(
+            &self.initial,
+            &mut self.accounts,
+            &mut self.journal,
+            address,
+        );
+        if account.original.is_none() {
+            account.current.get_or_insert_with(|| Account {
                 code_hash: KECCAK_EMPTY,
                 code: Bytecode::default(),
                 ..Account::default()
@@ -840,18 +896,17 @@ impl<D: Database> State<D> {
     /// transaction substate such as touches and selfdestructs, while finalization
     /// turns that substate into account deletions, storage wipes, or pre-EIP-161
     /// empty-account materialization.
-    pub(super) fn finalize_transaction(&mut self, spec: crate::SpecId) {
+    pub(super) fn finalize_transaction(&mut self, spec: SpecId) {
         let selfdestructs = core::mem::take(&mut self.selfdestructs);
         for address in selfdestructs.iter().copied() {
             self.delete_account_for_finalization(address);
         }
 
         let touched = core::mem::take(&mut self.touched);
-        if spec.enables(crate::SpecId::SPURIOUS_DRAGON) {
+        if spec.enables(SpecId::SPURIOUS_DRAGON) {
             for address in touched {
                 // EIP-161 deletes touched dead accounts at transaction finalization.
                 if self.is_existing_dead(address) {
-                    self.ensure_account_overlay(address);
                     self.delete_account_for_finalization(address);
                 }
             }
@@ -881,13 +936,15 @@ impl<D: Database> State<D> {
             if original != current {
                 changes.accounts.insert(address, Tracked { original, current });
             }
-            if let Some(account) = tracked.current.as_ref()
-                && account.code_changed
-                && !account.code.is_empty()
-                && !account.code_hash.is_zero()
-                && account.code_hash != KECCAK_EMPTY
-            {
-                changes.code.insert(account.code_hash, account.code.clone());
+            if let Some(account) = tracked.current.as_ref() {
+                let code_hash = account.code_hash;
+                if account.code_changed
+                    && !account.code.is_empty()
+                    && !code_hash.is_zero()
+                    && code_hash != KECCAK_EMPTY
+                {
+                    changes.code.insert(code_hash, account.code.clone());
+                }
             }
         }
 

--- a/crates/evm2/src/evm/state.rs
+++ b/crates/evm2/src/evm/state.rs
@@ -417,15 +417,21 @@ impl<D> State<D> {
         self.accessed_accounts.contains(&address)
     }
 
-    /// Marks an account as warm and returns whether it was cold before this access.
+    /// Marks an account as warm.
     #[inline]
-    #[must_use]
-    pub fn warm_account(&mut self, address: Address) -> bool {
+    pub fn warm_account(&mut self, address: Address) {
         if self.accessed_accounts.insert(address) {
             self.journal.push(JournalEntry::AccountWarmed { address });
-            true
-        } else {
-            false
+        }
+    }
+
+    /// Marks accounts as warm.
+    #[inline]
+    pub fn warm_accounts(&mut self, addresses: impl IntoIterator<Item = Address>) {
+        let addresses = addresses.into_iter();
+        self.accessed_accounts.reserve(addresses.size_hint().0);
+        for address in addresses {
+            self.warm_account(address);
         }
     }
 

--- a/crates/evm2/src/interpreter/instructions/block.rs
+++ b/crates/evm2/src/interpreter/instructions/block.rs
@@ -10,11 +10,9 @@ const BLOCK_HASH_HISTORY: u64 = 256;
 #[instruction]
 pub(crate) fn blockhash(cx: _, [number]: [Word]) -> Result<out> {
     *out = if let Some(diff) = cx.state.host.block_env().number.checked_sub(number) {
-        let diff = u64::try_from(diff).unwrap_or(u64::MAX);
         if diff == 0 || diff > BLOCK_HASH_HISTORY {
             Word::ZERO
         } else {
-            let number = u64::try_from(number).unwrap_or(u64::MAX);
             cx.state
                 .host
                 .block_hash(number)
@@ -92,7 +90,7 @@ mod tests {
         SpecId,
         env::{BlockEnv, TxEnv},
         interpreter::{
-            InstrStop, Word,
+            InstrStop, Message, Word,
             instructions::tests::{RunConfig, TestHost, push, run},
             op,
         },
@@ -194,11 +192,7 @@ mod tests {
     fn selfbalance_opcode() {
         let address = Address::from([0x66; 20]);
         let mut host = TestHost::default();
-        let message = crate::interpreter::Message {
-            destination: address,
-            gas_limit: 10_000,
-            ..Default::default()
-        };
+        let message = Message { destination: address, gas_limit: 10_000, ..Default::default() };
         let interpreter =
             run(RunConfig::new([op::SELFBALANCE, op::STOP]).host(&mut host).message(message));
         core::assert_matches!(interpreter.err, InstrStop::Stop);

--- a/crates/evm2/src/interpreter/instructions/host.rs
+++ b/crates/evm2/src/interpreter/instructions/host.rs
@@ -293,11 +293,7 @@ mod tests {
     fn log0_opcode() {
         let mut host = TestHost::default();
         let address = Address::from([0x11; 20]);
-        let message = crate::interpreter::Message {
-            destination: address,
-            gas_limit: 10_000,
-            ..Default::default()
-        };
+        let message = Message { destination: address, gas_limit: 10_000, ..Default::default() };
         let interpreter = run(RunConfig::new(log_code(30, 2, [])).host(&mut host).message(message));
         core::assert_matches!(interpreter.err, InstrStop::Stop);
         assert!(interpreter.stack().is_empty());

--- a/crates/evm2/src/interpreter/instructions/tests.rs
+++ b/crates/evm2/src/interpreter/instructions/tests.rs
@@ -3,12 +3,12 @@ use crate::{
     bytecode::Bytecode,
     env::{BlockEnv, TxEnv},
     interpreter::{
-        Host, InstrStop, Interpreter, Message, MessageKind, MessageResult, Stack, Word, op,
+        Gas, Host, InstrStop, Interpreter, Memory, Message, MessageKind, MessageResult, Stack,
+        Word, op,
     },
 };
 use alloc::{boxed::Box, vec::Vec};
-use alloy_primitives::{Address, B256, Bytes, Log};
-use std::collections::HashMap;
+use alloy_primitives::{Address, B256, Bytes, Log, map::HashMap};
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub(crate) struct TestTypes;
@@ -47,8 +47,8 @@ impl Default for TestHost {
             code: Bytes::new(),
             is_empty: false,
             is_cold: false,
-            storage: HashMap::new(),
-            transient_storage: HashMap::new(),
+            storage: HashMap::default(),
+            transient_storage: HashMap::default(),
             logs: Vec::new(),
             execute_result: MessageResult { stop: InstrStop::Return, ..MessageResult::default() },
             selfdestruct_result: SelfDestructResult::default(),
@@ -86,8 +86,8 @@ impl Host for TestHost {
         })
     }
 
-    fn block_hash(&mut self, number: u64) -> Option<B256> {
-        Some(B256::with_last_byte(number as u8))
+    fn block_hash(&mut self, number: Word) -> Option<B256> {
+        Some(B256::with_last_byte(number.wrapping_to::<u8>()))
     }
 
     fn sload(&mut self, address: Address, key: Word) -> StorageLoad {
@@ -139,8 +139,8 @@ impl Host for TestHost {
 pub(super) struct TestInterpreter {
     pub(super) stack: Box<[Word; Stack::CAPACITY]>,
     pub(super) stack_len: usize,
-    pub(super) gas: crate::interpreter::Gas,
-    pub(super) memory: crate::interpreter::Memory,
+    pub(super) gas: Gas,
+    pub(super) memory: Memory,
     pub(super) output: *const [u8],
     pub(super) err: InstrStop,
 }

--- a/crates/evm2/src/interpreter/state.rs
+++ b/crates/evm2/src/interpreter/state.rs
@@ -144,7 +144,7 @@ pub trait Host {
     ) -> Result<AccountLoad, InstrStop>;
 
     /// Returns a historical block hash.
-    fn block_hash(&mut self, number: u64) -> Option<B256>;
+    fn block_hash(&mut self, number: Word) -> Option<B256>;
 
     /// Loads a persistent storage slot.
     fn sload(&mut self, address: Address, key: Word) -> StorageLoad;


### PR DESCRIPTION
This cleans up the state and database internals around the cache database work. CacheDB now wraps another database, uses mutable reads so misses populate the cache, keeps bytecode separate from account info, and preserves U256 block hash plumbing through the host API.

It also carries the state overlay cleanup, registry map change, empty DB type shape, and the merge from main with the new precompile work and KECCAK256_EMPTY constant naming.
