### PR TITLE
feat(evm): implement eip7702 transactions

### DIFF
--- a/crates/evm2-statetest/src/execute.rs
+++ b/crates/evm2-statetest/src/execute.rs
@@ -3,7 +3,7 @@ use crate::{
     types::{AccountInfo, Env, Test, TestSuite, TestUnit, TransactionParts, TxPartIndices},
 };
 use alloy_consensus::{TypedTransaction, transaction::Recovered};
-use alloy_eips::{eip4844, eip7691};
+use alloy_eips::{eip4844, eip7691, eip7702::SignedAuthorization};
 use alloy_primitives::{Address, B256, Bytes, Log, TxKind, U256, keccak256};
 use alloy_rpc_types_eth::{
     AccessList as RpcAccessList, AccessListItem as RpcAccessListItem, TransactionInput,
@@ -323,8 +323,7 @@ fn storage_for_root(state: &InMemoryDB, address: Address) -> Vec<(B256, U256)> {
 fn parse_state(pre: &BTreeMap<Address, AccountInfo>) -> Result<InMemoryDB, TestErrorKind> {
     let mut database = InMemoryDB::default();
     for (address, account) in pre {
-        let mut info =
-            EvmAccountInfo::default().with_code(Bytecode::new_legacy(account.code.clone()));
+        let mut info = EvmAccountInfo::default().with_code(parse_bytecode(account.code.clone()));
         info.nonce = account.nonce;
         info.balance = account.balance;
         database.insert_account_info(*address, info);
@@ -333,6 +332,10 @@ fn parse_state(pre: &BTreeMap<Address, AccountInfo>) -> Result<InMemoryDB, TestE
         }
     }
     Ok(database)
+}
+
+fn parse_bytecode(code: Bytes) -> Bytecode {
+    Bytecode::new_raw_checked(code.clone()).unwrap_or_else(|_| Bytecode::new_legacy(code))
 }
 
 fn parse_block(env: &Env, spec: SpecId) -> BlockEnv {
@@ -433,6 +436,7 @@ fn build_tx(
         .transpose()
         .map_err(|_| TestErrorKind::Overflow("maxFeePerBlobGas"))?;
     request.access_list = access_list(raw, indexes.data)?;
+    request.authorization_list = authorization_list(raw)?;
     if raw.max_fee_per_blob_gas.is_some()
         || matches!(raw.tx_type, Some(3))
         || !raw.blob_versioned_hashes.is_empty()
@@ -443,6 +447,19 @@ fn build_tx(
     let tx =
         request.build_consensus_tx().map_err(|err| TestErrorKind::BuildTransaction(err.error))?;
     recovered_envelope(tx, caller)
+}
+
+fn authorization_list(
+    raw: &TransactionParts,
+) -> Result<Option<Vec<SignedAuthorization>>, TestErrorKind> {
+    let Some(authorizations) = &raw.authorization_list else {
+        return Ok(None);
+    };
+    let authorizations = authorizations
+        .iter()
+        .map(|authorization| serde_json::from_value(authorization.value.clone()))
+        .collect::<Result<_, _>>()?;
+    Ok(Some(authorizations))
 }
 
 fn access_list(

--- a/crates/evm2/Cargo.toml
+++ b/crates/evm2/Cargo.toml
@@ -17,7 +17,7 @@ workspace = true
 evm2-macros.workspace = true
 
 alloy-consensus.workspace = true
-alloy-eips.workspace = true
+alloy-eips = { workspace = true, features = ["k256"] }
 alloy-primitives.workspace = true
 alloy-rlp.workspace = true
 alloy-trie = { workspace = true, features = ["ethereum"] }

--- a/crates/evm2/src/ethereum/eip1559.rs
+++ b/crates/evm2/src/ethereum/eip1559.rs
@@ -2,8 +2,8 @@ use super::{
     access_list_counts, charge_upfront, effective_gas_price, floor_gas, initial_message,
     intrinsic_gas, rollback_failed_execution, settle_gas, validate_block_gas_limit,
     validate_create_initcode, validate_floor_gas, validate_gas_price, validate_intrinsic_gas,
-    validate_nonce_not_overflow, validate_priority_fee, validate_sender, validate_tx_gas_limit_cap,
-    warm_access_list, warm_base_accounts,
+    validate_nonce_not_overflow, validate_priority_fee, validate_regular_gas_limit_cap,
+    validate_sender, validate_tx_gas_limit_cap, warm_access_list, warm_base_accounts,
 };
 use crate::{
     Evm, EvmTypes, SpecId, TxResult,
@@ -46,6 +46,7 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     validate_intrinsic_gas(tx.gas_limit, intrinsic)?;
     let floor_gas = floor_gas(req.host.version(), &tx.input);
     validate_floor_gas(tx.gas_limit, floor_gas)?;
+    validate_regular_gas_limit_cap(spec_id, tx.gas_limit, intrinsic, floor_gas)?;
 
     let max_gas_cost = U256::from(tx.gas_limit) * max_fee_per_gas;
     validate_sender(req.host, caller, tx.nonce, max_gas_cost.saturating_add(tx.value))?;

--- a/crates/evm2/src/ethereum/eip2930.rs
+++ b/crates/evm2/src/ethereum/eip2930.rs
@@ -2,7 +2,8 @@ use super::{
     access_list_counts, charge_upfront, floor_gas, initial_message, intrinsic_gas,
     rollback_failed_execution, settle_gas, validate_block_gas_limit, validate_create_initcode,
     validate_floor_gas, validate_gas_price, validate_intrinsic_gas, validate_nonce_not_overflow,
-    validate_sender, validate_tx_gas_limit_cap, warm_access_list, warm_base_accounts,
+    validate_regular_gas_limit_cap, validate_sender, validate_tx_gas_limit_cap, warm_access_list,
+    warm_base_accounts,
 };
 use crate::{
     Evm, EvmTypes, SpecId, TxResult,
@@ -41,6 +42,7 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     validate_intrinsic_gas(tx.gas_limit, intrinsic)?;
     let floor_gas = floor_gas(req.host.version(), &tx.input);
     validate_floor_gas(tx.gas_limit, floor_gas)?;
+    validate_regular_gas_limit_cap(spec_id, tx.gas_limit, intrinsic, floor_gas)?;
 
     let max_gas_cost = U256::from(tx.gas_limit) * gas_price;
     validate_sender(req.host, caller, tx.nonce, max_gas_cost.saturating_add(tx.value))?;

--- a/crates/evm2/src/ethereum/eip4844.rs
+++ b/crates/evm2/src/ethereum/eip4844.rs
@@ -2,8 +2,8 @@ use super::{
     access_list_counts, charge_upfront, effective_gas_price, floor_gas, initial_message,
     intrinsic_gas, rollback_failed_execution, settle_gas, validate_block_gas_limit,
     validate_create_initcode, validate_floor_gas, validate_gas_price, validate_intrinsic_gas,
-    validate_nonce_not_overflow, validate_priority_fee, validate_sender, validate_tx_gas_limit_cap,
-    warm_access_list, warm_base_accounts,
+    validate_nonce_not_overflow, validate_priority_fee, validate_regular_gas_limit_cap,
+    validate_sender, validate_tx_gas_limit_cap, warm_access_list, warm_base_accounts,
 };
 use crate::{
     Evm, EvmTypes, SpecId, TxResult,
@@ -53,6 +53,7 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     validate_intrinsic_gas(tx.gas_limit, intrinsic)?;
     let floor_gas = floor_gas(req.host.version(), &tx.input);
     validate_floor_gas(tx.gas_limit, floor_gas)?;
+    validate_regular_gas_limit_cap(spec_id, tx.gas_limit, intrinsic, floor_gas)?;
 
     let blob_gas_cost = U256::from(DATA_GAS_PER_BLOB) * U256::from(tx.blob_versioned_hashes.len());
     let max_blob_gas_cost = blob_gas_cost * max_fee_per_blob_gas;

--- a/crates/evm2/src/ethereum/eip7702.rs
+++ b/crates/evm2/src/ethereum/eip7702.rs
@@ -2,8 +2,8 @@ use super::{
     access_list_counts, charge_upfront, effective_gas_price, floor_gas, initial_message,
     intrinsic_gas, rollback_failed_execution, settle_gas, validate_block_gas_limit,
     validate_create_initcode, validate_floor_gas, validate_gas_price, validate_intrinsic_gas,
-    validate_nonce_not_overflow, validate_priority_fee, validate_sender, validate_tx_gas_limit_cap,
-    warm_access_list, warm_base_accounts,
+    validate_nonce_not_overflow, validate_priority_fee, validate_regular_gas_limit_cap,
+    validate_sender, validate_tx_gas_limit_cap, warm_access_list, warm_base_accounts,
 };
 use crate::{
     Evm, EvmTypes, SpecId, TxResult,
@@ -52,6 +52,7 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     validate_intrinsic_gas(tx.gas_limit, intrinsic)?;
     let floor_gas = floor_gas(req.host.version(), &tx.input);
     validate_floor_gas(tx.gas_limit, floor_gas)?;
+    validate_regular_gas_limit_cap(spec_id, tx.gas_limit, intrinsic, floor_gas)?;
 
     let max_gas_cost = U256::from(tx.gas_limit) * max_fee_per_gas;
     validate_sender(req.host, caller, tx.nonce, max_gas_cost.saturating_add(tx.value))?;

--- a/crates/evm2/src/ethereum/eip7702.rs
+++ b/crates/evm2/src/ethereum/eip7702.rs
@@ -1,0 +1,141 @@
+use super::{
+    access_list_counts, charge_upfront, effective_gas_price, floor_gas, initial_message,
+    intrinsic_gas, rollback_failed_execution, settle_gas, validate_block_gas_limit,
+    validate_create_initcode, validate_floor_gas, validate_gas_price, validate_intrinsic_gas,
+    validate_nonce_not_overflow, validate_priority_fee, validate_sender, validate_tx_gas_limit_cap,
+    warm_access_list, warm_base_accounts,
+};
+use crate::{
+    Evm, EvmTypes, SpecId, TxResult,
+    bytecode::Bytecode,
+    env::TxEnv,
+    interpreter::Host,
+    registry::{HandlerError, HandlerResult, TxRequest},
+    version::GasId,
+};
+use alloy_consensus::{TxEip7702, transaction::Recovered};
+use alloy_eips::eip7702::SignedAuthorization;
+use alloy_primitives::{Address, U256};
+
+pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
+    req: TxRequest<'_, Recovered<TxEip7702>, Evm<T>>,
+) -> HandlerResult<TxResult> {
+    let spec_id = req.host.spec_id();
+    if !spec_id.enables(SpecId::PRAGUE) {
+        return Err(HandlerError::Eip7702NotSupported);
+    }
+
+    let caller = req.tx.signer();
+    let tx = req.tx.inner();
+    if tx.authorization_list.is_empty() {
+        return Err(HandlerError::EmptyAuthorizationList);
+    }
+    let max_fee_per_gas = U256::from(tx.max_fee_per_gas);
+    let max_priority_fee_per_gas = U256::from(tx.max_priority_fee_per_gas);
+    let gas_price =
+        effective_gas_price(max_fee_per_gas, max_priority_fee_per_gas, req.host.block.basefee);
+
+    validate_priority_fee(max_fee_per_gas, max_priority_fee_per_gas)?;
+    validate_gas_price(spec_id, gas_price, req.host.block.basefee)?;
+    validate_tx_gas_limit_cap(spec_id, tx.gas_limit)?;
+    validate_block_gas_limit(tx.gas_limit, req.host.block.gas_limit)?;
+    validate_create_initcode(spec_id, tx.to.into(), &tx.input)?;
+    validate_nonce_not_overflow(tx.nonce)?;
+    let (access_list_accounts, access_list_storage_keys) = access_list_counts(&tx.access_list);
+    let intrinsic = intrinsic_gas(
+        req.host.version(),
+        tx.to.into(),
+        &tx.input,
+        access_list_accounts,
+        access_list_storage_keys,
+    ) + eip7702_authorization_gas(req.host, tx.authorization_list.len());
+    validate_intrinsic_gas(tx.gas_limit, intrinsic)?;
+    let floor_gas = floor_gas(req.host.version(), &tx.input);
+    validate_floor_gas(tx.gas_limit, floor_gas)?;
+
+    let max_gas_cost = U256::from(tx.gas_limit) * max_fee_per_gas;
+    validate_sender(req.host, caller, tx.nonce, max_gas_cost.saturating_add(tx.value))?;
+
+    warm_base_accounts(req.host, spec_id, caller, tx.to.into());
+    warm_access_list(req.host, &tx.access_list);
+
+    let effective_gas_cost = U256::from(tx.gas_limit) * gas_price;
+    charge_upfront(req.host, caller, effective_gas_cost);
+    req.host.state.increment_nonce(caller);
+    let eip7702_refund = apply_auth_list(req.host, tx.chain_id, &tx.authorization_list);
+    let execution_checkpoint = req.host.state.checkpoint();
+
+    let gas_limit = tx.gas_limit - intrinsic;
+    let tx_env =
+        TxEnv { origin: caller, gas_price, chain_id: U256::from(tx.chain_id), ..TxEnv::default() };
+    let (bytecode, message) =
+        initial_message(req.host, caller, tx.nonce, tx.to.into(), &tx.input, tx.value, gas_limit);
+    let mut result = req.host.execute_message(&tx_env, bytecode, &message, false);
+    rollback_failed_execution(req.host, execution_checkpoint, &mut result);
+    result.gas_refunded =
+        result.gas_refunded.saturating_add(i64::try_from(eip7702_refund).unwrap_or(i64::MAX));
+
+    Ok(settle_gas(req.host, spec_id, caller, gas_price, tx.gas_limit, floor_gas, result))
+}
+
+fn eip7702_authorization_gas<T: EvmTypes<Host = Evm<T>>>(
+    host: &Evm<T>,
+    authorizations: usize,
+) -> u64 {
+    let per_auth = u64::from(host.version().gas_params().get(GasId::TxEip7702PerEmptyAccountCost));
+    u64::try_from(authorizations).unwrap_or(u64::MAX).saturating_mul(per_auth)
+}
+
+fn apply_auth_list<T: EvmTypes<Host = Evm<T>>>(
+    host: &mut Evm<T>,
+    chain_id: u64,
+    authorizations: &[SignedAuthorization],
+) -> u64 {
+    let mut refunded_accounts = 0u64;
+    for authorization in authorizations {
+        if !authorization.chain_id().is_zero() && authorization.chain_id() != &U256::from(chain_id)
+        {
+            continue;
+        }
+        if authorization.nonce() == u64::MAX {
+            continue;
+        }
+
+        let Ok(authority) = authorization.recover_authority() else {
+            continue;
+        };
+        host.state.warm_account(authority);
+        let authority_info = host.state.account_info(authority);
+        let existed = authority_info.is_some();
+        let authority_info = authority_info.unwrap_or_default();
+        let code = host.state.get_code(authority);
+        if !code.is_empty() && !code.is_eip7702() {
+            continue;
+        }
+        if authorization.nonce() != authority_info.nonce {
+            continue;
+        }
+
+        if existed {
+            refunded_accounts = refunded_accounts.saturating_add(1);
+        }
+        set_delegation(host, authority, *authorization.address());
+    }
+
+    let refund_per_auth = u64::from(host.version().gas_params().get(GasId::TxEip7702AuthRefund));
+    refunded_accounts.saturating_mul(refund_per_auth)
+}
+
+fn set_delegation<T: EvmTypes<Host = Evm<T>>>(
+    host: &mut Evm<T>,
+    authority: Address,
+    delegated_address: Address,
+) {
+    let code = if delegated_address.is_zero() {
+        Bytecode::default()
+    } else {
+        Bytecode::new_eip7702(delegated_address)
+    };
+    host.state.set_code(authority, code);
+    host.state.increment_nonce(authority);
+}

--- a/crates/evm2/src/ethereum/legacy.rs
+++ b/crates/evm2/src/ethereum/legacy.rs
@@ -1,8 +1,8 @@
 use super::{
     charge_upfront, floor_gas, initial_message, intrinsic_gas, rollback_failed_execution,
     settle_gas, validate_block_gas_limit, validate_create_initcode, validate_floor_gas,
-    validate_gas_price, validate_intrinsic_gas, validate_nonce_not_overflow, validate_sender,
-    validate_tx_gas_limit_cap, warm_base_accounts,
+    validate_gas_price, validate_intrinsic_gas, validate_nonce_not_overflow,
+    validate_regular_gas_limit_cap, validate_sender, validate_tx_gas_limit_cap, warm_base_accounts,
 };
 use crate::{
     Evm, EvmTypes, TxResult,
@@ -30,6 +30,7 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     validate_intrinsic_gas(tx.gas_limit, intrinsic)?;
     let floor_gas = floor_gas(req.host.version(), &tx.input);
     validate_floor_gas(tx.gas_limit, floor_gas)?;
+    validate_regular_gas_limit_cap(spec_id, tx.gas_limit, intrinsic, floor_gas)?;
 
     let max_gas_cost = U256::from(tx.gas_limit) * gas_price;
     validate_sender(req.host, caller, tx.nonce, max_gas_cost.saturating_add(tx.value))?;

--- a/crates/evm2/src/ethereum/mod.rs
+++ b/crates/evm2/src/ethereum/mod.rs
@@ -154,12 +154,32 @@ pub(super) const fn validate_tx_gas_limit_cap(
     spec_id: SpecId,
     tx_gas_limit: u64,
 ) -> HandlerResult<()> {
-    // EIP-7825 caps each transaction gas limit to 2^24 starting in Osaka.
-    if spec_id.enables(SpecId::OSAKA) && tx_gas_limit > EIP7825_TX_GAS_LIMIT_CAP {
+    // EIP-7825 caps each transaction gas limit to 2^24 in Osaka. Amsterdam/EIP-8037
+    // replaces this with a regular-gas cap while allowing extra transaction gas to serve as
+    // the state-gas reservoir.
+    if matches!(spec_id, SpecId::OSAKA) && tx_gas_limit > EIP7825_TX_GAS_LIMIT_CAP {
         return Err(HandlerError::TxGasLimitGreaterThanCap {
             gas_limit: tx_gas_limit,
             cap: EIP7825_TX_GAS_LIMIT_CAP,
         });
+    }
+    Ok(())
+}
+
+pub(super) const fn validate_regular_gas_limit_cap(
+    spec_id: SpecId,
+    tx_gas_limit: u64,
+    intrinsic: u64,
+    floor_gas: u64,
+) -> HandlerResult<()> {
+    if spec_id.enables(SpecId::AMSTERDAM) && tx_gas_limit > EIP7825_TX_GAS_LIMIT_CAP {
+        let required_regular_gas = if intrinsic > floor_gas { intrinsic } else { floor_gas };
+        if required_regular_gas > EIP7825_TX_GAS_LIMIT_CAP {
+            return Err(HandlerError::TxGasLimitGreaterThanCap {
+                gas_limit: required_regular_gas,
+                cap: EIP7825_TX_GAS_LIMIT_CAP,
+            });
+        }
     }
     Ok(())
 }
@@ -268,7 +288,7 @@ pub(super) fn initial_message<T: EvmTypes<Host = Evm<T>>>(
 ) -> (Bytecode, Message) {
     match to {
         TxKind::Call(to) => {
-            let code = initial_call_code(host, to);
+            let initial_code = initial_call_code(host, to);
             let message = Message {
                 kind: MessageKind::Call,
                 depth: 0,
@@ -277,10 +297,11 @@ pub(super) fn initial_message<T: EvmTypes<Host = Evm<T>>>(
                 caller,
                 input: input.clone(),
                 value,
-                code_address: to,
+                code_address: initial_code.code_address,
+                disable_precompiles: initial_code.disable_precompiles,
                 salt: B256::ZERO,
             };
-            (code, message)
+            (initial_code.code, message)
         }
         TxKind::Create => {
             let address = caller.create(nonce);
@@ -293,6 +314,7 @@ pub(super) fn initial_message<T: EvmTypes<Host = Evm<T>>>(
                 input: Bytes::new(),
                 value,
                 code_address: address,
+                disable_precompiles: false,
                 salt: B256::ZERO,
             };
             (Bytecode::new_legacy(input.clone()), message)
@@ -300,15 +322,28 @@ pub(super) fn initial_message<T: EvmTypes<Host = Evm<T>>>(
     }
 }
 
-fn initial_call_code<T: EvmTypes<Host = Evm<T>>>(host: &mut Evm<T>, to: Address) -> Bytecode {
+struct InitialCallCode {
+    code: Bytecode,
+    code_address: Address,
+    disable_precompiles: bool,
+}
+
+fn initial_call_code<T: EvmTypes<Host = Evm<T>>>(
+    host: &mut Evm<T>,
+    to: Address,
+) -> InitialCallCode {
     let code = host.state.get_code(to);
     if host.spec_id().enables(SpecId::PRAGUE)
         && let Some(delegated_address) = code.eip7702_address()
     {
         host.state.warm_account(delegated_address);
-        return host.state.get_code(delegated_address);
+        return InitialCallCode {
+            code: host.state.get_code(delegated_address),
+            code_address: delegated_address,
+            disable_precompiles: true,
+        };
     }
-    code
+    InitialCallCode { code, code_address: to, disable_precompiles: false }
 }
 
 pub(super) fn rollback_failed_execution<T: EvmTypes<Host = Evm<T>>>(
@@ -416,6 +451,13 @@ pub(super) fn intrinsic_gas(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{
+        BaseEvmTypes, Precompiles,
+        env::{BlockEnv, TxEnv},
+        evm::InMemoryDB,
+        interpreter::{Host, InstrStop, op},
+        registry::TxRegistry,
+    };
     use alloc::vec;
 
     #[test]
@@ -478,5 +520,86 @@ mod tests {
         };
 
         assert_eq!(final_tx_gas(&result, 100_000, true, 60_000), (30_000, 70_000));
+    }
+
+    #[test]
+    fn initial_delegated_call_uses_delegated_code_address() {
+        let caller = Address::with_last_byte(0xaa);
+        let target = Address::with_last_byte(0x02);
+        let delegated = Address::with_last_byte(0x33);
+        let delegated_code = Bytecode::new_legacy(Bytes::from_static(&[
+            op::PUSH1,
+            0x2a,
+            op::PUSH0,
+            op::MSTORE,
+            op::PUSH1,
+            0x20,
+            op::PUSH0,
+            op::RETURN,
+        ]));
+        let mut database = InMemoryDB::default();
+        database.insert_account_info(
+            target,
+            AccountInfo::default().with_code(Bytecode::new_eip7702(delegated)),
+        );
+        database.insert_account_info(delegated, AccountInfo::default().with_code(delegated_code));
+        let mut evm = Evm::<BaseEvmTypes>::new(
+            SpecId::PRAGUE,
+            BlockEnv::default(),
+            TxRegistry::new(),
+            database,
+            Precompiles::base(SpecId::PRAGUE),
+        );
+
+        let (bytecode, message) = initial_message(
+            &mut evm,
+            caller,
+            0,
+            TxKind::Call(target),
+            &Bytes::new(),
+            U256::ZERO,
+            100_000,
+        );
+        assert_eq!(message.destination, target);
+        assert_eq!(message.code_address, delegated);
+        assert!(message.disable_precompiles);
+
+        let result = Host::execute_message(&mut evm, &TxEnv::default(), bytecode, &message, false);
+
+        assert_eq!(result.stop, InstrStop::Return);
+        assert_eq!(result.output.len(), 32);
+        assert_eq!(result.output[31], 0x2a);
+    }
+
+    #[test]
+    fn amsterdam_allows_total_gas_above_osaka_cap_when_regular_gas_fits() {
+        let tx_gas_limit = EIP7825_TX_GAS_LIMIT_CAP + 1;
+        let intrinsic = 21_000;
+        let floor_gas = 21_000;
+
+        assert_eq!(
+            validate_tx_gas_limit_cap(SpecId::OSAKA, tx_gas_limit),
+            Err(HandlerError::TxGasLimitGreaterThanCap {
+                gas_limit: tx_gas_limit,
+                cap: EIP7825_TX_GAS_LIMIT_CAP
+            })
+        );
+        assert_eq!(validate_tx_gas_limit_cap(SpecId::AMSTERDAM, tx_gas_limit), Ok(()));
+        assert_eq!(
+            validate_regular_gas_limit_cap(SpecId::AMSTERDAM, tx_gas_limit, intrinsic, floor_gas),
+            Ok(())
+        );
+        assert_eq!(
+            validate_regular_gas_limit_cap(
+                SpecId::AMSTERDAM,
+                tx_gas_limit,
+                EIP7825_TX_GAS_LIMIT_CAP + 1,
+                floor_gas,
+            ),
+            Err(HandlerError::TxGasLimitGreaterThanCap {
+                gas_limit: EIP7825_TX_GAS_LIMIT_CAP + 1,
+                cap: EIP7825_TX_GAS_LIMIT_CAP
+            })
+        );
     }
 }

--- a/crates/evm2/src/ethereum/mod.rs
+++ b/crates/evm2/src/ethereum/mod.rs
@@ -3,6 +3,7 @@
 mod eip1559;
 mod eip2930;
 mod eip4844;
+mod eip7702;
 mod legacy;
 
 use crate::{
@@ -101,6 +102,7 @@ pub fn ethereum_tx_registry<T: EvmTypes<Host = Evm<T>>>()
         .with_handler(1, RecoveredTxEnvelope::as_eip2930, eip2930::handle::<T>)
         .with_handler(2, RecoveredTxEnvelope::as_eip1559, eip1559::handle::<T>)
         .with_handler(3, RecoveredTxEnvelope::as_eip4844, eip4844::handle::<T>)
+        .with_handler(4, RecoveredTxEnvelope::as_eip7702, eip7702::handle::<T>)
 }
 
 pub(super) fn validate_gas_price(
@@ -266,7 +268,7 @@ pub(super) fn initial_message<T: EvmTypes<Host = Evm<T>>>(
 ) -> (Bytecode, Message) {
     match to {
         TxKind::Call(to) => {
-            let code = host.state.get_code(to);
+            let code = initial_call_code(host, to);
             let message = Message {
                 kind: MessageKind::Call,
                 depth: 0,
@@ -296,6 +298,17 @@ pub(super) fn initial_message<T: EvmTypes<Host = Evm<T>>>(
             (Bytecode::new_legacy(input.clone()), message)
         }
     }
+}
+
+fn initial_call_code<T: EvmTypes<Host = Evm<T>>>(host: &mut Evm<T>, to: Address) -> Bytecode {
+    let code = host.state.get_code(to);
+    if host.spec_id().enables(SpecId::PRAGUE)
+        && let Some(delegated_address) = code.eip7702_address()
+    {
+        host.state.warm_account(delegated_address);
+        return host.state.get_code(delegated_address);
+    }
+    code
 }
 
 pub(super) fn rollback_failed_execution<T: EvmTypes<Host = Evm<T>>>(

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -204,6 +204,9 @@ impl<T: EvmTypes> Evm<T> {
         message: &Message,
         gas: &mut Gas,
     ) -> Option<Result<PrecompileOutput, PrecompileError>> {
+        if message.disable_precompiles {
+            return None;
+        }
         self.precompiles.execute(message.code_address, &message.input, gas)
     }
 }
@@ -337,6 +340,7 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
         let create_message = Message {
             destination: address,
             code_address: address,
+            disable_precompiles: false,
             input: Bytes::new(),
 
             kind: message.kind,

--- a/crates/evm2/src/evm/registry.rs
+++ b/crates/evm2/src/evm/registry.rs
@@ -141,6 +141,12 @@ pub enum HandlerError {
     /// EIP-1559 transaction is not enabled in the active specification.
     #[error("EIP-1559 transaction not supported")]
     Eip1559NotSupported,
+    /// EIP-7702 transaction is not enabled in the active specification.
+    #[error("EIP-7702 transaction not supported")]
+    Eip7702NotSupported,
+    /// EIP-7702 authorization list is empty.
+    #[error("EIP-7702 authorization list is empty")]
+    EmptyAuthorizationList,
     /// EIP-4844 transaction is not enabled in the active specification.
     #[error("EIP-4844 transaction not supported")]
     Eip4844NotSupported,

--- a/crates/evm2/src/interpreter/instructions/system.rs
+++ b/crates/evm2/src/interpreter/instructions/system.rs
@@ -2,6 +2,7 @@
 
 use crate::{
     EvmTypes, SpecId,
+    bytecode::{EIP7702_BYTECODE_LEN, EIP7702_MAGIC_BYTES, EIP7702_VERSION},
     constants::{CALL_DEPTH_LIMIT, MAX_INITCODE_SIZE},
     interpreter::{
         Host, InstrStop, InstructionCx, Message, MessageKind, MessageResult, Result, StackMut,
@@ -80,6 +81,16 @@ fn memory_range_bytes<T: EvmTypes>(
     Ok(Bytes::copy_from_slice(cx.state.memory().slice(range.start, range.len())))
 }
 
+fn eip7702_address(code: &Bytes) -> Option<Address> {
+    if code.len() == EIP7702_BYTECODE_LEN
+        && code.starts_with(EIP7702_MAGIC_BYTES)
+        && code[2] == EIP7702_VERSION
+    {
+        return Some(Address::from_slice(&code[3..]));
+    }
+    None
+}
+
 fn load_acc_and_calc_gas<T: EvmTypes>(
     cx: &mut InstructionCx<'_, '_, T>,
     to: Address,
@@ -92,12 +103,29 @@ fn load_acc_and_calc_gas<T: EvmTypes>(
     }
 
     let additional_cold_cost = cx.state.gas_params().cold_account_additional_cost();
-    let skip_cold_load = cx.gas.remaining() < additional_cold_cost;
+    let remaining_gas = cx.gas.remaining();
+    let skip_cold_load = remaining_gas < additional_cold_cost;
     let account = cx.state.host.load_account(to, true, skip_cold_load)?;
 
     let mut cost = 0;
     if account.is_cold {
         cost += additional_cold_cost;
+    }
+    let mut code = account.code;
+    if cx.state.spec.enables(SpecId::PRAGUE)
+        && let Some(delegated_address) = eip7702_address(&code)
+    {
+        cost += u64::from(cx.state.gas_params().get(GasId::WarmStorageReadCost));
+        if cost > remaining_gas {
+            return Err(InstrStop::OutOfGas);
+        }
+        let skip_cold_load = remaining_gas < cost.saturating_add(additional_cold_cost);
+        let delegated_account =
+            cx.state.host.load_account(delegated_address, true, skip_cold_load)?;
+        if delegated_account.is_cold {
+            cost += additional_cold_cost;
+        }
+        code = delegated_account.code;
     }
     if create_empty_account
         && should_charge_new_account_gas(
@@ -121,7 +149,7 @@ fn load_acc_and_calc_gas<T: EvmTypes>(
         gas_limit = gas_limit.saturating_add(cx.state.gas_params().get(GasId::CallStipend).into());
     }
 
-    Ok((gas_limit, account.code))
+    Ok((gas_limit, code))
 }
 
 #[inline(never)]

--- a/crates/evm2/src/interpreter/instructions/system.rs
+++ b/crates/evm2/src/interpreter/instructions/system.rs
@@ -97,7 +97,7 @@ fn load_acc_and_calc_gas<T: EvmTypes>(
     transfers_value: bool,
     create_empty_account: bool,
     stack_gas_limit: u64,
-) -> Result<(u64, Bytes)> {
+) -> Result<(u64, Bytes, Address, bool)> {
     if transfers_value {
         cx.gas.spend(cx.state.gas_params().get(GasId::TransferValueCost).into())?;
     }
@@ -112,6 +112,7 @@ fn load_acc_and_calc_gas<T: EvmTypes>(
         cost += additional_cold_cost;
     }
     let mut code = account.code;
+    let mut code_address = to;
     if cx.state.spec.enables(SpecId::PRAGUE)
         && let Some(delegated_address) = eip7702_address(&code)
     {
@@ -126,6 +127,7 @@ fn load_acc_and_calc_gas<T: EvmTypes>(
             cost += additional_cold_cost;
         }
         code = delegated_account.code;
+        code_address = delegated_address;
     }
     if create_empty_account
         && should_charge_new_account_gas(
@@ -149,7 +151,8 @@ fn load_acc_and_calc_gas<T: EvmTypes>(
         gas_limit = gas_limit.saturating_add(cx.state.gas_params().get(GasId::CallStipend).into());
     }
 
-    Ok((gas_limit, code))
+    let disable_precompiles = code_address != to;
+    Ok((gas_limit, code, code_address, disable_precompiles))
 }
 
 #[inline(never)]
@@ -180,7 +183,7 @@ fn call_inner<T: EvmTypes>(
         return_offset,
         return_len,
     )?;
-    let (gas_limit, code) = load_acc_and_calc_gas(
+    let (gas_limit, code, resolved_code_address, disable_precompiles) = load_acc_and_calc_gas(
         &mut cx,
         to,
         has_transfer,
@@ -191,10 +194,14 @@ fn call_inner<T: EvmTypes>(
 
     let current = cx.state.message();
     let (destination, caller, call_value, code_address) = match kind {
-        MessageKind::Call => (to, current.destination, value, to),
-        MessageKind::CallCode => (current.destination, current.destination, value, to),
-        MessageKind::DelegateCall => (current.destination, current.caller, current.value, to),
-        MessageKind::StaticCall => (to, current.destination, Word::ZERO, to),
+        MessageKind::Call => (to, current.destination, value, resolved_code_address),
+        MessageKind::CallCode => {
+            (current.destination, current.destination, value, resolved_code_address)
+        }
+        MessageKind::DelegateCall => {
+            (current.destination, current.caller, current.value, resolved_code_address)
+        }
+        MessageKind::StaticCall => (to, current.destination, Word::ZERO, resolved_code_address),
         _ => unreachable!("invalid call message kind"),
     };
     let message = Message {
@@ -206,6 +213,7 @@ fn call_inner<T: EvmTypes>(
         input,
         value: call_value,
         code_address,
+        disable_precompiles,
         salt: B256::ZERO,
     };
     let caller_is_static = cx.state.is_static();
@@ -295,6 +303,7 @@ fn create_inner<T: EvmTypes>(
         input: input.clone(),
         value,
         code_address: current.destination,
+        disable_precompiles: false,
         salt: salt.map(|salt| B256::from(salt.to_be_bytes())).unwrap_or_default(),
     };
     let bytecode = crate::bytecode::Bytecode::new_legacy(input);

--- a/crates/evm2/src/interpreter/instructions/tests.rs
+++ b/crates/evm2/src/interpreter/instructions/tests.rs
@@ -30,8 +30,8 @@ pub(crate) struct TestHost {
     pub(super) code: Bytes,
     pub(super) exists: bool,
     pub(super) is_empty: bool,
-    pub(super) is_touched: bool,
     pub(super) is_cold: bool,
+    pub(super) is_touched: bool,
     pub(super) storage: HashMap<(Address, Word), Word>,
     pub(super) original_storage: HashMap<(Address, Word), Word>,
     pub(super) transient_storage: HashMap<(Address, Word), Word>,
@@ -51,8 +51,8 @@ impl Default for TestHost {
             code: Bytes::new(),
             exists: true,
             is_empty: false,
-            is_touched: false,
             is_cold: false,
+            is_touched: false,
             storage: HashMap::default(),
             original_storage: HashMap::default(),
             transient_storage: HashMap::default(),
@@ -96,10 +96,9 @@ impl Host for TestHost {
 
     fn target_is_empty_for_new_account_gas(&mut self, _address: Address, spec: SpecId) -> bool {
         if spec.enables(SpecId::SPURIOUS_DRAGON) {
-            self.is_empty
-        } else {
-            !self.exists && !self.is_touched
+            return !self.exists || self.is_empty;
         }
+        !self.exists && !self.is_touched
     }
 
     fn block_hash(&mut self, number: Word) -> Option<B256> {

--- a/crates/evm2/src/interpreter/message.rs
+++ b/crates/evm2/src/interpreter/message.rs
@@ -36,9 +36,12 @@ pub struct Message {
     pub input: Bytes,
     /// Value transferred with the message.
     pub value: U256,
-    /// Address whose code is being executed. This can differ from `destination` for `CALLCODE`
-    /// and `DELEGATECALL`.
+    /// Address whose code is being executed. This can differ from `destination` for `CALLCODE`,
+    /// `DELEGATECALL`, and EIP-7702 delegated-code execution.
     pub code_address: Address,
+    /// Whether native precompile dispatch is disabled for this frame because its bytecode was
+    /// loaded through an EIP-7702 delegation designation.
+    pub disable_precompiles: bool,
     /// CREATE2 salt. Ignored for other message kinds.
     pub salt: B256,
 }
@@ -55,6 +58,7 @@ impl Default for Message {
             input: Bytes::new(),
             value: U256::ZERO,
             code_address: Address::ZERO,
+            disable_precompiles: false,
             salt: B256::ZERO,
         }
     }

--- a/crates/evm2/src/interpreter/state.rs
+++ b/crates/evm2/src/interpreter/state.rs
@@ -159,10 +159,10 @@ impl MessageResult {
         if self.stop.is_success() { self.gas_refunded } else { 0 }
     }
 
-    /// Calculates the final refund amount for a top-level successful transaction.
+    /// Calculates the final refund amount for a top-level transaction.
     #[inline]
     pub const fn final_refund(&self, gas_limit: u64, is_london: bool) -> u64 {
-        if !self.stop.is_success() || self.gas_refunded <= 0 {
+        if self.gas_refunded <= 0 {
             return 0;
         }
         let max_refund_quotient = if is_london { 5 } else { 2 };


### PR DESCRIPTION
This implements EIP-7702 set-code transaction support and wires the statetest harness to build type-4 transactions from authorizationList fixtures. The handler applies authorizations before execution, installs or clears delegation designators, settles the EIP-7702 refund outside frame success handling, and resolves delegated bytecode for transaction entry and call-like execution while leaving EXTCODE* inspection on the designator itself.

The behavior was checked against revm's apply_auth_list/load_account_delegated/post-execution refund paths and evmone's EIP-7702 state transition tests/source for empty authorization-list rejection, delegated code loading, precompile delegation behavior, and access-gas/refund accounting.

Full statetest delta from the previous branch tip: 7796 tests run: 7717 passed, 79 failed, 115 skipped before; 7796 passed, 0 failed, 115 skipped after. The remaining previously failing files were the EIP-7702/type-4/auth/set-code fixtures under prague/eip7702_set_code_tx plus type-4 coverage in EIP-7623 calldata floor, EIP-4844 blobhash, EIP-7825 gas-cap, CHAINID, and EIP-7939 CLZ tests.



