### PR TITLE
fix(evm): apply tx gas cap and floor

### DIFF
--- a/crates/evm2/src/ethereum/eip1559.rs
+++ b/crates/evm2/src/ethereum/eip1559.rs
@@ -2,8 +2,8 @@ use super::{
     access_list_counts, charge_upfront, effective_gas_price, floor_gas, initial_message,
     intrinsic_gas, rollback_failed_execution, settle_gas, validate_block_gas_limit,
     validate_create_initcode, validate_floor_gas, validate_gas_price, validate_intrinsic_gas,
-    validate_nonce_not_overflow, validate_priority_fee, validate_sender, warm_access_list,
-    warm_base_accounts,
+    validate_nonce_not_overflow, validate_priority_fee, validate_sender, validate_tx_gas_limit_cap,
+    warm_access_list, warm_base_accounts,
 };
 use crate::{
     Evm, EvmTypes, SpecId, TxResult,
@@ -31,6 +31,7 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
 
     validate_priority_fee(max_fee_per_gas, max_priority_fee_per_gas)?;
     validate_gas_price(spec_id, gas_price, req.host.block.basefee)?;
+    validate_tx_gas_limit_cap(spec_id, tx.gas_limit)?;
     validate_block_gas_limit(tx.gas_limit, req.host.block.gas_limit)?;
     validate_create_initcode(spec_id, tx.to, &tx.input)?;
     validate_nonce_not_overflow(tx.nonce)?;
@@ -43,7 +44,8 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
         access_list_storage_keys,
     );
     validate_intrinsic_gas(tx.gas_limit, intrinsic)?;
-    validate_floor_gas(tx.gas_limit, floor_gas(req.host.version(), &tx.input))?;
+    let floor_gas = floor_gas(req.host.version(), &tx.input);
+    validate_floor_gas(tx.gas_limit, floor_gas)?;
 
     let max_gas_cost = U256::from(tx.gas_limit) * max_fee_per_gas;
     validate_sender(req.host, caller, tx.nonce, max_gas_cost.saturating_add(tx.value))?;
@@ -64,5 +66,5 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     let mut result = req.host.execute_message(&tx_env, bytecode, &message, false);
     rollback_failed_execution(req.host, execution_checkpoint, &mut result);
 
-    Ok(settle_gas(req.host, spec_id, caller, gas_price, tx.gas_limit, result))
+    Ok(settle_gas(req.host, spec_id, caller, gas_price, tx.gas_limit, floor_gas, result))
 }

--- a/crates/evm2/src/ethereum/eip2930.rs
+++ b/crates/evm2/src/ethereum/eip2930.rs
@@ -2,7 +2,7 @@ use super::{
     access_list_counts, charge_upfront, floor_gas, initial_message, intrinsic_gas,
     rollback_failed_execution, settle_gas, validate_block_gas_limit, validate_create_initcode,
     validate_floor_gas, validate_gas_price, validate_intrinsic_gas, validate_nonce_not_overflow,
-    validate_sender, warm_access_list, warm_base_accounts,
+    validate_sender, validate_tx_gas_limit_cap, warm_access_list, warm_base_accounts,
 };
 use crate::{
     Evm, EvmTypes, SpecId, TxResult,
@@ -26,6 +26,7 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     let gas_price = U256::from(tx.gas_price);
 
     validate_gas_price(spec_id, gas_price, req.host.block.basefee)?;
+    validate_tx_gas_limit_cap(spec_id, tx.gas_limit)?;
     validate_block_gas_limit(tx.gas_limit, req.host.block.gas_limit)?;
     validate_create_initcode(spec_id, tx.to, &tx.input)?;
     validate_nonce_not_overflow(tx.nonce)?;
@@ -38,7 +39,8 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
         access_list_storage_keys,
     );
     validate_intrinsic_gas(tx.gas_limit, intrinsic)?;
-    validate_floor_gas(tx.gas_limit, floor_gas(req.host.version(), &tx.input))?;
+    let floor_gas = floor_gas(req.host.version(), &tx.input);
+    validate_floor_gas(tx.gas_limit, floor_gas)?;
 
     let max_gas_cost = U256::from(tx.gas_limit) * gas_price;
     validate_sender(req.host, caller, tx.nonce, max_gas_cost.saturating_add(tx.value))?;
