### PR TITLE
fix(evm): touch staticcall destinations

### DIFF
--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -420,7 +420,8 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
         caller_is_static: bool,
     ) -> MessageResult {
         let checkpoint = self.state.checkpoint();
-        if matches!(message.kind, MessageKind::Call)
+        // EIP-161 state clearing depends on zero-value direct call targets being touched.
+        if matches!(message.kind, MessageKind::Call | MessageKind::StaticCall)
             && !self.state.transfer(message.caller, message.destination, message.value)
         {
             return MessageResult {
@@ -773,6 +774,83 @@ mod tests {
 
         let result = Host::execute_message(&mut evm, &TxEnv::default(), bytecode, &message, false);
         assert!(result.stop.is_success());
+    }
+
+    #[test]
+    fn staticcall_touches_empty_existing_destination() {
+        let target = Address::from([0x11; 20]);
+        let mut database = InMemoryDB::default();
+        database.insert_account_info(target, AccountInfo::default());
+        database.insert_account_storage(target, Word::ZERO, Word::from(1));
+        let mut evm = Evm::<TestEvmTypes>::new(
+            SpecId::SPURIOUS_DRAGON,
+            BlockEnv::default(),
+            TxRegistry::new(),
+            database,
+            Precompiles::base(SpecId::SPURIOUS_DRAGON),
+        );
+        let message = Message {
+            kind: MessageKind::StaticCall,
+            destination: target,
+            code_address: target,
+            gas_limit: 50_000,
+            ..Message::default()
+        };
+
+        let result = Host::execute_message(
+            &mut evm,
+            &TxEnv::default(),
+            Bytecode::default(),
+            &message,
+            false,
+        );
+        assert!(result.stop.is_success());
+
+        evm.state.finalize_transaction(SpecId::SPURIOUS_DRAGON);
+        let changes = evm.state.build_state_changes();
+        let account = changes.accounts.get(&target).expect("empty destination should be deleted");
+        assert!(account.original.is_some());
+        assert_eq!(account.current, None);
+        assert!(changes.storage.get(&target).is_some_and(|storage| storage.wipe));
+    }
+
+    #[test]
+    fn delegatecall_does_not_touch_empty_code_address() {
+        let destination = Address::from([0x11; 20]);
+        let code_address = Address::from([0x22; 20]);
+        let mut database = InMemoryDB::default();
+        database
+            .insert_account_info(destination, AccountInfo::default().with_balance(Word::from(1)));
+        database.insert_account_info(code_address, AccountInfo::default());
+        database.insert_account_storage(code_address, Word::ZERO, Word::from(1));
+        let mut evm = Evm::<TestEvmTypes>::new(
+            SpecId::SPURIOUS_DRAGON,
+            BlockEnv::default(),
+            TxRegistry::new(),
+            database,
+            Precompiles::base(SpecId::SPURIOUS_DRAGON),
+        );
+        let message = Message {
+            kind: MessageKind::DelegateCall,
+            destination,
+            code_address,
+            gas_limit: 50_000,
+            ..Message::default()
+        };
+
+        let result = Host::execute_message(
+            &mut evm,
+            &TxEnv::default(),
+            Bytecode::default(),
+            &message,
+            false,
+        );
+        assert!(result.stop.is_success());
+
+        evm.state.finalize_transaction(SpecId::SPURIOUS_DRAGON);
+        let changes = evm.state.build_state_changes();
+        assert!(!changes.accounts.contains_key(&code_address));
+        assert!(!changes.storage.contains_key(&code_address));
     }
 
     #[test]


### PR DESCRIPTION

Revm marks direct call targets touched even when the transferred value is zero, which matters for EIP-161 empty-account clearing. Mirror that for STATICCALL while keeping DELEGATECALL from touching only its code address.

Full statetest run improved from 7692 passed / 110 failed / 115 skipped to 7712 passed / 90 failed / 115 skipped out of 7802 executed tests in the original stacked branch.

Fixed statetest files:

- legacy_cancun::stRevertTest/RevertPrecompiledTouchExactOOG.json
- legacy_cancun::stTimeConsuming/sstore_combinations_initial00.json
- legacy_cancun::stTimeConsuming/sstore_combinations_initial00_2.json
- legacy_cancun::stTimeConsuming/sstore_combinations_initial01.json
- legacy_cancun::stTimeConsuming/sstore_combinations_initial01_2.json
- legacy_cancun::stTimeConsuming/sstore_combinations_initial10.json
- legacy_cancun::stTimeConsuming/sstore_combinations_initial10_2.json
- legacy_cancun::stTimeConsuming/sstore_combinations_initial11.json
- legacy_cancun::stTimeConsuming/sstore_combinations_initial11_2.json
- legacy_cancun::stTimeConsuming/sstore_combinations_initial20.json
- legacy_cancun::stTimeConsuming/sstore_combinations_initial20_2.json
- legacy_cancun::stTimeConsuming/sstore_combinations_initial21.json
- legacy_cancun::stTimeConsuming/sstore_combinations_initial21_2.json
- legacy_constantinople::stRevertTest/RevertPrecompiledTouchExactOOG.json
- legacy_constantinople::stTimeConsuming/sstore_combinations_initial0.json
- legacy_constantinople::stTimeConsuming/sstore_combinations_initial0_2.json
- legacy_constantinople::stTimeConsuming/sstore_combinations_initial1.json
- legacy_constantinople::stTimeConsuming/sstore_combinations_initial1_2.json
- legacy_constantinople::stTimeConsuming/sstore_combinations_initial2.json
- legacy_constantinople::stTimeConsuming/sstore_combinations_initial2_1.json


Unstacked replacement for #49.
