### PR TITLE
fix(evm): skip repeated eip150 call surcharge

### DIFF
--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -43,6 +43,8 @@ pub struct AccountLoad {
     pub exists: bool,
     /// Whether the account is empty.
     pub is_empty: bool,
+    /// Whether the account was already touched in this transaction.
+    pub is_touched: bool,
     /// Whether the account access was cold.
     pub is_cold: bool,
 }
@@ -563,6 +565,7 @@ impl<T: EvmTypes<Host = Self>> Host for Evm<T> {
             },
             exists,
             is_empty: info.is_empty(),
+            is_touched: self.state.touched.contains(&address),
             is_cold,
         })
     }

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -118,8 +118,8 @@ impl SStore {
 pub struct SelfDestructResult {
     /// Whether the destroyed account had non-zero value.
     pub had_value: bool,
-    /// Whether the beneficiary account already exists.
-    pub target_exists: bool,
+    /// Whether the beneficiary is empty/non-existent for new-account gas checks.
+    pub target_is_empty: bool,
     /// Whether the beneficiary access was cold.
     pub is_cold: bool,
     /// Whether this account was already destroyed in this transaction.
@@ -567,12 +567,8 @@ impl<T: EvmTypes<Host = Self>> Host for Evm<T> {
         })
     }
 
