### PR TITLE
feat: add tx gas limit cap to version

### DIFF
--- a/crates/evm2/examples/custom_evm.rs
+++ b/crates/evm2/examples/custom_evm.rs
@@ -65,7 +65,7 @@ impl<const BASE_SPEC_ID: u8> EvmConfig<CustomTypes> for CustomConfig<BASE_SPEC_I
     const VERSION: Version = Version::new(
         SpecId::try_from_u8(BASE_SPEC_ID).unwrap(),
         &Self::GAS_PARAMS,
-        Version::base(SpecId::try_from_u8(BASE_SPEC_ID).unwrap()).max_tx_gas_limit(),
+        Version::base(SpecId::try_from_u8(BASE_SPEC_ID).unwrap()).tx_gas_limit_cap(),
     );
     const VERSION_TABLES: &'static VersionTables<CustomTypes> =
         &custom_version_tables::<BASE_SPEC_ID>();

--- a/crates/evm2/examples/custom_evm.rs
+++ b/crates/evm2/examples/custom_evm.rs
@@ -13,11 +13,14 @@ use evm2::{
     evm::{InMemoryDB, precompile::NoPrecompiles},
     interpreter::{Host, InstrStop, Instruction, Message, Word, op},
     registry::{HandlerResult, TxRegistry, TxRequest},
+    version::GasId,
 };
 use evm2_macros::instruction;
 
 const CUSTOM_OPCODE: u8 = 0x0c;
 const CUSTOM_OPCODE_GAS: u16 = 7;
+const CUSTOM_OPCODE_DYNAMIC_GAS_ID: GasId = GasId::Custom0;
+const CUSTOM_OPCODE_DYNAMIC_GAS: u32 = 3;
 const CUSTOM_TX_TYPE: u8 = 0x7f;
 
 // Runtime spec IDs