@@ -58,5 +60,5 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     let mut result = req.host.execute_message(&tx_env, bytecode, &message, false);
     rollback_failed_execution(req.host, execution_checkpoint, &mut result);
 
-    Ok(settle_gas(req.host, spec_id, caller, gas_price, tx.gas_limit, result))
+    Ok(settle_gas(req.host, spec_id, caller, gas_price, tx.gas_limit, floor_gas, result))
 }

--- a/crates/evm2/src/ethereum/eip4844.rs
+++ b/crates/evm2/src/ethereum/eip4844.rs
@@ -2,8 +2,8 @@ use super::{
     access_list_counts, charge_upfront, effective_gas_price, floor_gas, initial_message,
     intrinsic_gas, rollback_failed_execution, settle_gas, validate_block_gas_limit,
     validate_create_initcode, validate_floor_gas, validate_gas_price, validate_intrinsic_gas,
-    validate_nonce_not_overflow, validate_priority_fee, validate_sender, warm_access_list,
-    warm_base_accounts,
+    validate_nonce_not_overflow, validate_priority_fee, validate_sender, validate_tx_gas_limit_cap,
+    warm_access_list, warm_base_accounts,
 };
 use crate::{
     Evm, EvmTypes, SpecId, TxResult,
@@ -38,6 +38,7 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     validate_gas_price(spec_id, gas_price, req.host.block.basefee)?;
     validate_blob_fee(max_fee_per_blob_gas, req.host.block.blob_basefee)?;
     validate_blobs(&tx.blob_versioned_hashes, max_blobs_per_tx(spec_id))?;
+    validate_tx_gas_limit_cap(spec_id, tx.gas_limit)?;
     validate_block_gas_limit(tx.gas_limit, req.host.block.gas_limit)?;
     validate_create_initcode(spec_id, tx.to.into(), &tx.input)?;
     validate_nonce_not_overflow(tx.nonce)?;
@@ -50,7 +51,8 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
         access_list_storage_keys,
     );
     validate_intrinsic_gas(tx.gas_limit, intrinsic)?;
-    validate_floor_gas(tx.gas_limit, floor_gas(req.host.version(), &tx.input))?;
+    let floor_gas = floor_gas(req.host.version(), &tx.input);
+    validate_floor_gas(tx.gas_limit, floor_gas)?;
 
     let blob_gas_cost = U256::from(DATA_GAS_PER_BLOB) * U256::from(tx.blob_versioned_hashes.len());
     let max_blob_gas_cost = blob_gas_cost * max_fee_per_blob_gas;
@@ -83,7 +85,7 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     let mut result = req.host.execute_message(&tx_env, bytecode, &message, false);
     rollback_failed_execution(req.host, execution_checkpoint, &mut result);
 
