### PR TITLE
fix(evm): check callcode self-transfer funds

### DIFF
--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -420,7 +420,7 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
         caller_is_static: bool,
     ) -> MessageResult {
         let checkpoint = self.state.checkpoint();
-        if matches!(message.kind, MessageKind::Call)
+        if matches!(message.kind, MessageKind::Call | MessageKind::CallCode)
             && !self.state.transfer(message.caller, message.destination, message.value)
         {
             return MessageResult {

--- a/crates/evm2/src/evm/state.rs
+++ b/crates/evm2/src/evm/state.rs
@@ -661,12 +661,19 @@ impl<D: Database> State<D> {
     #[inline]
     #[must_use]
     pub fn transfer(&mut self, from: Address, to: Address, value: Word) -> bool {
-        if value.is_zero() || from == to {
+        if value.is_zero() {
             self.touch(to);
             return true;
         }
 
         let from_balance = self.account_info(from).map_or(Word::ZERO, |info| info.balance);
+        if from == to {
+            if from_balance < value {
+                return false;
+            }
+            self.touch(to);
+            return true;
+        }
         let Some(new_from_balance) = from_balance.checked_sub(value) else {
             return false;
         };
@@ -1121,6 +1128,17 @@ mod tests {
         state.commit_transaction_overlay();
         state.clear_transaction_state();
         assert!(state.logs().is_empty());
+    }
+
+    #[test]
+    fn transfer_to_self_requires_balance() {
+        let address = Address::from([0x77; 20]);
+        let mut database = CacheDB::default();
+        database.insert_account_info(address, AccountInfo::default().with_balance(Word::from(3)));
+        let mut state = State::new(database);
+
+        assert!(!state.transfer(address, address, Word::from(4)));
+        assert!(state.transfer(address, address, Word::from(3)));
     }
 
     #[test]


### PR DESCRIPTION

CALLCODE transfers value from the caller account to itself, but the
funds check still has to run before execution. revm returns OutOfFunds for
from == to when the balance is insufficient and leaves balances unchanged
otherwise.

Fixed statetest files:
- eest::frontier/identity_precompile/test_call_identity_precompile.json
- eest::static/state_tests/stCallCodes/callcodeInInitcodeToEmptyContract.json
- eest::static/state_tests/stCallCodes/callcodeInInitcodeToExisContractWithVTransferNEMoney.json
- eest::static/state_tests/stCallCreateCallCodeTest/callcodeWithHighValue.json
- eest::static/state_tests/stCallCreateCallCodeTest/callcodeWithHighValueAndGasOOG.json
- eest::static/state_tests/stEIP150Specific/NewGasPriceForCodes.json
- eest::static/state_tests/stMemExpandingEIP150Calls/NewGasPriceForCodesWithMemExpandingCalls.json
- eest::static/state_tests/stNonZeroCallsTest/NonZeroValue_CALLCODE_ToNonNonZeroBalance.json
- eest::static/state_tests/stRandom/randomStatetest248.json
- eest::static/state_tests/stStaticCall/static_callcallcodecallcode_011_OOGE_2.json
- eest::static/state_tests/stStaticCall/static_callcallcodecallcode_011_OOGMBefore2.json
- eest::static/state_tests/stStaticCall/static_callcodecallcodecall_1102.json
- eest::static/state_tests/stStaticCall/static_callcodecallcodecall_110_2.json
- eest::static/state_tests/stStaticCall/static_callcodecallcodecall_110_OOGE2.json
- eest::static/state_tests/stStaticCall/static_callcodecallcodecall_110_OOGMBefore2.json
- legacy_cancun::stCallCodes/callcodeInInitcodeToEmptyContract.json
- legacy_cancun::stCallCodes/callcodeInInitcodeToExisContractWithVTransferNEMoney.json
- legacy_cancun::stCallCreateCallCodeTest/callcodeWithHighValue.json
- legacy_cancun::stCallCreateCallCodeTest/callcodeWithHighValueAndGasOOG.json
- legacy_cancun::stEIP150Specific/NewGasPriceForCodes.json
- legacy_cancun::stMemExpandingEIP150Calls/NewGasPriceForCodesWithMemExpandingCalls.json
- legacy_cancun::stNonZeroCallsTest/NonZeroValue_CALLCODE_ToNonNonZeroBalance.json
- legacy_cancun::stRandom/randomStatetest248.json
- legacy_cancun::stStaticCall/static_callcallcodecallcode_011_OOGE_2.json
- legacy_cancun::stStaticCall/static_callcallcodecallcode_011_OOGMBefore2.json
- legacy_cancun::stStaticCall/static_callcodecallcodecall_1102.json
- legacy_cancun::stStaticCall/static_callcodecallcodecall_110_2.json
- legacy_cancun::stStaticCall/static_callcodecallcodecall_110_OOGE2.json
- legacy_cancun::stStaticCall/static_callcodecallcodecall_110_OOGMBefore2.json
- legacy_constantinople::stCallCodes/callcodeInInitcodeToExisContractWithVTransferNEMoney.json
- legacy_constantinople::stCallCreateCallCodeTest/callcodeWithHighValue.json
- legacy_constantinople::stCallCreateCallCodeTest/callcodeWithHighValueAndGasOOG.json
- legacy_constantinople::stEIP150Specific/NewGasPriceForCodes.json
- legacy_constantinople::stMemExpandingEIP150Calls/NewGasPriceForCodesWithMemExpandingCalls.json
- legacy_constantinople::stNonZeroCallsTest/NonZeroValue_CALLCODE_ToNonNonZeroBalance.json
- legacy_constantinople::stRandom/randomStatetest248.json
- legacy_constantinople::stStaticCall/static_callcallcodecallcode_011_OOGE_2.json
- legacy_constantinople::stStaticCall/static_callcallcodecallcode_011_OOGMBefore2.json
- legacy_constantinople::stStaticCall/static_callcodecallcodecall_1102.json
- legacy_constantinople::stStaticCall/static_callcodecallcodecall_110_2.json
- legacy_constantinople::stStaticCall/static_callcodecallcodecall_110_OOGE2.json
- legacy_constantinople::stStaticCall/static_callcodecallcodecall_110_OOGMBefore2.json


Unstacked replacement for #44.
