### PR TITLE
fix(storage): align storage op gas and refunds

### DIFF
--- a/crates/evm2/src/ethereum.rs
+++ b/crates/evm2/src/ethereum.rs
@@ -170,8 +170,11 @@ fn handle_legacy<T: EvmTypes<Host = Evm<T>>>(
         }
     }
 
-    let gas_used = tx.gas_limit - result.gas_remaining;
-    req.host.state.add_balance(caller, U256::from(result.gas_remaining) * gas_price);
+    let gas_remaining =
+        result.gas_remaining_after_final_refund(tx.gas_limit, spec_id.enables(SpecId::LONDON));
+    let gas_used =
+        result.gas_used_after_final_refund(tx.gas_limit, spec_id.enables(SpecId::LONDON));
+    req.host.state.add_balance(caller, U256::from(gas_remaining) * gas_price);
     let beneficiary_gas_price = if spec_id.enables(SpecId::LONDON) {
         gas_price.saturating_sub(req.host.block.basefee)
     } else {

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -11,7 +11,6 @@ use crate::{
 };
 use alloy_eips::eip2718::Typed2718;
 use alloy_primitives::{Address, B256, Bytes, Log};
-use core::cmp::min;
 
 pub mod config;
 pub mod env;
@@ -44,13 +43,70 @@ pub struct AccountLoad {
     pub is_cold: bool,
 }
 
-/// Loaded storage slot value.
+/// Result of an `SLOAD` host operation.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
-pub struct StorageLoad {
+pub struct SLoad {
     /// Storage slot value.
     pub value: Word,
     /// Whether the storage slot access was cold.
     pub is_cold: bool,
+}
+
+/// Result of an `SSTORE` host operation.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub struct SStore {
+    /// Storage value at the start of the transaction.
+    pub original_value: Word,
+    /// Storage value immediately before this `SSTORE`.
+    pub present_value: Word,
+    /// Storage value written by this `SSTORE`.
+    pub new_value: Word,
+    /// Whether the storage slot access was cold.
+    pub is_cold: bool,
+}
+
+impl SStore {
+    /// Returns whether this `SSTORE` leaves the slot unchanged (`new == present`).
+    #[inline]
+    #[must_use]
+    pub fn is_noop(&self) -> bool {
+        self.new_value == self.present_value
+    }
+
+    /// Returns whether the slot is clean (`original == present`).
+    #[inline]
+    #[must_use]
+    pub fn is_clean(&self) -> bool {
+        self.original_value == self.present_value
+    }
+
+    /// Returns whether this `SSTORE` restores the slot to its original value (`new == original`).
+    #[inline]
+    #[must_use]
+    pub fn resets_original(&self) -> bool {
+        self.original_value == self.new_value
+    }
+
+    /// Returns whether the original value is zero.
+    #[inline]
+    #[must_use]
+    pub fn original_is_zero(&self) -> bool {
+        self.original_value.is_zero()
+    }
+
+    /// Returns whether the present value is zero.
+    #[inline]
+    #[must_use]
+    pub fn present_is_zero(&self) -> bool {
+        self.present_value.is_zero()
+    }
+
+    /// Returns whether the new value is zero.
+    #[inline]
+    #[must_use]
+    pub fn new_is_zero(&self) -> bool {
+        self.new_value.is_zero()
+    }
 }
 
 /// Result of a `SELFDESTRUCT` host operation.
@@ -260,14 +316,41 @@ impl<T: EvmTypes<Host = Self>> Host for Evm<T> {
         self.state.initial_mut().get_block_hash(number)
     }
 
-    fn sload(&mut self, address: Address, key: Word) -> StorageLoad {
+    fn sload(
+        &mut self,
+        address: Address,
+        key: Word,
+        skip_cold_load: bool,
+    ) -> Result<SLoad, InstrStop> {
         let is_cold =
-            self.spec_id().enables(SpecId::BERLIN) && self.state.warm_storage(address, key);
-        StorageLoad { value: self.state.storage(address, key), is_cold }
+            self.spec_id().enables(SpecId::BERLIN) && !self.state.is_storage_warm(address, key);
+        if skip_cold_load && is_cold {
+            return Err(InstrStop::OutOfGas);
+        }
+        if is_cold {
+            let _ = self.state.warm_storage(address, key);
+        }
+        Ok(SLoad { value: self.state.storage(address, key), is_cold })
     }
 
-    fn sstore(&mut self, address: Address, key: Word, value: Word) {
-        self.state.set_storage(address, key, value);
+    fn sstore(
+        &mut self,
+        address: Address,
+        key: Word,
+        value: Word,
+        skip_cold_load: bool,
+    ) -> Result<SStore, InstrStop> {
+        let is_cold =
+            self.spec_id().enables(SpecId::BERLIN) && !self.state.is_storage_warm(address, key);
+        if skip_cold_load && is_cold {
+            return Err(InstrStop::OutOfGas);
+        }
+        if is_cold {
+            let _ = self.state.warm_storage(address, key);
+        }
+        let mut result = self.state.set_storage(address, key, value);
+        result.is_cold = is_cold;
+        Ok(result)
     }
 
     fn tload(&mut self, address: Address, key: Word) -> Word {
@@ -343,12 +426,9 @@ impl<T: EvmTypes<Host = Self>> Host for Evm<T> {
                 Interpreter::<T>::new(bytecode, tx_env, create_message, caller_is_static);
             let stop = interpreter.run_with(self.execution_config, self);
             let mut gas = interpreter.gas();
-            if stop.is_success() || stop.is_revert() {
-                gas.set_final_refund(self.spec_id().enables(SpecId::LONDON));
-            }
             let output = Bytes::copy_from_slice(interpreter.output());
-            let mut gas_remaining =
-                min(gas.remaining().saturating_add(gas.refunded() as u64), gas.limit());
+            let mut gas_remaining = gas.remaining();
+            let mut gas_refunded = if stop.is_success() { gas.refunded() } else { 0 };
 
             if stop.is_success() {
                 let stop = if self.spec_id().enables(SpecId::SPURIOUS_DRAGON)
@@ -369,11 +449,17 @@ impl<T: EvmTypes<Host = Self>> Host for Evm<T> {
                 if let Some(stop) = stop {
                     self.state.rollback(checkpoint);
                     gas_remaining = if stop.is_halt() { 0 } else { gas.remaining() };
-                    return MessageResult { stop, gas_remaining, output, created_address: None };
+                    return MessageResult {
+                        stop,
+                        gas_remaining,
+                        gas_refunded: 0,
+                        output,
+                        created_address: None,
+                    };
                 }
 
-                gas_remaining =
-                    min(gas.remaining().saturating_add(gas.refunded() as u64), gas.limit());
+                gas_remaining = gas.remaining();
+                gas_refunded = gas.refunded();
                 self.state.set_code(address, Bytecode::new_legacy(output.clone()));
             } else {
                 self.state.rollback(checkpoint);
@@ -385,6 +471,7 @@ impl<T: EvmTypes<Host = Self>> Host for Evm<T> {
             return MessageResult {
                 stop,
                 gas_remaining,
+                gas_refunded: if stop.is_success() { gas_refunded } else { 0 },
                 output,
                 created_address: stop.is_success().then_some(address),
             };
@@ -420,18 +507,20 @@ impl<T: EvmTypes<Host = Self>> Host for Evm<T> {
             if !stop.is_success() {
                 self.state.rollback(checkpoint);
             }
-            return MessageResult { stop, gas_remaining, output, created_address: None };
+            return MessageResult {
+                stop,
+                gas_remaining,
+                gas_refunded: 0,
+                output,
+                created_address: None,
+            };
         }
 
         let mut interpreter = Interpreter::<T>::new(bytecode, tx_env, message, caller_is_static);
         let stop = interpreter.run_with(self.execution_config, self);
-        let mut gas = interpreter.gas();
-        if stop.is_success() || stop.is_revert() {
-            gas.set_final_refund(self.spec_id().enables(SpecId::LONDON));
-        }
+        let gas = interpreter.gas();
         let output = Bytes::copy_from_slice(interpreter.output());
-        let mut gas_remaining =
-            min(gas.remaining().saturating_add(gas.refunded() as u64), gas.limit());
+        let mut gas_remaining = gas.remaining();
 
         if !stop.is_success() {
             self.state.rollback(checkpoint);
@@ -440,7 +529,13 @@ impl<T: EvmTypes<Host = Self>> Host for Evm<T> {
             }
         }
 
-        MessageResult { stop, gas_remaining, output, created_address: None }
+        MessageResult {
+            stop,
+            gas_remaining,
+            gas_refunded: if stop.is_success() { gas.refunded() } else { 0 },
+            output,
+            created_address: None,
+        }
     }
 
     fn selfdestruct(

--- a/crates/evm2/src/evm/state.rs
+++ b/crates/evm2/src/evm/state.rs
@@ -1,6 +1,6 @@
 //! Basic in-memory EVM host state.
 
-use super::db::Database;
+use super::{SStore, db::Database};
 use crate::{
     SpecId,
     bytecode::Bytecode,
@@ -435,6 +435,13 @@ impl<D> State<D> {
         }
     }
 
+    /// Returns whether a storage slot is warm in the current transaction.
+    #[inline]
+    #[must_use]
+    pub fn is_storage_warm(&self, address: Address, key: Word) -> bool {
+        self.accessed_storage.contains(&(address, key))
+    }
+
     /// Marks a storage slot as warm and returns whether it was cold before this access.
     #[inline]
     #[must_use]
@@ -604,17 +611,30 @@ impl<D: Database> State<D> {
         self.storage_slot_mut(address, key, false).current
     }
 
-    /// Stores persistent storage.
+    /// Stores persistent storage and returns values needed for `SSTORE` gas metering.
+    ///
+    /// This is a raw state mutation helper, not the full EVM `SSTORE` host operation. It does
+    /// not perform static-call checks, gas/stipend checks, EIP-2929 cold-access handling, refund
+    /// accounting, or Amsterdam state-gas charging. Instruction implementations should call the
+    /// host `sstore` operation instead, and only use this lower-level helper when those concerns
+    /// are handled elsewhere.
     #[inline]
-    pub fn set_storage(&mut self, address: Address, key: Word, value: Word) {
+    pub fn set_storage(&mut self, address: Address, key: Word, value: Word) -> SStore {
         let _ = self.account_mut(address);
-        let previous = {
-            let slot = self.storage_slot_mut(address, key, true);
+        self.touch(address);
+        let slot = self.storage_slot_mut(address, key, true);
+        let result = SStore {
+            original_value: slot.original,
+            present_value: slot.current,
+            new_value: value,
+            is_cold: false,
+        };
+        if slot.current != value {
             let previous = slot.current;
             slot.current = value;
-            previous
-        };
-        self.journal.push(JournalEntry::StorageChange { address, key, previous });
+            self.journal.push(JournalEntry::StorageChange { address, key, previous });
+        }
+        result
     }
 
     /// Marks an account as touched by the current transaction.

--- a/crates/evm2/src/interpreter/gas/mod.rs
+++ b/crates/evm2/src/interpreter/gas/mod.rs
@@ -198,14 +198,6 @@ impl GasTracker {
     pub const fn spend_all(&mut self) {
         self.remaining = 0;
     }
-
-    /// Applies the final refund cap.
-    #[inline]
-    pub fn set_final_refund(&mut self, is_london: bool) {
-        let max_refund_quotient = if is_london { 5 } else { 2 };
-        let gas_used = self.spent().saturating_sub(self.reservoir);
-        self.refunded = (self.refunded as u64).min(gas_used / max_refund_quotient) as i64;
-    }
 }
 
 /// Interpreter gas state.
@@ -376,12 +368,6 @@ impl Gas {
     #[inline]
     pub const fn spend_all(&mut self) {
         self.tracker.spend_all();
-    }
-
-    /// Applies the final refund cap.
-    #[inline]
-    pub fn set_final_refund(&mut self, is_london: bool) {
-        self.tracker.set_final_refund(is_london);
     }
 }
 

--- a/crates/evm2/src/interpreter/instructions/host.rs
+++ b/crates/evm2/src/interpreter/instructions/host.rs
@@ -17,9 +17,15 @@ fn require_non_staticcall<T: EvmTypes>(cx: &InstructionCx<'_, '_, T>) -> Result 
 
 #[instruction]
 pub(crate) fn sload(cx: _, [key]: [Word]) -> Result<out> {
-    let load = cx.state.host.sload(cx.state.message().destination, key);
+    // EIP-2929: SLOAD pays the warm read cost as static opcode gas, then only
+    // charges the additional cold cost when the slot was not already warm. Avoid
+    // touching the host/database if the frame cannot afford that cold surcharge.
+    let additional_cold_cost = cx.state.gas_params().get(GasId::ColdStorageAdditionalCost).into();
+    let skip_cold_load =
+        cx.state.spec.enables(SpecId::BERLIN) && cx.gas.remaining() < additional_cold_cost;
+    let load = cx.state.host.sload(cx.state.message().destination, key, skip_cold_load)?;
     if load.is_cold {
-        cx.gas.spend(cx.state.gas_params().get(GasId::ColdStorageAdditionalCost).into())?;
+        cx.gas.spend(additional_cold_cost)?;
     }
     *out = load.value;
 }
@@ -29,28 +35,43 @@ pub(crate) fn sstore(cx: _) -> Result {
     require_non_staticcall(&cx)?;
     let [key, value] = stack.popn()?;
     let gas_params = cx.state.gas_params();
-    if cx.state.spec.enables(SpecId::ISTANBUL)
-        && cx.gas.remaining() <= gas_params.get(GasId::CallStipend).into()
-    {
+    let is_istanbul = cx.state.spec.enables(SpecId::ISTANBUL);
+
+    // EIP-2200: SSTORE may not execute with only the value-transfer stipend left. This
+    // check happens before any gas is charged or host storage is touched.
+    if is_istanbul && cx.gas.remaining() <= gas_params.get(GasId::CallStipend).into() {
         return Err(InstrStop::ReentrancySentryOOG);
     }
-    let load = cx.state.host.sload(cx.state.message().destination, key);
-    let old_value = load.value;
+
+    // Frontier through Petersburg charge a fixed SSTORE_RESET static cost. Istanbul
+    // (EIP-2200) turns this into the SLOAD-equivalent cost, and Berlin (EIP-2929)
+    // makes that the warm storage read cost.
     cx.gas.spend(gas_params.get(GasId::SstoreStatic).into())?;
-    if load.is_cold {
-        cx.gas.spend(gas_params.get(GasId::ColdStorageCost).into())?;
+
+    // EIP-2929: avoid performing a cold storage load if the frame cannot afford the
+    // additional cold-load charge. The host performs the write and returns
+    // original/present/new values for net metering.
+    let skip_cold_load = cx.state.spec.enables(SpecId::BERLIN)
+        && cx.gas.remaining() < gas_params.get(GasId::ColdStorageAdditionalCost).into();
+    let state_load =
+        cx.state.host.sstore(cx.state.message().destination, key, value, skip_cold_load)?;
+
+    // EIP-2200 net gas metering depends on original, present, and new slot values:
+    // clean slots pay set/reset costs, dirty slots generally only pay the load cost,
+    // and reset-to-original transitions are handled through refunds.
+    cx.gas.spend(gas_params.sstore_dynamic_gas(is_istanbul, &state_load))?;
+
+    // EIP-8037 / Amsterdam: creating a new storage slot (original == present == 0,
+    // new != 0) also consumes state gas from the reservoir before spilling into
+    // regular gas.
+    if cx.state.spec.enables(SpecId::AMSTERDAM) {
+        cx.gas.spend_state(gas_params.sstore_state_gas(&state_load))?;
     }
-    if old_value == value {
-        // No-op stores only pay the load/static cost after Istanbul.
-    } else if old_value.is_zero() {
-        cx.gas.spend(gas_params.get(GasId::SstoreSetWithoutLoadCost).into())?;
-    } else if value.is_zero() {
-        cx.gas.record_refund(gas_params.get(GasId::SstoreClearingSlotRefund) as i64);
-        cx.gas.spend(gas_params.get(GasId::SstoreResetWithoutColdLoadCost).into())?;
-    } else {
-        cx.gas.spend(gas_params.get(GasId::SstoreResetWithoutColdLoadCost).into())?;
-    }
-    cx.state.host.sstore(cx.state.message().destination, key, value);
+
+    // EIP-2200 and EIP-3529 refund rules, including negative refund adjustments for
+    // dirty nonzero slots and London's reduced clearing-slot refund via gas params.
+    cx.gas.record_refund(gas_params.sstore_refund(is_istanbul, &state_load));
+    Ok(())
 }
 
 #[instruction(no_stack_preamble)]
@@ -213,6 +234,58 @@ mod tests {
 
         core::assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.gas_remaining(), 2894);
+    }
+
+    #[test]
+    fn sstore_dirty_slot_write_only_pays_load_cost() {
+        let mut host = TestHost::default();
+        let mut code = Vec::new();
+        push(&mut code, 1);
+        push(&mut code, 0);
+        code.push(op::SSTORE);
+        push(&mut code, 2);
+        push(&mut code, 0);
+        code.extend([op::SSTORE, op::STOP]);
+
+        let interpreter =
+            run(RunConfig::new(code).host(&mut host).spec(SpecId::BERLIN).gas_limit(50_000));
+
+        core::assert_matches!(interpreter.err, InstrStop::Stop);
+        assert_eq!(interpreter.gas_remaining(), 29_888);
+        assert_eq!(interpreter.gas_refunded(), 0);
+    }
+
+    #[test]
+    fn sstore_reset_to_original_records_refund() {
+        let mut host = TestHost::default();
+        host.storage.insert((Address::ZERO, Word::from(0)), Word::from(5));
+        let mut code = Vec::new();
+        push(&mut code, 7);
+        push(&mut code, 0);
+        code.push(op::SSTORE);
+        push(&mut code, 5);
+        push(&mut code, 0);
+        code.extend([op::SSTORE, op::STOP]);
+
+        let interpreter =
+            run(RunConfig::new(code).host(&mut host).spec(SpecId::BERLIN).gas_limit(50_000));
+
+        core::assert_matches!(interpreter.err, InstrStop::Stop);
+        assert_eq!(interpreter.gas_remaining(), 46_988);
+        assert_eq!(interpreter.gas_refunded(), 2_800);
+    }
+
+    #[test]
+    fn sstore_amsterdam_new_slot_charges_state_gas() {
+        let mut host = TestHost::default();
+        let interpreter = run(RunConfig::new([op::PUSH1, 1, op::PUSH1, 0, op::SSTORE, op::STOP])
+            .host(&mut host)
+            .spec(SpecId::AMSTERDAM)
+            .gas_limit(100_000));
+
+        core::assert_matches!(interpreter.err, InstrStop::Stop);
+        assert_eq!(interpreter.gas_remaining(), 59_526);
+        assert_eq!(interpreter.state_gas_spent(), 37_568);
     }
 
     #[test]

--- a/crates/evm2/src/interpreter/instructions/system.rs
+++ b/crates/evm2/src/interpreter/instructions/system.rs
@@ -166,7 +166,8 @@ fn call_inner<T: EvmTypes>(
     let bytecode = crate::bytecode::Bytecode::new_legacy(code);
     let result =
         cx.state.host.execute_message(cx.state.tx().clone(), bytecode, message, caller_is_static);
-    cx.gas.erase_cost(result.gas_remaining);
+    cx.gas.erase_cost(result.gas_returned_to_parent());
+    cx.gas.record_refund(result.refund_propagated_to_parent());
     let copy_len = min(return_memory_range.len(), result.output.len());
     cx.state.memory().set(return_memory_range.start, &result.output[..copy_len]);
     cx.state.set_return_data(result.output);
@@ -247,7 +248,8 @@ fn create_inner<T: EvmTypes>(
     };
     let bytecode = crate::bytecode::Bytecode::new_legacy(input);
     let result = cx.state.host.execute_message(cx.state.tx().clone(), bytecode, message, false);
-    cx.gas.erase_cost(result.gas_remaining);
+    cx.gas.erase_cost(result.gas_returned_to_parent());
+    cx.gas.record_refund(result.refund_propagated_to_parent());
     if !result.stop.is_success() {
         cx.state.set_return_data(result.output);
     } else {

--- a/crates/evm2/src/interpreter/instructions/tests.rs
+++ b/crates/evm2/src/interpreter/instructions/tests.rs
@@ -2,7 +2,7 @@ use crate::{
     BaseEvmConfig, EvmConfig, EvmTypes, SpecId,
     bytecode::Bytecode,
     env::{BlockEnv, TxEnv},
-    evm::{AccountLoad, SelfDestructResult, StorageLoad},
+    evm::{AccountLoad, SLoad, SStore, SelfDestructResult},
     interpreter::{
         Gas, Host, InstrStop, Interpreter, Memory, Message, MessageKind, MessageResult, Stack,
         Word, op,
@@ -31,6 +31,7 @@ pub(crate) struct TestHost {
     pub(super) is_empty: bool,
     pub(super) is_cold: bool,
     pub(super) storage: HashMap<(Address, Word), Word>,
+    pub(super) original_storage: HashMap<(Address, Word), Word>,
     pub(super) transient_storage: HashMap<(Address, Word), Word>,
     pub(super) logs: Vec<Log>,
     pub(super) execute_result: MessageResult,
@@ -49,6 +50,7 @@ impl Default for TestHost {
             is_empty: false,
             is_cold: false,
             storage: HashMap::default(),
+            original_storage: HashMap::default(),
             transient_storage: HashMap::default(),
             logs: Vec::new(),
             execute_result: MessageResult { stop: InstrStop::Return, ..MessageResult::default() },
@@ -91,15 +93,40 @@ impl Host for TestHost {
         Some(B256::with_last_byte(number.wrapping_to::<u8>()))
     }
 
-    fn sload(&mut self, address: Address, key: Word) -> StorageLoad {
-        StorageLoad {
+    fn sload(
+        &mut self,
+        address: Address,
+        key: Word,
+        skip_cold_load: bool,
+    ) -> Result<SLoad, InstrStop> {
+        if skip_cold_load && self.is_cold {
+            return Err(InstrStop::OutOfGas);
+        }
+        Ok(SLoad {
             value: self.storage.get(&(address, key)).copied().unwrap_or_default(),
             is_cold: self.is_cold,
-        }
+        })
     }
 
-    fn sstore(&mut self, address: Address, key: Word, value: Word) {
-        self.storage.insert((address, key), value);
+    fn sstore(
+        &mut self,
+        address: Address,
+        key: Word,
+        value: Word,
+        skip_cold_load: bool,
+    ) -> Result<SStore, InstrStop> {
+        if skip_cold_load && self.is_cold {
+            return Err(InstrStop::OutOfGas);
+        }
+        let storage_key = (address, key);
+        let present_value = self.storage.get(&storage_key).copied().unwrap_or_default();
+        let original_value = *self.original_storage.entry(storage_key).or_insert(present_value);
+        if value.is_zero() {
+            self.storage.remove(&storage_key);
+        } else {
+            self.storage.insert(storage_key, value);
+        }
+        Ok(SStore { original_value, present_value, new_value: value, is_cold: self.is_cold })
     }
 
     fn tload(&mut self, address: Address, key: Word) -> Word {
@@ -157,6 +184,14 @@ impl TestInterpreter {
 
     pub(super) fn gas_remaining(&self) -> u64 {
         self.gas.remaining()
+    }
+
+    pub(super) fn gas_refunded(&self) -> i64 {
+        self.gas.refunded()
+    }
+
+    pub(super) fn state_gas_spent(&self) -> u64 {
+        self.gas.state_gas_spent()
     }
 
     pub(super) fn output(&self) -> &[u8] {
@@ -257,7 +292,7 @@ fn run_with_config<C: EvmConfig<TestTypes>>(config: RunConfig<'_>) -> TestInterp
     }
 }
 
-pub(super) trait ToWord {
+pub(crate) trait ToWord {
     fn to_word(self) -> Word;
 }
 
@@ -318,7 +353,7 @@ macro_rules! assert_stack {
 }
 pub(crate) use assert_stack;
 
-pub(super) fn push(code: &mut Vec<u8>, value: impl ToWord) {
+pub(crate) fn push(code: &mut Vec<u8>, value: impl ToWord) {
     let value = value.to_word();
     if value.is_zero() {
         code.extend([op::PUSH1, 0]);

--- a/crates/evm2/src/interpreter/state.rs
+++ b/crates/evm2/src/interpreter/state.rs
@@ -3,7 +3,7 @@ use crate::{
     EvmTypes, SpecId, Version,
     bytecode::Bytecode,
     env::{BlockEnv, TxEnv},
-    evm::{AccountLoad, SelfDestructResult, StorageLoad},
+    evm::{AccountLoad, SLoad, SStore, SelfDestructResult},
     version::GasParams,
 };
 use alloy_primitives::{Address, B256, Bytes, Log};
@@ -108,12 +108,26 @@ impl<T: EvmTypes> fmt::Debug for State<'_, T> {
 }
 
 /// Result of executing a call/create message.
+///
+/// Gas accounting is split into unused gas and the refund counter because EVM refunds are not
+/// immediately spendable by the parent frame and are capped only at the top-level transaction. Use
+/// [`Self::gas_returned_to_parent`] and [`Self::refund_propagated_to_parent`] when applying a child
+/// result to a caller frame. Use [`Self::gas_remaining_after_final_refund`] or
+/// [`Self::gas_used_after_final_refund`] for top-level transaction accounting.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct MessageResult {
     /// Interpreter stop reason.
     pub stop: InstrStop,
-    /// Gas left in the child frame after refunds.
+    /// Gas left in the child frame before refund accounting.
+    ///
+    /// Do not use this field directly for parent-frame or transaction-level refund handling; see
+    /// the [`MessageResult`] docs and helper methods.
     pub gas_remaining: u64,
+    /// Raw refund counter produced by this frame.
+    ///
+    /// This value may be negative locally. Do not use this field directly for propagation or final
+    /// transaction refunds; see the [`MessageResult`] docs and helper methods.
+    pub gas_refunded: i64,
     /// Return or revert output.
     pub output: Bytes,
     /// Created address for successful create messages.
@@ -125,6 +139,51 @@ impl MessageResult {
     #[inline]
     pub const fn is_success(&self) -> bool {
         self.stop.is_success()
+    }
+
+    /// Returns whether the message can return unused gas to its parent frame.
+    #[inline]
+    pub const fn returns_unused_gas(&self) -> bool {
+        self.stop.is_success() || self.stop.is_revert()
+    }
+
+    /// Returns unused gas that should be returned to the parent frame.
+    #[inline]
+    pub const fn gas_returned_to_parent(&self) -> u64 {
+        if self.returns_unused_gas() { self.gas_remaining } else { 0 }
+    }
+
+    /// Returns the refund counter delta that should be propagated to the parent frame.
+    #[inline]
+    pub const fn refund_propagated_to_parent(&self) -> i64 {
+        if self.stop.is_success() { self.gas_refunded } else { 0 }
+    }
+
+    /// Calculates the final refund amount for a top-level successful transaction.
+    #[inline]
+    pub const fn final_refund(&self, gas_limit: u64, is_london: bool) -> u64 {
+        if !self.stop.is_success() || self.gas_refunded <= 0 {
+            return 0;
+        }
+        let max_refund_quotient = if is_london { 5 } else { 2 };
+        let spent = gas_limit.saturating_sub(self.gas_remaining);
+        let refund = self.gas_refunded as u64;
+        let cap = spent / max_refund_quotient;
+        if refund < cap { refund } else { cap }
+    }
+
+    /// Returns top-level gas remaining after applying the final refund cap.
+    #[inline]
+    pub const fn gas_remaining_after_final_refund(&self, gas_limit: u64, is_london: bool) -> u64 {
+        let refunded = self.final_refund(gas_limit, is_london);
+        let remaining = self.gas_remaining.saturating_add(refunded);
+        if remaining < gas_limit { remaining } else { gas_limit }
+    }
+
+    /// Returns top-level gas used after applying the final refund cap.
+    #[inline]
+    pub const fn gas_used_after_final_refund(&self, gas_limit: u64, is_london: bool) -> u64 {
+        gas_limit.saturating_sub(self.gas_remaining_after_final_refund(gas_limit, is_london))
     }
 }
 
@@ -148,10 +207,21 @@ pub trait Host {
     fn block_hash(&mut self, number: Word) -> Option<B256>;
 
     /// Loads a persistent storage slot.
-    fn sload(&mut self, address: Address, key: Word) -> StorageLoad;
+    fn sload(
+        &mut self,
+        address: Address,
+        key: Word,
+        skip_cold_load: bool,
+    ) -> Result<SLoad, InstrStop>;
 
     /// Stores a persistent storage slot.
-    fn sstore(&mut self, address: Address, key: Word, value: Word);
+    fn sstore(
+        &mut self,
+        address: Address,
+        key: Word,
+        value: Word,
+        skip_cold_load: bool,
+    ) -> Result<SStore, InstrStop>;
 
     /// Loads a transient storage slot.
     fn tload(&mut self, address: Address, key: Word) -> Word;

--- a/crates/evm2/src/tests.rs
+++ b/crates/evm2/src/tests.rs
@@ -3,9 +3,10 @@ use crate::{
     bytecode::Bytecode,
     env::{BlockEnv, TxEnv},
     evm::{AccountInfo, InMemoryDB},
-    interpreter::{Host, InstrStop, Message, Word, op},
+    interpreter::{Host, InstrStop, Message, Word, instructions::tests::push, op},
     registry::TxRegistry,
 };
+use alloc::vec::Vec;
 use alloy_primitives::{Address, Bytes};
 
 type TestEvm = Evm<BaseEvmTypes>;
@@ -78,6 +79,63 @@ fn evm_runs_transactions_against_initial_state() {
     assert!(evm.state().account_ref(contract).is_some());
     assert_eq!(evm.state().storage[&contract].slots[&Word::from(1)].current, Word::from(7));
     assert_eq!(evm.state().storage[&contract].slots[&Word::from(2)].current, Word::from(42));
+}
+
+#[test]
+fn evm_propagates_child_sstore_negative_refund() {
+    let contract = Address::with_last_byte(0x44);
+    let mut child_code = Vec::new();
+    push(&mut child_code, 7);
+    push(&mut child_code, 0);
+    child_code.extend([op::SSTORE, op::STOP]);
+
+    let mut database = InMemoryDB::default();
+    database.insert_account_info(
+        contract,
+        AccountInfo {
+            nonce: 1,
+            code: Some(Bytecode::new_legacy(Bytes::from(child_code))),
+            ..Default::default()
+        },
+    );
+    database.insert_account_storage(contract, Word::from(0), Word::from(5));
+    let mut evm = TestEvm::new(
+        SpecId::LONDON,
+        BlockEnv::default(),
+        TxRegistry::new(),
+        database,
+        Precompiles::base(SpecId::LONDON),
+    );
+
+    let mut parent_code = Vec::new();
+    push(&mut parent_code, 0);
+    push(&mut parent_code, 0);
+    parent_code.push(op::SSTORE);
+    push(&mut parent_code, 0); // return length
+    push(&mut parent_code, 0); // return offset
+    push(&mut parent_code, 0); // input length
+    push(&mut parent_code, 0); // input offset
+    push(&mut parent_code, 0); // value
+    push(&mut parent_code, 0x44); // callee
+    push(&mut parent_code, 50_000); // gas
+    parent_code.extend([op::CALL, op::STOP]);
+
+    let message = Message {
+        destination: contract,
+        code_address: contract,
+        gas_limit: 100_000,
+        ..Default::default()
+    };
+    let result = Host::execute_message(
+        &mut evm,
+        TxEnv::default(),
+        Bytecode::new_legacy(Bytes::from(parent_code)),
+        message,
+        false,
+    );
+
+    assert!(result.stop.is_success());
+    assert_eq!(result.gas_refunded, 0);
 }
 
 #[test]

--- a/crates/evm2/src/version/gas_params.rs
+++ b/crates/evm2/src/version/gas_params.rs
@@ -1,4 +1,4 @@
-use crate::utils::num_words;
+use crate::{evm::SStore, utils::num_words};
 use alloy_primitives::U256;
 use core::ops::{Index, IndexMut};
 
@@ -297,6 +297,80 @@ impl GasParams {
     #[inline]
     pub const fn call_stipend_reduction(&self, gas_limit: u64) -> u64 {
         gas_limit - gas_limit / self.get(GasId::CallStipendReduction) as u64
+    }
+
+    /// Calculates dynamic `SSTORE` gas.
+    #[inline]
+    pub fn sstore_dynamic_gas(&self, is_istanbul: bool, vals: &SStore) -> u64 {
+        if !is_istanbul {
+            if vals.present_is_zero() && !vals.new_is_zero() {
+                return self.get(GasId::SstoreSetWithoutLoadCost) as u64;
+            }
+            return self.get(GasId::SstoreResetWithoutColdLoadCost) as u64;
+        }
+
+        let mut gas = 0;
+        if vals.is_cold {
+            gas += self.get(GasId::ColdStorageCost) as u64;
+        }
+
+        if !vals.is_noop() && vals.is_clean() {
+            gas += if vals.original_is_zero() {
+                self.get(GasId::SstoreSetWithoutLoadCost) as u64
+            } else {
+                self.get(GasId::SstoreResetWithoutColdLoadCost) as u64
+            };
+        }
+        gas
+    }
+
+    /// Calculates `SSTORE` refund.
+    #[inline]
+    pub fn sstore_refund(&self, is_istanbul: bool, vals: &SStore) -> i64 {
+        let clearing_slot_refund = self.get(GasId::SstoreClearingSlotRefund) as i64;
+
+        if !is_istanbul {
+            if !vals.present_is_zero() && vals.new_is_zero() {
+                return clearing_slot_refund;
+            }
+            return 0;
+        }
+
+        if vals.is_noop() {
+            return 0;
+        }
+
+        if vals.is_clean() && vals.new_is_zero() {
+            return clearing_slot_refund;
+        }
+
+        let mut refund = 0;
+        if !vals.original_is_zero() {
+            if vals.present_is_zero() {
+                refund -= clearing_slot_refund;
+            } else if vals.new_is_zero() {
+                refund += clearing_slot_refund;
+            }
+        }
+
+        if vals.resets_original() {
+            if vals.original_is_zero() {
+                refund += self.get(GasId::SstoreSetRefund) as i64;
+            } else {
+                refund += self.get(GasId::SstoreResetRefund) as i64;
+            }
+        }
+        refund
+    }
+
+    /// Calculates `SSTORE` state gas for new slot creation.
+    #[inline]
+    pub fn sstore_state_gas(&self, vals: &SStore) -> u64 {
+        if !vals.is_noop() && vals.is_clean() && vals.original_is_zero() {
+            self.get(GasId::SstoreSetState) as u64
+        } else {
+            0
+        }
     }
 
     /// Returns `SELFDESTRUCT` cold account cost.


### PR DESCRIPTION
- Align `SLOAD`/`SSTORE` host interaction with revm, including cold-load skipping and original/present/new slot tracking.
- Implement EIP-2200 net metering, EIP-2929 cold storage costs, EIP-3529 refund behavior, and Amsterdam state gas for `SSTORE`.
- Propagate child-frame gas refunds separately from unused gas so refunds are capped only at the top-level transaction and negative local refund deltas are handled correctly.
- Add regression coverage for dirty-slot writes, reset-to-original refunds, Amsterdam state gas, and child refund propagation.

This fixes around 600 execution tests.