### PR TITLE
feat(ethereum): handle eip1559 transactions

### DIFF
--- a/crates/evm2/src/ethereum/eip1559.rs
+++ b/crates/evm2/src/ethereum/eip1559.rs
@@ -1,0 +1,68 @@
+use super::{
+    access_list_counts, charge_upfront, effective_gas_price, floor_gas, initial_message,
+    intrinsic_gas, rollback_failed_execution, settle_gas, validate_block_gas_limit,
+    validate_create_initcode, validate_floor_gas, validate_gas_price, validate_intrinsic_gas,
+    validate_nonce_not_overflow, validate_priority_fee, validate_sender, warm_access_list,
+    warm_base_accounts,
+};
+use crate::{
+    Evm, EvmTypes, SpecId, TxResult,
+    env::TxEnv,
+    interpreter::Host,
+    registry::{HandlerError, HandlerResult, TxRequest},
+};
+use alloy_consensus::{TxEip1559, transaction::Recovered};
+use alloy_primitives::U256;
+
+pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
+    req: TxRequest<'_, Recovered<TxEip1559>, Evm<T>>,
+) -> HandlerResult<TxResult> {
+    let spec_id = req.host.spec_id();
+    if !spec_id.enables(SpecId::LONDON) {
+        return Err(HandlerError::Eip1559NotSupported);
+    }
+
+    let caller = req.tx.signer();
+    let tx = req.tx.inner();
+    let max_fee_per_gas = U256::from(tx.max_fee_per_gas);
+    let max_priority_fee_per_gas = U256::from(tx.max_priority_fee_per_gas);
+    let gas_price =
+        effective_gas_price(max_fee_per_gas, max_priority_fee_per_gas, req.host.block.basefee);
+
+    validate_priority_fee(max_fee_per_gas, max_priority_fee_per_gas)?;
+    validate_gas_price(spec_id, gas_price, req.host.block.basefee)?;
+    validate_block_gas_limit(tx.gas_limit, req.host.block.gas_limit)?;
+    validate_create_initcode(spec_id, tx.to, &tx.input)?;
+    validate_nonce_not_overflow(tx.nonce)?;
+    let (access_list_accounts, access_list_storage_keys) = access_list_counts(&tx.access_list);
+    let intrinsic = intrinsic_gas(
+        req.host.version(),
+        tx.to,
+        &tx.input,
+        access_list_accounts,
+        access_list_storage_keys,
+    );
+    validate_intrinsic_gas(tx.gas_limit, intrinsic)?;
+    validate_floor_gas(tx.gas_limit, floor_gas(req.host.version(), &tx.input))?;
+
+    let max_gas_cost = U256::from(tx.gas_limit) * max_fee_per_gas;
+    validate_sender(req.host, caller, tx.nonce, max_gas_cost.saturating_add(tx.value))?;
+
+    warm_base_accounts(req.host, spec_id, caller, tx.to);
+    warm_access_list(req.host, &tx.access_list);
+
+    let effective_gas_cost = U256::from(tx.gas_limit) * gas_price;
+    charge_upfront(req.host, caller, effective_gas_cost);
+    req.host.state.increment_nonce(caller);
+    let execution_checkpoint = req.host.state.checkpoint();
+
+    let gas_limit = tx.gas_limit - intrinsic;
+    let tx_env =
+        TxEnv { origin: caller, gas_price, chain_id: U256::from(tx.chain_id), ..TxEnv::default() };
+    let (bytecode, message) =
+        initial_message(req.host, caller, tx.nonce, tx.to, &tx.input, tx.value, gas_limit);
+    let mut result = req.host.execute_message(tx_env, bytecode, message, false);
+    rollback_failed_execution(req.host, execution_checkpoint, &mut result);
+
+    Ok(settle_gas(req.host, spec_id, caller, gas_price, tx.gas_limit, result))
+}

--- a/crates/evm2/src/ethereum/mod.rs
+++ b/crates/evm2/src/ethereum/mod.rs
@@ -1,5 +1,6 @@
 //! Ethereum transaction envelope and handlers.
 
+mod eip1559;
 mod eip2930;
 mod legacy;
 
@@ -82,6 +83,7 @@ pub fn ethereum_tx_registry<T: EvmTypes<Host = Evm<T>>>()
     TxRegistry::new()
         .with_handler(0, RecoveredTxEnvelope::as_legacy, legacy::handle::<T>)
         .with_handler(1, RecoveredTxEnvelope::as_eip2930, eip2930::handle::<T>)
+        .with_handler(2, RecoveredTxEnvelope::as_eip1559, eip1559::handle::<T>)
 }
 
 pub(super) fn validate_gas_price(
@@ -96,6 +98,24 @@ pub(super) fn validate_gas_price(
         });
     }
     Ok(())
+}
+
+pub(super) fn validate_priority_fee(
+    max_fee_per_gas: U256,
+    max_priority_fee_per_gas: U256,
+) -> HandlerResult<()> {
+    if max_priority_fee_per_gas > max_fee_per_gas {
+        return Err(HandlerError::PriorityFeeGreaterThanMaxFee);
+    }
+    Ok(())
+}
+
+pub(super) fn effective_gas_price(
+    max_fee_per_gas: U256,
+    max_priority_fee_per_gas: U256,
+    basefee: U256,
+) -> U256 {
+    max_fee_per_gas.min(basefee.saturating_add(max_priority_fee_per_gas))
 }
 
 pub(super) fn validate_block_gas_limit(

--- a/crates/evm2/src/evm/registry.rs
+++ b/crates/evm2/src/evm/registry.rs
@@ -130,6 +130,12 @@ pub enum HandlerError {
     /// EIP-2930 transaction is not enabled in the active specification.
     #[error("EIP-2930 transaction not supported")]
     Eip2930NotSupported,
+    /// EIP-1559 transaction is not enabled in the active specification.
+    #[error("EIP-1559 transaction not supported")]
+    Eip1559NotSupported,
+    /// Priority fee is greater than max fee.
+    #[error("priority fee greater than max fee")]
+    PriorityFeeGreaterThanMaxFee,
     /// Unsupported caller for this handler.
     #[error("unsupported caller {0}")]
     UnsupportedCaller(Address),


### PR DESCRIPTION
Adds the EIP-1559 transaction handler, registers transaction type 2, applies dynamic-fee validation and effective gas pricing, reuses access-list handling, and validates calldata floor gas.

Stacks on top of #32.