### PR TITLE
fix(evm): stop create at max nonce

### DIFF
--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -301,6 +301,18 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
             };
         }
 
+        if message.depth > 0 {
+            // EIP-2681 caps account nonces at u64::MAX; CREATE/CREATE2 return zero
+            // instead of wrapping or saturating the creator nonce.
+            if self.state.account_info(message.caller).is_some_and(|info| info.nonce == u64::MAX) {
+                return MessageResult {
+                    stop: InstrStop::Return,
+                    gas_remaining: message.gas_limit,
+                    ..MessageResult::default()
+                };
+            }
+        }
+
         let address = self.create_address(&bytecode, message);
 
         self.state.warm_account(address);


### PR DESCRIPTION

Match revm's create path, where bump_nonce returns failure once the creator nonce reaches u64::MAX. EIP-2681 caps account nonces, so CREATE and CREATE2 return zero at that boundary instead of wrapping, saturating, or creating the target account.

Fixed statetest files:

- eest::static/state_tests/stCreate2/CREATE2_HighNonce.json
- eest::static/state_tests/stCreate2/CREATE2_HighNonceDelegatecall.json
- eest::static/state_tests/stCreateTest/CREATE_HighNonce.json
- eest::static/state_tests/stCreateTest/CreateAddressWarmAfterFail.json
- legacy_cancun::stCreate2/CREATE2_HighNonce.json
- legacy_cancun::stCreate2/CREATE2_HighNonceDelegatecall.json
- legacy_cancun::stCreateTest/CREATE_HighNonce.json
- legacy_cancun::stCreateTest/CreateAddressWarmAfterFail.json


Stacked on https://github.com/DaniPopes/evm2/pull/46.
