### PR TITLE
feat(evm): implement eip4844 transactions

### DIFF
--- a/crates/evm2-statetest/Cargo.toml
+++ b/crates/evm2-statetest/Cargo.toml
@@ -18,6 +18,7 @@ workspace = true
 evm2 = { path = "../evm2", features = ["std", "serde"] }
 
 alloy-consensus = { workspace = true, features = ["std"] }
+alloy-eips = { workspace = true, features = ["std"] }
 alloy-primitives = { workspace = true, features = ["std", "serde", "rlp"] }
 alloy-rlp = { workspace = true, features = ["std"] }
 alloy-rpc-types-eth = { workspace = true, features = ["std"] }

--- a/crates/evm2-statetest/src/execute.rs
+++ b/crates/evm2-statetest/src/execute.rs
@@ -3,6 +3,7 @@ use crate::{
     types::{AccountInfo, Env, Test, TestSuite, TestUnit, TransactionParts, TxPartIndices},
 };
 use alloy_consensus::{TypedTransaction, transaction::Recovered};
+use alloy_eips::{eip4844, eip7691};
 use alloy_primitives::{Address, B256, Bytes, Log, TxKind, U256, keccak256};
 use alloy_rpc_types_eth::{
     AccessList as RpcAccessList, AccessListItem as RpcAccessListItem, TransactionInput,
@@ -73,11 +74,11 @@ fn execute_unit(
     config: ExecuteConfig,
 ) -> Result<(), TestError> {
     let state = parse_state(&unit.pre).map_err(|err| TestError::case(path, name, err))?;
-    let block = parse_block(&unit.env);
     for (spec_name, posts) in &unit.post {
         let Some(spec) = spec_name.to_spec_id() else {
             continue;
         };
+        let block = parse_block(&unit.env, spec);
         for post in posts {
             let tx = match build_tx(&unit.transaction, &post.indexes, unit.env.current_chain_id) {
                 Ok(tx) => tx,
@@ -334,7 +335,7 @@ fn parse_state(pre: &BTreeMap<Address, AccountInfo>) -> Result<InMemoryDB, TestE
     Ok(database)
 }
 
-fn parse_block(env: &Env) -> BlockEnv {
+fn parse_block(env: &Env, spec: SpecId) -> BlockEnv {
     BlockEnv {
         number: env.current_number,
         beneficiary: env.current_coinbase,
@@ -345,8 +346,25 @@ fn parse_block(env: &Env) -> BlockEnv {
         prevrandao: env
             .current_random
             .map_or(U256::ZERO, |random| U256::from_be_slice(random.as_slice())),
+        blob_basefee: env
+            .current_excess_blob_gas
+            .map_or(U256::ONE, |excess| U256::from(blob_basefee(excess, spec))),
         slot_num: env.slot_number.unwrap_or_default(),
-        ..BlockEnv::default()
+    }
+}
+
+fn blob_basefee(excess_blob_gas: U256, spec: SpecId) -> u128 {
+    let excess_blob_gas = excess_blob_gas.saturating_to::<u64>();
+    // EIP-4844 defines blob base fee with fake exponential; EIP-7691 changes the
+    // update fraction from Prague.
+    if spec.enables(SpecId::PRAGUE) {
+        eip7691::calc_blob_gasprice(excess_blob_gas)
+    } else {
+        eip4844::fake_exponential(
+            eip4844::BLOB_TX_MIN_BLOB_GASPRICE,
+            excess_blob_gas as u128,
+            eip4844::BLOB_GASPRICE_UPDATE_FRACTION,
+        )
     }
 }
 
@@ -415,7 +433,10 @@ fn build_tx(
         .transpose()
         .map_err(|_| TestErrorKind::Overflow("maxFeePerBlobGas"))?;
     request.access_list = access_list(raw, indexes.data)?;
-    if !raw.blob_versioned_hashes.is_empty() {
+    if raw.max_fee_per_blob_gas.is_some()
+        || matches!(raw.tx_type, Some(3))
+        || !raw.blob_versioned_hashes.is_empty()
+    {
         request.blob_versioned_hashes = Some(raw.blob_versioned_hashes.clone());
     }
 
@@ -459,12 +480,12 @@ fn recovered_envelope(
         TypedTransaction::Eip1559(tx) => {
             Ok(RecoveredTxEnvelope::Eip1559(Recovered::new_unchecked(tx, caller)))
         }
+        TypedTransaction::Eip4844(tx) => {
+            Ok(RecoveredTxEnvelope::Eip4844(Recovered::new_unchecked(tx, caller)))
+        }
         TypedTransaction::Eip7702(tx) => {
             Ok(RecoveredTxEnvelope::Eip7702(Recovered::new_unchecked(tx, caller)))
         }
-        TypedTransaction::Eip4844(_) => Err(TestErrorKind::BuildTransaction(
-            "EIP-4844 transactions are not supported".to_string(),
-        )),
     }
 }
 

--- a/crates/evm2/src/ethereum/eip4844.rs
+++ b/crates/evm2/src/ethereum/eip4844.rs
@@ -1,0 +1,120 @@
+use super::{
+    access_list_counts, charge_upfront, effective_gas_price, floor_gas, initial_message,
+    intrinsic_gas, rollback_failed_execution, settle_gas, validate_block_gas_limit,
+    validate_create_initcode, validate_floor_gas, validate_gas_price, validate_intrinsic_gas,
+    validate_nonce_not_overflow, validate_priority_fee, validate_sender, warm_access_list,
+    warm_base_accounts,
+};
+use crate::{
+    Evm, EvmTypes, SpecId, TxResult,
+    env::TxEnv,
+    interpreter::Host,
+    registry::{HandlerError, HandlerResult, TxRequest},
+    utils::b256_to_word,
+};
+use alloy_consensus::transaction::{Recovered, TxEip4844Variant};
+use alloy_eips::eip4844::{
+    DATA_GAS_PER_BLOB, MAX_BLOBS_PER_BLOCK_DENCUN, VERSIONED_HASH_VERSION_KZG,
+};
+use alloy_primitives::U256;
+
+pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
+    req: TxRequest<'_, Recovered<TxEip4844Variant>, Evm<T>>,
+) -> HandlerResult<TxResult> {
+    let spec_id = req.host.spec_id();
+    if !spec_id.enables(SpecId::CANCUN) {
+        return Err(HandlerError::Eip4844NotSupported);
+    }
+
+    let caller = req.tx.signer();
+    let tx = req.tx.inner().tx();
+    let max_fee_per_gas = U256::from(tx.max_fee_per_gas);
+    let max_priority_fee_per_gas = U256::from(tx.max_priority_fee_per_gas);
+    let gas_price =
+        effective_gas_price(max_fee_per_gas, max_priority_fee_per_gas, req.host.block.basefee);
+    let max_fee_per_blob_gas = U256::from(tx.max_fee_per_blob_gas);
+
+    validate_priority_fee(max_fee_per_gas, max_priority_fee_per_gas)?;
+    validate_gas_price(spec_id, gas_price, req.host.block.basefee)?;
+    validate_blob_fee(max_fee_per_blob_gas, req.host.block.blob_basefee)?;
+    validate_blobs(&tx.blob_versioned_hashes, max_blobs_per_tx(spec_id))?;
+    validate_block_gas_limit(tx.gas_limit, req.host.block.gas_limit)?;
+    validate_create_initcode(spec_id, tx.to.into(), &tx.input)?;
+    validate_nonce_not_overflow(tx.nonce)?;
+    let (access_list_accounts, access_list_storage_keys) = access_list_counts(&tx.access_list);
+    let intrinsic = intrinsic_gas(
+        req.host.version(),
+        tx.to.into(),
+        &tx.input,
+        access_list_accounts,
+        access_list_storage_keys,
+    );
+    validate_intrinsic_gas(tx.gas_limit, intrinsic)?;
+    validate_floor_gas(tx.gas_limit, floor_gas(req.host.version(), &tx.input))?;
+
+    let blob_gas_cost = U256::from(DATA_GAS_PER_BLOB) * U256::from(tx.blob_versioned_hashes.len());
+    let max_blob_gas_cost = blob_gas_cost * max_fee_per_blob_gas;
+    let max_gas_cost = U256::from(tx.gas_limit) * max_fee_per_gas;
+    validate_sender(
+        req.host,
+        caller,
+        tx.nonce,
+        max_gas_cost.saturating_add(max_blob_gas_cost).saturating_add(tx.value),
+    )?;
+
+    warm_base_accounts(req.host, spec_id, caller, tx.to.into());
+    warm_access_list(req.host, &tx.access_list);
+
+    let effective_gas_cost = U256::from(tx.gas_limit) * gas_price;
+    let blob_basefee_cost = blob_gas_cost * req.host.block.blob_basefee;
+    charge_upfront(req.host, caller, effective_gas_cost + blob_basefee_cost);
+    req.host.state.increment_nonce(caller);
+    let execution_checkpoint = req.host.state.checkpoint();
+
+    let gas_limit = tx.gas_limit - intrinsic;
+    let tx_env = TxEnv {
+        origin: caller,
+        gas_price,
+        chain_id: U256::from(tx.chain_id),
+        blob_hashes: tx.blob_versioned_hashes.iter().copied().map(b256_to_word).collect(),
+    };
+    let (bytecode, message) =
+        initial_message(req.host, caller, tx.nonce, tx.to.into(), &tx.input, tx.value, gas_limit);
+    let mut result = req.host.execute_message(&tx_env, bytecode, &message, false);
+    rollback_failed_execution(req.host, execution_checkpoint, &mut result);
+
+    Ok(settle_gas(req.host, spec_id, caller, gas_price, tx.gas_limit, result))
+}
+
+fn validate_blob_fee(max_fee_per_blob_gas: U256, blob_basefee: U256) -> HandlerResult<()> {
+    if max_fee_per_blob_gas < blob_basefee {
+        return Err(HandlerError::BlobFeeCapLessThanBlobBaseFee {
+            max_fee_per_blob_gas,
+            blob_base_fee: blob_basefee,
+        });
+    }
+    Ok(())
+}
+
+fn validate_blobs(blobs: &[alloy_primitives::B256], max_blobs: usize) -> HandlerResult<()> {
+    if blobs.is_empty() {
+        return Err(HandlerError::EmptyBlobs);
+    }
+    if blobs.len() > max_blobs {
+        return Err(HandlerError::TooManyBlobs { have: blobs.len(), max: max_blobs });
+    }
+    if blobs.iter().any(|blob| blob[0] != VERSIONED_HASH_VERSION_KZG) {
+        return Err(HandlerError::BlobVersionNotSupported);
+    }
+    Ok(())
+}
+
+const fn max_blobs_per_tx(spec_id: SpecId) -> usize {
+    // EIP-7594 Osaka tests keep the per-transaction blob cap at the Cancun cap, while
+    // Prague allows nine blobs per transaction.
+    if spec_id.enables(SpecId::PRAGUE) && !spec_id.enables(SpecId::OSAKA) {
+        9
+    } else {
+        MAX_BLOBS_PER_BLOCK_DENCUN
+    }
+}

--- a/crates/evm2/src/ethereum/mod.rs
+++ b/crates/evm2/src/ethereum/mod.rs
@@ -2,6 +2,7 @@
 
 mod eip1559;
 mod eip2930;
+mod eip4844;
 mod legacy;
 
 use crate::{
@@ -14,7 +15,10 @@ use crate::{
     utils::num_words,
     version::GasId,
 };
-use alloy_consensus::{TxEip1559, TxEip2930, TxEip7702, TxLegacy, transaction::Recovered};
+use alloy_consensus::{
+    TxEip1559, TxEip2930, TxEip7702, TxLegacy,
+    transaction::{Recovered, TxEip4844Variant},
+};
 use alloy_eips::{eip2718::Typed2718, eip2930::AccessList};
 use alloy_primitives::{Address, B256, Bytes, KECCAK256_EMPTY, TxKind, U256};
 
@@ -27,6 +31,8 @@ pub enum RecoveredTxEnvelope {
     Eip2930(Recovered<TxEip2930>),
     /// EIP-1559 dynamic-fee transaction.
     Eip1559(Recovered<TxEip1559>),
+    /// EIP-4844 blob transaction.
+    Eip4844(Recovered<TxEip4844Variant>),
     /// EIP-7702 set-code transaction.
     Eip7702(Recovered<TxEip7702>),
 }
@@ -36,7 +42,7 @@ impl RecoveredTxEnvelope {
     pub const fn as_legacy(&self) -> Option<&Recovered<TxLegacy>> {
         match self {
             Self::Legacy(tx) => Some(tx),
-            Self::Eip2930(_) | Self::Eip1559(_) | Self::Eip7702(_) => None,
+            Self::Eip2930(_) | Self::Eip1559(_) | Self::Eip4844(_) | Self::Eip7702(_) => None,
         }
     }
 
@@ -44,7 +50,7 @@ impl RecoveredTxEnvelope {
     pub const fn as_eip2930(&self) -> Option<&Recovered<TxEip2930>> {
         match self {
             Self::Eip2930(tx) => Some(tx),
-            Self::Legacy(_) | Self::Eip1559(_) | Self::Eip7702(_) => None,
+            Self::Legacy(_) | Self::Eip1559(_) | Self::Eip4844(_) | Self::Eip7702(_) => None,
         }
     }
 
@@ -52,7 +58,15 @@ impl RecoveredTxEnvelope {
     pub const fn as_eip1559(&self) -> Option<&Recovered<TxEip1559>> {
         match self {
             Self::Eip1559(tx) => Some(tx),
-            Self::Legacy(_) | Self::Eip2930(_) | Self::Eip7702(_) => None,
+            Self::Legacy(_) | Self::Eip2930(_) | Self::Eip4844(_) | Self::Eip7702(_) => None,
+        }
+    }
+
+    /// Returns the contained EIP-4844 transaction, if this is EIP-4844.
+    pub const fn as_eip4844(&self) -> Option<&Recovered<TxEip4844Variant>> {
+        match self {
+            Self::Eip4844(tx) => Some(tx),
+            Self::Legacy(_) | Self::Eip2930(_) | Self::Eip1559(_) | Self::Eip7702(_) => None,
         }
     }
 
@@ -60,7 +74,7 @@ impl RecoveredTxEnvelope {
     pub const fn as_eip7702(&self) -> Option<&Recovered<TxEip7702>> {
         match self {
             Self::Eip7702(tx) => Some(tx),
-            Self::Legacy(_) | Self::Eip2930(_) | Self::Eip1559(_) => None,
+            Self::Legacy(_) | Self::Eip2930(_) | Self::Eip1559(_) | Self::Eip4844(_) => None,
         }
     }
 }
@@ -71,6 +85,7 @@ impl Typed2718 for RecoveredTxEnvelope {
             Self::Legacy(tx) => tx.ty(),
             Self::Eip2930(tx) => tx.ty(),
             Self::Eip1559(tx) => tx.ty(),
+            Self::Eip4844(tx) => tx.ty(),
             Self::Eip7702(tx) => tx.ty(),
         }
     }
@@ -83,6 +98,7 @@ pub fn ethereum_tx_registry<T: EvmTypes<Host = Evm<T>>>()
         .with_handler(0, RecoveredTxEnvelope::as_legacy, legacy::handle::<T>)
         .with_handler(1, RecoveredTxEnvelope::as_eip2930, eip2930::handle::<T>)
         .with_handler(2, RecoveredTxEnvelope::as_eip1559, eip1559::handle::<T>)
+        .with_handler(3, RecoveredTxEnvelope::as_eip4844, eip4844::handle::<T>)
 }
 
 pub(super) fn validate_gas_price(

--- a/crates/evm2/src/evm/registry.rs
+++ b/crates/evm2/src/evm/registry.rs
@@ -133,6 +133,33 @@ pub enum HandlerError {
     /// EIP-1559 transaction is not enabled in the active specification.
     #[error("EIP-1559 transaction not supported")]
     Eip1559NotSupported,
+    /// EIP-4844 transaction is not enabled in the active specification.
+    #[error("EIP-4844 transaction not supported")]
+    Eip4844NotSupported,
+    /// EIP-4844 blob fee cap is lower than the block blob base fee.
+    #[error(
+        "blob fee cap less than blob base fee: max_fee_per_blob_gas {max_fee_per_blob_gas}, blob_base_fee {blob_base_fee}"
+    )]
+    BlobFeeCapLessThanBlobBaseFee {
+        /// Maximum fee per blob gas.
+        max_fee_per_blob_gas: U256,
+        /// Block blob base fee.
+        blob_base_fee: U256,
+    },
+    /// EIP-4844 blob transaction contains no blob hashes.
+    #[error("empty blobs")]
+    EmptyBlobs,
+    /// EIP-4844 blob transaction contains too many blob hashes.
+    #[error("too many blobs: have {have}, max {max}")]
+    TooManyBlobs {
+        /// Blob count in the transaction.
+        have: usize,
+        /// Maximum allowed blob count.
+        max: usize,
+    },
+    /// EIP-4844 blob transaction contains an unsupported versioned hash.
+    #[error("blob version not supported")]
+    BlobVersionNotSupported,
     /// Priority fee is greater than max fee.
     #[error("priority fee greater than max fee")]
     PriorityFeeGreaterThanMaxFee,


### PR DESCRIPTION

Add EIP-4844 type-3 transaction execution, blob base fee derivation for state tests, blob hash validation, blob fee charging, and the Osaka/EIP-7594 per-transaction blob cap used by fixtures.

Fixed statetest files:

- eest::cancun/eip4844_blobs/test_blob_gas_subtraction_tx.json
- eest::cancun/eip4844_blobs/test_blob_tx_attribute_calldata_opcodes.json
- eest::cancun/eip4844_blobs/test_blob_tx_attribute_gasprice_opcode.json
- eest::cancun/eip4844_blobs/test_blob_tx_attribute_opcodes.json
- eest::cancun/eip4844_blobs/test_blob_tx_attribute_value_opcode.json
- eest::cancun/eip4844_blobs/test_blob_type_tx_pre_fork.json
- eest::cancun/eip4844_blobs/test_blobhash_opcode_contexts.json
- eest::cancun/eip4844_blobs/test_invalid_tx_blob_count.json
- eest::osaka/eip7594_peerdas/test_valid_max_blobs_per_tx.json
- eest::static/state_tests/Cancun/stEIP4844_blobtransactions/emptyBlobhashList.json
- eest::static/state_tests/Cancun/stEIP4844_blobtransactions/opcodeBlobhBounds.json
- eest::static/state_tests/Cancun/stEIP4844_blobtransactions/opcodeBlobhashOutOfRange.json
- legacy_cancun::Cancun/stEIP4844-blobtransactions/blobhashListBounds3.json
- legacy_cancun::Cancun/stEIP4844-blobtransactions/blobhashListBounds4.json
- legacy_cancun::Cancun/stEIP4844-blobtransactions/blobhashListBounds5.json
- legacy_cancun::Cancun/stEIP4844-blobtransactions/blobhashListBounds6.json
- legacy_cancun::Cancun/stEIP4844-blobtransactions/emptyBlobhashList.json
- legacy_cancun::Cancun/stEIP4844-blobtransactions/opcodeBlobhBounds.json
- legacy_cancun::Cancun/stEIP4844-blobtransactions/opcodeBlobhashOutOfRange.json
- legacy_cancun::Pyspecs/cancun/eip4844_blobs/blob_gas_subtraction_tx.json
- legacy_cancun::Pyspecs/cancun/eip4844_blobs/blob_tx_attribute_calldata_opcodes.json
- legacy_cancun::Pyspecs/cancun/eip4844_blobs/blob_tx_attribute_gasprice_opcode.json
- legacy_cancun::Pyspecs/cancun/eip4844_blobs/blob_tx_attribute_opcodes.json
- legacy_cancun::Pyspecs/cancun/eip4844_blobs/blob_tx_attribute_value_opcode.json
- legacy_cancun::Pyspecs/cancun/eip4844_blobs/blob_type_tx_pre_fork.json
- legacy_cancun::Pyspecs/cancun/eip4844_blobs/invalid_tx_blob_count.json
- legacy_cancun::Pyspecs/cancun/eip4844_blobs/sufficient_balance_blob_tx.json