-    fn account_exists(&mut self, address: Address) -> bool {
-        let Some(info) = self.state.account_info(address) else {
-            return !self.spec_id().enables(SpecId::SPURIOUS_DRAGON)
-                && self.state.touched.contains(&address);
-        };
-        !self.spec_id().enables(SpecId::SPURIOUS_DRAGON) || !info.is_empty()
+    fn target_is_empty_for_new_account_gas(&mut self, address: Address, spec: SpecId) -> bool {
+        self.state.target_is_empty_for_new_account_gas(address, spec)
     }
 
     fn block_hash(&mut self, number: Word) -> Option<B256> {
@@ -668,14 +664,8 @@ impl<T: EvmTypes<Host = Self>> Host for Evm<T> {
             return Err(InstrStop::OutOfGas);
         }
         self.state.warm_account(target);
-        // EIP-161 changes account emptiness semantics: before Spurious Dragon, an empty
-        // account that exists in state is still an existing `SELFDESTRUCT` beneficiary and
-        // must not be charged EIP-150's new-account topup.
-        let target_exists = if self.spec_id().enables(SpecId::SPURIOUS_DRAGON) {
-            self.state.account_info(target).is_some_and(|info| !info.is_empty())
-        } else {
-            self.state.account_info(target).is_some()
-        };
+        let target_is_empty_for_new_account_gas =
+            self.state.target_is_empty_for_new_account_gas(target, self.spec_id());
         let previously_destroyed = self.state.is_selfdestructed(contract);
         let balance = self.state.account_info(contract).map_or(Word::ZERO, |info| info.balance);
         let should_destroy = !self.spec_id().enables(SpecId::CANCUN)
@@ -692,7 +682,7 @@ impl<T: EvmTypes<Host = Self>> Host for Evm<T> {
 
         Ok(SelfDestructResult {
             had_value: !balance.is_zero(),
-            target_exists,
+            target_is_empty: target_is_empty_for_new_account_gas,
             is_cold,
             previously_destroyed,
         })

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -43,8 +43,6 @@ pub struct AccountLoad {
     pub exists: bool,
     /// Whether the account is empty.
     pub is_empty: bool,
-    /// Whether the account was already touched in this transaction.
-    pub is_touched: bool,
     /// Whether the account access was cold.
     pub is_cold: bool,
 }
@@ -565,9 +563,16 @@ impl<T: EvmTypes<Host = Self>> Host for Evm<T> {
             },
             exists,
             is_empty: info.is_empty(),
-            is_touched: self.state.touched.contains(&address),
             is_cold,
         })
+    }
+
+    fn account_exists(&mut self, address: Address) -> bool {
+        let Some(info) = self.state.account_info(address) else {
+            return !self.spec_id().enables(SpecId::SPURIOUS_DRAGON)
+                && self.state.touched.contains(&address);
+        };
+        !self.spec_id().enables(SpecId::SPURIOUS_DRAGON) || !info.is_empty()
     }
 
     fn block_hash(&mut self, number: Word) -> Option<B256> {

--- a/crates/evm2/src/evm/state.rs
+++ b/crates/evm2/src/evm/state.rs
@@ -541,6 +541,20 @@ impl<D: Database> State<D> {
         self.initial.get_account(address)
     }
 
+    /// Returns whether an account is empty/non-existent for EIP-150 new-account gas checks.
+    #[inline]
+    #[must_use]
+    pub(super) fn target_is_empty_for_new_account_gas(
+        &mut self,
+        address: Address,
+        spec: SpecId,
+    ) -> bool {
+        if spec.enables(SpecId::SPURIOUS_DRAGON) {
+            return self.account_info(address).is_none_or(|info| info.is_empty());
+        }
+        self.account_info(address).is_none() && !self.touched.contains(&address)
+    }
+
     /// Returns an account if it exists.
     #[inline]
     #[must_use]

--- a/crates/evm2/src/interpreter/instructions/system.rs
+++ b/crates/evm2/src/interpreter/instructions/system.rs
@@ -28,6 +28,16 @@ const fn success(stop: InstrStop) -> bool {
 }
 
 #[inline]
+const fn should_charge_new_account_gas(
+    spec: SpecId,
+    transfers_value: bool,
+    target_is_empty_for_new_account_gas: bool,
+) -> bool {
+    target_is_empty_for_new_account_gas
+        && (!spec.enables(SpecId::SPURIOUS_DRAGON) || transfers_value)
+}
+
+#[inline]
 fn call_too_deep_result(gas_limit: u64) -> MessageResult {
     MessageResult { stop: InstrStop::CallTooDeep, gas_remaining: gas_limit, ..Default::default() }
 }
@@ -89,16 +99,13 @@ fn load_acc_and_calc_gas<T: EvmTypes>(
     if account.is_cold {
         cost += additional_cold_cost;
     }
-    let is_spurious_dragon = cx.state.spec.enables(SpecId::SPURIOUS_DRAGON);
-    let creates_empty_account = create_empty_account && (!is_spurious_dragon || transfers_value);
-    // EIP-150 charges CALL new-account gas only when the target does not exist.
-    // EIP-161 changes this to empty accounts only when value is transferred.
-    let target_is_empty = if is_spurious_dragon {
-        account.is_empty
-    } else {
-        !account.exists && !cx.state.host.account_exists(to)
-    };
-    if creates_empty_account && target_is_empty {
+    if create_empty_account
+        && should_charge_new_account_gas(
+            cx.state.spec,
+            transfers_value,
+            cx.state.host.target_is_empty_for_new_account_gas(to, cx.state.spec),
+        )
+    {
         cost += u64::from(cx.state.gas_params().get(GasId::NewAccountCost));
     }
     cx.gas.spend(cost)?;
@@ -294,11 +301,8 @@ pub(crate) fn selfdestruct(cx: _, [target]: [Word]) -> Result {
     let cold_load_gas = cx.state.gas_params().selfdestruct_cold_cost();
     let skip_cold_load = cx.gas.remaining() < cold_load_gas;
     let res = cx.state.host.selfdestruct(cx.state.message().destination, target, skip_cold_load)?;
-    let should_charge_topup = if cx.state.spec.enables(SpecId::SPURIOUS_DRAGON) {
-        res.had_value && !res.target_exists
-    } else {
-        !res.target_exists
-    };
+    let should_charge_topup =
+        should_charge_new_account_gas(cx.state.spec, res.had_value, res.target_is_empty);
     cx.gas.spend(cx.state.gas_params().selfdestruct_cost(should_charge_topup, res.is_cold))?;
     if !res.previously_destroyed {
         cx.gas.record_refund(cx.state.gas_params().get(GasId::SelfdestructRefund) as i64);

--- a/crates/evm2/src/interpreter/instructions/system.rs
+++ b/crates/evm2/src/interpreter/instructions/system.rs
@@ -91,10 +91,13 @@ fn load_acc_and_calc_gas<T: EvmTypes>(
     }
     let is_spurious_dragon = cx.state.spec.enables(SpecId::SPURIOUS_DRAGON);
     let creates_empty_account = create_empty_account && (!is_spurious_dragon || transfers_value);
-    // EIP-150 charges CALL new-account gas for untouched non-existing accounts.
-    // EIP-161 changed the check to empty accounts only when value is transferred.
-    let target_is_empty =
-        if is_spurious_dragon { account.is_empty } else { !account.exists && !account.is_touched };
+    // EIP-150 charges CALL new-account gas only when the target does not exist.
+    // EIP-161 changes this to empty accounts only when value is transferred.
+    let target_is_empty = if is_spurious_dragon {
+        account.is_empty
+    } else {
+        !account.exists && !cx.state.host.account_exists(to)
+    };
     if creates_empty_account && target_is_empty {
         cost += u64::from(cx.state.gas_params().get(GasId::NewAccountCost));
     }

--- a/crates/evm2/src/interpreter/instructions/system.rs
+++ b/crates/evm2/src/interpreter/instructions/system.rs
@@ -91,7 +91,10 @@ fn load_acc_and_calc_gas<T: EvmTypes>(
     }
     let is_spurious_dragon = cx.state.spec.enables(SpecId::SPURIOUS_DRAGON);
     let creates_empty_account = create_empty_account && (!is_spurious_dragon || transfers_value);
-    let target_is_empty = if is_spurious_dragon { account.is_empty } else { !account.exists };
+    // EIP-150 charges CALL new-account gas for untouched non-existing accounts.
+    // EIP-161 changed the check to empty accounts only when value is transferred.
+    let target_is_empty =
+        if is_spurious_dragon { account.is_empty } else { !account.exists && !account.is_touched };
     if creates_empty_account && target_is_empty {
         cost += u64::from(cx.state.gas_params().get(GasId::NewAccountCost));
     }
@@ -469,6 +472,37 @@ mod tests {
         core::assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [Word::ZERO]);
         assert_eq!(interpreter.gas_remaining(), 24_279);
+        assert!(host.calls.is_empty());
+    }
+
+    #[test]
+    fn call_too_deep_skips_pre_spurious_touched_empty_account_cost() {
+        let target = Address::from([0x22; 20]);
+        let mut host =
+            TestHost { exists: false, is_empty: true, is_touched: true, ..Default::default() };
+        let mut code = Vec::new();
+        push_all(
+            &mut code,
+            [
+                Word::ZERO,
+                Word::ZERO,
+                Word::ZERO,
+                Word::ZERO,
+                Word::ZERO,
+                address_to_word(target),
+                Word::ZERO,
+            ],
+        );
+        code.extend([op::CALL, op::STOP]);
+
+        let interpreter = run(RunConfig::new(code)
+            .host(&mut host)
+            .spec(SpecId::TANGERINE)
+            .message(Message { depth: CALL_DEPTH_LIMIT, ..Default::default() })
+            .gas_limit(50_000));
+        core::assert_matches!(interpreter.err, InstrStop::Stop);
+        assert_eq!(interpreter.stack(), [Word::ZERO]);
+        assert_eq!(interpreter.gas_remaining(), 49_279);
         assert!(host.calls.is_empty());
     }
 

--- a/crates/evm2/src/interpreter/instructions/tests.rs
+++ b/crates/evm2/src/interpreter/instructions/tests.rs
@@ -90,9 +90,12 @@ impl Host for TestHost {
             code: if load_code { self.code.clone() } else { Bytes::new() },
             exists: self.exists,
             is_empty: self.is_empty,
-            is_touched: self.is_touched,
             is_cold: self.is_cold,
         })
+    }
+
+    fn account_exists(&mut self, _address: Address) -> bool {
+        self.exists || self.is_touched
     }
 
     fn block_hash(&mut self, number: Word) -> Option<B256> {

--- a/crates/evm2/src/interpreter/instructions/tests.rs
+++ b/crates/evm2/src/interpreter/instructions/tests.rs
@@ -94,8 +94,12 @@ impl Host for TestHost {
         })
     }
 
-    fn account_exists(&mut self, _address: Address) -> bool {
-        self.exists || self.is_touched
+    fn target_is_empty_for_new_account_gas(&mut self, _address: Address, spec: SpecId) -> bool {
+        if spec.enables(SpecId::SPURIOUS_DRAGON) {
+            self.is_empty
+        } else {
+            !self.exists && !self.is_touched
+        }
     }
 
     fn block_hash(&mut self, number: Word) -> Option<B256> {

--- a/crates/evm2/src/interpreter/instructions/tests.rs
+++ b/crates/evm2/src/interpreter/instructions/tests.rs
@@ -30,6 +30,7 @@ pub(crate) struct TestHost {
     pub(super) code: Bytes,
     pub(super) exists: bool,
     pub(super) is_empty: bool,
+    pub(super) is_touched: bool,
     pub(super) is_cold: bool,
     pub(super) storage: HashMap<(Address, Word), Word>,
     pub(super) original_storage: HashMap<(Address, Word), Word>,
@@ -50,6 +51,7 @@ impl Default for TestHost {
             code: Bytes::new(),
             exists: true,
             is_empty: false,
+            is_touched: false,
             is_cold: false,
             storage: HashMap::default(),
             original_storage: HashMap::default(),
@@ -88,6 +90,7 @@ impl Host for TestHost {
             code: if load_code { self.code.clone() } else { Bytes::new() },
             exists: self.exists,
             is_empty: self.is_empty,
+            is_touched: self.is_touched,
             is_cold: self.is_cold,
         })
     }

--- a/crates/evm2/src/interpreter/state.rs
+++ b/crates/evm2/src/interpreter/state.rs
@@ -203,8 +203,8 @@ pub trait Host {
         skip_cold_load: bool,
     ) -> Result<AccountLoad, InstrStop>;
 
-    /// Returns whether an account exists for CALL new-account gas checks.
-    fn account_exists(&mut self, address: Address) -> bool;
+    /// Returns whether an account is empty/non-existent for new-account gas checks.
+    fn target_is_empty_for_new_account_gas(&mut self, address: Address, spec: SpecId) -> bool;
 
     /// Returns a historical block hash.
     fn block_hash(&mut self, number: Word) -> Option<B256>;

--- a/crates/evm2/src/interpreter/state.rs
+++ b/crates/evm2/src/interpreter/state.rs
@@ -203,6 +203,9 @@ pub trait Host {
         skip_cold_load: bool,
     ) -> Result<AccountLoad, InstrStop>;
 
+    /// Returns whether an account exists for CALL new-account gas checks.
+    fn account_exists(&mut self, address: Address) -> bool;
+
     /// Returns a historical block hash.
     fn block_hash(&mut self, number: Word) -> Option<B256>;
 


### PR DESCRIPTION
Avoid charging the pre-Spurious Dragon EIP-150 CALL new-account surcharge again when the target was already touched earlier in the transaction.

The implementation keeps loaded account data small and mirrors evmone's shape more closely: CALL only asks the host whether the account exists on the pre-Spurious Dragon path where the new-account surcharge can apply and the initial load reported a missing account. Post-Spurious Dragon keeps using the already-loaded account emptiness check, matching the EIP-161 rule.

This fixes:

- legacy_constantinople::stSpecialTest/tx_e1c174e2.json