-    Ok(settle_gas(req.host, spec_id, caller, gas_price, tx.gas_limit, result))
+    Ok(settle_gas(req.host, spec_id, caller, gas_price, tx.gas_limit, floor_gas, result))
 }
 
 fn validate_blob_fee(max_fee_per_blob_gas: U256, blob_basefee: U256) -> HandlerResult<()> {

--- a/crates/evm2/src/ethereum/legacy.rs
+++ b/crates/evm2/src/ethereum/legacy.rs
@@ -2,7 +2,7 @@ use super::{
     charge_upfront, floor_gas, initial_message, intrinsic_gas, rollback_failed_execution,
     settle_gas, validate_block_gas_limit, validate_create_initcode, validate_floor_gas,
     validate_gas_price, validate_intrinsic_gas, validate_nonce_not_overflow, validate_sender,
-    warm_base_accounts,
+    validate_tx_gas_limit_cap, warm_base_accounts,
 };
 use crate::{
     Evm, EvmTypes, TxResult,
@@ -22,12 +22,14 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     let gas_price = U256::from(tx.gas_price);
 
     validate_gas_price(spec_id, gas_price, req.host.block.basefee)?;
+    validate_tx_gas_limit_cap(spec_id, tx.gas_limit)?;
     validate_block_gas_limit(tx.gas_limit, req.host.block.gas_limit)?;
     validate_create_initcode(spec_id, tx.to, &tx.input)?;
     validate_nonce_not_overflow(tx.nonce)?;
     let intrinsic = intrinsic_gas(req.host.version(), tx.to, &tx.input, 0, 0);
     validate_intrinsic_gas(tx.gas_limit, intrinsic)?;
-    validate_floor_gas(tx.gas_limit, floor_gas(req.host.version(), &tx.input))?;
+    let floor_gas = floor_gas(req.host.version(), &tx.input);
+    validate_floor_gas(tx.gas_limit, floor_gas)?;
 
     let max_gas_cost = U256::from(tx.gas_limit) * gas_price;
     validate_sender(req.host, caller, tx.nonce, max_gas_cost.saturating_add(tx.value))?;
@@ -50,5 +52,5 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     let mut result = req.host.execute_message(&tx_env, bytecode, &message, false);
     rollback_failed_execution(req.host, execution_checkpoint, &mut result);
 
-    Ok(settle_gas(req.host, spec_id, caller, gas_price, tx.gas_limit, result))
+    Ok(settle_gas(req.host, spec_id, caller, gas_price, tx.gas_limit, floor_gas, result))
 }

--- a/crates/evm2/src/ethereum/mod.rs
+++ b/crates/evm2/src/ethereum/mod.rs
@@ -18,6 +18,8 @@ use alloy_consensus::{TxEip1559, TxEip2930, TxEip7702, TxLegacy, transaction::Re
 use alloy_eips::{eip2718::Typed2718, eip2930::AccessList};
 use alloy_primitives::{Address, B256, Bytes, KECCAK256_EMPTY, TxKind, U256};
 
+const EIP7825_TX_GAS_LIMIT_CAP: u64 = 16_777_216;
+
 /// Ethereum transaction envelope containing recovered transactions.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum RecoveredTxEnvelope {
@@ -125,6 +127,20 @@ pub(super) fn validate_block_gas_limit(
         return Err(HandlerError::GasLimitMoreThanBlock {
             gas_limit: tx_gas_limit,
             block_gas_limit,
+        });
+    }
+    Ok(())
+}
+
+pub(super) const fn validate_tx_gas_limit_cap(
+    spec_id: SpecId,
+    tx_gas_limit: u64,
+) -> HandlerResult<()> {
+    // EIP-7825 caps each transaction gas limit to 2^24 starting in Osaka.
+    if spec_id.enables(SpecId::OSAKA) && tx_gas_limit > EIP7825_TX_GAS_LIMIT_CAP {
+        return Err(HandlerError::TxGasLimitGreaterThanCap {
+            gas_limit: tx_gas_limit,
+            cap: EIP7825_TX_GAS_LIMIT_CAP,
         });
     }
     Ok(())
@@ -285,12 +301,11 @@ pub(super) fn settle_gas<T: EvmTypes<Host = Evm<T>>>(
     caller: Address,
     gas_price: U256,
     tx_gas_limit: u64,
+    floor_gas: u64,
     result: MessageResult,
 ) -> TxResult {
-    let gas_remaining =
-        result.gas_remaining_after_final_refund(tx_gas_limit, spec_id.enables(SpecId::LONDON));
-    let gas_used =
-        result.gas_used_after_final_refund(tx_gas_limit, spec_id.enables(SpecId::LONDON));
+    let (gas_remaining, gas_used) =
+        final_tx_gas(&result, tx_gas_limit, spec_id.enables(SpecId::LONDON), floor_gas);
     host.state.add_balance(caller, U256::from(gas_remaining) * gas_price);
     let beneficiary_gas_price = if spec_id.enables(SpecId::LONDON) {
         gas_price.saturating_sub(host.block.basefee)
@@ -305,6 +320,21 @@ pub(super) fn settle_gas<T: EvmTypes<Host = Evm<T>>>(
         output: result.output,
         ..TxResult::default()
     }
+}
+
+const fn final_tx_gas(
+    result: &MessageResult,
+    tx_gas_limit: u64,
+    is_london: bool,
+    floor_gas: u64,
+) -> (u64, u64) {
+    let gas_remaining = result.gas_remaining_after_final_refund(tx_gas_limit, is_london);
+    let gas_used = result.gas_used_after_final_refund(tx_gas_limit, is_london);
+    // EIP-7623 charges at least the calldata floor after applying refunds.
+    if gas_used < floor_gas {
+        return (tx_gas_limit.saturating_sub(floor_gas), floor_gas);
+    }
+    (gas_remaining, gas_used)
 }
 
 pub(super) fn access_list_counts(access_list: &AccessList) -> (u64, u64) {
@@ -395,5 +425,29 @@ mod tests {
 
         assert_eq!(floor_gas(&Version::base(SpecId::SHANGHAI), &input), 0);
         assert_eq!(floor_gas(&Version::base(SpecId::PRAGUE), &input), 21_000 + 9 * 10);
+    }
+
+    #[test]
+    fn final_tx_gas_charges_calldata_floor_after_refund() {
+        let result = MessageResult {
+            stop: crate::interpreter::InstrStop::Return,
+            gas_remaining: 50_000,
+            gas_refunded: 10_000,
+            ..MessageResult::default()
+        };
+
+        assert_eq!(final_tx_gas(&result, 100_000, true, 60_000), (40_000, 60_000));
+    }
+
+    #[test]
+    fn final_tx_gas_preserves_higher_actual_usage() {
+        let result = MessageResult {
+            stop: crate::interpreter::InstrStop::Return,
+            gas_remaining: 30_000,
+            gas_refunded: 0,
+            ..MessageResult::default()
+        };
+
+        assert_eq!(final_tx_gas(&result, 100_000, true, 60_000), (30_000, 70_000));
     }
 }

--- a/crates/evm2/src/evm/registry.rs
+++ b/crates/evm2/src/evm/registry.rs
@@ -105,6 +105,14 @@ pub enum HandlerError {
         /// Block gas limit.
         block_gas_limit: U256,
     },
+    /// Transaction gas limit exceeds the active per-transaction gas cap.
+    #[error("transaction gas limit {gas_limit} exceeds cap {cap}")]
+    TxGasLimitGreaterThanCap {
+        /// Transaction gas limit.
+        gas_limit: u64,
+        /// Active transaction gas limit cap.
+        cap: u64,
+    },
     /// Create transaction initcode exceeds the active size limit.
     #[error("create initcode size limit exceeded: limit {limit}, got {got}")]
     CreateInitCodeSizeLimit {


### PR DESCRIPTION

Enforce the EIP-7825 per-transaction gas limit cap from Osaka and
charge the EIP-7623 calldata floor during gas settlement after refunds,
matching revm validation and post-execution accounting.

Fixed statetest files:
- eest::cancun/eip4844_blobs/test_sufficient_balance_blob_tx.json
- eest::osaka/eip7823_modexp_upper_bounds/test_modexp_upper_bounds.json
- eest::osaka/eip7825_transaction_gas_limit_cap/test_tx_gas_limit_cap_access_list_with_diff_addr.json
- eest::osaka/eip7825_transaction_gas_limit_cap/test_tx_gas_limit_cap_access_list_with_diff_keys.json
- eest::osaka/eip7825_transaction_gas_limit_cap/test_tx_gas_limit_cap_contract_creation.json
- eest::osaka/eip7825_transaction_gas_limit_cap/test_tx_gas_limit_cap_full_calldata.json
- eest::osaka/eip7883_modexp_gas_increase/test_modexp_used_in_transaction_entry_points.json
- eest::prague/eip2537_bls_12_381_precompiles/test_invalid.json
- eest::prague/eip7623_increase_calldata_cost/test_transaction_validity_type_0.json
- eest::prague/eip7623_increase_calldata_cost/test_transaction_validity_type_1_type_2.json
- eest::prague/eip7623_increase_calldata_cost/test_transaction_validity_type_3.json
- eest::shanghai/eip3860_initcode/test_contract_creating_tx.json
- eest::shanghai/eip3860_initcode/test_create_opcode_initcode.json
- eest::shanghai/eip3860_initcode/test_legacy_create_edge_code_size.json
- eest::static/state_tests/Cancun/stEIP5656_MCOPY/MCOPY_memory_expansion_cost.json
- eest::static/state_tests/Shanghai/stEIP3860_limitmeterinitcode/creationTxInitCodeSizeLimit.json
- eest::static/state_tests/stEIP150singleCodeGasPrices/gasCostExp.json
- eest::static/state_tests/stEIP150singleCodeGasPrices/gasCostMemSeg.json
- eest::static/state_tests/stEIP150singleCodeGasPrices/gasCostMemory.json
- eest::static/state_tests/stEIP2930/transactionCosts.json
- eest::static/state_tests/stMemoryTest/memReturn.json
- eest::static/state_tests/stNonZeroCallsTest/NonZeroValue_TransactionCALLwithData.json
- eest::static/state_tests/stNonZeroCallsTest/NonZeroValue_TransactionCALLwithData_ToEmpty_Paris.json
- eest::static/state_tests/stNonZeroCallsTest/NonZeroValue_TransactionCALLwithData_ToNonNonZeroBalance.json
- eest::static/state_tests/stNonZeroCallsTest/NonZeroValue_TransactionCALLwithData_ToOneStorageKey_Paris.json
- eest::static/state_tests/stPreCompiledContracts2/modexpRandomInput.json
- eest::static/state_tests/stRandom/randomStatetest0.json
- eest::static/state_tests/stRandom/randomStatetest126.json
- eest::static/state_tests/stRandom/randomStatetest144.json
- eest::static/state_tests/stRandom/randomStatetest157.json
- eest::static/state_tests/stRandom/randomStatetest172.json
- eest::static/state_tests/stRandom/randomStatetest176.json
- eest::static/state_tests/stRandom/randomStatetest190.json
- eest::static/state_tests/stRandom/randomStatetest197.json
- eest::static/state_tests/stRandom/randomStatetest209.json
- eest::static/state_tests/stRandom/randomStatetest230.json
- eest::static/state_tests/stRandom/randomStatetest25.json
- eest::static/state_tests/stRandom/randomStatetest251.json
- eest::static/state_tests/stRandom/randomStatetest252.json
- eest::static/state_tests/stRandom/randomStatetest271.json
- eest::static/state_tests/stRandom/randomStatetest275.json
- eest::static/state_tests/stRandom/randomStatetest288.json
- eest::static/state_tests/stRandom/randomStatetest300.json
- eest::static/state_tests/stRandom/randomStatetest312.json
- eest::static/state_tests/stRandom/randomStatetest321.json
- eest::static/state_tests/stRandom/randomStatetest323.json
- eest::static/state_tests/stRandom/randomStatetest345.json
- eest::static/state_tests/stRandom/randomStatetest350.json
- eest::static/state_tests/stRandom/randomStatetest45.json
- eest::static/state_tests/stRandom/randomStatetest5.json
- eest::static/state_tests/stRandom/randomStatetest57.json
- eest::static/state_tests/stRandom/randomStatetest72.json
- eest::static/state_tests/stRandom/randomStatetest78.json
- eest::static/state_tests/stRandom/randomStatetest82.json
- eest::static/state_tests/stRandom2/randomStatetest396.json
- eest::static/state_tests/stRandom2/randomStatetest404.json
- eest::static/state_tests/stRandom2/randomStatetest414.json
- eest::static/state_tests/stRandom2/randomStatetest420.json
- eest::static/state_tests/stRandom2/randomStatetest428.json
- eest::static/state_tests/stRandom2/randomStatetest444.json
- eest::static/state_tests/stRandom2/randomStatetest478.json
- eest::static/state_tests/stRandom2/randomStatetest509.json
- eest::static/state_tests/stRandom2/randomStatetest531.json
- eest::static/state_tests/stRandom2/randomStatetest543.json
- eest::static/state_tests/stRandom2/randomStatetest558.json
- eest::static/state_tests/stRandom2/randomStatetest567.json
- eest::static/state_tests/stRandom2/randomStatetest572.json
- eest::static/state_tests/stRandom2/randomStatetest609.json
- eest::static/state_tests/stRandom2/randomStatetest624.json
- eest::static/state_tests/stRandom2/randomStatetest644.json
- eest::static/state_tests/stRandom2/randomStatetest645.json
- eest::static/state_tests/stRevertTest/PythonRevertTestTue201814-1430.json
- eest::static/state_tests/stStackTests/stackOverflowM1PUSH.json
- eest::static/state_tests/stTransactionTest/HighGasLimit.json
- eest::static/state_tests/stTransactionTest/OverflowGasRequire2.json
- eest::static/state_tests/stTransactionTest/TransactionDataCosts652.json
- eest::static/state_tests/stZeroCallsTest/ZeroValue_TransactionCALLwithData.json
- eest::static/state_tests/stZeroCallsTest/ZeroValue_TransactionCALLwithData_ToEmpty_Paris.json
- eest::static/state_tests/stZeroCallsTest/ZeroValue_TransactionCALLwithData_ToNonZeroBalance.json
- eest::static/state_tests/stZeroCallsTest/ZeroValue_TransactionCALLwithData_ToOneStorageKey_Paris.json




