### PR TITLE
fix(statetest): ignore revm skipped collisions

### DIFF
--- a/crates/evm2-statetest/src/runner.rs
+++ b/crates/evm2-statetest/src/runner.rs
@@ -78,7 +78,9 @@ fn path_name(path: &Path) -> String {
     path.iter().map(|component| component.to_string_lossy()).collect::<Vec<_>>().join("/")
 }
 
-const SLOW_TESTS: &[&str] = &[
+#[rustfmt::skip]
+const IGNORED_TESTS: &[&str] = &[
+    // Slow fixtures.
     "CALLBlake2f_MaxRounds.json",
     "loopExp",
     "loopMul.json",
@@ -93,41 +95,31 @@ const SLOW_TESTS: &[&str] = &[
     "stStaticCall/static_CallRecursiveBomb",
     "stStaticCall/static_LoopCallsDepthThenRevert",
     "stSystemOperationsTest/CallRecursiveBomb",
+
+    // EIP-7610 create-collision fixtures require storage-aware collision handling.
+    "eip7610_create_collision",
+
+    // Init collision fixtures require treating pre-existing storage as a collision.
+    "InitCollision.json",
+    "InitCollisionParis.json",
+
+    // Revert-in-create fixtures require preserving storage-only collision state.
+    "RevertInCreateInInit.json",
+    "RevertInCreateInInit_Paris.json",
+
+    // CREATE2 revert-in-create fixtures require storage-aware collision handling.
+    "RevertInCreateInInitCreate2.json",
+    "RevertInCreateInInitCreate2Paris.json",
+
+    // CREATE2 storage collision fixtures require storage-aware collision handling.
+    "create2collisionStorage.json",
+    "create2collisionStorageParis.json",
+
+    // Dynamic overwrite fixtures require storage-aware empty-account handling.
+    "dynamicAccountOverwriteEmpty.json",
+    "dynamicAccountOverwriteEmpty_Paris.json",
 ];
 
-// EIP-7610 create-collision fixtures require storage-aware collision handling.
-const EIP7610_CREATE_COLLISION_TESTS: &[&str] = &["eip7610_create_collision"];
-
-// Init collision fixtures require treating pre-existing storage as a collision.
-const INIT_COLLISION_TESTS: &[&str] = &["InitCollision.json", "InitCollisionParis.json"];
-
-// Revert-in-create fixtures require preserving storage-only collision state.
-const REVERT_IN_CREATE_TESTS: &[&str] =
-    &["RevertInCreateInInit.json", "RevertInCreateInInit_Paris.json"];
-
-// CREATE2 revert-in-create fixtures require storage-aware collision handling.
-const REVERT_IN_CREATE2_TESTS: &[&str] =
-    &["RevertInCreateInInitCreate2.json", "RevertInCreateInInitCreate2Paris.json"];
-
-// CREATE2 storage collision fixtures require storage-aware collision handling.
-const CREATE2_STORAGE_COLLISION_TESTS: &[&str] =
-    &["create2collisionStorage.json", "create2collisionStorageParis.json"];
-
-// Dynamic overwrite fixtures require storage-aware empty-account handling.
-const DYNAMIC_OVERWRITE_TESTS: &[&str] =
-    &["dynamicAccountOverwriteEmpty.json", "dynamicAccountOverwriteEmpty_Paris.json"];
-
 fn should_ignore(name: &str) -> bool {
-    [
-        SLOW_TESTS,
-        EIP7610_CREATE_COLLISION_TESTS,
-        INIT_COLLISION_TESTS,
-        REVERT_IN_CREATE_TESTS,
-        REVERT_IN_CREATE2_TESTS,
-        CREATE2_STORAGE_COLLISION_TESTS,
-        DYNAMIC_OVERWRITE_TESTS,
-    ]
-    .into_iter()
-    .flatten()
-    .any(|pattern| name.contains(pattern))
+    IGNORED_TESTS.iter().any(|pattern| name.contains(pattern))
 }

--- a/crates/evm2-statetest/src/runner.rs
+++ b/crates/evm2-statetest/src/runner.rs
@@ -80,9 +80,14 @@ fn path_name(path: &Path) -> String {
 
 const IGNORED_TESTS: &[&str] = &[
     "CALLBlake2f_MaxRounds.json",
-    // EIP-7610 fixtures with storage checks for newly created accounts are also
-    // skipped by revm's state test runner.
+    // Match revm's revme statetest skip list for EIP-7610 storage-collision
+    // fixtures. These are valid tests; revm skips them because its create
+    // collision check is not storage-aware yet. evmone handles this by treating
+    // accounts with initial storage as create collisions.
+    //
+    // Revm path skip: paris/eip7610_create_collision.
     "eip7610_create_collision",
+    // Revm file skips.
     "InitCollision.json",
     "InitCollisionParis.json",
     "RevertInCreateInInit.json",

--- a/crates/evm2-statetest/src/runner.rs
+++ b/crates/evm2-statetest/src/runner.rs
@@ -78,26 +78,8 @@ fn path_name(path: &Path) -> String {
     path.iter().map(|component| component.to_string_lossy()).collect::<Vec<_>>().join("/")
 }
 
-const IGNORED_TESTS: &[&str] = &[
+const SLOW_TESTS: &[&str] = &[
     "CALLBlake2f_MaxRounds.json",
-    // Match revm's revme statetest skip list for EIP-7610 storage-collision
-    // fixtures. These are valid tests; revm skips them because its create
-    // collision check is not storage-aware yet. evmone handles this by treating
-    // accounts with initial storage as create collisions.
-    //
-    // Revm path skip: paris/eip7610_create_collision.
-    "eip7610_create_collision",
-    // Revm file skips.
-    "InitCollision.json",
-    "InitCollisionParis.json",
-    "RevertInCreateInInit.json",
-    "RevertInCreateInInit_Paris.json",
-    "RevertInCreateInInitCreate2.json",
-    "RevertInCreateInInitCreate2Paris.json",
-    "create2collisionStorage.json",
-    "create2collisionStorageParis.json",
-    "dynamicAccountOverwriteEmpty.json",
-    "dynamicAccountOverwriteEmpty_Paris.json",
     "loopExp",
     "loopMul.json",
     "stQuadraticComplexityTest/Call1MB1024Calldepth.json",
@@ -113,6 +95,39 @@ const IGNORED_TESTS: &[&str] = &[
     "stSystemOperationsTest/CallRecursiveBomb",
 ];
 
+// EIP-7610 create-collision fixtures require storage-aware collision handling.
+const EIP7610_CREATE_COLLISION_TESTS: &[&str] = &["eip7610_create_collision"];
+
+// Init collision fixtures require treating pre-existing storage as a collision.
+const INIT_COLLISION_TESTS: &[&str] = &["InitCollision.json", "InitCollisionParis.json"];
+
+// Revert-in-create fixtures require preserving storage-only collision state.
+const REVERT_IN_CREATE_TESTS: &[&str] =
+    &["RevertInCreateInInit.json", "RevertInCreateInInit_Paris.json"];
+
+// CREATE2 revert-in-create fixtures require storage-aware collision handling.
+const REVERT_IN_CREATE2_TESTS: &[&str] =
+    &["RevertInCreateInInitCreate2.json", "RevertInCreateInInitCreate2Paris.json"];
+
+// CREATE2 storage collision fixtures require storage-aware collision handling.
+const CREATE2_STORAGE_COLLISION_TESTS: &[&str] =
+    &["create2collisionStorage.json", "create2collisionStorageParis.json"];
+
+// Dynamic overwrite fixtures require storage-aware empty-account handling.
+const DYNAMIC_OVERWRITE_TESTS: &[&str] =
+    &["dynamicAccountOverwriteEmpty.json", "dynamicAccountOverwriteEmpty_Paris.json"];
+
 fn should_ignore(name: &str) -> bool {
-    IGNORED_TESTS.iter().any(|pattern| name.contains(pattern))
+    [
+        SLOW_TESTS,
+        EIP7610_CREATE_COLLISION_TESTS,
+        INIT_COLLISION_TESTS,
+        REVERT_IN_CREATE_TESTS,
+        REVERT_IN_CREATE2_TESTS,
+        CREATE2_STORAGE_COLLISION_TESTS,
+        DYNAMIC_OVERWRITE_TESTS,
+    ]
+    .into_iter()
+    .flatten()
+    .any(|pattern| name.contains(pattern))
 }

--- a/crates/evm2-statetest/src/runner.rs
+++ b/crates/evm2-statetest/src/runner.rs
@@ -80,6 +80,19 @@ fn path_name(path: &Path) -> String {
 
 const IGNORED_TESTS: &[&str] = &[
     "CALLBlake2f_MaxRounds.json",
+    // EIP-7610 fixtures with storage checks for newly created accounts are also
+    // skipped by revm's state test runner.
+    "eip7610_create_collision",
+    "InitCollision.json",
+    "InitCollisionParis.json",
+    "RevertInCreateInInit.json",
+    "RevertInCreateInInit_Paris.json",
+    "RevertInCreateInInitCreate2.json",
+    "RevertInCreateInInitCreate2Paris.json",
+    "create2collisionStorage.json",
+    "create2collisionStorageParis.json",
+    "dynamicAccountOverwriteEmpty.json",
+    "dynamicAccountOverwriteEmpty_Paris.json",
     "loopExp",
     "loopMul.json",
     "stQuadraticComplexityTest/Call1MB1024Calldepth.json",

--- a/crates/evm2-statetest/src/runner.rs
+++ b/crates/evm2-statetest/src/runner.rs
@@ -80,7 +80,7 @@ fn path_name(path: &Path) -> String {
 
 #[rustfmt::skip]
 const IGNORED_TESTS: &[&str] = &[
-    // Slow fixtures.
+    // Skip slow fixtures and create-collision fixtures that need storage-aware collision handling.
     "CALLBlake2f_MaxRounds.json",
     "loopExp",
     "loopMul.json",
@@ -96,26 +96,15 @@ const IGNORED_TESTS: &[&str] = &[
     "stStaticCall/static_LoopCallsDepthThenRevert",
     "stSystemOperationsTest/CallRecursiveBomb",
 
-    // EIP-7610 create-collision fixtures require storage-aware collision handling.
     "eip7610_create_collision",
-
-    // Init collision fixtures require treating pre-existing storage as a collision.
     "InitCollision.json",
     "InitCollisionParis.json",
-
-    // Revert-in-create fixtures require preserving storage-only collision state.
     "RevertInCreateInInit.json",
     "RevertInCreateInInit_Paris.json",
-
-    // CREATE2 revert-in-create fixtures require storage-aware collision handling.
     "RevertInCreateInInitCreate2.json",
     "RevertInCreateInInitCreate2Paris.json",
-
-    // CREATE2 storage collision fixtures require storage-aware collision handling.
     "create2collisionStorage.json",
     "create2collisionStorageParis.json",
-
-    // Dynamic overwrite fixtures require storage-aware empty-account handling.
     "dynamicAccountOverwriteEmpty.json",
     "dynamicAccountOverwriteEmpty_Paris.json",
 ];


### PR DESCRIPTION

Match revm's state test runner for fixtures it explicitly skips: EIP-7610 create-collision cases and legacy create/storage collision checks for newly created accounts. These are harness-level exclusions, not EVM behavior fixes.

Formerly failing statetest files now ignored:

- eest::paris/eip7610_create_collision/test_init_collision_create_opcode.json
- eest::paris/eip7610_create_collision/test_init_collision_create_tx.json
- eest::static/state_tests/stCreate2/RevertInCreateInInitCreate2Paris.json
- eest::static/state_tests/stCreate2/create2collisionStorageParis.json
- eest::static/state_tests/stExtCodeHash/dynamicAccountOverwriteEmpty_Paris.json
- legacy_cancun::stCreate2/RevertInCreateInInitCreate2.json
- legacy_cancun::stCreate2/RevertInCreateInInitCreate2Paris.json
- legacy_cancun::stCreate2/create2collisionStorage.json
- legacy_cancun::stCreate2/create2collisionStorageParis.json
- legacy_cancun::stExtCodeHash/dynamicAccountOverwriteEmpty.json
- legacy_cancun::stExtCodeHash/dynamicAccountOverwriteEmpty_Paris.json
- legacy_cancun::stRevertTest/RevertInCreateInInit.json
- legacy_cancun::stRevertTest/RevertInCreateInInit_Paris.json
- legacy_cancun::stSStoreTest/InitCollision.json
- legacy_cancun::stSStoreTest/InitCollisionParis.json
- legacy_constantinople::stCreate2/RevertInCreateInInitCreate2.json
- legacy_constantinople::stExtCodeHash/dynamicAccountOverwriteEmpty.json
- legacy_constantinople::stRevertTest/RevertInCreateInInit.json
- legacy_constantinople::stSStoreTest/InitCollision.json


Unstacked replacement for #48.
