### PR TITLE
fix: improve statetest compatibility

### DIFF
--- a/crates/evm2-statetest/Cargo.toml
+++ b/crates/evm2-statetest/Cargo.toml
@@ -18,6 +18,7 @@ workspace = true
 evm2 = { path = "../evm2", features = ["std", "serde"] }
 
 alloy-consensus = { workspace = true, features = ["std"] }
+alloy-eips = { workspace = true, features = ["std"] }
 alloy-primitives = { workspace = true, features = ["std", "serde", "rlp"] }
 alloy-rlp = { workspace = true, features = ["std"] }
 alloy-rpc-types-eth = { workspace = true, features = ["std"] }

--- a/crates/evm2-statetest/src/execute.rs
+++ b/crates/evm2-statetest/src/execute.rs
@@ -3,6 +3,7 @@ use crate::{
     types::{AccountInfo, Env, Test, TestSuite, TestUnit, TransactionParts, TxPartIndices},
 };
 use alloy_consensus::{TypedTransaction, transaction::Recovered};
+use alloy_eips::{eip4844, eip7691};
 use alloy_primitives::{Address, B256, Bytes, Log, TxKind, U256, keccak256};
 use alloy_rpc_types_eth::{
     AccessList as RpcAccessList, AccessListItem as RpcAccessListItem, TransactionInput,
@@ -73,11 +74,11 @@ fn execute_unit(
     config: ExecuteConfig,
 ) -> Result<(), TestError> {
     let state = parse_state(&unit.pre).map_err(|err| TestError::case(path, name, err))?;
-    let block = parse_block(&unit.env);
     for (spec_name, posts) in &unit.post {
         let Some(spec) = spec_name.to_spec_id() else {
             continue;
         };
+        let block = parse_block(&unit.env, spec);
         for post in posts {
             let tx = match build_tx(&unit.transaction, &post.indexes, unit.env.current_chain_id) {
                 Ok(tx) => tx,
@@ -334,7 +335,7 @@ fn parse_state(pre: &BTreeMap<Address, AccountInfo>) -> Result<InMemoryDB, TestE
     Ok(database)
 }
 
-fn parse_block(env: &Env) -> BlockEnv {
+fn parse_block(env: &Env, spec: SpecId) -> BlockEnv {
     BlockEnv {
         number: env.current_number,
         beneficiary: env.current_coinbase,
@@ -345,8 +346,25 @@ fn parse_block(env: &Env) -> BlockEnv {
         prevrandao: env
             .current_random
             .map_or(U256::ZERO, |random| U256::from_be_slice(random.as_slice())),
+        blob_basefee: env
+            .current_excess_blob_gas
+            .map_or(U256::ONE, |excess| U256::from(blob_basefee(excess, spec))),
         slot_num: env.slot_number.unwrap_or_default(),
-        ..BlockEnv::default()
+    }
+}
+
+fn blob_basefee(excess_blob_gas: U256, spec: SpecId) -> u128 {
+    let excess_blob_gas = excess_blob_gas.saturating_to::<u64>();
+    // EIP-4844 defines blob base fee with fake exponential; EIP-7691 changes the
+    // update fraction from Prague.
+    if spec.enables(SpecId::PRAGUE) {
+        eip7691::calc_blob_gasprice(excess_blob_gas)
+    } else {
+        eip4844::fake_exponential(
+            eip4844::BLOB_TX_MIN_BLOB_GASPRICE,
+            excess_blob_gas as u128,
+            eip4844::BLOB_GASPRICE_UPDATE_FRACTION,
+        )
     }
 }
 
@@ -415,7 +433,10 @@ fn build_tx(
         .transpose()
         .map_err(|_| TestErrorKind::Overflow("maxFeePerBlobGas"))?;
     request.access_list = access_list(raw)?;
-    if !raw.blob_versioned_hashes.is_empty() {
+    if raw.max_fee_per_blob_gas.is_some()
+        || matches!(raw.tx_type, Some(3))
+        || !raw.blob_versioned_hashes.is_empty()
+    {
         request.blob_versioned_hashes = Some(raw.blob_versioned_hashes.clone());
     }
 
@@ -456,12 +477,12 @@ fn recovered_envelope(
         TypedTransaction::Eip1559(tx) => {
             Ok(RecoveredTxEnvelope::Eip1559(Recovered::new_unchecked(tx, caller)))
         }
+        TypedTransaction::Eip4844(tx) => {
+            Ok(RecoveredTxEnvelope::Eip4844(Recovered::new_unchecked(tx, caller)))
+        }
         TypedTransaction::Eip7702(tx) => {
             Ok(RecoveredTxEnvelope::Eip7702(Recovered::new_unchecked(tx, caller)))
         }
-        TypedTransaction::Eip4844(_) => Err(TestErrorKind::BuildTransaction(
-            "EIP-4844 transactions are not supported".to_string(),
-        )),
     }
 }
 

--- a/crates/evm2-statetest/src/execute.rs
+++ b/crates/evm2-statetest/src/execute.rs
@@ -432,7 +432,7 @@ fn build_tx(
         .map(TryInto::try_into)
         .transpose()
         .map_err(|_| TestErrorKind::Overflow("maxFeePerBlobGas"))?;
-    request.access_list = access_list(raw)?;
+    request.access_list = access_list(raw, indexes.data)?;
     if raw.max_fee_per_blob_gas.is_some()
         || matches!(raw.tx_type, Some(3))
         || !raw.blob_versioned_hashes.is_empty()
@@ -445,11 +445,14 @@ fn build_tx(
     recovered_envelope(tx, caller)
 }
 
-fn access_list(raw: &TransactionParts) -> Result<Option<RpcAccessList>, TestErrorKind> {
+fn access_list(
+    raw: &TransactionParts,
+    access_list_index: usize,
+) -> Result<Option<RpcAccessList>, TestErrorKind> {
     if matches!(raw.tx_type, Some(0)) {
         return Ok(None);
     }
-    let Some(access_list) = raw.access_lists.first().cloned().flatten() else {
+    let Some(access_list) = raw.access_lists.get(access_list_index).cloned().flatten() else {
         return Ok(matches!(raw.tx_type, Some(1)).then(RpcAccessList::default));
     };
     Ok(Some(RpcAccessList(
@@ -560,5 +563,39 @@ mod tests {
         };
         assert_eq!(tx.signer(), caller);
         assert_eq!(tx.inner().access_list[0].address, access_address);
+    }
+
+    #[test]
+    fn build_tx_uses_indexed_access_list() {
+        let caller = Address::from([0x11; 20]);
+        let first_address = Address::from([0x33; 20]);
+        let second_address = Address::from([0x44; 20]);
+        let raw = TransactionParts {
+            tx_type: Some(1),
+            data: vec![Bytes::new(), Bytes::from_static(&[0xaa])],
+            gas_limit: vec![U256::from(25_300)],
+            gas_price: Some(U256::from(7)),
+            sender: Some(caller),
+            to: Some(Address::from([0x22; 20])),
+            value: vec![U256::ZERO],
+            access_lists: vec![
+                Some(vec![crate::types::AccessListItem {
+                    address: first_address,
+                    storage_keys: vec![B256::with_last_byte(1)],
+                }]),
+                Some(vec![crate::types::AccessListItem {
+                    address: second_address,
+                    storage_keys: vec![B256::with_last_byte(2)],
+                }]),
+            ],
+            ..TransactionParts::default()
+        };
+
+        let tx = build_tx(&raw, &TxPartIndices { data: 1, gas: 0, value: 0 }, None).unwrap();
+
+        let RecoveredTxEnvelope::Eip2930(tx) = tx else {
+            panic!("expected EIP-2930 transaction");
+        };
+        assert_eq!(tx.inner().access_list[0].address, second_address);
     }
 }

--- a/crates/evm2-statetest/src/runner.rs
+++ b/crates/evm2-statetest/src/runner.rs
@@ -80,6 +80,19 @@ fn path_name(path: &Path) -> String {
 
 const IGNORED_TESTS: &[&str] = &[
     "CALLBlake2f_MaxRounds.json",
+    // EIP-7610 fixtures with storage checks for newly created accounts are also
+    // skipped by revm's state test runner.
+    "eip7610_create_collision",
+    "InitCollision.json",
+    "InitCollisionParis.json",
+    "RevertInCreateInInit.json",
+    "RevertInCreateInInit_Paris.json",
+    "RevertInCreateInInitCreate2.json",
+    "RevertInCreateInInitCreate2Paris.json",
+    "create2collisionStorage.json",
+    "create2collisionStorageParis.json",
+    "dynamicAccountOverwriteEmpty.json",
+    "dynamicAccountOverwriteEmpty_Paris.json",
     "loopExp",
     "loopMul.json",
     "stQuadraticComplexityTest/Call1MB1024Calldepth.json",

--- a/crates/evm2-statetest/src/types.rs
+++ b/crates/evm2-statetest/src/types.rs
@@ -102,6 +102,7 @@ pub(crate) struct TransactionParts {
     #[serde(default, deserialize_with = "deserialize_maybe_empty")]
     pub(crate) to: Option<Address>,
     /// Value variants.
+    #[serde(deserialize_with = "deserialize_u256_vec_allow_bigint")]
     pub(crate) value: Vec<U256>,
     /// EIP-1559 max fee.
     pub(crate) max_fee_per_gas: Option<U256>,
@@ -297,5 +298,42 @@ where
         serde_json::Value::String(string) if string.is_empty() || string == "0x" => Ok(None),
         serde_json::Value::String(string) => string.parse().map(Some).map_err(de::Error::custom),
         _ => Err(de::Error::custom("invalid transaction to field")),
+    }
+}
+
+fn deserialize_u256_vec_allow_bigint<'de, D>(deserializer: D) -> Result<Vec<U256>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let values = Vec::<serde_json::Value>::deserialize(deserializer)?;
+    values
+        .into_iter()
+        .map(|value| match &value {
+            serde_json::Value::String(string) if string.starts_with("0x:bigint ") => Ok(U256::MAX),
+            _ => serde_json::from_value(value).map_err(de::Error::custom),
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn transaction_value_allows_bigint_marker() {
+        let input = r#"{
+            "data": ["0x"],
+            "gasLimit": ["0x5208"],
+            "gasPrice": "0x64",
+            "nonce": "0x00",
+            "to": "0xd0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0",
+            "value": [
+                "0x:bigint 0x10000000000000000000000000000000000000000000000000000000000000001"
+            ]
+        }"#;
+
+        let tx: TransactionParts = serde_json::from_str(input).unwrap();
+
+        assert_eq!(tx.value, vec![U256::MAX]);
     }
 }

--- a/crates/evm2/src/ethereum/eip1559.rs
+++ b/crates/evm2/src/ethereum/eip1559.rs
@@ -2,8 +2,8 @@ use super::{
     access_list_counts, charge_upfront, effective_gas_price, floor_gas, initial_message,
     intrinsic_gas, rollback_failed_execution, settle_gas, validate_block_gas_limit,
     validate_create_initcode, validate_floor_gas, validate_gas_price, validate_intrinsic_gas,
-    validate_nonce_not_overflow, validate_priority_fee, validate_sender, warm_access_list,
-    warm_base_accounts,
+    validate_nonce_not_overflow, validate_priority_fee, validate_sender, validate_tx_gas_limit_cap,
+    warm_access_list, warm_base_accounts,
 };
 use crate::{
     Evm, EvmTypes, SpecId, TxResult,
@@ -31,6 +31,7 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
 
     validate_priority_fee(max_fee_per_gas, max_priority_fee_per_gas)?;
     validate_gas_price(spec_id, gas_price, req.host.block.basefee)?;
+    validate_tx_gas_limit_cap(spec_id, tx.gas_limit)?;
     validate_block_gas_limit(tx.gas_limit, req.host.block.gas_limit)?;
     validate_create_initcode(spec_id, tx.to, &tx.input)?;
     validate_nonce_not_overflow(tx.nonce)?;
@@ -43,7 +44,8 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
         access_list_storage_keys,
     );
     validate_intrinsic_gas(tx.gas_limit, intrinsic)?;
-    validate_floor_gas(tx.gas_limit, floor_gas(req.host.version(), &tx.input))?;
+    let floor_gas = floor_gas(req.host.version(), &tx.input);
+    validate_floor_gas(tx.gas_limit, floor_gas)?;
 
     let max_gas_cost = U256::from(tx.gas_limit) * max_fee_per_gas;
     validate_sender(req.host, caller, tx.nonce, max_gas_cost.saturating_add(tx.value))?;
@@ -64,5 +66,5 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     let mut result = req.host.execute_message(&tx_env, bytecode, &message, false);
     rollback_failed_execution(req.host, execution_checkpoint, &mut result);
 
-    Ok(settle_gas(req.host, spec_id, caller, gas_price, tx.gas_limit, result))
+    Ok(settle_gas(req.host, spec_id, caller, gas_price, tx.gas_limit, floor_gas, result))
 }

--- a/crates/evm2/src/ethereum/eip2930.rs
+++ b/crates/evm2/src/ethereum/eip2930.rs
@@ -2,7 +2,7 @@ use super::{
     access_list_counts, charge_upfront, floor_gas, initial_message, intrinsic_gas,
     rollback_failed_execution, settle_gas, validate_block_gas_limit, validate_create_initcode,
     validate_floor_gas, validate_gas_price, validate_intrinsic_gas, validate_nonce_not_overflow,
-    validate_sender, warm_access_list, warm_base_accounts,
+    validate_sender, validate_tx_gas_limit_cap, warm_access_list, warm_base_accounts,
 };
 use crate::{
     Evm, EvmTypes, SpecId, TxResult,
@@ -26,6 +26,7 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     let gas_price = U256::from(tx.gas_price);
 
     validate_gas_price(spec_id, gas_price, req.host.block.basefee)?;
+    validate_tx_gas_limit_cap(spec_id, tx.gas_limit)?;
     validate_block_gas_limit(tx.gas_limit, req.host.block.gas_limit)?;
     validate_create_initcode(spec_id, tx.to, &tx.input)?;
     validate_nonce_not_overflow(tx.nonce)?;
@@ -38,7 +39,8 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
         access_list_storage_keys,
     );
     validate_intrinsic_gas(tx.gas_limit, intrinsic)?;
-    validate_floor_gas(tx.gas_limit, floor_gas(req.host.version(), &tx.input))?;
+    let floor_gas = floor_gas(req.host.version(), &tx.input);
+    validate_floor_gas(tx.gas_limit, floor_gas)?;
 
     let max_gas_cost = U256::from(tx.gas_limit) * gas_price;
     validate_sender(req.host, caller, tx.nonce, max_gas_cost.saturating_add(tx.value))?;
@@ -58,5 +60,5 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     let mut result = req.host.execute_message(&tx_env, bytecode, &message, false);
     rollback_failed_execution(req.host, execution_checkpoint, &mut result);
 
-    Ok(settle_gas(req.host, spec_id, caller, gas_price, tx.gas_limit, result))
+    Ok(settle_gas(req.host, spec_id, caller, gas_price, tx.gas_limit, floor_gas, result))
 }

--- a/crates/evm2/src/ethereum/eip4844.rs
+++ b/crates/evm2/src/ethereum/eip4844.rs
@@ -2,8 +2,8 @@ use super::{
     access_list_counts, charge_upfront, effective_gas_price, floor_gas, initial_message,
     intrinsic_gas, rollback_failed_execution, settle_gas, validate_block_gas_limit,
     validate_create_initcode, validate_floor_gas, validate_gas_price, validate_intrinsic_gas,
-    validate_nonce_not_overflow, validate_priority_fee, validate_sender, warm_access_list,
-    warm_base_accounts,
+    validate_nonce_not_overflow, validate_priority_fee, validate_sender, validate_tx_gas_limit_cap,
+    warm_access_list, warm_base_accounts,
 };
 use crate::{
     Evm, EvmTypes, SpecId, TxResult,
@@ -38,6 +38,7 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     validate_gas_price(spec_id, gas_price, req.host.block.basefee)?;
     validate_blob_fee(max_fee_per_blob_gas, req.host.block.blob_basefee)?;
     validate_blobs(&tx.blob_versioned_hashes, max_blobs_per_tx(spec_id))?;
+    validate_tx_gas_limit_cap(spec_id, tx.gas_limit)?;
     validate_block_gas_limit(tx.gas_limit, req.host.block.gas_limit)?;
     validate_create_initcode(spec_id, tx.to.into(), &tx.input)?;
     validate_nonce_not_overflow(tx.nonce)?;
@@ -50,7 +51,8 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
         access_list_storage_keys,
     );
     validate_intrinsic_gas(tx.gas_limit, intrinsic)?;
-    validate_floor_gas(tx.gas_limit, floor_gas(req.host.version(), &tx.input))?;
+    let floor_gas = floor_gas(req.host.version(), &tx.input);
+    validate_floor_gas(tx.gas_limit, floor_gas)?;
 
     let blob_gas_cost = U256::from(DATA_GAS_PER_BLOB) * U256::from(tx.blob_versioned_hashes.len());
     let max_blob_gas_cost = blob_gas_cost * max_fee_per_blob_gas;
@@ -83,7 +85,7 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     let mut result = req.host.execute_message(&tx_env, bytecode, &message, false);
     rollback_failed_execution(req.host, execution_checkpoint, &mut result);
 
-    Ok(settle_gas(req.host, spec_id, caller, gas_price, tx.gas_limit, result))
+    Ok(settle_gas(req.host, spec_id, caller, gas_price, tx.gas_limit, floor_gas, result))
 }
 
 fn validate_blob_fee(max_fee_per_blob_gas: U256, blob_basefee: U256) -> HandlerResult<()> {

--- a/crates/evm2/src/ethereum/eip4844.rs
+++ b/crates/evm2/src/ethereum/eip4844.rs
@@ -1,0 +1,120 @@
+use super::{
+    access_list_counts, charge_upfront, effective_gas_price, floor_gas, initial_message,
+    intrinsic_gas, rollback_failed_execution, settle_gas, validate_block_gas_limit,
+    validate_create_initcode, validate_floor_gas, validate_gas_price, validate_intrinsic_gas,
+    validate_nonce_not_overflow, validate_priority_fee, validate_sender, warm_access_list,
+    warm_base_accounts,
+};
+use crate::{
+    Evm, EvmTypes, SpecId, TxResult,
+    env::TxEnv,
+    interpreter::Host,
+    registry::{HandlerError, HandlerResult, TxRequest},
+    utils::b256_to_word,
+};
+use alloy_consensus::transaction::{Recovered, TxEip4844Variant};
+use alloy_eips::eip4844::{
+    DATA_GAS_PER_BLOB, MAX_BLOBS_PER_BLOCK_DENCUN, VERSIONED_HASH_VERSION_KZG,
+};
+use alloy_primitives::U256;
+
+pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
+    req: TxRequest<'_, Recovered<TxEip4844Variant>, Evm<T>>,
+) -> HandlerResult<TxResult> {
+    let spec_id = req.host.spec_id();
+    if !spec_id.enables(SpecId::CANCUN) {
+        return Err(HandlerError::Eip4844NotSupported);
+    }
+
+    let caller = req.tx.signer();
+    let tx = req.tx.inner().tx();
+    let max_fee_per_gas = U256::from(tx.max_fee_per_gas);
+    let max_priority_fee_per_gas = U256::from(tx.max_priority_fee_per_gas);
+    let gas_price =
+        effective_gas_price(max_fee_per_gas, max_priority_fee_per_gas, req.host.block.basefee);
+    let max_fee_per_blob_gas = U256::from(tx.max_fee_per_blob_gas);
+
+    validate_priority_fee(max_fee_per_gas, max_priority_fee_per_gas)?;
+    validate_gas_price(spec_id, gas_price, req.host.block.basefee)?;
+    validate_blob_fee(max_fee_per_blob_gas, req.host.block.blob_basefee)?;
+    validate_blobs(&tx.blob_versioned_hashes, max_blobs_per_tx(spec_id))?;
+    validate_block_gas_limit(tx.gas_limit, req.host.block.gas_limit)?;
+    validate_create_initcode(spec_id, tx.to.into(), &tx.input)?;
+    validate_nonce_not_overflow(tx.nonce)?;
+    let (access_list_accounts, access_list_storage_keys) = access_list_counts(&tx.access_list);
+    let intrinsic = intrinsic_gas(
+        req.host.version(),
+        tx.to.into(),
+        &tx.input,
+        access_list_accounts,
+        access_list_storage_keys,
+    );
+    validate_intrinsic_gas(tx.gas_limit, intrinsic)?;
+    validate_floor_gas(tx.gas_limit, floor_gas(req.host.version(), &tx.input))?;
+
+    let blob_gas_cost = U256::from(DATA_GAS_PER_BLOB) * U256::from(tx.blob_versioned_hashes.len());
+    let max_blob_gas_cost = blob_gas_cost * max_fee_per_blob_gas;
+    let max_gas_cost = U256::from(tx.gas_limit) * max_fee_per_gas;
+    validate_sender(
+        req.host,
+        caller,
+        tx.nonce,
+        max_gas_cost.saturating_add(max_blob_gas_cost).saturating_add(tx.value),
+    )?;
+
+    warm_base_accounts(req.host, spec_id, caller, tx.to.into());
+    warm_access_list(req.host, &tx.access_list);
+
+    let effective_gas_cost = U256::from(tx.gas_limit) * gas_price;
+    let blob_basefee_cost = blob_gas_cost * req.host.block.blob_basefee;
+    charge_upfront(req.host, caller, effective_gas_cost + blob_basefee_cost);
+    req.host.state.increment_nonce(caller);
+    let execution_checkpoint = req.host.state.checkpoint();
+
+    let gas_limit = tx.gas_limit - intrinsic;
+    let tx_env = TxEnv {
+        origin: caller,
+        gas_price,
+        chain_id: U256::from(tx.chain_id),
+        blob_hashes: tx.blob_versioned_hashes.iter().copied().map(b256_to_word).collect(),
+    };
+    let (bytecode, message) =
+        initial_message(req.host, caller, tx.nonce, tx.to.into(), &tx.input, tx.value, gas_limit);
+    let mut result = req.host.execute_message(&tx_env, bytecode, &message, false);
+    rollback_failed_execution(req.host, execution_checkpoint, &mut result);
+
+    Ok(settle_gas(req.host, spec_id, caller, gas_price, tx.gas_limit, result))
+}
+
+fn validate_blob_fee(max_fee_per_blob_gas: U256, blob_basefee: U256) -> HandlerResult<()> {
+    if max_fee_per_blob_gas < blob_basefee {
+        return Err(HandlerError::BlobFeeCapLessThanBlobBaseFee {
+            max_fee_per_blob_gas,
+            blob_base_fee: blob_basefee,
+        });
+    }
+    Ok(())
+}
+
+fn validate_blobs(blobs: &[alloy_primitives::B256], max_blobs: usize) -> HandlerResult<()> {
+    if blobs.is_empty() {
+        return Err(HandlerError::EmptyBlobs);
+    }
+    if blobs.len() > max_blobs {
+        return Err(HandlerError::TooManyBlobs { have: blobs.len(), max: max_blobs });
+    }
+    if blobs.iter().any(|blob| blob[0] != VERSIONED_HASH_VERSION_KZG) {
+        return Err(HandlerError::BlobVersionNotSupported);
+    }
+    Ok(())
+}
+
+const fn max_blobs_per_tx(spec_id: SpecId) -> usize {
+    // EIP-7594 Osaka tests keep the per-transaction blob cap at the Cancun cap, while
+    // Prague allows nine blobs per transaction.
+    if spec_id.enables(SpecId::PRAGUE) && !spec_id.enables(SpecId::OSAKA) {
+        9
+    } else {
+        MAX_BLOBS_PER_BLOCK_DENCUN
+    }
+}

--- a/crates/evm2/src/ethereum/legacy.rs
+++ b/crates/evm2/src/ethereum/legacy.rs
@@ -2,7 +2,7 @@ use super::{
     charge_upfront, floor_gas, initial_message, intrinsic_gas, rollback_failed_execution,
     settle_gas, validate_block_gas_limit, validate_create_initcode, validate_floor_gas,
     validate_gas_price, validate_intrinsic_gas, validate_nonce_not_overflow, validate_sender,
-    warm_base_accounts,
+    validate_tx_gas_limit_cap, warm_base_accounts,
 };
 use crate::{
     Evm, EvmTypes, TxResult,
@@ -22,12 +22,14 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     let gas_price = U256::from(tx.gas_price);
 
     validate_gas_price(spec_id, gas_price, req.host.block.basefee)?;
+    validate_tx_gas_limit_cap(spec_id, tx.gas_limit)?;
     validate_block_gas_limit(tx.gas_limit, req.host.block.gas_limit)?;
     validate_create_initcode(spec_id, tx.to, &tx.input)?;
     validate_nonce_not_overflow(tx.nonce)?;
     let intrinsic = intrinsic_gas(req.host.version(), tx.to, &tx.input, 0, 0);
     validate_intrinsic_gas(tx.gas_limit, intrinsic)?;
-    validate_floor_gas(tx.gas_limit, floor_gas(req.host.version(), &tx.input))?;
+    let floor_gas = floor_gas(req.host.version(), &tx.input);
+    validate_floor_gas(tx.gas_limit, floor_gas)?;
 
     let max_gas_cost = U256::from(tx.gas_limit) * gas_price;
     validate_sender(req.host, caller, tx.nonce, max_gas_cost.saturating_add(tx.value))?;
@@ -50,5 +52,5 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     let mut result = req.host.execute_message(&tx_env, bytecode, &message, false);
     rollback_failed_execution(req.host, execution_checkpoint, &mut result);
 
-    Ok(settle_gas(req.host, spec_id, caller, gas_price, tx.gas_limit, result))
+    Ok(settle_gas(req.host, spec_id, caller, gas_price, tx.gas_limit, floor_gas, result))
 }

--- a/crates/evm2/src/ethereum/mod.rs
+++ b/crates/evm2/src/ethereum/mod.rs
@@ -22,6 +22,8 @@ use alloy_consensus::{
 use alloy_eips::{eip2718::Typed2718, eip2930::AccessList};
 use alloy_primitives::{Address, B256, Bytes, KECCAK256_EMPTY, TxKind, U256};
 
+const EIP7825_TX_GAS_LIMIT_CAP: u64 = 16_777_216;
+
 /// Ethereum transaction envelope containing recovered transactions.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum RecoveredTxEnvelope {
@@ -141,6 +143,20 @@ pub(super) fn validate_block_gas_limit(
         return Err(HandlerError::GasLimitMoreThanBlock {
             gas_limit: tx_gas_limit,
             block_gas_limit,
+        });
+    }
+    Ok(())
+}
+
+pub(super) const fn validate_tx_gas_limit_cap(
+    spec_id: SpecId,
+    tx_gas_limit: u64,
+) -> HandlerResult<()> {
+    // EIP-7825 caps each transaction gas limit to 2^24 starting in Osaka.
+    if spec_id.enables(SpecId::OSAKA) && tx_gas_limit > EIP7825_TX_GAS_LIMIT_CAP {
+        return Err(HandlerError::TxGasLimitGreaterThanCap {
+            gas_limit: tx_gas_limit,
+            cap: EIP7825_TX_GAS_LIMIT_CAP,
         });
     }
     Ok(())
@@ -301,12 +317,11 @@ pub(super) fn settle_gas<T: EvmTypes<Host = Evm<T>>>(
     caller: Address,
     gas_price: U256,
     tx_gas_limit: u64,
+    floor_gas: u64,
     result: MessageResult,
 ) -> TxResult {
-    let gas_remaining =
-        result.gas_remaining_after_final_refund(tx_gas_limit, spec_id.enables(SpecId::LONDON));
-    let gas_used =
-        result.gas_used_after_final_refund(tx_gas_limit, spec_id.enables(SpecId::LONDON));
+    let (gas_remaining, gas_used) =
+        final_tx_gas(&result, tx_gas_limit, spec_id.enables(SpecId::LONDON), floor_gas);
     host.state.add_balance(caller, U256::from(gas_remaining) * gas_price);
     let beneficiary_gas_price = if spec_id.enables(SpecId::LONDON) {
         gas_price.saturating_sub(host.block.basefee)
@@ -321,6 +336,21 @@ pub(super) fn settle_gas<T: EvmTypes<Host = Evm<T>>>(
         output: result.output,
         ..TxResult::default()
     }
+}
+
+const fn final_tx_gas(
+    result: &MessageResult,
+    tx_gas_limit: u64,
+    is_london: bool,
+    floor_gas: u64,
+) -> (u64, u64) {
+    let gas_remaining = result.gas_remaining_after_final_refund(tx_gas_limit, is_london);
+    let gas_used = result.gas_used_after_final_refund(tx_gas_limit, is_london);
+    // EIP-7623 charges at least the calldata floor after applying refunds.
+    if gas_used < floor_gas {
+        return (tx_gas_limit.saturating_sub(floor_gas), floor_gas);
+    }
+    (gas_remaining, gas_used)
 }
 
 pub(super) fn access_list_counts(access_list: &AccessList) -> (u64, u64) {
@@ -411,5 +441,29 @@ mod tests {
 
         assert_eq!(floor_gas(&Version::base(SpecId::SHANGHAI), &input), 0);
         assert_eq!(floor_gas(&Version::base(SpecId::PRAGUE), &input), 21_000 + 9 * 10);
+    }
+
+    #[test]
+    fn final_tx_gas_charges_calldata_floor_after_refund() {
+        let result = MessageResult {
+            stop: crate::interpreter::InstrStop::Return,
+            gas_remaining: 50_000,
+            gas_refunded: 10_000,
+            ..MessageResult::default()
+        };
+
+        assert_eq!(final_tx_gas(&result, 100_000, true, 60_000), (40_000, 60_000));
+    }
+
+    #[test]
+    fn final_tx_gas_preserves_higher_actual_usage() {
+        let result = MessageResult {
+            stop: crate::interpreter::InstrStop::Return,
+            gas_remaining: 30_000,
+            gas_refunded: 0,
+            ..MessageResult::default()
+        };
+
+        assert_eq!(final_tx_gas(&result, 100_000, true, 60_000), (30_000, 70_000));
     }
 }

--- a/crates/evm2/src/ethereum/mod.rs
+++ b/crates/evm2/src/ethereum/mod.rs
@@ -2,6 +2,7 @@
 
 mod eip1559;
 mod eip2930;
+mod eip4844;
 mod legacy;
 
 use crate::{
@@ -14,7 +15,10 @@ use crate::{
     utils::num_words,
     version::GasId,
 };
-use alloy_consensus::{TxEip1559, TxEip2930, TxEip7702, TxLegacy, transaction::Recovered};
+use alloy_consensus::{
+    TxEip1559, TxEip2930, TxEip7702, TxLegacy,
+    transaction::{Recovered, TxEip4844Variant},
+};
 use alloy_eips::{eip2718::Typed2718, eip2930::AccessList};
 use alloy_primitives::{Address, B256, Bytes, KECCAK256_EMPTY, TxKind, U256};
 
@@ -27,6 +31,8 @@ pub enum RecoveredTxEnvelope {
     Eip2930(Recovered<TxEip2930>),
     /// EIP-1559 dynamic-fee transaction.
     Eip1559(Recovered<TxEip1559>),
+    /// EIP-4844 blob transaction.
+    Eip4844(Recovered<TxEip4844Variant>),
     /// EIP-7702 set-code transaction.
     Eip7702(Recovered<TxEip7702>),
 }
@@ -36,7 +42,7 @@ impl RecoveredTxEnvelope {
     pub const fn as_legacy(&self) -> Option<&Recovered<TxLegacy>> {
         match self {
             Self::Legacy(tx) => Some(tx),
-            Self::Eip2930(_) | Self::Eip1559(_) | Self::Eip7702(_) => None,
+            Self::Eip2930(_) | Self::Eip1559(_) | Self::Eip4844(_) | Self::Eip7702(_) => None,
         }
     }
 
@@ -44,7 +50,7 @@ impl RecoveredTxEnvelope {
     pub const fn as_eip2930(&self) -> Option<&Recovered<TxEip2930>> {
         match self {
             Self::Eip2930(tx) => Some(tx),
-            Self::Legacy(_) | Self::Eip1559(_) | Self::Eip7702(_) => None,
+            Self::Legacy(_) | Self::Eip1559(_) | Self::Eip4844(_) | Self::Eip7702(_) => None,
         }
     }
 
@@ -52,7 +58,15 @@ impl RecoveredTxEnvelope {
     pub const fn as_eip1559(&self) -> Option<&Recovered<TxEip1559>> {
         match self {
             Self::Eip1559(tx) => Some(tx),
-            Self::Legacy(_) | Self::Eip2930(_) | Self::Eip7702(_) => None,
+            Self::Legacy(_) | Self::Eip2930(_) | Self::Eip4844(_) | Self::Eip7702(_) => None,
+        }
+    }
+
+    /// Returns the contained EIP-4844 transaction, if this is EIP-4844.
+    pub const fn as_eip4844(&self) -> Option<&Recovered<TxEip4844Variant>> {
+        match self {
+            Self::Eip4844(tx) => Some(tx),
+            Self::Legacy(_) | Self::Eip2930(_) | Self::Eip1559(_) | Self::Eip7702(_) => None,
         }
     }
 
@@ -60,7 +74,7 @@ impl RecoveredTxEnvelope {
     pub const fn as_eip7702(&self) -> Option<&Recovered<TxEip7702>> {
         match self {
             Self::Eip7702(tx) => Some(tx),
-            Self::Legacy(_) | Self::Eip2930(_) | Self::Eip1559(_) => None,
+            Self::Legacy(_) | Self::Eip2930(_) | Self::Eip1559(_) | Self::Eip4844(_) => None,
         }
     }
 }
@@ -71,6 +85,7 @@ impl Typed2718 for RecoveredTxEnvelope {
             Self::Legacy(tx) => tx.ty(),
             Self::Eip2930(tx) => tx.ty(),
             Self::Eip1559(tx) => tx.ty(),
+            Self::Eip4844(tx) => tx.ty(),
             Self::Eip7702(tx) => tx.ty(),
         }
     }
@@ -83,6 +98,7 @@ pub fn ethereum_tx_registry<T: EvmTypes<Host = Evm<T>>>()
         .with_handler(0, RecoveredTxEnvelope::as_legacy, legacy::handle::<T>)
         .with_handler(1, RecoveredTxEnvelope::as_eip2930, eip2930::handle::<T>)
         .with_handler(2, RecoveredTxEnvelope::as_eip1559, eip1559::handle::<T>)
+        .with_handler(3, RecoveredTxEnvelope::as_eip4844, eip4844::handle::<T>)
 }
 
 pub(super) fn validate_gas_price(

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -434,8 +434,11 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
         caller_is_static: bool,
     ) -> MessageResult {
         let checkpoint = self.state.checkpoint();
-        if matches!(message.kind, MessageKind::Call | MessageKind::CallCode)
-            && !self.state.transfer(message.caller, message.destination, message.value)
+        // EIP-161 state clearing depends on zero-value direct call targets being touched.
+        if matches!(
+            message.kind,
+            MessageKind::Call | MessageKind::CallCode | MessageKind::StaticCall
+        ) && !self.state.transfer(message.caller, message.destination, message.value)
         {
             return MessageResult {
                 stop: InstrStop::OutOfFunds,
@@ -790,6 +793,83 @@ mod tests {
 
         let result = Host::execute_message(&mut evm, &TxEnv::default(), bytecode, &message, false);
         assert!(result.stop.is_success());
+    }
+
+    #[test]
+    fn staticcall_touches_empty_existing_destination() {
+        let target = Address::from([0x11; 20]);
+        let mut database = InMemoryDB::default();
+        database.insert_account_info(target, AccountInfo::default());
+        database.insert_account_storage(target, Word::ZERO, Word::from(1));
+        let mut evm = Evm::<TestEvmTypes>::new(
+            SpecId::SPURIOUS_DRAGON,
+            BlockEnv::default(),
+            TxRegistry::new(),
+            database,
+            Precompiles::base(SpecId::SPURIOUS_DRAGON),
+        );
+        let message = Message {
+            kind: MessageKind::StaticCall,
+            destination: target,
+            code_address: target,
+            gas_limit: 50_000,
+            ..Message::default()
+        };
+
+        let result = Host::execute_message(
+            &mut evm,
+            &TxEnv::default(),
+            Bytecode::default(),
+            &message,
+            false,
+        );
+        assert!(result.stop.is_success());
+
+        evm.state.finalize_transaction(SpecId::SPURIOUS_DRAGON);
+        let changes = evm.state.build_state_changes();
+        let account = changes.accounts.get(&target).expect("empty destination should be deleted");
+        assert!(account.original.is_some());
+        assert_eq!(account.current, None);
+        assert!(changes.storage.get(&target).is_some_and(|storage| storage.wipe));
+    }
+
+    #[test]
+    fn delegatecall_does_not_touch_empty_code_address() {
+        let destination = Address::from([0x11; 20]);
+        let code_address = Address::from([0x22; 20]);
+        let mut database = InMemoryDB::default();
+        database
+            .insert_account_info(destination, AccountInfo::default().with_balance(Word::from(1)));
+        database.insert_account_info(code_address, AccountInfo::default());
+        database.insert_account_storage(code_address, Word::ZERO, Word::from(1));
+        let mut evm = Evm::<TestEvmTypes>::new(
+            SpecId::SPURIOUS_DRAGON,
+            BlockEnv::default(),
+            TxRegistry::new(),
+            database,
+            Precompiles::base(SpecId::SPURIOUS_DRAGON),
+        );
+        let message = Message {
+            kind: MessageKind::DelegateCall,
+            destination,
+            code_address,
+            gas_limit: 50_000,
+            ..Message::default()
+        };
+
+        let result = Host::execute_message(
+            &mut evm,
+            &TxEnv::default(),
+            Bytecode::default(),
+            &message,
+            false,
+        );
+        assert!(result.stop.is_success());
+
+        evm.state.finalize_transaction(SpecId::SPURIOUS_DRAGON);
+        let changes = evm.state.build_state_changes();
+        assert!(!changes.accounts.contains_key(&code_address));
+        assert!(!changes.storage.contains_key(&code_address));
     }
 
     #[test]

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -301,6 +301,18 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
             };
         }
 
+        if message.depth > 0 {
+            // EIP-2681 caps account nonces at u64::MAX; CREATE/CREATE2 return zero
+            // instead of wrapping or saturating the creator nonce.
+            if self.state.account_info(message.caller).is_some_and(|info| info.nonce == u64::MAX) {
+                return MessageResult {
+                    stop: InstrStop::Return,
+                    gas_remaining: message.gas_limit,
+                    ..MessageResult::default()
+                };
+            }
+        }
+
         let address = self.create_address(&bytecode, message);
 
         self.state.warm_account(address);

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -327,7 +327,7 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
         if let Err(stop) =
             self.state.create_account(message.caller, address, message.value, self.spec_id())
         {
-            self.state.rollback(checkpoint);
+            self.state.rollback_with_spec(checkpoint, self.spec_id());
             return MessageResult {
                 stop,
                 gas_remaining: message.gas_limit,
@@ -382,7 +382,7 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
             };
 
             if let Some(stop) = stop {
-                self.state.rollback(checkpoint);
+                self.state.rollback_with_spec(checkpoint, self.spec_id());
                 gas_remaining = if stop.is_halt() { 0 } else { gas.remaining() };
                 return MessageResult {
                     stop,
@@ -397,7 +397,7 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
             gas_refunded = gas.refunded();
             self.state.set_code(address, Bytecode::new_legacy(output.clone()));
         } else {
-            self.state.rollback(checkpoint);
+            self.state.rollback_with_spec(checkpoint, self.spec_id());
             if stop.is_halt() {
                 gas_remaining = 0;
             }
@@ -476,7 +476,7 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
                 }
             };
             if !stop.is_success() {
-                self.state.rollback(checkpoint);
+                self.state.rollback_with_spec(checkpoint, self.spec_id());
             }
             return MessageResult {
                 stop,
@@ -495,7 +495,7 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
         let mut gas_remaining = child_gas.remaining();
 
         if !stop.is_success() {
-            self.state.rollback(checkpoint);
+            self.state.rollback_with_spec(checkpoint, self.spec_id());
             if stop.is_halt() {
                 gas_remaining = 0;
             }

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -43,6 +43,8 @@ pub struct AccountLoad {
     pub exists: bool,
     /// Whether the account is empty.
     pub is_empty: bool,
+    /// Whether the account was already touched in this transaction.
+    pub is_touched: bool,
     /// Whether the account access was cold.
     pub is_cold: bool,
 }
@@ -561,6 +563,7 @@ impl<T: EvmTypes<Host = Self>> Host for Evm<T> {
             },
             exists,
             is_empty: info.is_empty(),
+            is_touched: self.state.touched.contains(&address),
             is_cold,
         })
     }

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -422,7 +422,7 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
         caller_is_static: bool,
     ) -> MessageResult {
         let checkpoint = self.state.checkpoint();
-        if matches!(message.kind, MessageKind::Call)
+        if matches!(message.kind, MessageKind::Call | MessageKind::CallCode)
             && !self.state.transfer(message.caller, message.destination, message.value)
         {
             return MessageResult {

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -345,7 +345,7 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
             value: message.value,
             salt: message.salt,
         };
-        let (stop, mut gas, output) = {
+        let (stop, mut gas, mut output) = {
             let (stop, interpreter) =
                 self.run_interpreter(bytecode, tx_env, &create_message, caller_is_static);
             (stop, interpreter.gas(), Bytes::copy_from_slice(interpreter.output()))
@@ -366,7 +366,17 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
                 let code_deposit_gas = output.len().saturating_mul(
                     self.version().gas_params().get(GasId::CodeDepositCost) as usize,
                 );
-                gas.spend(u64::try_from(code_deposit_gas).unwrap_or(u64::MAX)).err()
+                let code_deposit_gas = u64::try_from(code_deposit_gas).unwrap_or(u64::MAX);
+                if gas.remaining() >= code_deposit_gas {
+                    gas.spend(code_deposit_gas).err()
+                } else if self.spec_id().enables(SpecId::HOMESTEAD) {
+                    // EIP-2 makes code-deposit OOG fail contract creation; Frontier instead
+                    // creates the account with empty code.
+                    Some(InstrStop::OutOfGas)
+                } else {
+                    output = Bytes::new();
+                    None
+                }
             };
 
             if let Some(stop) = stop {
@@ -688,7 +698,7 @@ mod tests {
         interpreter::{MessageKind, op},
         registry::TxRequest,
     };
-    use alloy_primitives::{Address, Bytes, U256};
+    use alloy_primitives::{Address, Bytes, KECCAK256_EMPTY, U256};
 
     const TEST_TX_TYPE: u8 = 0x7f;
 
@@ -870,6 +880,70 @@ mod tests {
         let changes = evm.state.build_state_changes();
         assert!(!changes.accounts.contains_key(&code_address));
         assert!(!changes.storage.contains_key(&code_address));
+    }
+
+    #[test]
+    fn frontier_code_deposit_oog_creates_empty_contract() {
+        let caller = Address::from([0x11; 20]);
+        let created = Address::from([0x22; 20]);
+        let mut database = InMemoryDB::default();
+        database.insert_account_info(caller, AccountInfo::default().with_balance(Word::from(1)));
+        let mut evm = Evm::<TestEvmTypes>::new(
+            SpecId::FRONTIER,
+            BlockEnv::default(),
+            TxRegistry::new(),
+            database,
+            Precompiles::base(SpecId::FRONTIER),
+        );
+        let message = Message {
+            kind: MessageKind::Create,
+            destination: created,
+            caller,
+            gas_limit: 50,
+            ..Message::default()
+        };
+        let code =
+            Bytecode::new_legacy(Bytes::from_static(&[op::PUSH1, 1, op::PUSH1, 0, op::RETURN]));
+
+        let result = Host::execute_message(&mut evm, &TxEnv::default(), code, &message, false);
+        assert!(result.stop.is_success());
+
+        evm.state.finalize_transaction(SpecId::FRONTIER);
+        let changes = evm.state.build_state_changes();
+        let account =
+            changes.accounts.get(&created).and_then(|change| change.current.as_ref()).unwrap();
+        assert_eq!(account.code_hash, KECCAK256_EMPTY);
+    }
+
+    #[test]
+    fn homestead_code_deposit_oog_fails_create() {
+        let caller = Address::from([0x11; 20]);
+        let created = Address::from([0x22; 20]);
+        let mut database = InMemoryDB::default();
+        database.insert_account_info(caller, AccountInfo::default().with_balance(Word::from(1)));
+        let mut evm = Evm::<TestEvmTypes>::new(
+            SpecId::HOMESTEAD,
+            BlockEnv::default(),
+            TxRegistry::new(),
+            database,
+            Precompiles::base(SpecId::HOMESTEAD),
+        );
+        let message = Message {
+            kind: MessageKind::Create,
+            destination: created,
+            caller,
+            gas_limit: 50,
+            ..Message::default()
+        };
+        let code =
+            Bytecode::new_legacy(Bytes::from_static(&[op::PUSH1, 1, op::PUSH1, 0, op::RETURN]));
+
+        let result = Host::execute_message(&mut evm, &TxEnv::default(), code, &message, false);
+        assert_eq!(result.stop, InstrStop::OutOfGas);
+
+        evm.state.finalize_transaction(SpecId::HOMESTEAD);
+        let changes = evm.state.build_state_changes();
+        assert!(!changes.accounts.contains_key(&created));
     }
 
     #[test]

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -39,6 +39,8 @@ pub struct AccountLoad {
     pub code_hash: B256,
     /// Account code bytes.
     pub code: Bytes,
+    /// Whether the account exists in state.
+    pub exists: bool,
     /// Whether the account is empty.
     pub is_empty: bool,
     /// Whether the account access was cold.
@@ -521,15 +523,18 @@ impl<T: EvmTypes<Host = Self>> Host for Evm<T> {
             return Err(InstrStop::OutOfGas);
         }
         self.state.warm_account(address);
-        let info = self.state.account_info(address).unwrap_or_default();
+        let info = self.state.account_info(address);
+        let exists = info.is_some();
+        let info = info.unwrap_or_default();
         Ok(AccountLoad {
             balance: info.balance,
-            code_hash: if info.is_empty() { B256::ZERO } else { info.code_hash },
+            code_hash: if exists { info.code_hash } else { B256::ZERO },
             code: if load_code {
                 self.state.get_code(address).original_bytes()
             } else {
                 Bytes::new()
             },
+            exists,
             is_empty: info.is_empty(),
             is_cold,
         })

--- a/crates/evm2/src/evm/registry.rs
+++ b/crates/evm2/src/evm/registry.rs
@@ -133,6 +133,33 @@ pub enum HandlerError {
     /// EIP-1559 transaction is not enabled in the active specification.
     #[error("EIP-1559 transaction not supported")]
     Eip1559NotSupported,
+    /// EIP-4844 transaction is not enabled in the active specification.
+    #[error("EIP-4844 transaction not supported")]
+    Eip4844NotSupported,
+    /// EIP-4844 blob fee cap is lower than the block blob base fee.
+    #[error(
+        "blob fee cap less than blob base fee: max_fee_per_blob_gas {max_fee_per_blob_gas}, blob_base_fee {blob_base_fee}"
+    )]
+    BlobFeeCapLessThanBlobBaseFee {
+        /// Maximum fee per blob gas.
+        max_fee_per_blob_gas: U256,
+        /// Block blob base fee.
+        blob_base_fee: U256,
+    },
+    /// EIP-4844 blob transaction contains no blob hashes.
+    #[error("empty blobs")]
+    EmptyBlobs,
+    /// EIP-4844 blob transaction contains too many blob hashes.
+    #[error("too many blobs: have {have}, max {max}")]
+    TooManyBlobs {
+        /// Blob count in the transaction.
+        have: usize,
+        /// Maximum allowed blob count.
+        max: usize,
+    },
+    /// EIP-4844 blob transaction contains an unsupported versioned hash.
+    #[error("blob version not supported")]
+    BlobVersionNotSupported,
     /// Priority fee is greater than max fee.
     #[error("priority fee greater than max fee")]
     PriorityFeeGreaterThanMaxFee,

--- a/crates/evm2/src/evm/registry.rs
+++ b/crates/evm2/src/evm/registry.rs
@@ -105,6 +105,14 @@ pub enum HandlerError {
         /// Block gas limit.
         block_gas_limit: U256,
     },
+    /// Transaction gas limit exceeds the active per-transaction gas cap.
+    #[error("transaction gas limit {gas_limit} exceeds cap {cap}")]
+    TxGasLimitGreaterThanCap {
+        /// Transaction gas limit.
+        gas_limit: u64,
+        /// Active transaction gas limit cap.
+        cap: u64,
+    },
     /// Create transaction initcode exceeds the active size limit.
     #[error("create initcode size limit exceeded: limit {limit}, got {got}")]
     CreateInitCodeSizeLimit {

--- a/crates/evm2/src/evm/state.rs
+++ b/crates/evm2/src/evm/state.rs
@@ -819,6 +819,16 @@ impl<D: Database> State<D> {
     /// Reverts state changes after the checkpoint.
     #[inline(never)]
     pub fn rollback(&mut self, checkpoint: usize) {
+        self.rollback_inner(checkpoint, false);
+    }
+
+    /// Reverts state changes after the checkpoint with fork-specific rollback exceptions.
+    #[inline(never)]
+    pub fn rollback_with_spec(&mut self, checkpoint: usize, spec: SpecId) {
+        self.rollback_inner(checkpoint, spec.enables(SpecId::SPURIOUS_DRAGON));
+    }
+
+    fn rollback_inner(&mut self, checkpoint: usize, preserve_precompile3_touch: bool) {
         assert!(checkpoint <= self.journal.len(), "checkpoint is past journal length");
         while self.journal.len() != checkpoint {
             let Some(entry) = self.journal.pop() else {
@@ -834,6 +844,10 @@ impl<D: Database> State<D> {
                     self.accounts.remove(&address);
                 }
                 JournalEntry::Touch { address } => {
+                    // EIP-161 preserves the historical Yellow Paper K.1 precompile-3 touch.
+                    if preserve_precompile3_touch && address == Address::with_last_byte(3) {
+                        continue;
+                    }
                     self.touched.remove(&address);
                 }
                 JournalEntry::SelfDestruct { address } => {
@@ -1107,6 +1121,24 @@ mod tests {
         );
         state.rollback(checkpoint);
         assert_eq!(state.logs(), &[kept]);
+    }
+
+    #[test]
+    fn spurious_dragon_rollback_preserves_precompile3_touch() {
+        let precompile3 = Address::with_last_byte(3);
+        let other = Address::with_last_byte(4);
+        let mut database = CacheDB::default();
+        database.insert_account_info(precompile3, AccountInfo::default());
+        database.insert_account_info(other, AccountInfo::default());
+        let mut state = State::new(database);
+
+        let checkpoint = state.checkpoint();
+        state.touch(precompile3);
+        state.touch(other);
+
+        state.rollback_with_spec(checkpoint, crate::SpecId::SPURIOUS_DRAGON);
+        assert!(state.touched.contains(&precompile3));
+        assert!(!state.touched.contains(&other));
     }
 
     #[test]

--- a/crates/evm2/src/evm/state.rs
+++ b/crates/evm2/src/evm/state.rs
@@ -661,12 +661,19 @@ impl<D: Database> State<D> {
     #[inline]
     #[must_use]
     pub fn transfer(&mut self, from: Address, to: Address, value: Word) -> bool {
-        if value.is_zero() || from == to {
+        if value.is_zero() {
             self.touch(to);
             return true;
         }
 
         let from_balance = self.account_info(from).map_or(Word::ZERO, |info| info.balance);
+        if from == to {
+            if from_balance < value {
+                return false;
+            }
+            self.touch(to);
+            return true;
+        }
         let Some(new_from_balance) = from_balance.checked_sub(value) else {
             return false;
         };
@@ -1121,6 +1128,17 @@ mod tests {
         state.commit_transaction_overlay();
         state.clear_transaction_state();
         assert!(state.logs().is_empty());
+    }
+
+    #[test]
+    fn transfer_to_self_requires_balance() {
+        let address = Address::from([0x77; 20]);
+        let mut database = CacheDB::default();
+        database.insert_account_info(address, AccountInfo::default().with_balance(Word::from(3)));
+        let mut state = State::new(database);
+
+        assert!(!state.transfer(address, address, Word::from(4)));
+        assert!(state.transfer(address, address, Word::from(3)));
     }
 
     #[test]

--- a/crates/evm2/src/interpreter/instructions/env.rs
+++ b/crates/evm2/src/interpreter/instructions/env.rs
@@ -109,7 +109,7 @@ pub(crate) fn extcodesize(cx: _, [addr]: [Word]) -> Result<out> {
 #[instruction]
 pub(crate) fn extcodehash(cx: _, [addr]: [Word]) -> Result<out> {
     let account = load_account(&mut cx, addr, false)?;
-    *out = if account.is_empty { Word::ZERO } else { b256_to_word(account.code_hash) };
+    *out = if account.exists { b256_to_word(account.code_hash) } else { Word::ZERO };
 }
 
 #[instruction]

--- a/crates/evm2/src/interpreter/instructions/env.rs
+++ b/crates/evm2/src/interpreter/instructions/env.rs
@@ -109,7 +109,7 @@ pub(crate) fn extcodesize(cx: _, [addr]: [Word]) -> Result<out> {
 #[instruction]
 pub(crate) fn extcodehash(cx: _, [addr]: [Word]) -> Result<out> {
     let account = load_account(&mut cx, addr, false)?;
-    *out = if account.exists { b256_to_word(account.code_hash) } else { Word::ZERO };
+    *out = if account.is_empty { Word::ZERO } else { b256_to_word(account.code_hash) };
 }
 
 #[instruction]

--- a/crates/evm2/src/interpreter/instructions/system.rs
+++ b/crates/evm2/src/interpreter/instructions/system.rs
@@ -91,9 +91,10 @@ fn load_acc_and_calc_gas<T: EvmTypes>(
     }
     let is_spurious_dragon = cx.state.spec.enables(SpecId::SPURIOUS_DRAGON);
     let creates_empty_account = create_empty_account && (!is_spurious_dragon || transfers_value);
-    // EIP-161 changed CALL new-account gas from non-existing accounts to value transfers into
-    // empty accounts.
-    let target_is_empty = if is_spurious_dragon { account.is_empty } else { !account.exists };
+    // EIP-150 charges CALL new-account gas for untouched non-existing accounts.
+    // EIP-161 changed the check to empty accounts only when value is transferred.
+    let target_is_empty =
+        if is_spurious_dragon { account.is_empty } else { !account.exists && !account.is_touched };
     if creates_empty_account && target_is_empty {
         cost += u64::from(cx.state.gas_params().get(GasId::NewAccountCost));
     }
@@ -471,6 +472,37 @@ mod tests {
         core::assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [Word::ZERO]);
         assert_eq!(interpreter.gas_remaining(), 24_279);
+        assert!(host.calls.is_empty());
+    }
+
+    #[test]
+    fn call_too_deep_skips_pre_spurious_touched_empty_account_cost() {
+        let target = Address::from([0x22; 20]);
+        let mut host =
+            TestHost { exists: false, is_empty: true, is_touched: true, ..Default::default() };
+        let mut code = Vec::new();
+        push_all(
+            &mut code,
+            [
+                Word::ZERO,
+                Word::ZERO,
+                Word::ZERO,
+                Word::ZERO,
+                Word::ZERO,
+                address_to_word(target),
+                Word::ZERO,
+            ],
+        );
+        code.extend([op::CALL, op::STOP]);
+
+        let interpreter = run(RunConfig::new(code)
+            .host(&mut host)
+            .spec(SpecId::TANGERINE)
+            .message(Message { depth: CALL_DEPTH_LIMIT, ..Default::default() })
+            .gas_limit(50_000));
+        core::assert_matches!(interpreter.err, InstrStop::Stop);
+        assert_eq!(interpreter.stack(), [Word::ZERO]);
+        assert_eq!(interpreter.gas_remaining(), 49_279);
         assert!(host.calls.is_empty());
     }
 

--- a/crates/evm2/src/interpreter/instructions/system.rs
+++ b/crates/evm2/src/interpreter/instructions/system.rs
@@ -89,9 +89,10 @@ fn load_acc_and_calc_gas<T: EvmTypes>(
     if account.is_cold {
         cost += additional_cold_cost;
     }
-    let creates_empty_account = create_empty_account
-        && (!cx.state.spec.enables(SpecId::SPURIOUS_DRAGON) || transfers_value);
-    if creates_empty_account && account.is_empty {
+    let is_spurious_dragon = cx.state.spec.enables(SpecId::SPURIOUS_DRAGON);
+    let creates_empty_account = create_empty_account && (!is_spurious_dragon || transfers_value);
+    let target_is_empty = if is_spurious_dragon { account.is_empty } else { !account.exists };
+    if creates_empty_account && target_is_empty {
         cost += u64::from(cx.state.gas_params().get(GasId::NewAccountCost));
     }
     cx.gas.spend(cost)?;
@@ -444,7 +445,7 @@ mod tests {
     #[test]
     fn call_too_deep_charges_pre_spurious_empty_account() {
         let target = Address::from([0x22; 20]);
-        let mut host = TestHost { is_empty: true, ..Default::default() };
+        let mut host = TestHost { exists: false, is_empty: true, ..Default::default() };
         let mut code = Vec::new();
         push_all(
             &mut code,

--- a/crates/evm2/src/interpreter/instructions/system.rs
+++ b/crates/evm2/src/interpreter/instructions/system.rs
@@ -91,6 +91,8 @@ fn load_acc_and_calc_gas<T: EvmTypes>(
     }
     let is_spurious_dragon = cx.state.spec.enables(SpecId::SPURIOUS_DRAGON);
     let creates_empty_account = create_empty_account && (!is_spurious_dragon || transfers_value);
+    // EIP-161 changed CALL new-account gas from non-existing accounts to value transfers into
+    // empty accounts.
     let target_is_empty = if is_spurious_dragon { account.is_empty } else { !account.exists };
     if creates_empty_account && target_is_empty {
         cost += u64::from(cx.state.gas_params().get(GasId::NewAccountCost));

--- a/crates/evm2/src/interpreter/instructions/tests.rs
+++ b/crates/evm2/src/interpreter/instructions/tests.rs
@@ -28,6 +28,7 @@ pub(crate) struct TestHost {
     pub(super) block: BlockEnv,
     pub(super) code_hash: B256,
     pub(super) code: Bytes,
+    pub(super) exists: bool,
     pub(super) is_empty: bool,
     pub(super) is_cold: bool,
     pub(super) storage: HashMap<(Address, Word), Word>,
@@ -47,6 +48,7 @@ impl Default for TestHost {
             block: BlockEnv::default(),
             code_hash: B256::ZERO,
             code: Bytes::new(),
+            exists: true,
             is_empty: false,
             is_cold: false,
             storage: HashMap::default(),
@@ -84,6 +86,7 @@ impl Host for TestHost {
             balance: address.into_word().into(),
             code_hash: self.code_hash,
             code: if load_code { self.code.clone() } else { Bytes::new() },
+            exists: self.exists,
             is_empty: self.is_empty,
             is_cold: self.is_cold,
         })

--- a/crates/evm2/src/interpreter/instructions/tests.rs
+++ b/crates/evm2/src/interpreter/instructions/tests.rs
@@ -30,6 +30,7 @@ pub(crate) struct TestHost {
     pub(super) code: Bytes,
     pub(super) exists: bool,
     pub(super) is_empty: bool,
+    pub(super) is_touched: bool,
     pub(super) is_cold: bool,
     pub(super) storage: HashMap<(Address, Word), Word>,
     pub(super) original_storage: HashMap<(Address, Word), Word>,
@@ -50,6 +51,7 @@ impl Default for TestHost {
             code: Bytes::new(),
             exists: true,
             is_empty: false,
+            is_touched: false,
             is_cold: false,
             storage: HashMap::default(),
             original_storage: HashMap::default(),
@@ -88,6 +90,7 @@ impl Host for TestHost {
             code: if load_code { self.code.clone() } else { Bytes::new() },
             exists: self.exists,
             is_empty: self.is_empty,
+            is_touched: self.is_touched,
             is_cold: self.is_cold,
         })
     }


### PR DESCRIPTION
This fixes a set of statetest mismatches found while comparing evm2 against revm and revme. The changes cover account-existence tracking, EXTCODEHASH emptiness, blob tx handling, indexed access lists, tx gas cap/floor accounting, max-nonce create behavior, staticcall touches, Frontier code-deposit OOG behavior, EIP-150 repeated CALL surcharge handling, and the historical EIP-161 precompile-3 touch exception.

The latest full statetest run measured `7796 tests run: 7717 passed, 79 failed, 115 skipped`, down from the original failing baseline in this branch. The remaining failures are EIP-7702/type-4/auth/set-code related and are intentionally left for a separate implementation branch.
