### PR TITLE
perf: track log rollback in state checkpoints

### DIFF
--- a/crates/evm2/src/ethereum/mod.rs
+++ b/crates/evm2/src/ethereum/mod.rs
@@ -10,7 +10,7 @@ use crate::{
     Evm, EvmTypes, SpecId, TxResult, Version,
     bytecode::Bytecode,
     constants::MAX_INITCODE_SIZE,
-    evm::{AccountInfo, precompile::PrecompileProvider},
+    evm::{AccountInfo, Checkpoint, precompile::PrecompileProvider},
     interpreter::{Message, MessageKind, MessageResult, Word},
     registry::{HandlerError, HandlerResult, TxRegistry},
     utils::num_words,
@@ -348,7 +348,7 @@ fn initial_call_code<T: EvmTypes<Host = Evm<T>>>(
 
 pub(super) fn rollback_failed_execution<T: EvmTypes<Host = Evm<T>>>(
     host: &mut Evm<T>,
-    checkpoint: usize,
+    checkpoint: Checkpoint,
     result: &mut MessageResult,
 ) {
     if !result.stop.is_success() {

--- a/crates/evm2/src/ethereum/mod.rs
+++ b/crates/evm2/src/ethereum/mod.rs
@@ -10,7 +10,7 @@ use crate::{
     Evm, EvmTypes, SpecId, TxResult, Version,
     bytecode::Bytecode,
     constants::MAX_INITCODE_SIZE,
-    evm::{AccountInfo, Checkpoint, precompile::PrecompileProvider},
+    evm::{AccountInfo, StateCheckpoint, precompile::PrecompileProvider},
     interpreter::{Message, MessageKind, MessageResult, Word},
     registry::{HandlerError, HandlerResult, TxRegistry},
     utils::num_words,
@@ -348,7 +348,7 @@ fn initial_call_code<T: EvmTypes<Host = Evm<T>>>(
 
 pub(super) fn rollback_failed_execution<T: EvmTypes<Host = Evm<T>>>(
     host: &mut Evm<T>,
-    checkpoint: Checkpoint,
+    checkpoint: StateCheckpoint,
     result: &mut MessageResult,
 ) {
     if !result.stop.is_success() {

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -26,8 +26,8 @@ pub use db::{Cache, CacheDB, Database, EmptyDB, InMemoryDB};
 
 mod state;
 pub use state::{
-    Account, AccountInfo, JournalEntry, State, StateChanges, StorageChangeSet, StorageOverlay,
-    Tracked,
+    Account, AccountInfo, Checkpoint, JournalEntry, State, StateChanges, StorageChangeSet,
+    StorageOverlay, Tracked,
 };
 
 /// Loaded account information.

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -26,7 +26,7 @@ pub use db::{Cache, CacheDB, Database, EmptyDB, InMemoryDB};
 
 mod state;
 pub use state::{
-    Account, AccountInfo, Checkpoint, JournalEntry, State, StateChanges, StorageChangeSet,
+    Account, AccountInfo, JournalEntry, State, StateChanges, StateCheckpoint, StorageChangeSet,
     StorageOverlay, Tracked,
 };
 

--- a/crates/evm2/src/evm/state.rs
+++ b/crates/evm2/src/evm/state.rs
@@ -238,10 +238,10 @@ pub struct StorageChangeSet {
     pub slots: BTreeMap<Word, Tracked<Word>>,
 }
 
-/// Checkpoint for reverting state changes.
+/// State checkpoint for reverting state changes.
 #[allow(missing_copy_implementations)]
 #[derive(Debug, Eq, PartialEq)]
-pub struct Checkpoint {
+pub struct StateCheckpoint {
     /// Revert journal length at the checkpoint.
     journal_len: usize,
     /// Emitted log count at the checkpoint.
@@ -378,8 +378,8 @@ impl<D> State<D> {
 
     /// Returns a checkpoint for later rollback.
     #[inline]
-    pub const fn checkpoint(&self) -> Checkpoint {
-        Checkpoint { journal_len: self.journal.len(), logs_len: self.logs.len() }
+    pub const fn checkpoint(&self) -> StateCheckpoint {
+        StateCheckpoint { journal_len: self.journal.len(), logs_len: self.logs.len() }
     }
 
     /// Returns the initial database.
@@ -835,7 +835,7 @@ impl<D: Database> State<D> {
 
     /// Reverts state changes after the checkpoint.
     #[inline(never)]
-    pub fn rollback(&mut self, checkpoint: Checkpoint, spec: SpecId) {
+    pub fn rollback(&mut self, checkpoint: StateCheckpoint, spec: SpecId) {
         assert!(checkpoint.journal_len <= self.journal.len(), "checkpoint is past journal length");
         assert!(checkpoint.logs_len <= self.logs.len(), "checkpoint is past logs length");
         self.logs.truncate(checkpoint.logs_len);

--- a/crates/evm2/src/evm/state.rs
+++ b/crates/evm2/src/evm/state.rs
@@ -238,6 +238,16 @@ pub struct StorageChangeSet {
     pub slots: BTreeMap<Word, Tracked<Word>>,
 }
 
+/// Checkpoint for reverting state changes.
+#[allow(missing_copy_implementations)]
+#[derive(Debug, Eq, PartialEq)]
+pub struct Checkpoint {
+    /// Revert journal length at the checkpoint.
+    journal_len: usize,
+    /// Emitted log count at the checkpoint.
+    logs_len: usize,
+}
+
 /// Compact journal entry for reverting state changes.
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[non_exhaustive]
@@ -308,11 +318,6 @@ pub enum JournalEntry {
         /// Storage key.
         key: Word,
     },
-    /// Log was emitted.
-    Log {
-        /// Log index before emission.
-        index: usize,
-    },
 }
 
 /// Mutable EVM state with an overlay and reversible journal.
@@ -373,8 +378,8 @@ impl<D> State<D> {
 
     /// Returns a checkpoint for later rollback.
     #[inline]
-    pub const fn checkpoint(&self) -> usize {
-        self.journal.len()
+    pub const fn checkpoint(&self) -> Checkpoint {
+        Checkpoint { journal_len: self.journal.len(), logs_len: self.logs.len() }
     }
 
     /// Returns the initial database.
@@ -395,11 +400,9 @@ impl<D> State<D> {
         &self.logs
     }
 
-    /// Records a transaction log and journals it for rollback.
+    /// Records a transaction log.
     #[inline]
     pub fn log(&mut self, log: Log) {
-        let index = self.logs.len();
-        self.journal.push(JournalEntry::Log { index });
         self.logs.push(log);
     }
 
@@ -832,9 +835,11 @@ impl<D: Database> State<D> {
 
     /// Reverts state changes after the checkpoint.
     #[inline(never)]
-    pub fn rollback(&mut self, checkpoint: usize, spec: SpecId) {
-        assert!(checkpoint <= self.journal.len(), "checkpoint is past journal length");
-        while self.journal.len() != checkpoint {
+    pub fn rollback(&mut self, checkpoint: Checkpoint, spec: SpecId) {
+        assert!(checkpoint.journal_len <= self.journal.len(), "checkpoint is past journal length");
+        assert!(checkpoint.logs_len <= self.logs.len(), "checkpoint is past logs length");
+        self.logs.truncate(checkpoint.logs_len);
+        while self.journal.len() != checkpoint.journal_len {
             let Some(entry) = self.journal.pop() else {
                 unreachable!("checkpoint is checked above")
             };
@@ -892,9 +897,6 @@ impl<D: Database> State<D> {
                 }
                 JournalEntry::StorageWarmed { address, key } => {
                     self.accessed_storage.remove(&(address, key));
-                }
-                JournalEntry::Log { index } => {
-                    self.logs.truncate(index);
                 }
             }
         }


### PR DESCRIPTION
Adds a State checkpoint type that captures both journal and log positions. Logs no longer occupy journal entries; rollback truncates emitted logs from the checkpoint instead.