### PR TITLE
fix(evm): preserve spurious precompile touch

### DIFF
--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -327,7 +327,7 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
         if let Err(stop) =
             self.state.create_account(message.caller, address, message.value, self.spec_id())
         {
-            self.state.rollback(checkpoint);
+            self.state.rollback_with_spec(checkpoint, self.spec_id());
             return MessageResult {
                 stop,
                 gas_remaining: message.gas_limit,
@@ -382,7 +382,7 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
             };
 
             if let Some(stop) = stop {
-                self.state.rollback(checkpoint);
+                self.state.rollback_with_spec(checkpoint, self.spec_id());
                 gas_remaining = if stop.is_halt() { 0 } else { gas.remaining() };
                 return MessageResult {
                     stop,
@@ -397,7 +397,7 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
             gas_refunded = gas.refunded();
             self.state.set_code(address, Bytecode::new_legacy(output.clone()));
         } else {
-            self.state.rollback(checkpoint);
+            self.state.rollback_with_spec(checkpoint, self.spec_id());
             if stop.is_halt() {
                 gas_remaining = 0;
             }
@@ -476,7 +476,7 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
                 }
             };
             if !stop.is_success() {
-                self.state.rollback(checkpoint);
+                self.state.rollback_with_spec(checkpoint, self.spec_id());
             }
             return MessageResult {
                 stop,
@@ -495,7 +495,7 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
         let mut gas_remaining = child_gas.remaining();
 
         if !stop.is_success() {
-            self.state.rollback(checkpoint);
+            self.state.rollback_with_spec(checkpoint, self.spec_id());
             if stop.is_halt() {
                 gas_remaining = 0;
             }

--- a/crates/evm2/src/evm/state.rs
+++ b/crates/evm2/src/evm/state.rs
@@ -819,6 +819,16 @@ impl<D: Database> State<D> {
     /// Reverts state changes after the checkpoint.
     #[inline(never)]
     pub fn rollback(&mut self, checkpoint: usize) {
+        self.rollback_inner(checkpoint, false);
+    }
+
+    /// Reverts state changes after the checkpoint with fork-specific rollback exceptions.
+    #[inline(never)]
+    pub fn rollback_with_spec(&mut self, checkpoint: usize, spec: SpecId) {
+        self.rollback_inner(checkpoint, spec.enables(SpecId::SPURIOUS_DRAGON));
+    }
+
+    fn rollback_inner(&mut self, checkpoint: usize, preserve_precompile3_touch: bool) {
         assert!(checkpoint <= self.journal.len(), "checkpoint is past journal length");
         while self.journal.len() != checkpoint {
             let Some(entry) = self.journal.pop() else {
@@ -834,6 +844,10 @@ impl<D: Database> State<D> {
                     self.accounts.remove(&address);
                 }
                 JournalEntry::Touch { address } => {
+                    // EIP-161 preserves the historical Yellow Paper K.1 precompile-3 touch.
+                    if preserve_precompile3_touch && address == Address::with_last_byte(3) {
+                        continue;
+                    }
                     self.touched.remove(&address);
                 }
                 JournalEntry::SelfDestruct { address } => {
@@ -1107,6 +1121,24 @@ mod tests {
         );
         state.rollback(checkpoint);
         assert_eq!(state.logs(), &[kept]);
+    }
+
+    #[test]
+    fn spurious_dragon_rollback_preserves_precompile3_touch() {
+        let precompile3 = Address::with_last_byte(3);
+        let other = Address::with_last_byte(4);
+        let mut database = CacheDB::default();
+        database.insert_account_info(precompile3, AccountInfo::default());
+        database.insert_account_info(other, AccountInfo::default());
+        let mut state = State::new(database);
+
+        let checkpoint = state.checkpoint();
+        state.touch(precompile3);
+        state.touch(other);
+
+        state.rollback_with_spec(checkpoint, crate::SpecId::SPURIOUS_DRAGON);
+        assert!(state.touched.contains(&precompile3));
+        assert!(!state.touched.contains(&other));
     }
 
     #[test]


### PR DESCRIPTION

Keep the historical precompile 0x03 touch when rolling back a failed frame under Spurious Dragon and later. Revm preserves this EIP-161 Yellow Paper K.1 exception so the empty precompile account is deleted at transaction finalization.

Full statetest delta: 85 -> 79 failures with cargo nextest run --no-fail-fast --ignore-default-filter.

Fixed statetest files:

- legacy_cancun::stRevertTest/RevertPrecompiledTouch.json

- legacy_cancun::stRevertTest/RevertPrecompiledTouch_storage.json

- legacy_cancun::stSpecialTest/failed_tx_xcf416c53.json

- legacy_constantinople::stRevertTest/RevertPrecompiledTouch.json

- legacy_constantinople::stRevertTest/RevertPrecompiledTouch_storage.json

- legacy_constantinople::stSpecialTest/failed_tx_xcf416c53.json


Stacked on https://github.com/DaniPopes/evm2/pull/51.
