### PR TITLE
fix(evm): reject storage create collisions

### DIFF
--- a/crates/evm2-statetest/src/runner.rs
+++ b/crates/evm2-statetest/src/runner.rs
@@ -80,7 +80,7 @@ fn path_name(path: &Path) -> String {
 
 #[rustfmt::skip]
 const IGNORED_TESTS: &[&str] = &[
-    // Skip slow fixtures and create-collision fixtures that need storage-aware collision handling.
+    // Skip slow fixtures.
     "CALLBlake2f_MaxRounds.json",
     "loopExp",
     "loopMul.json",
@@ -95,18 +95,6 @@ const IGNORED_TESTS: &[&str] = &[
     "stStaticCall/static_CallRecursiveBomb",
     "stStaticCall/static_LoopCallsDepthThenRevert",
     "stSystemOperationsTest/CallRecursiveBomb",
-
-    "eip7610_create_collision",
-    "InitCollision.json",
-    "InitCollisionParis.json",
-    "RevertInCreateInInit.json",
-    "RevertInCreateInInit_Paris.json",
-    "RevertInCreateInInitCreate2.json",
-    "RevertInCreateInInitCreate2Paris.json",
-    "create2collisionStorage.json",
-    "create2collisionStorageParis.json",
-    "dynamicAccountOverwriteEmpty.json",
-    "dynamicAccountOverwriteEmpty_Paris.json",
 ];
 
 fn should_ignore(name: &str) -> bool {

--- a/crates/evm2/src/evm/db.rs
+++ b/crates/evm2/src/evm/db.rs
@@ -19,6 +19,11 @@ pub trait Database {
     /// Loads a persistent storage slot.
     fn get_storage(&mut self, address: Address, key: Word) -> Word;
 
+    /// Returns whether an account has any non-zero persistent storage.
+    fn has_storage(&mut self, _address: Address) -> bool {
+        false
+    }
+
     /// Loads a historical block hash.
     fn get_block_hash(&mut self, number: Word) -> Option<B256>;
 }
@@ -41,6 +46,11 @@ impl Database for EmptyDB {
     #[inline]
     fn get_storage(&mut self, _address: Address, _key: Word) -> Word {
         Word::ZERO
+    }
+
+    #[inline]
+    fn has_storage(&mut self, _address: Address) -> bool {
+        false
     }
 
     #[inline]

--- a/crates/evm2/src/evm/db/cache.rs
+++ b/crates/evm2/src/evm/db/cache.rs
@@ -159,6 +159,15 @@ impl<ExtDB: Database> Database for CacheDB<ExtDB> {
     }
 
     #[inline]
+    fn has_storage(&mut self, address: Address) -> bool {
+        self.cache
+            .storage
+            .iter()
+            .any(|(&(account, _), value)| account == address && !value.is_zero())
+            || self.db.has_storage(address)
+    }
+
+    #[inline]
     fn get_block_hash(&mut self, number: Word) -> Option<B256> {
         match self.cache.block_hashes.entry(number) {
             Entry::Occupied(entry) => Some(*entry.get()),
@@ -201,6 +210,10 @@ mod tests {
         fn get_storage(&mut self, _address: Address, _key: Word) -> Word {
             self.storage_loads += 1;
             self.storage
+        }
+
+        fn has_storage(&mut self, _address: Address) -> bool {
+            !self.storage.is_zero()
         }
 
         fn get_block_hash(&mut self, _number: Word) -> Option<B256> {

--- a/crates/evm2/src/evm/state.rs
+++ b/crates/evm2/src/evm/state.rs
@@ -535,6 +535,10 @@ impl<D: Database> State<D> {
     #[inline]
     #[must_use]
     pub fn account_info(&mut self, address: Address) -> Option<AccountInfo> {
+        self.load_account(address)?.current.as_ref().map(Account::info)
+    }
+
+    fn create_collision_account_info(&mut self, address: Address) -> Option<AccountInfo> {
         if let Some(account) = self.accounts.get(&address) {
             return account.current.as_ref().map(Account::info);
         }
@@ -579,6 +583,21 @@ impl<D: Database> State<D> {
         } else {
             self.initial.get_storage(address, key)
         }
+    }
+
+    fn has_create_collision_storage(&mut self, address: Address) -> bool {
+        if let Some(storage) = self.storage.get(&address) {
+            if storage.slots.values().any(|slot| !slot.current.is_zero()) {
+                return true;
+            }
+            if storage.wiped {
+                return false;
+            }
+        }
+        if self.accounts.get(&address).is_some_and(|account| account.original.is_none()) {
+            return false;
+        }
+        self.initial.has_storage(address)
     }
 
     #[must_use]
@@ -704,9 +723,13 @@ impl<D: Database> State<D> {
         value: Word,
         spec: SpecId,
     ) -> Result<(), InstrStop> {
-        if let Some(info) = self.account_info(address)
+        if let Some(info) = self.create_collision_account_info(address)
             && (info.nonce != 0 || info.code_hash != KECCAK256_EMPTY)
         {
+            return Err(InstrStop::CreateCollision);
+        }
+        // EIP-7610 extends create collision checks to storage-only accounts.
+        if self.has_create_collision_storage(address) {
             return Err(InstrStop::CreateCollision);
         }
 
@@ -1163,6 +1186,38 @@ mod tests {
 
         assert!(!state.transfer(address, address, Word::from(4)));
         assert!(state.transfer(address, address, Word::from(3)));
+    }
+
+    #[test]
+    fn create_collides_with_storage_only_account() {
+        let caller = Address::from([0x11; 20]);
+        let created = Address::from([0x22; 20]);
+        let mut database = CacheDB::default();
+        database.insert_account_info(caller, AccountInfo::default().with_balance(Word::from(1)));
+        database.insert_account_storage(created, Word::ZERO, Word::from(1));
+        let mut state = State::new(database);
+
+        assert_eq!(
+            state.create_account(caller, created, Word::ZERO, SpecId::SPURIOUS_DRAGON),
+            Err(InstrStop::CreateCollision)
+        );
+        assert_eq!(state.storage(created, Word::ZERO), Word::from(1));
+    }
+
+    #[test]
+    fn create_after_prior_account_load_collides_with_storage() {
+        let caller = Address::from([0x33; 20]);
+        let created = Address::from([0x44; 20]);
+        let mut database = CacheDB::default();
+        database.insert_account_info(caller, AccountInfo::default().with_balance(Word::from(1)));
+        database.insert_account_storage(created, Word::ZERO, Word::from(1));
+        let mut state = State::new(database);
+
+        assert!(state.find(created).is_some());
+        assert_eq!(
+            state.create_account(caller, created, Word::ZERO, SpecId::SPURIOUS_DRAGON),
+            Err(InstrStop::CreateCollision)
+        );
     }
 
     #[test]


### PR DESCRIPTION
Supersedes #66 by implementing the storage-aware CREATE collision behavior instead of extending the state-test skip list. EIP-7610 makes storage-only accounts collide with CREATE and CREATE2 targets, so the state overlay now asks the backing database/cache whether an account has non-zero persistent storage and rejects before any storage wipe can happen.

This follows evmone's statetest host shape, where loaded accounts carry `has_initial_storage` into the create-collision check. The revm statetest runner branch I compared against still skips these collision fixtures instead of modeling the storage check.

This is draft because the legacy Constantinople `stExtCodeHash/dynamicAccountOverwriteEmpty.json` fixture still has an expected-root disagreement after the storage-collision behavior is implemented, so #66 should stay open while that case is resolved.
