### PR TITLE
feat: add memory limit to version

### DIFF
--- a/crates/evm2/src/interpreter/instructions/memory.rs
+++ b/crates/evm2/src/interpreter/instructions/memory.rs
@@ -45,10 +45,10 @@ pub(crate) fn mcopy(cx: _, [dst, src, len]: [Word]) -> Result {
 #[cfg(test)]
 mod tests {
     use crate::{
-        SpecId,
+        EvmConfig, SpecId, Version, VersionTables,
         interpreter::{
             InstrStop, Word,
-            instructions::tests::{RunConfig, push, run, run_stack},
+            instructions::tests::{RunConfig, TestTypes, push, run, run_stack, run_with_config},
             op,
         },
     };
@@ -91,6 +91,32 @@ mod tests {
 
         let interpreter = run_stack([Word::MAX, Word::from(0)], op::MSTORE);
         core::assert_matches!(interpreter.err, InstrStop::InvalidOperandOOG);
+    }
+
+    #[test]
+    fn mstore_respects_version_memory_limit() {
+        struct Config;
+
+        impl EvmConfig<TestTypes> for Config {
+            const VERSION: &'static Version = &{
+                let mut version = *Version::base(SpecId::OSAKA);
+                version.memory_limit = 64;
+                version
+            };
+            const VERSION_TABLES: &'static VersionTables<TestTypes> =
+                &VersionTables::<TestTypes>::base::<Self>();
+        }
+
+        let mut code = Vec::new();
+        push(&mut code, Word::ZERO);
+        push(&mut code, Word::from(64));
+        code.push(op::MSTORE);
+        code.push(op::STOP);
+
+        let interpreter = run_with_config::<Config>(RunConfig::new(code));
+
+        core::assert_matches!(interpreter.err, InstrStop::MemoryLimitOOG);
+        assert_eq!(interpreter.memory.len(), 0);
     }
 
     #[test]

--- a/crates/evm2/src/interpreter/instructions/tests.rs
+++ b/crates/evm2/src/interpreter/instructions/tests.rs
@@ -284,7 +284,7 @@ pub(super) fn run(config: RunConfig<'_>) -> TestInterpreter {
     })
 }
 
-fn run_with_config<C: EvmConfig<TestTypes>>(config: RunConfig<'_>) -> TestInterpreter {
+pub(super) fn run_with_config<C: EvmConfig<TestTypes>>(config: RunConfig<'_>) -> TestInterpreter {
     let RunConfig { code, host, spec_id: _, tx_env, mut message, gas_limit, return_data } = config;
     let bytecode = Bytecode::new_legacy(Bytes::from(code));
     message.gas_limit = gas_limit;

--- a/crates/evm2/src/interpreter/memory.rs
+++ b/crates/evm2/src/interpreter/memory.rs
@@ -35,12 +35,6 @@ impl Memory {
         Self { data: Vec::with_capacity(capacity), memory_limit: u64::MAX }
     }
 
-    /// Creates memory with a byte limit.
-    #[inline]
-    pub fn new_with_memory_limit(memory_limit: u64) -> Self {
-        Self { memory_limit, ..Self::new() }
-    }
-
     /// Sets the memory byte limit.
     #[inline]
     pub const fn set_memory_limit(&mut self, limit: u64) {
@@ -268,7 +262,8 @@ mod tests {
     #[test]
     fn resize_memory_respects_memory_limit() {
         let mut gas = Gas::new(100_000);
-        let mut memory = Memory::new_with_memory_limit(64);
+        let mut memory = Memory::new();
+        memory.set_memory_limit(64);
 
         resize_memory(&mut gas, &mut memory, 0, 32).unwrap();
         assert_eq!(memory.len(), 32);

--- a/crates/evm2/src/interpreter/runtime.rs
+++ b/crates/evm2/src/interpreter/runtime.rs
@@ -149,6 +149,7 @@ impl<'frame, T: EvmTypes> Interpreter<'frame, T> {
     /// Runs the interpreter until it stops.
     pub fn run_with(&mut self, config: ExecutionConfig<T>, host: &mut T::Host) -> InstrStop {
         let _gas_start = self.gas.remaining();
+        self.memory.set_memory_limit(config.version.memory_limit);
 
         #[cfg(feature = "nightly")]
         let r = self.step_tail(config, host);

--- a/crates/evm2/src/version/mod.rs
+++ b/crates/evm2/src/version/mod.rs
@@ -25,6 +25,8 @@ pub struct Version {
     pub gas_params: GasParams,
     /// Transaction gas limit cap.
     pub tx_gas_limit_cap: u64,
+    /// Hard memory limit in bytes.
+    pub memory_limit: u64,
 }
 
 impl Version {
@@ -39,12 +41,15 @@ const fn base_tx_gas_limit_cap(spec_id: SpecId) -> u64 {
     if spec_id.enables(SpecId::OSAKA) { MAX_TX_GAS_LIMIT_OSAKA } else { u64::MAX }
 }
 
+const DEFAULT_MEMORY_LIMIT: u64 = (1 << 32) - 1;
+
 static BASE_VERSIONS: [Version; SpecId::COUNT] = {
     let mut versions = [const {
         Version {
             spec_id: SpecId::FRONTIER,
             gas_params: GasParams::empty(),
             tx_gas_limit_cap: u64::MAX,
+            memory_limit: DEFAULT_MEMORY_LIMIT,
         }
     }; SpecId::COUNT];
     let mut i = 0;
@@ -54,6 +59,7 @@ static BASE_VERSIONS: [Version; SpecId::COUNT] = {
             spec_id,
             gas_params: base_gas_params(spec_id),
             tx_gas_limit_cap: base_tx_gas_limit_cap(spec_id),
+            memory_limit: DEFAULT_MEMORY_LIMIT,
         };
         i += 1;
     }


### PR DESCRIPTION
Adds memory_limit to Version so custom EVM versions can configure the interpreter memory cap the same way they already configure gas params and transaction gas limit caps. Base versions default to the revm memory-limit default of 2^32 - 1 bytes.

Interpreter runs now apply the active version's memory limit before execution starts. The old direct Memory constructor for a limited instance is removed in favor of setting the limit through version configuration, with the remaining memory unit test using set_memory_limit directly.
