### PR TITLE
refactor(statetest): build consensus transactions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ alloy-consensus = { version = "2.0.4", default-features = false }
 alloy-eips = { version = "2.0.4", default-features = false }
 alloy-primitives = { version = "1.5.7", default-features = false }
 alloy-rlp = { version = "0.3", default-features = false }
+alloy-rpc-types-eth = { version = "2.0.4", default-features = false }
 alloy-trie = { version = "0.9", default-features = false }
 derive_more = { version = "2.0", default-features = false, features = ["debug"] }
 

--- a/crates/evm2-statetest/Cargo.toml
+++ b/crates/evm2-statetest/Cargo.toml
@@ -20,6 +20,7 @@ evm2 = { path = "../evm2", features = ["std", "serde"] }
 alloy-consensus = { workspace = true, features = ["std"] }
 alloy-primitives = { workspace = true, features = ["std", "serde", "rlp"] }
 alloy-rlp = { workspace = true, features = ["std"] }
+alloy-rpc-types-eth = { workspace = true, features = ["std"] }
 alloy-trie = { workspace = true, features = ["ethereum"] }
 k256 = { workspace = true, features = ["ecdsa", "std"] }
 libtest-mimic.workspace = true

--- a/crates/evm2-statetest/src/error.rs
+++ b/crates/evm2-statetest/src/error.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::{B256, Bytes, U256};
+use alloy_primitives::{B256, Bytes};
 use evm2::registry::HandlerError;
 use std::{io, path::PathBuf};
 use thiserror::Error;