@@ -54,10 +57,21 @@ impl EvmTypes for CustomTypes {
 
 struct CustomConfig<const BASE_SPEC_ID: u8>(());
 
+impl<const BASE_SPEC_ID: u8> CustomConfig<BASE_SPEC_ID> {
+    const VERSION_VALUE: Version = custom_version::<BASE_SPEC_ID>();
+}
+
 impl<const BASE_SPEC_ID: u8> EvmConfig<CustomTypes> for CustomConfig<BASE_SPEC_ID> {
-    const VERSION: &'static Version = Version::base(SpecId::try_from_u8(BASE_SPEC_ID).unwrap());
+    const VERSION: &'static Version = &Self::VERSION_VALUE;
     const VERSION_TABLES: &'static VersionTables<CustomTypes> =
         &custom_version_tables::<BASE_SPEC_ID>();
+}
+
+const fn custom_version<const BASE_SPEC_ID: u8>() -> Version {
+    let base_spec_id = SpecId::try_from_u8(BASE_SPEC_ID).unwrap();
+    let mut version = *Version::base(base_spec_id);
+    version.gas_params.set(CUSTOM_OPCODE_DYNAMIC_GAS_ID, CUSTOM_OPCODE_DYNAMIC_GAS);
+    version
 }
 
 const fn custom_version_tables<const BASE_SPEC_ID: u8>() -> VersionTables<CustomTypes> {
@@ -94,6 +108,7 @@ impl EvmConfigSelector<CustomTypes> for CustomConfigSelector {
 
 #[instruction]
 fn custom(cx: _) -> Result<out> {
+    cx.gas.spend(cx.state.gas_params().get(CUSTOM_OPCODE_DYNAMIC_GAS_ID).into())?;
     *out = Word::from(0xdead_u64);
 }
 
@@ -154,6 +169,7 @@ fn main() {
     let code = Bytes::from_static(&[CUSTOM_OPCODE, op::PUSH1, 0x01, op::SSTORE, op::STOP]);
     let tx = CustomTx { target: custom_target, code };
     let expected_custom_gas = u64::from(CUSTOM_OPCODE_GAS)
+        + u64::from(CUSTOM_OPCODE_DYNAMIC_GAS)
         + 3 // PUSH1
         + 2100 // Cold SSTORE load.
         + 20_000; // SSTORE zero to non-zero.
@@ -171,6 +187,13 @@ fn main() {
             .static_gas(CUSTOM_OPCODE),
         CUSTOM_OPCODE_GAS,
     );
+    assert_eq!(
+        <CustomConfig<{ SpecId::OSAKA as u8 }> as EvmConfig<CustomTypes>>::VERSION
+            .gas_params
+            .get(CUSTOM_OPCODE_DYNAMIC_GAS_ID),
+        CUSTOM_OPCODE_DYNAMIC_GAS,
+    );
+
     let result = evm.transact(&tx).expect("custom transaction should execute");
     assert_eq!(result.stop, InstrStop::Stop);
     assert!(result.status);

--- a/crates/evm2/examples/custom_evm.rs
+++ b/crates/evm2/examples/custom_evm.rs
@@ -62,8 +62,11 @@ impl<const BASE_SPEC_ID: u8> CustomConfig<BASE_SPEC_ID> {
 }
 
 impl<const BASE_SPEC_ID: u8> EvmConfig<CustomTypes> for CustomConfig<BASE_SPEC_ID> {
-    const VERSION: Version =
-        Version::new(SpecId::try_from_u8(BASE_SPEC_ID).unwrap(), &Self::GAS_PARAMS);
+    const VERSION: Version = Version::new(
+        SpecId::try_from_u8(BASE_SPEC_ID).unwrap(),
+        &Self::GAS_PARAMS,
+        Version::base(SpecId::try_from_u8(BASE_SPEC_ID).unwrap()).max_tx_gas_limit(),
+    );
     const VERSION_TABLES: &'static VersionTables<CustomTypes> =
         &custom_version_tables::<BASE_SPEC_ID>();
 }

--- a/crates/evm2/examples/custom_evm.rs
+++ b/crates/evm2/examples/custom_evm.rs
@@ -57,12 +57,8 @@ impl EvmTypes for CustomTypes {
 
 struct CustomConfig<const BASE_SPEC_ID: u8>(());
 
-impl<const BASE_SPEC_ID: u8> CustomConfig<BASE_SPEC_ID> {
-    const VERSION_VALUE: Version = custom_version::<BASE_SPEC_ID>();
-}
-
 impl<const BASE_SPEC_ID: u8> EvmConfig<CustomTypes> for CustomConfig<BASE_SPEC_ID> {
-    const VERSION: &'static Version = &Self::VERSION_VALUE;
+    const VERSION: &'static Version = &custom_version::<BASE_SPEC_ID>();
     const VERSION_TABLES: &'static VersionTables<CustomTypes> =
         &custom_version_tables::<BASE_SPEC_ID>();
 }

--- a/crates/evm2/examples/custom_evm.rs
+++ b/crates/evm2/examples/custom_evm.rs
@@ -13,14 +13,11 @@ use evm2::{
     evm::{InMemoryDB, precompile::NoPrecompiles},
     interpreter::{Host, InstrStop, Instruction, Message, Word, op},
     registry::{HandlerResult, TxRegistry, TxRequest},
-    version::{GasId, GasParams},
 };
 use evm2_macros::instruction;
 
 const CUSTOM_OPCODE: u8 = 0x0c;
 const CUSTOM_OPCODE_GAS: u16 = 7;
-const CUSTOM_OPCODE_DYNAMIC_GAS_ID: GasId = GasId::Custom0;
-const CUSTOM_OPCODE_DYNAMIC_GAS: u32 = 3;
 const CUSTOM_TX_TYPE: u8 = 0x7f;
 
 // Runtime spec IDs
@@ -57,25 +54,10 @@ impl EvmTypes for CustomTypes {
 
 struct CustomConfig<const BASE_SPEC_ID: u8>(());
 
-impl<const BASE_SPEC_ID: u8> CustomConfig<BASE_SPEC_ID> {
-    const GAS_PARAMS: GasParams = custom_gas_params::<BASE_SPEC_ID>();
-}
-
 impl<const BASE_SPEC_ID: u8> EvmConfig<CustomTypes> for CustomConfig<BASE_SPEC_ID> {
-    const VERSION: Version = Version::new(
-        SpecId::try_from_u8(BASE_SPEC_ID).unwrap(),
-        &Self::GAS_PARAMS,
-        Version::base(SpecId::try_from_u8(BASE_SPEC_ID).unwrap()).tx_gas_limit_cap(),
-    );
+    const VERSION: &'static Version = Version::base(SpecId::try_from_u8(BASE_SPEC_ID).unwrap());
     const VERSION_TABLES: &'static VersionTables<CustomTypes> =
         &custom_version_tables::<BASE_SPEC_ID>();
-}
-
-const fn custom_gas_params<const BASE_SPEC_ID: u8>() -> GasParams {
-    let base_spec_id = SpecId::try_from_u8(BASE_SPEC_ID).unwrap();
-    let mut gp = *Version::base(base_spec_id).gas_params();
-    gp.set(CUSTOM_OPCODE_DYNAMIC_GAS_ID, CUSTOM_OPCODE_DYNAMIC_GAS);
-    gp
 }
 
 const fn custom_version_tables<const BASE_SPEC_ID: u8>() -> VersionTables<CustomTypes> {
@@ -112,7 +94,6 @@ impl EvmConfigSelector<CustomTypes> for CustomConfigSelector {
 
 #[instruction]
 fn custom(cx: _) -> Result<out> {
-    cx.gas.spend(cx.state.gas_params().get(CUSTOM_OPCODE_DYNAMIC_GAS_ID).into())?;
     *out = Word::from(0xdead_u64);
 }
 
@@ -173,7 +154,6 @@ fn main() {
     let code = Bytes::from_static(&[CUSTOM_OPCODE, op::PUSH1, 0x01, op::SSTORE, op::STOP]);
     let tx = CustomTx { target: custom_target, code };
     let expected_custom_gas = u64::from(CUSTOM_OPCODE_GAS)
-        + u64::from(CUSTOM_OPCODE_DYNAMIC_GAS)
         + 3 // PUSH1
         + 2100 // Cold SSTORE load.
         + 20_000; // SSTORE zero to non-zero.
@@ -191,13 +171,6 @@ fn main() {
             .static_gas(CUSTOM_OPCODE),
         CUSTOM_OPCODE_GAS,
     );
-    assert_eq!(
-        <CustomConfig<{ SpecId::OSAKA as u8 }> as EvmConfig<CustomTypes>>::VERSION
-            .gas_params()
-            .get(CUSTOM_OPCODE_DYNAMIC_GAS_ID),
-        CUSTOM_OPCODE_DYNAMIC_GAS,
-    );
-
     let result = evm.transact(&tx).expect("custom transaction should execute");
     assert_eq!(result.stop, InstrStop::Stop);
     assert!(result.status);

--- a/crates/evm2/src/bytecode/mod.rs
+++ b/crates/evm2/src/bytecode/mod.rs
@@ -1,6 +1,10 @@
 //! EVM bytecode.
 
-use crate::{interpreter::op, once_lock::OnceLock};
+use crate::{
+    constants::{EIP7702_BYTECODE_LEN, EIP7702_MAGIC_BYTES, EIP7702_VERSION},
+    interpreter::op,
+    once_lock::OnceLock,
+};
 use alloc::sync::Arc;
 use alloy_primitives::{Address, B256, Bytes, KECCAK256_EMPTY, keccak256};
 use analysis::analyze_legacy;
@@ -14,20 +18,6 @@ mod jump_table;
 mod serde_impl;
 
 pub use jump_table::{JumpTable, JumpTableRef};
-
-/// EIP-7702 version magic.
-pub const EIP7702_MAGIC: u16 = 0xEF01;
-
-/// EIP-7702 version magic bytes.
-pub const EIP7702_MAGIC_BYTES: &[u8] = &EIP7702_MAGIC.to_be_bytes();
-
-/// EIP-7702 version.
-pub const EIP7702_VERSION: u8 = 0;
-
-/// EIP-7702 bytecode length.
-///
-/// 2 (magic) + 1 (version) + 20 (address) = 23 bytes.
-pub const EIP7702_BYTECODE_LEN: usize = 23;
 
 /// EIP-7702 decode errors.
 #[derive(Clone, Copy, Debug, Error, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/crates/evm2/src/constants.rs
+++ b/crates/evm2/src/constants.rs
@@ -1,4 +1,4 @@
-//! EVM protocol limits.
+//! EVM constants.
 
 /// Maximum deployed contract bytecode size.
 ///
@@ -18,3 +18,14 @@ pub(crate) const STACK_LIMIT: usize = 1024;
 
 /// Number of recent block hashes available to the `BLOCKHASH` opcode.
 pub(crate) const BLOCK_HASH_HISTORY: u64 = 256;
+
+/// EIP-7702 version magic.
+pub const EIP7702_MAGIC: u16 = 0xEF01;
+/// EIP-7702 version magic bytes.
+pub const EIP7702_MAGIC_BYTES: &[u8] = &EIP7702_MAGIC.to_be_bytes();
+/// EIP-7702 version.
+pub const EIP7702_VERSION: u8 = 0;
+/// EIP-7702 bytecode length.
+///
+/// 2 (magic) + 1 (version) + 20 (address) = 23 bytes.
+pub const EIP7702_BYTECODE_LEN: usize = 23;

--- a/crates/evm2/src/constants.rs
+++ b/crates/evm2/src/constants.rs
@@ -20,12 +20,12 @@ pub(crate) const STACK_LIMIT: usize = 1024;
 pub(crate) const BLOCK_HASH_HISTORY: u64 = 256;
 
 /// EIP-7702 version magic.
-pub const EIP7702_MAGIC: u16 = 0xEF01;
+pub(crate) const EIP7702_MAGIC: u16 = 0xEF01;
 /// EIP-7702 version magic bytes.
-pub const EIP7702_MAGIC_BYTES: &[u8] = &EIP7702_MAGIC.to_be_bytes();
+pub(crate) const EIP7702_MAGIC_BYTES: &[u8] = &EIP7702_MAGIC.to_be_bytes();
 /// EIP-7702 version.
-pub const EIP7702_VERSION: u8 = 0;
+pub(crate) const EIP7702_VERSION: u8 = 0;
 /// EIP-7702 bytecode length.
 ///
 /// 2 (magic) + 1 (version) + 20 (address) = 23 bytes.
-pub const EIP7702_BYTECODE_LEN: usize = 23;
+pub(crate) const EIP7702_BYTECODE_LEN: usize = 23;

--- a/crates/evm2/src/ethereum/eip1559.rs
+++ b/crates/evm2/src/ethereum/eip1559.rs
@@ -31,7 +31,7 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
 
     validate_priority_fee(max_fee_per_gas, max_priority_fee_per_gas)?;
     validate_gas_price(spec_id, gas_price, req.host.block.basefee)?;
-    validate_tx_gas_limit_cap(spec_id, tx.gas_limit)?;
+    validate_tx_gas_limit_cap(req.host.version(), tx.gas_limit)?;
     validate_block_gas_limit(tx.gas_limit, req.host.block.gas_limit)?;
     validate_create_initcode(spec_id, tx.to, &tx.input)?;
     validate_nonce_not_overflow(tx.nonce)?;
@@ -46,7 +46,7 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     validate_intrinsic_gas(tx.gas_limit, intrinsic)?;
     let floor_gas = floor_gas(req.host.version(), &tx.input);
     validate_floor_gas(tx.gas_limit, floor_gas)?;
-    validate_regular_gas_limit_cap(spec_id, tx.gas_limit, intrinsic, floor_gas)?;
+    validate_regular_gas_limit_cap(req.host.version(), tx.gas_limit, intrinsic, floor_gas)?;
 
     let max_gas_cost = U256::from(tx.gas_limit) * max_fee_per_gas;
     validate_sender(req.host, caller, tx.nonce, max_gas_cost.saturating_add(tx.value))?;

--- a/crates/evm2/src/ethereum/eip2930.rs
+++ b/crates/evm2/src/ethereum/eip2930.rs
@@ -27,7 +27,7 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     let gas_price = U256::from(tx.gas_price);
 
     validate_gas_price(spec_id, gas_price, req.host.block.basefee)?;
-    validate_tx_gas_limit_cap(spec_id, tx.gas_limit)?;
+    validate_tx_gas_limit_cap(req.host.version(), tx.gas_limit)?;
     validate_block_gas_limit(tx.gas_limit, req.host.block.gas_limit)?;
     validate_create_initcode(spec_id, tx.to, &tx.input)?;
     validate_nonce_not_overflow(tx.nonce)?;
@@ -42,7 +42,7 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     validate_intrinsic_gas(tx.gas_limit, intrinsic)?;
     let floor_gas = floor_gas(req.host.version(), &tx.input);
     validate_floor_gas(tx.gas_limit, floor_gas)?;
-    validate_regular_gas_limit_cap(spec_id, tx.gas_limit, intrinsic, floor_gas)?;
+    validate_regular_gas_limit_cap(req.host.version(), tx.gas_limit, intrinsic, floor_gas)?;
 
     let max_gas_cost = U256::from(tx.gas_limit) * gas_price;
     validate_sender(req.host, caller, tx.nonce, max_gas_cost.saturating_add(tx.value))?;

--- a/crates/evm2/src/ethereum/eip4844.rs
+++ b/crates/evm2/src/ethereum/eip4844.rs
@@ -38,7 +38,7 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     validate_gas_price(spec_id, gas_price, req.host.block.basefee)?;
     validate_blob_fee(max_fee_per_blob_gas, req.host.block.blob_basefee)?;
     validate_blobs(&tx.blob_versioned_hashes, max_blobs_per_tx(spec_id))?;
-    validate_tx_gas_limit_cap(spec_id, tx.gas_limit)?;
+    validate_tx_gas_limit_cap(req.host.version(), tx.gas_limit)?;
     validate_block_gas_limit(tx.gas_limit, req.host.block.gas_limit)?;
     validate_create_initcode(spec_id, tx.to.into(), &tx.input)?;
     validate_nonce_not_overflow(tx.nonce)?;
@@ -53,7 +53,7 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     validate_intrinsic_gas(tx.gas_limit, intrinsic)?;
     let floor_gas = floor_gas(req.host.version(), &tx.input);
     validate_floor_gas(tx.gas_limit, floor_gas)?;
-    validate_regular_gas_limit_cap(spec_id, tx.gas_limit, intrinsic, floor_gas)?;
+    validate_regular_gas_limit_cap(req.host.version(), tx.gas_limit, intrinsic, floor_gas)?;
 
     let blob_gas_cost = U256::from(DATA_GAS_PER_BLOB) * U256::from(tx.blob_versioned_hashes.len());
     let max_blob_gas_cost = blob_gas_cost * max_fee_per_blob_gas;

--- a/crates/evm2/src/ethereum/eip7702.rs
+++ b/crates/evm2/src/ethereum/eip7702.rs
@@ -83,7 +83,7 @@ fn eip7702_authorization_gas<T: EvmTypes<Host = Evm<T>>>(
     host: &Evm<T>,
     authorizations: usize,
 ) -> u64 {
-    let per_auth = u64::from(host.version().gas_params().get(GasId::TxEip7702PerEmptyAccountCost));
+    let per_auth = u64::from(host.version().gas_params.get(GasId::TxEip7702PerEmptyAccountCost));
     u64::try_from(authorizations).unwrap_or(u64::MAX).saturating_mul(per_auth)
 }
 
@@ -123,7 +123,7 @@ fn apply_auth_list<T: EvmTypes<Host = Evm<T>>>(
         set_delegation(host, authority, *authorization.address());
     }
 
-    let refund_per_auth = u64::from(host.version().gas_params().get(GasId::TxEip7702AuthRefund));
+    let refund_per_auth = u64::from(host.version().gas_params.get(GasId::TxEip7702AuthRefund));
     refunded_accounts.saturating_mul(refund_per_auth)
 }
 

--- a/crates/evm2/src/ethereum/eip7702.rs
+++ b/crates/evm2/src/ethereum/eip7702.rs
@@ -37,7 +37,7 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
 
     validate_priority_fee(max_fee_per_gas, max_priority_fee_per_gas)?;
     validate_gas_price(spec_id, gas_price, req.host.block.basefee)?;
-    validate_tx_gas_limit_cap(spec_id, tx.gas_limit)?;
+    validate_tx_gas_limit_cap(req.host.version(), tx.gas_limit)?;
     validate_block_gas_limit(tx.gas_limit, req.host.block.gas_limit)?;
     validate_create_initcode(spec_id, tx.to.into(), &tx.input)?;
     validate_nonce_not_overflow(tx.nonce)?;
@@ -52,7 +52,7 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     validate_intrinsic_gas(tx.gas_limit, intrinsic)?;
     let floor_gas = floor_gas(req.host.version(), &tx.input);
     validate_floor_gas(tx.gas_limit, floor_gas)?;
-    validate_regular_gas_limit_cap(spec_id, tx.gas_limit, intrinsic, floor_gas)?;
+    validate_regular_gas_limit_cap(req.host.version(), tx.gas_limit, intrinsic, floor_gas)?;
 
     let max_gas_cost = U256::from(tx.gas_limit) * max_fee_per_gas;
     validate_sender(req.host, caller, tx.nonce, max_gas_cost.saturating_add(tx.value))?;

--- a/crates/evm2/src/ethereum/legacy.rs
+++ b/crates/evm2/src/ethereum/legacy.rs
@@ -22,7 +22,7 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     let gas_price = U256::from(tx.gas_price);
 
     validate_gas_price(spec_id, gas_price, req.host.block.basefee)?;
-    validate_tx_gas_limit_cap(spec_id, tx.gas_limit)?;
+    validate_tx_gas_limit_cap(req.host.version(), tx.gas_limit)?;
     validate_block_gas_limit(tx.gas_limit, req.host.block.gas_limit)?;
     validate_create_initcode(spec_id, tx.to, &tx.input)?;
     validate_nonce_not_overflow(tx.nonce)?;
@@ -30,7 +30,7 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     validate_intrinsic_gas(tx.gas_limit, intrinsic)?;
     let floor_gas = floor_gas(req.host.version(), &tx.input);
     validate_floor_gas(tx.gas_limit, floor_gas)?;
-    validate_regular_gas_limit_cap(spec_id, tx.gas_limit, intrinsic, floor_gas)?;
+    validate_regular_gas_limit_cap(req.host.version(), tx.gas_limit, intrinsic, floor_gas)?;
 
     let max_gas_cost = U256::from(tx.gas_limit) * gas_price;
     validate_sender(req.host, caller, tx.nonce, max_gas_cost.saturating_add(tx.value))?;

--- a/crates/evm2/src/ethereum/mod.rs
+++ b/crates/evm2/src/ethereum/mod.rs
@@ -149,7 +149,7 @@ pub(super) fn validate_block_gas_limit(
 }
 
 pub(super) const fn validate_tx_gas_limit_cap(
-    version: &Version,
+    version: &'static Version,
     tx_gas_limit: u64,
 ) -> HandlerResult<()> {
     // EIP-7825 caps each transaction gas limit to 2^24 in Osaka. Amsterdam/EIP-8037
@@ -163,7 +163,7 @@ pub(super) const fn validate_tx_gas_limit_cap(
 }
 
 pub(super) const fn validate_regular_gas_limit_cap(
-    version: &Version,
+    version: &'static Version,
     tx_gas_limit: u64,
     intrinsic: u64,
     floor_gas: u64,
@@ -403,7 +403,7 @@ pub(super) fn access_list_counts(access_list: &AccessList) -> (u64, u64) {
 }
 
 /// Calculates transaction calldata floor gas.
-pub(super) fn floor_gas(version: &Version, input: &Bytes) -> u64 {
+pub(super) fn floor_gas(version: &'static Version, input: &Bytes) -> u64 {
     let params = version.gas_params();
     let floor_cost_per_token = u64::from(params.get(GasId::TxFloorCostPerToken));
     if floor_cost_per_token == 0 {
@@ -421,7 +421,7 @@ pub(super) fn floor_gas(version: &Version, input: &Bytes) -> u64 {
 
 /// Calculates intrinsic transaction gas.
 pub(super) fn intrinsic_gas(
-    version: &Version,
+    version: &'static Version,
     to: TxKind,
     input: &Bytes,
     access_list_accounts: u64,
@@ -462,11 +462,11 @@ mod tests {
         let input = Bytes::from(vec![1; 74]);
 
         assert_eq!(
-            intrinsic_gas(&Version::base(SpecId::LONDON), TxKind::Create, &input, 0, 0),
+            intrinsic_gas(Version::base(SpecId::LONDON), TxKind::Create, &input, 0, 0),
             21_000 + 32_000 + 74 * 16
         );
         assert_eq!(
-            intrinsic_gas(&Version::base(SpecId::SHANGHAI), TxKind::Create, &input, 0, 0),
+            intrinsic_gas(Version::base(SpecId::SHANGHAI), TxKind::Create, &input, 0, 0),
             21_000 + 32_000 + 74 * 16 + 3 * 2
         );
     }
@@ -476,13 +476,7 @@ mod tests {
         let input = Bytes::new();
 
         assert_eq!(
-            intrinsic_gas(
-                &Version::base(SpecId::BERLIN),
-                TxKind::Call(Address::ZERO),
-                &input,
-                2,
-                3
-            ),
+            intrinsic_gas(Version::base(SpecId::BERLIN), TxKind::Call(Address::ZERO), &input, 2, 3),
             21_000 + 2 * 2400 + 3 * 1900
         );
     }
@@ -491,8 +485,8 @@ mod tests {
     fn floor_gas_charges_prague_calldata_tokens() {
         let input = Bytes::from_static(&[0, 1, 2]);
 
-        assert_eq!(floor_gas(&Version::base(SpecId::SHANGHAI), &input), 0);
-        assert_eq!(floor_gas(&Version::base(SpecId::PRAGUE), &input), 21_000 + 9 * 10);
+        assert_eq!(floor_gas(Version::base(SpecId::SHANGHAI), &input), 0);
+        assert_eq!(floor_gas(Version::base(SpecId::PRAGUE), &input), 21_000 + 9 * 10);
     }
 
     #[test]
@@ -577,20 +571,20 @@ mod tests {
         let floor_gas = 21_000;
 
         assert_eq!(
-            validate_tx_gas_limit_cap(&osaka, tx_gas_limit),
+            validate_tx_gas_limit_cap(osaka, tx_gas_limit),
             Err(HandlerError::TxGasLimitGreaterThanCap {
                 gas_limit: tx_gas_limit,
                 cap: osaka.tx_gas_limit_cap()
             })
         );
-        assert_eq!(validate_tx_gas_limit_cap(&amsterdam, tx_gas_limit), Ok(()));
+        assert_eq!(validate_tx_gas_limit_cap(amsterdam, tx_gas_limit), Ok(()));
         assert_eq!(
-            validate_regular_gas_limit_cap(&amsterdam, tx_gas_limit, intrinsic, floor_gas),
+            validate_regular_gas_limit_cap(amsterdam, tx_gas_limit, intrinsic, floor_gas),
             Ok(())
         );
         assert_eq!(
             validate_regular_gas_limit_cap(
-                &amsterdam,
+                amsterdam,
                 tx_gas_limit,
                 amsterdam.tx_gas_limit_cap() + 1,
                 floor_gas,

--- a/crates/evm2/src/ethereum/mod.rs
+++ b/crates/evm2/src/ethereum/mod.rs
@@ -155,8 +155,8 @@ pub(super) const fn validate_tx_gas_limit_cap(
     // EIP-7825 caps each transaction gas limit to 2^24 in Osaka. Amsterdam/EIP-8037
     // replaces this with a regular-gas cap while allowing extra transaction gas to serve as
     // the state-gas reservoir.
-    let cap = version.tx_gas_limit_cap();
-    if matches!(version.spec_id(), SpecId::OSAKA) && tx_gas_limit > cap {
+    let cap = version.tx_gas_limit_cap;
+    if matches!(version.spec_id, SpecId::OSAKA) && tx_gas_limit > cap {
         return Err(HandlerError::TxGasLimitGreaterThanCap { gas_limit: tx_gas_limit, cap });
     }
     Ok(())
@@ -168,8 +168,8 @@ pub(super) const fn validate_regular_gas_limit_cap(
     intrinsic: u64,
     floor_gas: u64,
 ) -> HandlerResult<()> {
-    let cap = version.tx_gas_limit_cap();
-    if version.spec_id().enables(SpecId::AMSTERDAM) && tx_gas_limit > cap {
+    let cap = version.tx_gas_limit_cap;
+    if version.spec_id.enables(SpecId::AMSTERDAM) && tx_gas_limit > cap {
         let required_regular_gas = if intrinsic > floor_gas { intrinsic } else { floor_gas };
         if required_regular_gas > cap {
             return Err(HandlerError::TxGasLimitGreaterThanCap {
@@ -404,7 +404,7 @@ pub(super) fn access_list_counts(access_list: &AccessList) -> (u64, u64) {
 
 /// Calculates transaction calldata floor gas.
 pub(super) fn floor_gas(version: &'static Version, input: &Bytes) -> u64 {
-    let params = version.gas_params();
+    let params = &version.gas_params;
     let floor_cost_per_token = u64::from(params.get(GasId::TxFloorCostPerToken));
     if floor_cost_per_token == 0 {
         return 0;
@@ -427,8 +427,8 @@ pub(super) fn intrinsic_gas(
     access_list_accounts: u64,
     access_list_storage_keys: u64,
 ) -> u64 {
-    let spec = version.spec_id();
-    let params = version.gas_params();
+    let spec = version.spec_id;
+    let params = &version.gas_params;
     let non_zero_multiplier = if spec.enables(SpecId::ISTANBUL) { 16 } else { 68 };
     let mut gas = 21_000;
     for byte in input {
@@ -566,7 +566,7 @@ mod tests {
     fn amsterdam_allows_total_gas_above_osaka_cap_when_regular_gas_fits() {
         let osaka = Version::base(SpecId::OSAKA);
         let amsterdam = Version::base(SpecId::AMSTERDAM);
-        let tx_gas_limit = osaka.tx_gas_limit_cap() + 1;
+        let tx_gas_limit = osaka.tx_gas_limit_cap + 1;
         let intrinsic = 21_000;
         let floor_gas = 21_000;
 
@@ -574,7 +574,7 @@ mod tests {
             validate_tx_gas_limit_cap(osaka, tx_gas_limit),
             Err(HandlerError::TxGasLimitGreaterThanCap {
                 gas_limit: tx_gas_limit,
-                cap: osaka.tx_gas_limit_cap()
+                cap: osaka.tx_gas_limit_cap
             })
         );
         assert_eq!(validate_tx_gas_limit_cap(amsterdam, tx_gas_limit), Ok(()));
@@ -586,12 +586,12 @@ mod tests {
             validate_regular_gas_limit_cap(
                 amsterdam,
                 tx_gas_limit,
-                amsterdam.tx_gas_limit_cap() + 1,
+                amsterdam.tx_gas_limit_cap + 1,
                 floor_gas,
             ),
             Err(HandlerError::TxGasLimitGreaterThanCap {
-                gas_limit: amsterdam.tx_gas_limit_cap() + 1,
-                cap: amsterdam.tx_gas_limit_cap()
+                gas_limit: amsterdam.tx_gas_limit_cap + 1,
+                cap: amsterdam.tx_gas_limit_cap
             })
         );
     }

--- a/crates/evm2/src/ethereum/mod.rs
+++ b/crates/evm2/src/ethereum/mod.rs
@@ -155,11 +155,9 @@ pub(super) const fn validate_tx_gas_limit_cap(
     // EIP-7825 caps each transaction gas limit to 2^24 in Osaka. Amsterdam/EIP-8037
     // replaces this with a regular-gas cap while allowing extra transaction gas to serve as
     // the state-gas reservoir.
-    if matches!(version.spec_id(), SpecId::OSAKA) && tx_gas_limit > version.max_tx_gas_limit() {
-        return Err(HandlerError::TxGasLimitGreaterThanCap {
-            gas_limit: tx_gas_limit,
-            cap: version.max_tx_gas_limit(),
-        });
+    let cap = version.tx_gas_limit_cap();
+    if matches!(version.spec_id(), SpecId::OSAKA) && tx_gas_limit > cap {
+        return Err(HandlerError::TxGasLimitGreaterThanCap { gas_limit: tx_gas_limit, cap });
     }
     Ok(())
 }
@@ -170,12 +168,13 @@ pub(super) const fn validate_regular_gas_limit_cap(
     intrinsic: u64,
     floor_gas: u64,
 ) -> HandlerResult<()> {
-    if version.spec_id().enables(SpecId::AMSTERDAM) && tx_gas_limit > version.max_tx_gas_limit() {
+    let cap = version.tx_gas_limit_cap();
+    if version.spec_id().enables(SpecId::AMSTERDAM) && tx_gas_limit > cap {
         let required_regular_gas = if intrinsic > floor_gas { intrinsic } else { floor_gas };
-        if required_regular_gas > version.max_tx_gas_limit() {
+        if required_regular_gas > cap {
             return Err(HandlerError::TxGasLimitGreaterThanCap {
                 gas_limit: required_regular_gas,
-                cap: version.max_tx_gas_limit(),
+                cap,
             });
         }
     }
@@ -573,7 +572,7 @@ mod tests {
     fn amsterdam_allows_total_gas_above_osaka_cap_when_regular_gas_fits() {
         let osaka = Version::base(SpecId::OSAKA);
         let amsterdam = Version::base(SpecId::AMSTERDAM);
-        let tx_gas_limit = osaka.max_tx_gas_limit() + 1;
+        let tx_gas_limit = osaka.tx_gas_limit_cap() + 1;
         let intrinsic = 21_000;
         let floor_gas = 21_000;
 
@@ -581,7 +580,7 @@ mod tests {
             validate_tx_gas_limit_cap(&osaka, tx_gas_limit),
             Err(HandlerError::TxGasLimitGreaterThanCap {
                 gas_limit: tx_gas_limit,
-                cap: osaka.max_tx_gas_limit()
+                cap: osaka.tx_gas_limit_cap()
             })
         );
         assert_eq!(validate_tx_gas_limit_cap(&amsterdam, tx_gas_limit), Ok(()));
@@ -593,12 +592,12 @@ mod tests {
             validate_regular_gas_limit_cap(
                 &amsterdam,
                 tx_gas_limit,
-                amsterdam.max_tx_gas_limit() + 1,
+                amsterdam.tx_gas_limit_cap() + 1,
                 floor_gas,
             ),
             Err(HandlerError::TxGasLimitGreaterThanCap {
-                gas_limit: amsterdam.max_tx_gas_limit() + 1,
-                cap: amsterdam.max_tx_gas_limit()
+                gas_limit: amsterdam.tx_gas_limit_cap() + 1,
+                cap: amsterdam.tx_gas_limit_cap()
             })
         );
     }

--- a/crates/evm2/src/ethereum/mod.rs
+++ b/crates/evm2/src/ethereum/mod.rs
@@ -23,8 +23,6 @@ use alloy_consensus::{
 use alloy_eips::{eip2718::Typed2718, eip2930::AccessList};
 use alloy_primitives::{Address, B256, Bytes, KECCAK256_EMPTY, TxKind, U256};
 
-const EIP7825_TX_GAS_LIMIT_CAP: u64 = 16_777_216;
-
 /// Ethereum transaction envelope containing recovered transactions.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum RecoveredTxEnvelope {
@@ -151,33 +149,33 @@ pub(super) fn validate_block_gas_limit(
 }
 
 pub(super) const fn validate_tx_gas_limit_cap(
-    spec_id: SpecId,
+    version: &Version,
     tx_gas_limit: u64,
 ) -> HandlerResult<()> {
     // EIP-7825 caps each transaction gas limit to 2^24 in Osaka. Amsterdam/EIP-8037
     // replaces this with a regular-gas cap while allowing extra transaction gas to serve as
     // the state-gas reservoir.
-    if matches!(spec_id, SpecId::OSAKA) && tx_gas_limit > EIP7825_TX_GAS_LIMIT_CAP {
+    if matches!(version.spec_id(), SpecId::OSAKA) && tx_gas_limit > version.max_tx_gas_limit() {
         return Err(HandlerError::TxGasLimitGreaterThanCap {
             gas_limit: tx_gas_limit,
-            cap: EIP7825_TX_GAS_LIMIT_CAP,
+            cap: version.max_tx_gas_limit(),
         });
     }
     Ok(())
 }
 
 pub(super) const fn validate_regular_gas_limit_cap(
-    spec_id: SpecId,
+    version: &Version,
     tx_gas_limit: u64,
     intrinsic: u64,
     floor_gas: u64,
 ) -> HandlerResult<()> {
-    if spec_id.enables(SpecId::AMSTERDAM) && tx_gas_limit > EIP7825_TX_GAS_LIMIT_CAP {
+    if version.spec_id().enables(SpecId::AMSTERDAM) && tx_gas_limit > version.max_tx_gas_limit() {
         let required_regular_gas = if intrinsic > floor_gas { intrinsic } else { floor_gas };
-        if required_regular_gas > EIP7825_TX_GAS_LIMIT_CAP {
+        if required_regular_gas > version.max_tx_gas_limit() {
             return Err(HandlerError::TxGasLimitGreaterThanCap {
                 gas_limit: required_regular_gas,
-                cap: EIP7825_TX_GAS_LIMIT_CAP,
+                cap: version.max_tx_gas_limit(),
             });
         }
     }
@@ -573,32 +571,34 @@ mod tests {
 
     #[test]
     fn amsterdam_allows_total_gas_above_osaka_cap_when_regular_gas_fits() {
-        let tx_gas_limit = EIP7825_TX_GAS_LIMIT_CAP + 1;
+        let osaka = Version::base(SpecId::OSAKA);
+        let amsterdam = Version::base(SpecId::AMSTERDAM);
+        let tx_gas_limit = osaka.max_tx_gas_limit() + 1;
         let intrinsic = 21_000;
         let floor_gas = 21_000;
 
         assert_eq!(
-            validate_tx_gas_limit_cap(SpecId::OSAKA, tx_gas_limit),
+            validate_tx_gas_limit_cap(&osaka, tx_gas_limit),
             Err(HandlerError::TxGasLimitGreaterThanCap {
                 gas_limit: tx_gas_limit,
-                cap: EIP7825_TX_GAS_LIMIT_CAP
+                cap: osaka.max_tx_gas_limit()
             })
         );
-        assert_eq!(validate_tx_gas_limit_cap(SpecId::AMSTERDAM, tx_gas_limit), Ok(()));
+        assert_eq!(validate_tx_gas_limit_cap(&amsterdam, tx_gas_limit), Ok(()));
         assert_eq!(
-            validate_regular_gas_limit_cap(SpecId::AMSTERDAM, tx_gas_limit, intrinsic, floor_gas),
+            validate_regular_gas_limit_cap(&amsterdam, tx_gas_limit, intrinsic, floor_gas),
             Ok(())
         );
         assert_eq!(
             validate_regular_gas_limit_cap(
-                SpecId::AMSTERDAM,
+                &amsterdam,
                 tx_gas_limit,
-                EIP7825_TX_GAS_LIMIT_CAP + 1,
+                amsterdam.max_tx_gas_limit() + 1,
                 floor_gas,
             ),
             Err(HandlerError::TxGasLimitGreaterThanCap {
-                gas_limit: EIP7825_TX_GAS_LIMIT_CAP + 1,
-                cap: EIP7825_TX_GAS_LIMIT_CAP
+                gas_limit: amsterdam.max_tx_gas_limit() + 1,
+                cap: amsterdam.max_tx_gas_limit()
             })
         );
     }

--- a/crates/evm2/src/evm/config.rs
+++ b/crates/evm2/src/evm/config.rs
@@ -44,7 +44,7 @@ pub trait EvmTypes: Sized + 'static {
 /// type-specific `VersionTables` needed to build dispatch tables.
 pub trait EvmConfig<T: EvmTypes> {
     /// Active EVM version.
-    const VERSION: Version;
+    const VERSION: &'static Version;
 
     /// Active type-specific version tables.
     const VERSION_TABLES: &'static VersionTables<T>;
@@ -78,7 +78,7 @@ pub trait EvmConfigSelector<T: EvmTypes>: Sized {
 /// an EVM instance. This is the data passed to the interpreter when it runs.
 #[derive(derive_more::Debug)]
 pub struct ExecutionConfig<T: EvmTypes> {
-    pub(crate) version: Version,
+    pub(crate) version: &'static Version,
     #[debug(skip)]
     pub(crate) instructions: &'static InstructionTable<T>,
 }
@@ -112,8 +112,8 @@ impl<T: EvmTypes> ExecutionConfig<T> {
 
     /// Returns the active EVM version.
     #[inline]
-    pub const fn version(&self) -> &Version {
-        &self.version
+    pub const fn version(&self) -> &'static Version {
+        self.version
     }
 }
 
@@ -137,7 +137,7 @@ impl<Tx: 'static> EvmTypes for BaseEvmTypes<Tx> {
 pub struct BaseEvmConfig<const BASE_SPEC_ID: u8>(());
 
 impl<T: EvmTypes, const BASE_SPEC_ID: u8> EvmConfig<T> for BaseEvmConfig<BASE_SPEC_ID> {
-    const VERSION: Version = Version::base(SpecId::try_from_u8(BASE_SPEC_ID).unwrap());
+    const VERSION: &'static Version = Version::base(SpecId::try_from_u8(BASE_SPEC_ID).unwrap());
     const VERSION_TABLES: &'static VersionTables<T> = &VersionTables::<T>::base::<Self>();
 }
 

--- a/crates/evm2/src/evm/config.rs
+++ b/crates/evm2/src/evm/config.rs
@@ -52,7 +52,7 @@ pub trait EvmConfig<T: EvmTypes> {
     /// Active base specification ID.
     #[inline]
     fn spec_id() -> SpecId {
-        Self::VERSION.spec_id()
+        Self::VERSION.spec_id
     }
 }
 

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -243,7 +243,7 @@ impl<T: EvmTypes> Evm<T> {
     }
 
     /// Returns the active EVM version.
-    pub const fn version(&self) -> &crate::Version {
+    pub const fn version(&self) -> &'static crate::Version {
         self.execution_config.version()
     }
 

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -249,7 +249,7 @@ impl<T: EvmTypes> Evm<T> {
 
     /// Returns the active base specification ID.
     pub const fn spec_id(&self) -> SpecId {
-        self.version().spec_id()
+        self.version().spec_id
     }
 
     /// Returns the selector-specific runtime specification ID.
@@ -368,9 +368,9 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
             {
                 Some(InstrStop::CreateContractStartingWithEF)
             } else {
-                let code_deposit_gas = output.len().saturating_mul(
-                    self.version().gas_params().get(GasId::CodeDepositCost) as usize,
-                );
+                let code_deposit_gas = output
+                    .len()
+                    .saturating_mul(self.version().gas_params.get(GasId::CodeDepositCost) as usize);
                 let code_deposit_gas = u64::try_from(code_deposit_gas).unwrap_or(u64::MAX);
                 if gas.remaining() >= code_deposit_gas {
                     gas.spend(code_deposit_gas).err()

--- a/crates/evm2/src/interpreter/instructions/system.rs
+++ b/crates/evm2/src/interpreter/instructions/system.rs
@@ -2,8 +2,10 @@
 
 use crate::{
     EvmTypes, SpecId,
-    bytecode::{EIP7702_BYTECODE_LEN, EIP7702_MAGIC_BYTES, EIP7702_VERSION},
-    constants::{CALL_DEPTH_LIMIT, MAX_INITCODE_SIZE},
+    constants::{
+        CALL_DEPTH_LIMIT, EIP7702_BYTECODE_LEN, EIP7702_MAGIC_BYTES, EIP7702_VERSION,
+        MAX_INITCODE_SIZE,
+    },
     interpreter::{
         Host, InstrStop, InstructionCx, Message, MessageKind, MessageResult, Result, StackMut,
         Word, memory::resize_memory,

--- a/crates/evm2/src/interpreter/runtime.rs
+++ b/crates/evm2/src/interpreter/runtime.rs
@@ -207,7 +207,7 @@ impl<'frame, T: EvmTypes> Interpreter<'frame, T> {
             &mut State {
                 bytecode,
                 host,
-                spec: config.version.spec_id(),
+                spec: config.version.spec_id,
                 version: config.version,
                 raw_interp: raw,
             },
@@ -232,7 +232,7 @@ impl<'frame, T: EvmTypes> Interpreter<'frame, T> {
             &mut State {
                 bytecode,
                 host,
-                spec: config.version.spec_id(),
+                spec: config.version.spec_id,
                 version: config.version,
                 raw_interp: raw,
             },

--- a/crates/evm2/src/interpreter/state.rs
+++ b/crates/evm2/src/interpreter/state.rs
@@ -63,7 +63,7 @@ impl<'a, T: EvmTypes> State<'a, T> {
         // Gas params are data on the active version so changes automatically affect every
         // instruction that reads them. Tracking instruction dependencies on version tables is not
         // sustainable for custom forks.
-        self.version.gas_params()
+        &self.version.gas_params
     }
 
     /// Returns linear memory.

--- a/crates/evm2/src/interpreter/state.rs
+++ b/crates/evm2/src/interpreter/state.rs
@@ -18,7 +18,7 @@ pub struct State<'a, T: EvmTypes> {
     /// Active spec identifier.
     pub spec: SpecId,
     /// Active runtime version data.
-    pub version: Version,
+    pub version: &'static Version,
     pub(crate) raw_interp: *mut Interpreter<'a, T>,
 }
 

--- a/crates/evm2/src/lib.rs
+++ b/crates/evm2/src/lib.rs
@@ -11,7 +11,7 @@ extern crate self as evm2;
 extern crate alloc;
 
 pub mod bytecode;
-pub(crate) mod constants;
+pub mod constants;
 pub mod ethereum;
 pub mod interpreter;
 pub mod utils;

--- a/crates/evm2/src/lib.rs
+++ b/crates/evm2/src/lib.rs
@@ -11,7 +11,7 @@ extern crate self as evm2;
 extern crate alloc;
 
 pub mod bytecode;
-pub mod constants;
+pub(crate) mod constants;
 pub mod ethereum;
 pub mod interpreter;
 pub mod utils;

--- a/crates/evm2/src/version/gas_params.rs
+++ b/crates/evm2/src/version/gas_params.rs
@@ -406,7 +406,7 @@ mod tests {
     use crate::{SpecId, Version};
 
     fn gas_params(spec: SpecId) -> &'static GasParams {
-        Version::base(spec).gas_params()
+        &Version::base(spec).gas_params
     }
 
     #[test]

--- a/crates/evm2/src/version/mod.rs
+++ b/crates/evm2/src/version/mod.rs
@@ -33,24 +33,6 @@ impl Version {
     pub const fn base(spec_id: SpecId) -> &'static Self {
         &BASE_VERSIONS[spec_id as usize]
     }
-
-    /// Returns the base specification ID for this version.
-    #[inline]
-    pub const fn spec_id(&self) -> SpecId {
-        self.spec_id
-    }
-
-    /// Returns the dynamic gas parameter table for this version.
-    #[inline]
-    pub const fn gas_params(&'static self) -> &'static GasParams {
-        &self.gas_params
-    }
-
-    /// Returns the transaction gas limit cap for this version.
-    #[inline]
-    pub const fn tx_gas_limit_cap(&self) -> u64 {
-        self.tx_gas_limit_cap
-    }
 }
 
 const fn base_tx_gas_limit_cap(spec_id: SpecId) -> u64 {
@@ -111,7 +93,7 @@ macro_rules! evm_versions {
             use crate::interpreter::gas::*;
 
             let version = Cfg::VERSION;
-            let spec_id = version.spec_id();
+            let spec_id = version.spec_id;
             let mut v = VersionTables::empty(version);
 
             macro_rules! op {

--- a/crates/evm2/src/version/mod.rs
+++ b/crates/evm2/src/version/mod.rs
@@ -14,33 +14,23 @@ pub use tables::VersionTables;
 
 /// Runtime version data.
 ///
-/// Holds the active base `SpecId` and dynamic gas parameter table. This is copied into execution
-/// state so instructions can read version-dependent runtime parameters without monomorphization.
+/// Holds the active base `SpecId` and dynamic gas parameter table so instructions can read
+/// version-dependent runtime parameters without monomorphization.
 #[derive(Clone, Copy, Debug)]
 pub struct Version {
     /// Active base specification ID.
     spec_id: SpecId,
     /// Dynamic gas parameter table.
-    gas_params: &'static GasParams,
+    gas_params: GasParams,
     /// Transaction gas limit cap.
     tx_gas_limit_cap: u64,
 }
 
 impl Version {
-    /// Creates an EVM version from a base spec ID, gas parameter table, and transaction gas cap.
-    #[inline]
-    pub const fn new(
-        spec_id: SpecId,
-        gas_params: &'static GasParams,
-        tx_gas_limit_cap: u64,
-    ) -> Self {
-        Self { spec_id, gas_params, tx_gas_limit_cap }
-    }
-
     /// Returns the base EVM version for `spec_id`.
     #[inline]
-    pub const fn base(spec_id: SpecId) -> Self {
-        Self::new(spec_id, &BASE_GAS_PARAMS[spec_id as usize], base_tx_gas_limit_cap(spec_id))
+    pub const fn base(spec_id: SpecId) -> &'static Self {
+        &BASE_VERSIONS[spec_id as usize]
     }
 
     /// Returns the base specification ID for this version.
@@ -51,8 +41,8 @@ impl Version {
 
     /// Returns the dynamic gas parameter table for this version.
     #[inline]
-    pub const fn gas_params(&self) -> &'static GasParams {
-        self.gas_params
+    pub const fn gas_params(&'static self) -> &'static GasParams {
+        &self.gas_params
     }
 
     /// Returns the transaction gas limit cap for this version.
@@ -66,14 +56,25 @@ const fn base_tx_gas_limit_cap(spec_id: SpecId) -> u64 {
     if spec_id.enables(SpecId::OSAKA) { MAX_TX_GAS_LIMIT_OSAKA } else { u64::MAX }
 }
 
-static BASE_GAS_PARAMS: [GasParams; SpecId::COUNT] = {
-    let mut params = [const { GasParams::empty() }; SpecId::COUNT];
+static BASE_VERSIONS: [Version; SpecId::COUNT] = {
+    let mut versions = [const {
+        Version {
+            spec_id: SpecId::FRONTIER,
+            gas_params: GasParams::empty(),
+            tx_gas_limit_cap: u64::MAX,
+        }
+    }; SpecId::COUNT];
     let mut i = 0;
     while i < SpecId::COUNT {
-        params[i] = base_gas_params(SpecId::try_from_u8(i as u8).unwrap());
+        let spec_id = SpecId::try_from_u8(i as u8).unwrap();
+        versions[i] = Version {
+            spec_id,
+            gas_params: base_gas_params(spec_id),
+            tx_gas_limit_cap: base_tx_gas_limit_cap(spec_id),
+        };
         i += 1;
     }
-    params
+    versions
 };
 
 macro_rules! noop {

--- a/crates/evm2/src/version/mod.rs
+++ b/crates/evm2/src/version/mod.rs
@@ -17,13 +17,14 @@ pub use tables::VersionTables;
 /// Holds the active base `SpecId` and dynamic gas parameter table so instructions can read
 /// version-dependent runtime parameters without monomorphization.
 #[derive(Clone, Copy, Debug)]
+#[non_exhaustive]
 pub struct Version {
     /// Active base specification ID.
-    spec_id: SpecId,
+    pub spec_id: SpecId,
     /// Dynamic gas parameter table.
-    gas_params: GasParams,
+    pub gas_params: GasParams,
     /// Transaction gas limit cap.
-    tx_gas_limit_cap: u64,
+    pub tx_gas_limit_cap: u64,
 }
 
 impl Version {

--- a/crates/evm2/src/version/mod.rs
+++ b/crates/evm2/src/version/mod.rs
@@ -4,6 +4,7 @@ use crate::{
     EvmConfig, EvmTypes, SpecId,
     interpreter::{instructions as instr, opcode::op},
 };
+use alloy_eips::eip7825::MAX_TX_GAS_LIMIT_OSAKA;
 
 mod gas_params;
 pub use gas_params::{GasId, GasParams};
@@ -21,19 +22,25 @@ pub struct Version {
     spec_id: SpecId,
     /// Dynamic gas parameter table.
     gas_params: &'static GasParams,
+    /// Maximum transaction gas limit.
+    max_tx_gas_limit: u64,
 }
 
 impl Version {
-    /// Creates an EVM version from a base spec ID and gas parameter table.
+    /// Creates an EVM version from a base spec ID, gas parameter table, and transaction gas limit.
     #[inline]
-    pub const fn new(spec_id: SpecId, gas_params: &'static GasParams) -> Self {
-        Self { spec_id, gas_params }
+    pub const fn new(
+        spec_id: SpecId,
+        gas_params: &'static GasParams,
+        max_tx_gas_limit: u64,
+    ) -> Self {
+        Self { spec_id, gas_params, max_tx_gas_limit }
     }
 
     /// Returns the base EVM version for `spec_id`.
     #[inline]
     pub const fn base(spec_id: SpecId) -> Self {
-        Self::new(spec_id, &BASE_GAS_PARAMS[spec_id as usize])
+        Self::new(spec_id, &BASE_GAS_PARAMS[spec_id as usize], base_max_tx_gas_limit(spec_id))
     }
 
     /// Returns the base specification ID for this version.
@@ -47,6 +54,16 @@ impl Version {
     pub const fn gas_params(&self) -> &'static GasParams {
         self.gas_params
     }
+
+    /// Returns the maximum transaction gas limit for this version.
+    #[inline]
+    pub const fn max_tx_gas_limit(&self) -> u64 {
+        self.max_tx_gas_limit
+    }
+}
+
+const fn base_max_tx_gas_limit(spec_id: SpecId) -> u64 {
+    if spec_id.enables(SpecId::OSAKA) { MAX_TX_GAS_LIMIT_OSAKA } else { u64::MAX }
 }
 
 static BASE_GAS_PARAMS: [GasParams; SpecId::COUNT] = {

--- a/crates/evm2/src/version/mod.rs
+++ b/crates/evm2/src/version/mod.rs
@@ -22,25 +22,25 @@ pub struct Version {
     spec_id: SpecId,
     /// Dynamic gas parameter table.
     gas_params: &'static GasParams,
-    /// Maximum transaction gas limit.
-    max_tx_gas_limit: u64,
+    /// Transaction gas limit cap.
+    tx_gas_limit_cap: u64,
 }
 
 impl Version {
-    /// Creates an EVM version from a base spec ID, gas parameter table, and transaction gas limit.
+    /// Creates an EVM version from a base spec ID, gas parameter table, and transaction gas cap.
     #[inline]
     pub const fn new(
         spec_id: SpecId,
         gas_params: &'static GasParams,
-        max_tx_gas_limit: u64,
+        tx_gas_limit_cap: u64,
     ) -> Self {
-        Self { spec_id, gas_params, max_tx_gas_limit }
+        Self { spec_id, gas_params, tx_gas_limit_cap }
     }
 
     /// Returns the base EVM version for `spec_id`.
     #[inline]
     pub const fn base(spec_id: SpecId) -> Self {
-        Self::new(spec_id, &BASE_GAS_PARAMS[spec_id as usize], base_max_tx_gas_limit(spec_id))
+        Self::new(spec_id, &BASE_GAS_PARAMS[spec_id as usize], base_tx_gas_limit_cap(spec_id))
     }
 
     /// Returns the base specification ID for this version.
@@ -55,14 +55,14 @@ impl Version {
         self.gas_params
     }
 
-    /// Returns the maximum transaction gas limit for this version.
+    /// Returns the transaction gas limit cap for this version.
     #[inline]
-    pub const fn max_tx_gas_limit(&self) -> u64 {
-        self.max_tx_gas_limit
+    pub const fn tx_gas_limit_cap(&self) -> u64 {
+        self.tx_gas_limit_cap
     }
 }
 
-const fn base_max_tx_gas_limit(spec_id: SpecId) -> u64 {
+const fn base_tx_gas_limit_cap(spec_id: SpecId) -> u64 {
     if spec_id.enables(SpecId::OSAKA) { MAX_TX_GAS_LIMIT_OSAKA } else { u64::MAX }
 }
 

--- a/crates/evm2/src/version/tables.rs
+++ b/crates/evm2/src/version/tables.rs
@@ -10,7 +10,7 @@ use core::fmt;
 /// These tables are compile-time inputs used to build the final interpreter dispatch table.
 pub struct VersionTables<T: EvmTypes> {
     /// Active EVM version.
-    version: Version,
+    version: &'static Version,
     /// Static opcode gas table.
     static_gas_table: StaticGasTable,
     /// Instruction implementations.
@@ -31,7 +31,7 @@ impl<T: EvmTypes> VersionTables<T> {
 
     /// Creates empty type-specific version tables.
     #[inline]
-    pub(super) const fn empty(version: Version) -> Self {
+    pub(super) const fn empty(version: &'static Version) -> Self {
         Self {
             version,
             static_gas_table: StaticGasTable::empty(),
@@ -41,8 +41,8 @@ impl<T: EvmTypes> VersionTables<T> {
 
     /// Returns the active EVM version.
     #[inline]
-    pub const fn version(&self) -> &Version {
-        &self.version
+    pub const fn version(&self) -> &'static Version {
+        self.version
     }
 
     /// Returns the static gas cost for `opcode`.


### PR DESCRIPTION
Adds the EIP-7825 transaction gas limit cap to `Version` so transaction validation reads the cap from active version data instead of a local Ethereum-module constant.

This follows revm's config shape by exposing the value through `tx_gas_limit_cap()`: base versions use the spec default cap, and execution carries a `&'static Version`. `Version` stores gas params inline and is selected through `Version::base`, with no public constructor. The EIP-7702 bytecode constants are also centralized in the top-level constants module while keeping the explicit local bytecode constants.
