### PR TITLE
fix: enforce create initcode size limit

### DIFF
--- a/crates/evm2/src/constants.rs
+++ b/crates/evm2/src/constants.rs
@@ -1,0 +1,20 @@
+//! EVM protocol limits.
+
+/// Maximum deployed contract bytecode size.
+///
+/// EIP-170 - Contract code size limit.
+pub(crate) const MAX_CODE_SIZE: usize = 0x6000;
+
+/// Maximum contract creation initcode size.
+///
+/// EIP-3860 - Limit and meter initcode.
+pub(crate) const MAX_INITCODE_SIZE: usize = 2 * MAX_CODE_SIZE;
+
+/// Maximum message call depth.
+pub(crate) const CALL_DEPTH_LIMIT: u16 = 1024;
+
+/// Maximum EVM stack height.
+pub(crate) const STACK_LIMIT: usize = 1024;
+
+/// Number of recent block hashes available to the `BLOCKHASH` opcode.
+pub(crate) const BLOCK_HASH_HISTORY: u64 = 256;

--- a/crates/evm2/src/ethereum/mod.rs
+++ b/crates/evm2/src/ethereum/mod.rs
@@ -7,6 +7,7 @@ mod legacy;
 use crate::{
     Evm, EvmTypes, SpecId, TxResult, Version,
     bytecode::Bytecode,
+    constants::MAX_INITCODE_SIZE,
     evm::{AccountInfo, precompile::PrecompileProvider},
     interpreter::{Message, MessageKind, MessageResult, Word},
     registry::{HandlerError, HandlerResult, TxRegistry},
@@ -16,8 +17,6 @@ use crate::{
 use alloy_consensus::{TxEip1559, TxEip2930, TxEip7702, TxLegacy, transaction::Recovered};
 use alloy_eips::{eip2718::Typed2718, eip2930::AccessList};
 use alloy_primitives::{Address, B256, Bytes, KECCAK256_EMPTY, TxKind, U256};
-
-const MAX_INITCODE_SIZE: usize = 2 * 0x6000;
 
 /// Ethereum transaction envelope containing recovered transactions.
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -4,6 +4,7 @@ use self::precompile::{PrecompileOutput, PrecompileProvider};
 use crate::{
     EvmConfigSelector, EvmTypes, ExecutionConfig, PrecompileError, PrecompileHalt, SpecId,
     bytecode::Bytecode,
+    constants::{CALL_DEPTH_LIMIT, MAX_CODE_SIZE},
     env::{BlockEnv, TxEnv},
     interpreter::{
         Gas, Host, InstrStop, Interpreter, InterpreterPool, Message, MessageKind, MessageResult,
@@ -28,8 +29,6 @@ pub use state::{
     Account, AccountInfo, JournalEntry, State, StateChanges, StorageChangeSet, StorageOverlay,
     Tracked,
 };
-
-const MAX_CODE_SIZE: usize = 0x6000;
 
 /// Loaded account information.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
@@ -596,7 +595,7 @@ impl<T: EvmTypes<Host = Self>> Host for Evm<T> {
         message: &Message,
         caller_is_static: bool,
     ) -> MessageResult {
-        if message.depth > Message::CALL_DEPTH_LIMIT {
+        if message.depth > CALL_DEPTH_LIMIT {
             return MessageResult {
                 stop: InstrStop::CallTooDeep,
                 gas_remaining: message.gas_limit,
@@ -788,7 +787,7 @@ mod tests {
         let bytecode = Bytecode::new_legacy(Bytes::from_static(&[op::STOP]));
         let message = Message {
             kind: MessageKind::Call,
-            depth: Message::CALL_DEPTH_LIMIT,
+            depth: CALL_DEPTH_LIMIT,
             gas_limit: 50_000,
             ..Message::default()
         };
@@ -809,7 +808,7 @@ mod tests {
         let bytecode = Bytecode::new_legacy(Bytes::from_static(&[op::STOP]));
         let message = Message {
             kind: MessageKind::Call,
-            depth: Message::CALL_DEPTH_LIMIT + 1,
+            depth: CALL_DEPTH_LIMIT + 1,
             gas_limit: 50_000,
             ..Message::default()
         };

--- a/crates/evm2/src/interpreter/instructions/block.rs
+++ b/crates/evm2/src/interpreter/instructions/block.rs
@@ -1,11 +1,10 @@
 use crate::{
     SpecId,
+    constants::BLOCK_HASH_HISTORY,
     interpreter::{Host, InstrStop, Word},
     utils::{address_to_word, b256_to_word, word_to_usize_saturated},
 };
 use evm2_macros::instruction;
-
-const BLOCK_HASH_HISTORY: u64 = 256;
 
 #[instruction]
 pub(crate) fn blockhash(cx: _, [number]: [Word]) -> Result<out> {

--- a/crates/evm2/src/interpreter/instructions/system.rs
+++ b/crates/evm2/src/interpreter/instructions/system.rs
@@ -2,6 +2,7 @@
 
 use crate::{
     EvmTypes, SpecId,
+    constants::{CALL_DEPTH_LIMIT, MAX_INITCODE_SIZE},
     interpreter::{
         Host, InstrStop, InstructionCx, Message, MessageKind, MessageResult, Result, StackMut,
         Word, memory::resize_memory,
@@ -168,7 +169,7 @@ fn call_inner<T: EvmTypes>(
     let caller_is_static = cx.state.is_static();
     let bytecode = crate::bytecode::Bytecode::new_legacy(code);
     let tx_env = cx.state.tx() as *const _;
-    let result = if message.depth > Message::CALL_DEPTH_LIMIT {
+    let result = if message.depth > CALL_DEPTH_LIMIT {
         call_too_deep_result(message.gas_limit)
     } else {
         // SAFETY: `tx_env` points into the active interpreter frame and remains valid for the
@@ -222,6 +223,9 @@ fn create_inner<T: EvmTypes>(
 
     let len = word_to_usize(len)?;
     if cx.state.spec.enables(SpecId::SHANGHAI) {
+        if len > MAX_INITCODE_SIZE {
+            return Err(InstrStop::CreateInitCodeSizeLimit);
+        }
         cx.gas.spend(cx.state.gas_params().initcode_cost(len))?;
     }
     let code_range = resize_memory_range(&mut cx, offset, Word::from(len))?;
@@ -253,7 +257,7 @@ fn create_inner<T: EvmTypes>(
     };
     let bytecode = crate::bytecode::Bytecode::new_legacy(input);
     let tx_env = cx.state.tx() as *const _;
-    let result = if message.depth > Message::CALL_DEPTH_LIMIT {
+    let result = if message.depth > CALL_DEPTH_LIMIT {
         call_too_deep_result(message.gas_limit)
     } else {
         // SAFETY: `tx_env` points into the active interpreter frame and remains valid for the
@@ -299,6 +303,7 @@ pub(crate) fn selfdestruct(cx: _, [target]: [Word]) -> Result {
 mod tests {
     use crate::{
         SpecId,
+        constants::{CALL_DEPTH_LIMIT, MAX_INITCODE_SIZE},
         interpreter::{
             InstrStop, Message, MessageKind, MessageResult, Word,
             instructions::tests::{RunConfig, TestHost, push, run},
@@ -395,7 +400,7 @@ mod tests {
         let interpreter = run(RunConfig::new(code)
             .host(&mut host)
             .spec(SpecId::BERLIN)
-            .message(Message { depth: Message::CALL_DEPTH_LIMIT, ..Default::default() })
+            .message(Message { depth: CALL_DEPTH_LIMIT, ..Default::default() })
             .gas_limit(50_000));
         core::assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [Word::ZERO]);
@@ -429,7 +434,7 @@ mod tests {
         let interpreter = run(RunConfig::new(code)
             .host(&mut host)
             .spec(SpecId::TANGERINE)
-            .message(Message { depth: Message::CALL_DEPTH_LIMIT, ..Default::default() })
+            .message(Message { depth: CALL_DEPTH_LIMIT, ..Default::default() })
             .gas_limit(50_000));
         core::assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.gas_remaining(), 42_553);
@@ -458,7 +463,7 @@ mod tests {
         let interpreter = run(RunConfig::new(code)
             .host(&mut host)
             .spec(SpecId::TANGERINE)
-            .message(Message { depth: Message::CALL_DEPTH_LIMIT, ..Default::default() })
+            .message(Message { depth: CALL_DEPTH_LIMIT, ..Default::default() })
             .gas_limit(50_000));
         core::assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [Word::ZERO]);
@@ -691,11 +696,24 @@ mod tests {
         let interpreter = run(RunConfig::new(code)
             .host(&mut host)
             .spec(SpecId::BERLIN)
-            .message(Message { depth: Message::CALL_DEPTH_LIMIT, ..Default::default() })
+            .message(Message { depth: CALL_DEPTH_LIMIT, ..Default::default() })
             .gas_limit(50_000));
         core::assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [Word::ZERO]);
         assert_eq!(interpreter.gas_remaining(), 17_991);
+        assert!(host.calls.is_empty());
+    }
+
+    #[test]
+    fn create_initcode_size_limit_halts_after_shanghai() {
+        let mut host = TestHost::default();
+        let mut code = Vec::new();
+        push_all(&mut code, [Word::from(MAX_INITCODE_SIZE + 1), Word::ZERO, Word::ZERO]);
+        code.extend([op::CREATE, op::STOP]);
+
+        let interpreter =
+            run(RunConfig::new(code).host(&mut host).spec(SpecId::SHANGHAI).gas_limit(50_000));
+        core::assert_matches!(interpreter.err, InstrStop::CreateInitCodeSizeLimit);
         assert!(host.calls.is_empty());
     }
 

--- a/crates/evm2/src/interpreter/message.rs
+++ b/crates/evm2/src/interpreter/message.rs
@@ -43,11 +43,6 @@ pub struct Message {
     pub salt: B256,
 }
 
-impl Message {
-    /// EVM call depth limit.
-    pub const CALL_DEPTH_LIMIT: u16 = 1024;
-}
-
 impl Default for Message {
     #[inline]
     fn default() -> Self {

--- a/crates/evm2/src/interpreter/stack.rs
+++ b/crates/evm2/src/interpreter/stack.rs
@@ -1,21 +1,20 @@
 use super::{InstrStop, Result};
+use crate::constants::STACK_LIMIT;
 use alloy_primitives::U256;
 use core::{fmt, hint::cold_path};
 
 /// EVM stack word.
 pub type Word = U256;
 
-const STACK_CAPACITY: usize = 1024;
-
 /// Mutable EVM operand stack.
 pub struct Stack<'a> {
-    pub(crate) stack: &'a mut [Word; STACK_CAPACITY],
+    pub(crate) stack: &'a mut [Word; STACK_LIMIT],
     pub(crate) len: usize,
 }
 
 /// Borrowed mutable EVM operand stack.
 pub struct StackMut<'a> {
-    pub(crate) stack: &'a mut [Word; STACK_CAPACITY],
+    pub(crate) stack: &'a mut [Word; STACK_LIMIT],
     pub(crate) len: &'a mut usize,
 }
 
@@ -32,7 +31,7 @@ impl fmt::Debug for StackMut<'_> {
 }
 
 impl<'a> Stack<'a> {
-    pub(crate) const CAPACITY: usize = STACK_CAPACITY;
+    pub(crate) const CAPACITY: usize = STACK_LIMIT;
 
     #[inline]
     pub(crate) const fn new(stack: &'a mut [Word; Stack::CAPACITY], len: usize) -> Self {
@@ -69,7 +68,7 @@ impl<'a> Stack<'a> {
 }
 
 impl<'a> StackMut<'a> {
-    pub(crate) const CAPACITY: usize = STACK_CAPACITY;
+    pub(crate) const CAPACITY: usize = STACK_LIMIT;
 
     #[inline]
     #[cfg(test)]

--- a/crates/evm2/src/lib.rs
+++ b/crates/evm2/src/lib.rs
@@ -11,6 +11,7 @@ extern crate self as evm2;
 extern crate alloc;
 
 pub mod bytecode;
+pub(crate) mod constants;
 pub mod ethereum;
 pub mod interpreter;
 pub mod utils;


### PR DESCRIPTION
Enforces the EIP-3860 initcode size limit for runtime CREATE and CREATE2 execution, matching the existing transaction create validation path. This fixes the ignored Cancun Create1000 statetest, where oversized initcode must halt instead of executing successfully.

The shared EVM protocol limits are also collected in a root constants module so transaction validation, interpreter execution, stack sizing, call depth, blockhash history, and code-size checks use the same definitions.
