### PR TITLE
refactor(ethereum): split legacy handler module

### DIFF
--- a/crates/evm2/src/ethereum/legacy.rs
+++ b/crates/evm2/src/ethereum/legacy.rs
@@ -1,87 +1,17 @@
-//! Ethereum transaction envelope and handlers.
-
 use crate::{
     Evm, EvmTypes, SpecId, TxResult, Version,
     bytecode::Bytecode,
     env::TxEnv,
     evm::precompile::PrecompileProvider,
     interpreter::{Host, Message, MessageKind, Word},
-    registry::{HandlerError, HandlerResult, TxRegistry, TxRequest},
+    registry::{HandlerError, HandlerResult, TxRequest},
     utils::num_words,
     version::GasId,
 };
-use alloy_consensus::{TxEip1559, TxEip2930, TxEip7702, TxLegacy, transaction::Recovered};
-use alloy_eips::eip2718::Typed2718;
+use alloy_consensus::{TxLegacy, transaction::Recovered};
 use alloy_primitives::{B256, Bytes, TxKind, U256};
 
-/// Ethereum transaction envelope containing recovered transactions.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum RecoveredTxEnvelope {
-    /// Legacy transaction.
-    Legacy(Recovered<TxLegacy>),
-    /// EIP-2930 access-list transaction.
-    Eip2930(Recovered<TxEip2930>),
-    /// EIP-1559 dynamic-fee transaction.
-    Eip1559(Recovered<TxEip1559>),
-    /// EIP-7702 set-code transaction.
-    Eip7702(Recovered<TxEip7702>),
-}
-
-impl RecoveredTxEnvelope {
-    /// Returns the contained legacy transaction, if this is legacy.
-    pub const fn as_legacy(&self) -> Option<&Recovered<TxLegacy>> {
-        match self {
-            Self::Legacy(tx) => Some(tx),
-            Self::Eip2930(_) | Self::Eip1559(_) | Self::Eip7702(_) => None,
-        }
-    }
-
-    /// Returns the contained EIP-2930 transaction, if this is EIP-2930.
-    pub const fn as_eip2930(&self) -> Option<&Recovered<TxEip2930>> {
-        match self {
-            Self::Eip2930(tx) => Some(tx),
-            Self::Legacy(_) | Self::Eip1559(_) | Self::Eip7702(_) => None,
-        }
-    }
-
-    /// Returns the contained EIP-1559 transaction, if this is EIP-1559.
-    pub const fn as_eip1559(&self) -> Option<&Recovered<TxEip1559>> {
-        match self {
-            Self::Eip1559(tx) => Some(tx),
-            Self::Legacy(_) | Self::Eip2930(_) | Self::Eip7702(_) => None,
-        }
-    }
-
-    /// Returns the contained EIP-7702 transaction, if this is EIP-7702.
-    pub const fn as_eip7702(&self) -> Option<&Recovered<TxEip7702>> {
-        match self {
-            Self::Eip7702(tx) => Some(tx),
-            Self::Legacy(_) | Self::Eip2930(_) | Self::Eip1559(_) => None,
-        }
-    }
-}
-
-impl Typed2718 for RecoveredTxEnvelope {
-    fn ty(&self) -> u8 {
-        match self {
-            Self::Legacy(tx) => tx.ty(),
-            Self::Eip2930(tx) => tx.ty(),
-            Self::Eip1559(tx) => tx.ty(),
-            Self::Eip7702(tx) => tx.ty(),
-        }
-    }
-}
-
-/// Returns the Ethereum transaction registry.
-///
-/// Currently only legacy transactions are registered. Future Ethereum typed
-/// transaction handlers should be added here.
-pub fn ethereum_tx_registry<T: EvmTypes<Host = Evm<T>>>()
--> TxRegistry<RecoveredTxEnvelope, TxResult, Evm<T>> {
-    TxRegistry::new().with_handler(0, RecoveredTxEnvelope::as_legacy, handle_legacy::<T>)
-}
-
-fn handle_legacy<T: EvmTypes<Host = Evm<T>>>(
+pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     req: TxRequest<'_, Recovered<TxLegacy>, Evm<T>>,
 ) -> HandlerResult<TxResult> {
     let caller = req.tx.signer();
@@ -195,7 +125,7 @@ fn handle_legacy<T: EvmTypes<Host = Evm<T>>>(
 }
 
 /// Calculates intrinsic legacy transaction gas.
-pub fn legacy_intrinsic_gas(version: &Version, tx: &TxLegacy) -> u64 {
+pub(super) fn legacy_intrinsic_gas(version: &Version, tx: &TxLegacy) -> u64 {
     let spec = version.spec_id();
     let non_zero_multiplier = if spec.enables(SpecId::ISTANBUL) { 16 } else { 68 };
     let mut gas = 21_000;

--- a/crates/evm2/src/ethereum/mod.rs
+++ b/crates/evm2/src/ethereum/mod.rs
@@ -1,0 +1,74 @@
+//! Ethereum transaction envelope and handlers.
+
+mod legacy;
+
+use crate::{Evm, EvmTypes, TxResult, registry::TxRegistry};
+use alloy_consensus::{TxEip1559, TxEip2930, TxEip7702, TxLegacy, transaction::Recovered};
+use alloy_eips::eip2718::Typed2718;
+
+/// Ethereum transaction envelope containing recovered transactions.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum RecoveredTxEnvelope {
+    /// Legacy transaction.
+    Legacy(Recovered<TxLegacy>),
+    /// EIP-2930 access-list transaction.
+    Eip2930(Recovered<TxEip2930>),
+    /// EIP-1559 dynamic-fee transaction.
+    Eip1559(Recovered<TxEip1559>),
+    /// EIP-7702 set-code transaction.
+    Eip7702(Recovered<TxEip7702>),
+}
+
+impl RecoveredTxEnvelope {
+    /// Returns the contained legacy transaction, if this is legacy.
+    pub const fn as_legacy(&self) -> Option<&Recovered<TxLegacy>> {
+        match self {
+            Self::Legacy(tx) => Some(tx),
+            Self::Eip2930(_) | Self::Eip1559(_) | Self::Eip7702(_) => None,
+        }
+    }
+
+    /// Returns the contained EIP-2930 transaction, if this is EIP-2930.
+    pub const fn as_eip2930(&self) -> Option<&Recovered<TxEip2930>> {
+        match self {
+            Self::Eip2930(tx) => Some(tx),
+            Self::Legacy(_) | Self::Eip1559(_) | Self::Eip7702(_) => None,
+        }
+    }
+
+    /// Returns the contained EIP-1559 transaction, if this is EIP-1559.
+    pub const fn as_eip1559(&self) -> Option<&Recovered<TxEip1559>> {
+        match self {
+            Self::Eip1559(tx) => Some(tx),
+            Self::Legacy(_) | Self::Eip2930(_) | Self::Eip7702(_) => None,
+        }
+    }
+
+    /// Returns the contained EIP-7702 transaction, if this is EIP-7702.
+    pub const fn as_eip7702(&self) -> Option<&Recovered<TxEip7702>> {
+        match self {
+            Self::Eip7702(tx) => Some(tx),
+            Self::Legacy(_) | Self::Eip2930(_) | Self::Eip1559(_) => None,
+        }
+    }
+}
+
+impl Typed2718 for RecoveredTxEnvelope {
+    fn ty(&self) -> u8 {
+        match self {
+            Self::Legacy(tx) => tx.ty(),
+            Self::Eip2930(tx) => tx.ty(),
+            Self::Eip1559(tx) => tx.ty(),
+            Self::Eip7702(tx) => tx.ty(),
+        }
+    }
+}
+
+/// Returns the Ethereum transaction registry.
+///
+/// Currently only legacy transactions are registered. Future Ethereum typed
+/// transaction handlers should be added here.
+pub fn ethereum_tx_registry<T: EvmTypes<Host = Evm<T>>>()
+-> TxRegistry<RecoveredTxEnvelope, TxResult, Evm<T>> {
+    TxRegistry::new().with_handler(0, RecoveredTxEnvelope::as_legacy, legacy::handle::<T>)
+}


### PR DESCRIPTION
Splits the Ethereum transaction handling module into an ethereum/ directory, with the registry and envelope in mod.rs and the legacy handler in legacy.rs.

This PR is based on main.