@@ -73,16 +73,6 @@ pub(crate) enum TestErrorKind {
     /// Sender could not be recovered.
     #[error("unknown private key: {0:?}")]
     UnknownPrivateKey(B256),
-    /// Dynamic-fee transaction max fee is lower than the block base fee.
-    #[error(
-        "max fee per gas is lower than block base fee: max_fee_per_gas={max_fee_per_gas}, base_fee={base_fee}"
-    )]
-    FeeCapLessThanBaseFee {
-        /// Transaction fee cap.
-        max_fee_per_gas: U256,
-        /// Block base fee.
-        base_fee: U256,
-    },
     /// Unexpected exception status.
     #[error("unexpected exception: got {got_exception:?}, expected {expected_exception:?}")]
     UnexpectedException {
@@ -105,6 +95,9 @@ pub(crate) enum TestErrorKind {
     /// Transaction part index was invalid.
     #[error("bad transaction index: {0}")]
     BadIndex(&'static str),
+    /// Transaction request could not be converted to a consensus transaction.
+    #[error("could not build consensus transaction: {0}")]
+    BuildTransaction(String),
     /// EVM execution failed.
     #[error(transparent)]
     Evm(#[from] HandlerError),

--- a/crates/evm2-statetest/src/execute.rs
+++ b/crates/evm2-statetest/src/execute.rs
@@ -2,8 +2,12 @@ use crate::{
     error::{TestError, TestErrorKind},
     types::{AccountInfo, Env, Test, TestSuite, TestUnit, TransactionParts, TxPartIndices},
 };
-use alloy_consensus::{TxLegacy, transaction::Recovered};
+use alloy_consensus::{TypedTransaction, transaction::Recovered};
 use alloy_primitives::{Address, B256, Bytes, Log, TxKind, U256, keccak256};
+use alloy_rpc_types_eth::{
+    AccessList as RpcAccessList, AccessListItem as RpcAccessListItem, TransactionInput,
+    TransactionRequest,
+};
 use alloy_trie::{
     TrieAccount,
     root::{state_root_unhashed, storage_root_unhashed},
@@ -75,7 +79,7 @@ fn execute_unit(
             continue;
         };
         for post in posts {
-            let tx = match build_tx(&unit.transaction, &post.indexes, block.basefee) {
+            let tx = match build_tx(&unit.transaction, &post.indexes, unit.env.current_chain_id) {
                 Ok(tx) => tx,
                 Err(_) if post.expect_exception.is_some() => {
                     continue;
@@ -349,7 +353,7 @@ fn parse_block(env: &Env) -> BlockEnv {
 fn build_tx(
     raw: &TransactionParts,
     indexes: &TxPartIndices,
-    base_fee: U256,
+    chain_id: Option<U256>,
 ) -> Result<RecoveredTxEnvelope, TestErrorKind> {
     let caller = match raw.sender {
         Some(sender) => sender,
@@ -365,35 +369,100 @@ fn build_tx(
         .map_err(|_| TestErrorKind::Overflow("gasLimit"))?;
     let value = *raw.value.get(indexes.value).ok_or(TestErrorKind::BadIndex("value"))?;
     let nonce = raw.nonce.try_into().map_err(|_| TestErrorKind::Overflow("nonce"))?;
-    let gas_price = effective_gas_price(raw, base_fee)?
-        .try_into()
-        .map_err(|_| TestErrorKind::Overflow("gasPrice"))?;
-    let tx = TxLegacy {
-        chain_id: None,
-        nonce,
-        gas_price,
-        gas_limit,
-        to: TxKind::from(raw.to),
-        value,
-        input: data,
-    };
-    Ok(RecoveredTxEnvelope::Legacy(Recovered::new_unchecked(tx, caller)))
+
+    let mut request = TransactionRequest::default()
+        .from(caller)
+        .gas_limit(gas_limit)
+        .nonce(nonce)
+        .value(value)
+        .input(TransactionInput::from(data));
+    request.to = Some(TxKind::from(raw.to));
+    request.transaction_type = raw.tx_type;
+    request.chain_id = chain_id
+        .map(TryInto::try_into)
+        .transpose()
+        .map_err(|_| TestErrorKind::Overflow("chainId"))?;
+    if !matches!(raw.tx_type, Some(2..=4)) {
+        request.gas_price = raw
+            .gas_price
+            .map(TryInto::try_into)
+            .transpose()
+            .map_err(|_| TestErrorKind::Overflow("gasPrice"))?;
+        if request.gas_price.is_none()
+            && (matches!(raw.tx_type, Some(0 | 1))
+                || (raw.max_fee_per_gas.is_none() && raw.max_priority_fee_per_gas.is_none()))
+        {
+            request.gas_price = Some(0);
+        }
+    }
+    request.max_fee_per_gas = raw
+        .max_fee_per_gas
+        .map(TryInto::try_into)
+        .transpose()
+        .map_err(|_| TestErrorKind::Overflow("maxFeePerGas"))?;
+    request.max_priority_fee_per_gas =
+        if raw.max_fee_per_gas.is_some() && raw.max_priority_fee_per_gas.is_none() {
+            Some(0)
+        } else {
+            raw.max_priority_fee_per_gas
+                .map(TryInto::try_into)
+                .transpose()
+                .map_err(|_| TestErrorKind::Overflow("maxPriorityFeePerGas"))?
+        };
+    request.max_fee_per_blob_gas = raw
+        .max_fee_per_blob_gas
+        .map(TryInto::try_into)
+        .transpose()
+        .map_err(|_| TestErrorKind::Overflow("maxFeePerBlobGas"))?;
+    request.access_list = access_list(raw)?;
+    if !raw.blob_versioned_hashes.is_empty() {
+        request.blob_versioned_hashes = Some(raw.blob_versioned_hashes.clone());
+    }
+
+    let tx =
+        request.build_consensus_tx().map_err(|err| TestErrorKind::BuildTransaction(err.error))?;
+    recovered_envelope(tx, caller)
 }
 
-fn effective_gas_price(raw: &TransactionParts, base_fee: U256) -> Result<U256, TestErrorKind> {
-    if let Some(gas_price) = raw.gas_price {
-        return Ok(gas_price);
+fn access_list(raw: &TransactionParts) -> Result<Option<RpcAccessList>, TestErrorKind> {
+    if matches!(raw.tx_type, Some(0)) {
+        return Ok(None);
     }
-
-    let Some(max_fee_per_gas) = raw.max_fee_per_gas else {
-        return Ok(U256::ZERO);
+    let Some(access_list) = raw.access_lists.first().cloned().flatten() else {
+        return Ok(matches!(raw.tx_type, Some(1)).then(RpcAccessList::default));
     };
-    if max_fee_per_gas < base_fee {
-        return Err(TestErrorKind::FeeCapLessThanBaseFee { max_fee_per_gas, base_fee });
-    }
+    Ok(Some(RpcAccessList(
+        access_list
+            .into_iter()
+            .map(|item| RpcAccessListItem {
+                address: item.address,
+                storage_keys: item.storage_keys,
+            })
+            .collect(),
+    )))
+}
 
-    let priority_fee = raw.max_priority_fee_per_gas.unwrap_or_default();
-    Ok(max_fee_per_gas.min(base_fee.saturating_add(priority_fee)))
+fn recovered_envelope(
+    tx: TypedTransaction,
+    caller: Address,
+) -> Result<RecoveredTxEnvelope, TestErrorKind> {
+    match tx {
+        TypedTransaction::Legacy(tx) => {
+            Ok(RecoveredTxEnvelope::Legacy(Recovered::new_unchecked(tx, caller)))
+        }
+        TypedTransaction::Eip2930(tx) => {
+            Ok(RecoveredTxEnvelope::Eip2930(Recovered::new_unchecked(tx, caller)))
+        }
+        TypedTransaction::Eip1559(tx) => {
+            Ok(RecoveredTxEnvelope::Eip1559(Recovered::new_unchecked(tx, caller)))
+        }
+        TypedTransaction::Eip7702(tx) => {
+            Ok(RecoveredTxEnvelope::Eip7702(Recovered::new_unchecked(tx, caller)))
+        }
+        TypedTransaction::Eip4844(_) => Err(TestErrorKind::BuildTransaction(
+            "EIP-4844 transactions are not supported".to_string(),
+        )),
+    }
 }
 
 fn recover_address(private_key: &[u8]) -> Option<Address> {
@@ -423,42 +492,52 @@ mod tests {
     }
 
     #[test]
-    fn effective_gas_price_uses_legacy_gas_price() {
-        let tx = TransactionParts {
+    fn build_tx_builds_legacy_transaction() {
+        let caller = Address::from([0x11; 20]);
+        let raw = TransactionParts {
+            data: vec![Bytes::from_static(&[0xaa])],
+            gas_limit: vec![U256::from(21_000)],
             gas_price: Some(U256::from(7)),
-            max_fee_per_gas: Some(U256::from(10)),
-            max_priority_fee_per_gas: Some(U256::from(2)),
+            sender: Some(caller),
+            to: Some(Address::from([0x22; 20])),
+            value: vec![U256::from(3)],
             ..TransactionParts::default()
         };
 
-        assert_eq!(effective_gas_price(&tx, U256::from(100)).unwrap(), U256::from(7));
+        let tx = build_tx(&raw, &TxPartIndices { data: 0, gas: 0, value: 0 }, None).unwrap();
+
+        let RecoveredTxEnvelope::Legacy(tx) = tx else {
+            panic!("expected legacy transaction");
+        };
+        assert_eq!(tx.signer(), caller);
+        assert_eq!(tx.inner().gas_price, 7);
     }
 
     #[test]
-    fn effective_gas_price_caps_priority_fee() {
-        let tx = TransactionParts {
-            max_fee_per_gas: Some(U256::from(10)),
-            max_priority_fee_per_gas: Some(U256::from(3)),
+    fn build_tx_builds_eip2930_transaction() {
+        let caller = Address::from([0x11; 20]);
+        let access_address = Address::from([0x33; 20]);
+        let raw = TransactionParts {
+            tx_type: Some(1),
+            data: vec![Bytes::new()],
+            gas_limit: vec![U256::from(25_300)],
+            gas_price: Some(U256::from(7)),
+            sender: Some(caller),
+            to: Some(Address::from([0x22; 20])),
+            value: vec![U256::ZERO],
+            access_lists: vec![Some(vec![crate::types::AccessListItem {
+                address: access_address,
+                storage_keys: vec![B256::with_last_byte(1)],
+            }])],
             ..TransactionParts::default()
         };
 
-        assert_eq!(effective_gas_price(&tx, U256::from(8)).unwrap(), U256::from(10));
-    }
+        let tx = build_tx(&raw, &TxPartIndices { data: 0, gas: 0, value: 0 }, None).unwrap();
 
-    #[test]
-    fn effective_gas_price_rejects_fee_cap_below_base_fee() {
-        let tx = TransactionParts {
-            max_fee_per_gas: Some(U256::from(7)),
-            ..TransactionParts::default()
+        let RecoveredTxEnvelope::Eip2930(tx) = tx else {
+            panic!("expected EIP-2930 transaction");
         };
-
-        let err = effective_gas_price(&tx, U256::from(8)).unwrap_err();
-        assert!(matches!(
-            err,
-            TestErrorKind::FeeCapLessThanBaseFee {
-                max_fee_per_gas,
-                base_fee
-            } if max_fee_per_gas == U256::from(7) && base_fee == U256::from(8)
-        ));
+        assert_eq!(tx.signer(), caller);
+        assert_eq!(tx.inner().access_list[0].address, access_address);
     }
 }


### PR DESCRIPTION
Changes statetest transaction construction to build an alloy TransactionRequest and convert it with build_consensus_tx before wrapping the consensus transaction with Recovered.

Stacks on top of #31.