### PR TITLE
fix(evm): track account existence on loads

### DIFF
--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -39,6 +39,8 @@ pub struct AccountLoad {
     pub code_hash: B256,
     /// Account code bytes.
     pub code: Bytes,
+    /// Whether the account exists in state.
+    pub exists: bool,
     /// Whether the account is empty.
     pub is_empty: bool,
     /// Whether the account access was cold.
@@ -521,15 +523,18 @@ impl<T: EvmTypes<Host = Self>> Host for Evm<T> {
             return Err(InstrStop::OutOfGas);
         }
         self.state.warm_account(address);
-        let info = self.state.account_info(address).unwrap_or_default();
+        let info = self.state.account_info(address);
+        let exists = info.is_some();
+        let info = info.unwrap_or_default();
         Ok(AccountLoad {
             balance: info.balance,
-            code_hash: if info.is_empty() { B256::ZERO } else { info.code_hash },
+            code_hash: if exists { info.code_hash } else { B256::ZERO },
             code: if load_code {
                 self.state.get_code(address).original_bytes()
             } else {
                 Bytes::new()
             },
+            exists,
             is_empty: info.is_empty(),
             is_cold,
         })

--- a/crates/evm2/src/interpreter/instructions/env.rs
+++ b/crates/evm2/src/interpreter/instructions/env.rs
@@ -109,7 +109,7 @@ pub(crate) fn extcodesize(cx: _, [addr]: [Word]) -> Result<out> {
 #[instruction]
 pub(crate) fn extcodehash(cx: _, [addr]: [Word]) -> Result<out> {
     let account = load_account(&mut cx, addr, false)?;
-    *out = if account.is_empty { Word::ZERO } else { b256_to_word(account.code_hash) };
+    *out = if account.exists { b256_to_word(account.code_hash) } else { Word::ZERO };
 }
 
 #[instruction]

--- a/crates/evm2/src/interpreter/instructions/system.rs
+++ b/crates/evm2/src/interpreter/instructions/system.rs
@@ -89,9 +89,10 @@ fn load_acc_and_calc_gas<T: EvmTypes>(
     if account.is_cold {
         cost += additional_cold_cost;
     }
-    let creates_empty_account = create_empty_account
-        && (!cx.state.spec.enables(SpecId::SPURIOUS_DRAGON) || transfers_value);
-    if creates_empty_account && account.is_empty {
+    let is_spurious_dragon = cx.state.spec.enables(SpecId::SPURIOUS_DRAGON);
+    let creates_empty_account = create_empty_account && (!is_spurious_dragon || transfers_value);
+    let target_is_empty = if is_spurious_dragon { account.is_empty } else { !account.exists };
+    if creates_empty_account && target_is_empty {
         cost += u64::from(cx.state.gas_params().get(GasId::NewAccountCost));
     }
     cx.gas.spend(cost)?;
@@ -444,7 +445,7 @@ mod tests {
     #[test]
     fn call_too_deep_charges_pre_spurious_empty_account() {
         let target = Address::from([0x22; 20]);
-        let mut host = TestHost { is_empty: true, ..Default::default() };
+        let mut host = TestHost { exists: false, is_empty: true, ..Default::default() };
         let mut code = Vec::new();
         push_all(
             &mut code,

--- a/crates/evm2/src/interpreter/instructions/tests.rs
+++ b/crates/evm2/src/interpreter/instructions/tests.rs
@@ -28,6 +28,7 @@ pub(crate) struct TestHost {
     pub(super) block: BlockEnv,
     pub(super) code_hash: B256,
     pub(super) code: Bytes,
+    pub(super) exists: bool,
     pub(super) is_empty: bool,
     pub(super) is_cold: bool,
     pub(super) storage: HashMap<(Address, Word), Word>,
@@ -47,6 +48,7 @@ impl Default for TestHost {
             block: BlockEnv::default(),
             code_hash: B256::ZERO,
             code: Bytes::new(),
+            exists: true,
             is_empty: false,
             is_cold: false,
             storage: HashMap::default(),
@@ -84,6 +86,7 @@ impl Host for TestHost {
             balance: address.into_word().into(),
             code_hash: self.code_hash,
             code: if load_code { self.code.clone() } else { Bytes::new() },
+            exists: self.exists,
             is_empty: self.is_empty,
             is_cold: self.is_cold,
         })


### PR DESCRIPTION

Distinguish account existence from EIP-161 emptiness when loading accounts. This matches revm's state-clear-aware emptiness and evmone's separate account existence check for CALL new-account gas, and makes EXTCODEHASH return the empty-code hash for existing empty accounts.

Statetest delta with 16 nextest threads: 7515 passed / 306 failed before, 7520 passed / 301 failed after. Roughly 5 previously failing statetest files now pass.

