### PR TITLE
feat: allow dynamic version config

### DIFF
--- a/crates/evm2/examples/custom_evm.rs
+++ b/crates/evm2/examples/custom_evm.rs
@@ -159,20 +159,15 @@ fn custom_registry() -> TxRegistry<CustomTx, evm2::TxResult, Evm<CustomTypes>> {
 #[derive(Debug)]
 struct Args {
     spec_id: CustomSpecId,
-    memory_limit: Option<u64>,
+    version: Version,
 }
 
 impl Args {
     fn parse() -> Self {
-        Self { spec_id: CustomSpecId::CustomOsaka, memory_limit: Some(1 << 20) }
-    }
-
-    fn version(&self) -> Version {
-        let mut version = custom_version(self.spec_id.into());
-        if let Some(memory_limit) = self.memory_limit {
-            version.memory_limit = memory_limit;
-        }
-        version
+        let spec_id = CustomSpecId::CustomOsaka;
+        let mut version = custom_version(spec_id.into());
+        version.memory_limit = 1 << 20;
+        Self { spec_id, version }
     }
 }
 
@@ -192,7 +187,7 @@ fn main() {
         + 20_000; // SSTORE zero to non-zero.
 
     let execution_config =
-        CustomConfigSelector::execution_config(args.spec_id).with_version(args.version());
+        CustomConfigSelector::execution_config(args.spec_id).with_version(args.version);
 
     let mut evm = Evm::<CustomTypes>::new_with_execution_config(
         execution_config,
@@ -203,16 +198,14 @@ fn main() {
         NoPrecompiles,
     );
     assert_eq!(evm.spec_id(), SpecId::OSAKA);
-    if let Some(memory_limit) = args.memory_limit {
-        assert_eq!(evm.version().memory_limit, memory_limit);
-    }
+    assert_eq!(evm.version().memory_limit, args.version.memory_limit);
     assert_eq!(
         <CustomConfig<{ SpecId::OSAKA as u8 }> as EvmConfig<CustomTypes>>::VERSION_TABLES
             .static_gas(CUSTOM_OPCODE),
         CUSTOM_OPCODE_GAS,
     );
     assert_eq!(
-        args.version().gas_params.get(CUSTOM_OPCODE_DYNAMIC_GAS_ID),
+        args.version.gas_params.get(CUSTOM_OPCODE_DYNAMIC_GAS_ID),
         CUSTOM_OPCODE_DYNAMIC_GAS,
     );
 

--- a/crates/evm2/examples/custom_evm.rs
+++ b/crates/evm2/examples/custom_evm.rs
@@ -31,11 +31,17 @@ enum CustomSpecId {
     CustomOsaka,
 }
 
+impl CustomSpecId {
+    const fn base_spec_id(self) -> SpecId {
+        match self {
+            Self::MainnetOsaka | Self::CustomOsaka => SpecId::OSAKA,
+        }
+    }
+}
+
 impl From<CustomSpecId> for SpecId {
     fn from(spec_id: CustomSpecId) -> Self {
-        match spec_id {
-            CustomSpecId::MainnetOsaka | CustomSpecId::CustomOsaka => Self::OSAKA,
-        }
+        spec_id.base_spec_id()
     }
 }
 
@@ -60,10 +66,6 @@ struct CustomConfig<const BASE_SPEC_ID: u8>(());
 impl<const ID: u8> EvmConfig<CustomTypes> for CustomConfig<ID> {
     const BASE_SPEC_ID: SpecId = SpecId::try_from_u8(ID).unwrap();
     const VERSION_TABLES: &'static VersionTables<CustomTypes> = &custom_version_tables::<ID>();
-
-    fn version() -> Version {
-        custom_version(Self::BASE_SPEC_ID)
-    }
 }
 
 const fn custom_version(base_spec_id: SpecId) -> Version {
@@ -168,6 +170,14 @@ impl Args {
     const fn parse() -> Self {
         Self { spec_id: CustomSpecId::CustomOsaka, memory_limit: Some(1 << 20) }
     }
+
+    const fn version(&self) -> Version {
+        let mut version = custom_version(self.spec_id.base_spec_id());
+        if let Some(memory_limit) = self.memory_limit {
+            version.memory_limit = memory_limit;
+        }
+        version
+    }
 }
 
 // End-to-end check
@@ -185,12 +195,8 @@ fn main() {
         + 2100 // Cold SSTORE load.
         + 20_000; // SSTORE zero to non-zero.
 
-    let mut execution_config = CustomConfigSelector::execution_config(args.spec_id);
-    if let Some(memory_limit) = args.memory_limit {
-        let mut version = *execution_config.version();
-        version.memory_limit = memory_limit;
-        execution_config = execution_config.with_version(version);
-    }
+    let execution_config =
+        CustomConfigSelector::execution_config(args.spec_id).with_version(args.version());
 
     let mut evm = Evm::<CustomTypes>::new_with_execution_config(
         execution_config,
@@ -210,9 +216,7 @@ fn main() {
         CUSTOM_OPCODE_GAS,
     );
     assert_eq!(
-        <CustomConfig<{ SpecId::OSAKA as u8 }> as EvmConfig<CustomTypes>>::version()
-            .gas_params
-            .get(CUSTOM_OPCODE_DYNAMIC_GAS_ID),
+        args.version().gas_params.get(CUSTOM_OPCODE_DYNAMIC_GAS_ID),
         CUSTOM_OPCODE_DYNAMIC_GAS,
     );
 

--- a/crates/evm2/examples/custom_evm.rs
+++ b/crates/evm2/examples/custom_evm.rs
@@ -62,12 +62,11 @@ impl<const ID: u8> EvmConfig<CustomTypes> for CustomConfig<ID> {
     const VERSION_TABLES: &'static VersionTables<CustomTypes> = &custom_version_tables::<ID>();
 
     fn version() -> Version {
-        custom_version::<ID>()
+        custom_version(Self::BASE_SPEC_ID)
     }
 }
 
-const fn custom_version<const BASE_SPEC_ID: u8>() -> Version {
-    let base_spec_id = SpecId::try_from_u8(BASE_SPEC_ID).unwrap();
+const fn custom_version(base_spec_id: SpecId) -> Version {
     let mut version = *Version::base(base_spec_id);
     version.gas_params.set(CUSTOM_OPCODE_DYNAMIC_GAS_ID, CUSTOM_OPCODE_DYNAMIC_GAS);
     version
@@ -159,10 +158,23 @@ fn custom_registry() -> TxRegistry<CustomTx, evm2::TxResult, Evm<CustomTypes>> {
     TxRegistry::new().with_handler(CUSTOM_TX_TYPE, as_custom_tx, handle_custom_tx)
 }
 
+#[derive(Debug)]
+struct Args {
+    spec_id: CustomSpecId,
+    memory_limit: Option<u64>,
+}
+
+impl Args {
+    const fn parse() -> Self {
+        Self { spec_id: CustomSpecId::CustomOsaka, memory_limit: Some(1 << 20) }
+    }
+}
+
 // End-to-end check
 
 fn main() {
     assert_eq!(SpecId::from(CustomSpecId::MainnetOsaka), SpecId::OSAKA);
+    let args = Args::parse();
 
     let custom_target = Address::from([0xcc; 20]);
     let code = Bytes::from_static(&[CUSTOM_OPCODE, op::PUSH1, 0x01, op::SSTORE, op::STOP]);
@@ -173,14 +185,25 @@ fn main() {
         + 2100 // Cold SSTORE load.
         + 20_000; // SSTORE zero to non-zero.
 
-    let mut evm = Evm::<CustomTypes>::new(
-        CustomSpecId::CustomOsaka,
+    let mut execution_config = CustomConfigSelector::execution_config(args.spec_id);
+    if let Some(memory_limit) = args.memory_limit {
+        let mut version = *execution_config.version();
+        version.memory_limit = memory_limit;
+        execution_config = execution_config.with_version(version);
+    }
+
+    let mut evm = Evm::<CustomTypes>::new_with_execution_config(
+        execution_config,
+        args.spec_id,
         BlockEnv::default(),
         custom_registry(),
         InMemoryDB::default(),
         NoPrecompiles,
     );
     assert_eq!(evm.spec_id(), SpecId::OSAKA);
+    if let Some(memory_limit) = args.memory_limit {
+        assert_eq!(evm.version().memory_limit, memory_limit);
+    }
     assert_eq!(
         <CustomConfig<{ SpecId::OSAKA as u8 }> as EvmConfig<CustomTypes>>::VERSION_TABLES
             .static_gas(CUSTOM_OPCODE),
@@ -197,10 +220,6 @@ fn main() {
     assert_eq!(result.stop, InstrStop::Stop);
     assert!(result.status);
     assert_eq!(result.gas_used, expected_custom_gas);
-    assert_eq!(
-        result.state_changes.storage[&custom_target].slots[&Word::from(1)].current,
-        Word::from(0xdead_u64),
-    );
 
     let mut evm = Evm::<CustomTypes>::new(
         CustomSpecId::MainnetOsaka,

--- a/crates/evm2/examples/custom_evm.rs
+++ b/crates/evm2/examples/custom_evm.rs
@@ -57,10 +57,13 @@ impl EvmTypes for CustomTypes {
 
 struct CustomConfig<const BASE_SPEC_ID: u8>(());
 
-impl<const BASE_SPEC_ID: u8> EvmConfig<CustomTypes> for CustomConfig<BASE_SPEC_ID> {
-    const VERSION: &'static Version = &custom_version::<BASE_SPEC_ID>();
-    const VERSION_TABLES: &'static VersionTables<CustomTypes> =
-        &custom_version_tables::<BASE_SPEC_ID>();
+impl<const ID: u8> EvmConfig<CustomTypes> for CustomConfig<ID> {
+    const BASE_SPEC_ID: SpecId = SpecId::try_from_u8(ID).unwrap();
+    const VERSION_TABLES: &'static VersionTables<CustomTypes> = &custom_version_tables::<ID>();
+
+    fn version() -> Version {
+        custom_version::<ID>()
+    }
 }
 
 const fn custom_version<const BASE_SPEC_ID: u8>() -> Version {
@@ -184,7 +187,7 @@ fn main() {
         CUSTOM_OPCODE_GAS,
     );
     assert_eq!(
-        <CustomConfig<{ SpecId::OSAKA as u8 }> as EvmConfig<CustomTypes>>::VERSION
+        <CustomConfig<{ SpecId::OSAKA as u8 }> as EvmConfig<CustomTypes>>::version()
             .gas_params
             .get(CUSTOM_OPCODE_DYNAMIC_GAS_ID),
         CUSTOM_OPCODE_DYNAMIC_GAS,

--- a/crates/evm2/examples/custom_evm.rs
+++ b/crates/evm2/examples/custom_evm.rs
@@ -3,6 +3,8 @@
 //! The runtime `CustomSpecId` distinguishes base Osaka from custom Osaka, while the const generic
 //! `BASE_SPEC_ID` always names the inherited base `SpecId`.
 
+#![allow(clippy::missing_const_for_fn)]
+
 use alloy_eips::eip2718::Typed2718;
 use alloy_primitives::{Address, Bytes};
 use evm2::{
@@ -31,17 +33,11 @@ enum CustomSpecId {
     CustomOsaka,
 }
 
-impl CustomSpecId {
-    const fn base_spec_id(self) -> SpecId {
-        match self {
-            Self::MainnetOsaka | Self::CustomOsaka => SpecId::OSAKA,
-        }
-    }
-}
-
 impl From<CustomSpecId> for SpecId {
     fn from(spec_id: CustomSpecId) -> Self {
-        spec_id.base_spec_id()
+        match spec_id {
+            CustomSpecId::MainnetOsaka | CustomSpecId::CustomOsaka => Self::OSAKA,
+        }
     }
 }
 
@@ -167,12 +163,12 @@ struct Args {
 }
 
 impl Args {
-    const fn parse() -> Self {
+    fn parse() -> Self {
         Self { spec_id: CustomSpecId::CustomOsaka, memory_limit: Some(1 << 20) }
     }
 
-    const fn version(&self) -> Version {
-        let mut version = custom_version(self.spec_id.base_spec_id());
+    fn version(&self) -> Version {
+        let mut version = custom_version(self.spec_id.into());
         if let Some(memory_limit) = self.memory_limit {
             version.memory_limit = memory_limit;
         }

--- a/crates/evm2/src/ethereum/mod.rs
+++ b/crates/evm2/src/ethereum/mod.rs
@@ -149,7 +149,7 @@ pub(super) fn validate_block_gas_limit(
 }
 
 pub(super) const fn validate_tx_gas_limit_cap(
-    version: &'static Version,
+    version: &Version,
     tx_gas_limit: u64,
 ) -> HandlerResult<()> {
     // EIP-7825 caps each transaction gas limit to 2^24 in Osaka. Amsterdam/EIP-8037
@@ -163,7 +163,7 @@ pub(super) const fn validate_tx_gas_limit_cap(
 }
 
 pub(super) const fn validate_regular_gas_limit_cap(
-    version: &'static Version,
+    version: &Version,
     tx_gas_limit: u64,
     intrinsic: u64,
     floor_gas: u64,
@@ -404,7 +404,7 @@ pub(super) fn access_list_counts(access_list: &AccessList) -> (u64, u64) {
 }
 
 /// Calculates transaction calldata floor gas.
-pub(super) fn floor_gas(version: &'static Version, input: &Bytes) -> u64 {
+pub(super) fn floor_gas(version: &Version, input: &Bytes) -> u64 {
     let params = &version.gas_params;
     let floor_cost_per_token = u64::from(params.get(GasId::TxFloorCostPerToken));
     if floor_cost_per_token == 0 {
@@ -422,7 +422,7 @@ pub(super) fn floor_gas(version: &'static Version, input: &Bytes) -> u64 {
 
 /// Calculates intrinsic transaction gas.
 pub(super) fn intrinsic_gas(
-    version: &'static Version,
+    version: &Version,
     to: TxKind,
     input: &Bytes,
     access_list_accounts: u64,

--- a/crates/evm2/src/evm/config.rs
+++ b/crates/evm2/src/evm/config.rs
@@ -78,7 +78,7 @@ pub trait EvmConfigSelector<T: EvmTypes>: Sized {
 /// an EVM instance. This is the data passed to the interpreter when it runs.
 #[derive(derive_more::Debug)]
 pub struct ExecutionConfig<T: EvmTypes> {
-    pub(crate) version: &'static Version,
+    pub(crate) version: Version,
     #[debug(skip)]
     pub(crate) instructions: &'static InstructionTable<T>,
 }
@@ -96,7 +96,7 @@ impl<T: EvmTypes> ExecutionConfig<T> {
     /// Creates an execution config for a concrete compile-time config.
     #[inline]
     pub const fn for_config<C: EvmConfig<T>>() -> Self {
-        Self { version: C::VERSION, instructions: <T as InstructionTables<C>>::INSTRUCTIONS }
+        Self { version: *C::VERSION, instructions: <T as InstructionTables<C>>::INSTRUCTIONS }
     }
 
     /// Creates an execution config for a base `SpecId` through selector `F`.
@@ -110,10 +110,26 @@ impl<T: EvmTypes> ExecutionConfig<T> {
         })
     }
 
+    /// Creates an execution config for `spec_id` with dynamic runtime version data.
+    #[inline]
+    pub fn for_spec_and_version(spec_id: T::SpecId, version: Version) -> Self {
+        let config = <T::ConfigSelector as EvmConfigSelector<T>>::execution_config(spec_id);
+        assert_eq!(spec_id.into(), version.spec_id, "execution config version spec mismatch");
+        config.with_version(version)
+    }
+
+    /// Replaces the runtime version data while keeping the same dispatch table.
+    #[inline]
+    pub fn with_version(mut self, version: Version) -> Self {
+        assert_eq!(self.version.spec_id, version.spec_id, "execution config version spec mismatch");
+        self.version = version;
+        self
+    }
+
     /// Returns the active EVM version.
     #[inline]
-    pub const fn version(&self) -> &'static Version {
-        self.version
+    pub const fn version(&self) -> &Version {
+        &self.version
     }
 }
 

--- a/crates/evm2/src/evm/config.rs
+++ b/crates/evm2/src/evm/config.rs
@@ -47,12 +47,6 @@ pub trait EvmConfig<T: EvmTypes> {
 
     /// Active type-specific version tables.
     const VERSION_TABLES: &'static VersionTables<T>;
-
-    /// Creates the runtime version data for this config.
-    #[inline]
-    fn version() -> Version {
-        Version::new(Self::BASE_SPEC_ID)
-    }
 }
 
 /// Runtime EVM config selector.
@@ -94,8 +88,11 @@ impl<T: EvmTypes> Copy for ExecutionConfig<T> {}
 impl<T: EvmTypes> ExecutionConfig<T> {
     /// Creates an execution config for a concrete compile-time config.
     #[inline]
-    pub fn for_config<C: EvmConfig<T>>() -> Self {
-        Self { version: C::version(), instructions: <T as InstructionTables<C>>::INSTRUCTIONS }
+    pub const fn for_config<C: EvmConfig<T>>() -> Self {
+        Self {
+            version: Version::new(C::BASE_SPEC_ID),
+            instructions: <T as InstructionTables<C>>::INSTRUCTIONS,
+        }
     }
 
     /// Creates an execution config for a base `SpecId` through selector `F`.
@@ -103,7 +100,7 @@ impl<T: EvmTypes> ExecutionConfig<T> {
     /// The selector provides the concrete `Config<BASE_SPEC_ID>` used for the inherited base
     /// version.
     #[inline]
-    pub fn for_base_spec<F: EvmConfigSelector<T>>(base_spec_id: SpecId) -> Self {
+    pub const fn for_base_spec<F: EvmConfigSelector<T>>(base_spec_id: SpecId) -> Self {
         spec_to_generic!(base_spec_id, |BASE_SPEC_ID| {
             Self::for_config::<F::Config<BASE_SPEC_ID>>()
         })

--- a/crates/evm2/src/evm/config.rs
+++ b/crates/evm2/src/evm/config.rs
@@ -38,21 +38,20 @@ pub trait EvmTypes: Sized + 'static {
     type Precompiles: PrecompileProvider;
 }
 
-/// Compile-time EVM version configuration.
+/// Compile-time EVM table configuration.
 ///
-/// Names a concrete version for monomorphized code. It exposes the runtime `Version` data and the
-/// type-specific `VersionTables` needed to build dispatch tables.
+/// Names the inherited base spec and type-specific `VersionTables` needed to build dispatch tables.
 pub trait EvmConfig<T: EvmTypes> {
-    /// Active EVM version.
-    const VERSION: &'static Version;
+    /// Inherited base specification ID.
+    const BASE_SPEC_ID: SpecId;
 
     /// Active type-specific version tables.
     const VERSION_TABLES: &'static VersionTables<T>;
 
-    /// Active base specification ID.
+    /// Creates the runtime version data for this config.
     #[inline]
-    fn spec_id() -> SpecId {
-        Self::VERSION.spec_id
+    fn version() -> Version {
+        Version::new(Self::BASE_SPEC_ID)
     }
 }
 
@@ -95,8 +94,8 @@ impl<T: EvmTypes> Copy for ExecutionConfig<T> {}
 impl<T: EvmTypes> ExecutionConfig<T> {
     /// Creates an execution config for a concrete compile-time config.
     #[inline]
-    pub const fn for_config<C: EvmConfig<T>>() -> Self {
-        Self { version: *C::VERSION, instructions: <T as InstructionTables<C>>::INSTRUCTIONS }
+    pub fn for_config<C: EvmConfig<T>>() -> Self {
+        Self { version: C::version(), instructions: <T as InstructionTables<C>>::INSTRUCTIONS }
     }
 
     /// Creates an execution config for a base `SpecId` through selector `F`.
@@ -104,7 +103,7 @@ impl<T: EvmTypes> ExecutionConfig<T> {
     /// The selector provides the concrete `Config<BASE_SPEC_ID>` used for the inherited base
     /// version.
     #[inline]
-    pub const fn for_base_spec<F: EvmConfigSelector<T>>(base_spec_id: SpecId) -> Self {
+    pub fn for_base_spec<F: EvmConfigSelector<T>>(base_spec_id: SpecId) -> Self {
         spec_to_generic!(base_spec_id, |BASE_SPEC_ID| {
             Self::for_config::<F::Config<BASE_SPEC_ID>>()
         })
@@ -153,7 +152,7 @@ impl<Tx: 'static> EvmTypes for BaseEvmTypes<Tx> {
 pub struct BaseEvmConfig<const BASE_SPEC_ID: u8>(());
 
 impl<T: EvmTypes, const BASE_SPEC_ID: u8> EvmConfig<T> for BaseEvmConfig<BASE_SPEC_ID> {
-    const VERSION: &'static Version = Version::base(SpecId::try_from_u8(BASE_SPEC_ID).unwrap());
+    const BASE_SPEC_ID: SpecId = SpecId::try_from_u8(BASE_SPEC_ID).unwrap();
     const VERSION_TABLES: &'static VersionTables<T> = &VersionTables::<T>::base::<Self>();
 }
 

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -714,9 +714,6 @@ mod tests {
 
     type TestEvmTypes<Tx = ()> = BaseEvmTypes<Tx>;
 
-    const NO_CONFIG_EXECUTION: ExecutionConfig<TestEvmTypes<TestTx>> =
-        ExecutionConfig::for_config::<BaseEvmConfig<{ SpecId::OSAKA as u8 }>>();
-
     impl Typed2718 for TestTx {
         fn ty(&self) -> u8 {
             TEST_TX_TYPE
@@ -765,7 +762,7 @@ mod tests {
         let registry =
             TxRegistry::new().with_handler(TEST_TX_TYPE, extract_test_tx, handle_test_tx);
         let mut evm = Evm::<TestEvmTypes<TestTx>>::new_with_execution_config(
-            NO_CONFIG_EXECUTION,
+            ExecutionConfig::for_config::<BaseEvmConfig<{ SpecId::OSAKA as u8 }>>(),
             SpecId::OSAKA,
             BlockEnv::default(),
             registry,

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -243,7 +243,7 @@ impl<T: EvmTypes> Evm<T> {
     }
 
     /// Returns the active EVM version.
-    pub const fn version(&self) -> &'static crate::Version {
+    pub const fn version(&self) -> &crate::Version {
         self.execution_config.version()
     }
 
@@ -527,7 +527,8 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
         // pool after execution. Recursive calls may mutate the pool, but they cannot move this box.
         let interpreter_ref = unsafe { &mut *(&mut *interpreter as *mut Interpreter<'frame, T>) };
         interpreter_ref.init(bytecode, tx_env, message, caller_is_static);
-        let stop = interpreter_ref.run_with(self.execution_config, self);
+        let execution_config = self.execution_config;
+        let stop = interpreter_ref.run_with(&execution_config, self);
         let interpreter = self.interpreter_pool.push(interpreter);
         (stop, interpreter)
     }
@@ -733,6 +734,16 @@ mod tests {
         Ok(TxResult { status: true, gas_used: req.tx.value + 1, ..TxResult::default() })
     }
 
+    fn handle_test_tx_version(
+        req: TxRequest<'_, TestTx, Evm<TestEvmTypes<TestTx>>>,
+    ) -> HandlerResult<TxResult> {
+        Ok(TxResult {
+            status: true,
+            gas_used: req.host.version().tx_gas_limit_cap,
+            ..TxResult::default()
+        })
+    }
+
     #[test]
     fn dispatches_transaction_by_typed_2718_type() {
         let registry =
@@ -762,6 +773,25 @@ mod tests {
             Precompiles::base(SpecId::OSAKA),
         );
         let tx = TestTx { value: 41 };
+
+        assert_eq!(evm.transact(&tx).map(|result| result.gas_used), Ok(42));
+    }
+
+    #[test]
+    fn dispatches_transaction_with_dynamic_version() {
+        let registry =
+            TxRegistry::new().with_handler(TEST_TX_TYPE, extract_test_tx, handle_test_tx_version);
+        let mut version = crate::Version::new(SpecId::OSAKA);
+        version.tx_gas_limit_cap = 42;
+        let mut evm = Evm::<TestEvmTypes<TestTx>>::new_with_execution_config(
+            ExecutionConfig::for_spec_and_version(SpecId::OSAKA, version),
+            SpecId::OSAKA,
+            BlockEnv::default(),
+            registry,
+            InMemoryDB::default(),
+            Precompiles::base(SpecId::OSAKA),
+        );
+        let tx = TestTx { value: 0 };
 
         assert_eq!(evm.transact(&tx).map(|result| result.gas_used), Ok(42));
     }

--- a/crates/evm2/src/interpreter/instructions/host.rs
+++ b/crates/evm2/src/interpreter/instructions/host.rs
@@ -34,27 +34,27 @@ pub(crate) fn sload(cx: _, [key]: [Word]) -> Result<out> {
 pub(crate) fn sstore(cx: _) -> Result {
     require_non_staticcall(&cx)?;
     let [key, value] = stack.popn()?;
-    let gas_params = cx.state.gas_params();
     let is_istanbul = cx.state.spec.enables(SpecId::ISTANBUL);
 
     // EIP-2200: SSTORE may not execute with only the value-transfer stipend left. This
     // check happens before any gas is charged or host storage is touched.
-    if is_istanbul && cx.gas.remaining() <= gas_params.get(GasId::CallStipend).into() {
+    if is_istanbul && cx.gas.remaining() <= cx.state.gas_params().get(GasId::CallStipend).into() {
         return Err(InstrStop::ReentrancySentryOOG);
     }
 
     // Frontier through Petersburg charge a fixed SSTORE_RESET static cost. Istanbul
     // (EIP-2200) turns this into the SLOAD-equivalent cost, and Berlin (EIP-2929)
     // makes that the warm storage read cost.
-    cx.gas.spend(gas_params.get(GasId::SstoreStatic).into())?;
+    cx.gas.spend(cx.state.gas_params().get(GasId::SstoreStatic).into())?;
 
     // EIP-2929: avoid performing a cold storage load if the frame cannot afford the
     // additional cold-load charge. The host performs the write and returns
     // original/present/new values for net metering.
     let skip_cold_load = cx.state.spec.enables(SpecId::BERLIN)
-        && cx.gas.remaining() < gas_params.get(GasId::ColdStorageAdditionalCost).into();
+        && cx.gas.remaining() < cx.state.gas_params().get(GasId::ColdStorageAdditionalCost).into();
     let state_load =
         cx.state.host.sstore(cx.state.message().destination, key, value, skip_cold_load)?;
+    let gas_params = cx.state.gas_params();
 
     // EIP-2200 net gas metering depends on original, present, and new slot values:
     // clean slots pay set/reset costs, dirty slots generally only pay the load cost,

--- a/crates/evm2/src/interpreter/instructions/host.rs
+++ b/crates/evm2/src/interpreter/instructions/host.rs
@@ -34,27 +34,27 @@ pub(crate) fn sload(cx: _, [key]: [Word]) -> Result<out> {
 pub(crate) fn sstore(cx: _) -> Result {
     require_non_staticcall(&cx)?;
     let [key, value] = stack.popn()?;
+    let gas_params = cx.state.gas_params();
     let is_istanbul = cx.state.spec.enables(SpecId::ISTANBUL);
 
     // EIP-2200: SSTORE may not execute with only the value-transfer stipend left. This
     // check happens before any gas is charged or host storage is touched.
-    if is_istanbul && cx.gas.remaining() <= cx.state.gas_params().get(GasId::CallStipend).into() {
+    if is_istanbul && cx.gas.remaining() <= gas_params.get(GasId::CallStipend).into() {
         return Err(InstrStop::ReentrancySentryOOG);
     }
 
     // Frontier through Petersburg charge a fixed SSTORE_RESET static cost. Istanbul
     // (EIP-2200) turns this into the SLOAD-equivalent cost, and Berlin (EIP-2929)
     // makes that the warm storage read cost.
-    cx.gas.spend(cx.state.gas_params().get(GasId::SstoreStatic).into())?;
+    cx.gas.spend(gas_params.get(GasId::SstoreStatic).into())?;
 
     // EIP-2929: avoid performing a cold storage load if the frame cannot afford the
     // additional cold-load charge. The host performs the write and returns
     // original/present/new values for net metering.
     let skip_cold_load = cx.state.spec.enables(SpecId::BERLIN)
-        && cx.gas.remaining() < cx.state.gas_params().get(GasId::ColdStorageAdditionalCost).into();
+        && cx.gas.remaining() < gas_params.get(GasId::ColdStorageAdditionalCost).into();
     let state_load =
         cx.state.host.sstore(cx.state.message().destination, key, value, skip_cold_load)?;
-    let gas_params = cx.state.gas_params();
 
     // EIP-2200 net gas metering depends on original, present, and new slot values:
     // clean slots pay set/reset costs, dirty slots generally only pay the load cost,

--- a/crates/evm2/src/interpreter/instructions/memory.rs
+++ b/crates/evm2/src/interpreter/instructions/memory.rs
@@ -45,14 +45,17 @@ pub(crate) fn mcopy(cx: _, [dst, src, len]: [Word]) -> Result {
 #[cfg(test)]
 mod tests {
     use crate::{
-        EvmConfig, SpecId, Version, VersionTables,
+        ExecutionConfig, SpecId, Version,
+        bytecode::Bytecode,
+        env::TxEnv,
         interpreter::{
-            InstrStop, Word,
-            instructions::tests::{RunConfig, TestTypes, push, run, run_stack, run_with_config},
+            InstrStop, Interpreter, Message, Word,
+            instructions::tests::{RunConfig, TestHost, TestTypes, push, run, run_stack},
             op,
         },
     };
     use alloc::vec::Vec;
+    use alloy_primitives::Bytes;
 
     #[test]
     fn mload_opcode() {
@@ -95,27 +98,23 @@ mod tests {
 
     #[test]
     fn mstore_respects_version_memory_limit() {
-        struct Config;
-
-        impl EvmConfig<TestTypes> for Config {
-            const VERSION: &'static Version = &{
-                let mut version = *Version::base(SpecId::OSAKA);
-                version.memory_limit = 64;
-                version
-            };
-            const VERSION_TABLES: &'static VersionTables<TestTypes> =
-                &VersionTables::<TestTypes>::base::<Self>();
-        }
-
+        let mut version = Version::new(SpecId::OSAKA);
+        version.memory_limit = 64;
+        let config = ExecutionConfig::<TestTypes>::for_spec_and_version(SpecId::OSAKA, version);
         let mut code = Vec::new();
         push(&mut code, Word::ZERO);
         push(&mut code, Word::from(64));
         code.push(op::MSTORE);
         code.push(op::STOP);
 
-        let interpreter = run_with_config::<Config>(RunConfig::new(code));
+        let tx_env = TxEnv::default();
+        let message = Message { gas_limit: 10_000, ..Message::default() };
+        let bytecode = Bytecode::new_legacy(Bytes::from(code));
+        let mut interpreter = Interpreter::<TestTypes>::new(bytecode, &tx_env, &message, false);
+        let mut host = TestHost::default();
+        let err = interpreter.run_with(&config, &mut host);
 
-        core::assert_matches!(interpreter.err, InstrStop::MemoryLimitOOG);
+        core::assert_matches!(err, InstrStop::MemoryLimitOOG);
         assert_eq!(interpreter.memory.len(), 0);
     }
 

--- a/crates/evm2/src/interpreter/instructions/tests.rs
+++ b/crates/evm2/src/interpreter/instructions/tests.rs
@@ -284,7 +284,7 @@ pub(super) fn run(config: RunConfig<'_>) -> TestInterpreter {
     })
 }
 
-pub(super) fn run_with_config<C: EvmConfig<TestTypes>>(config: RunConfig<'_>) -> TestInterpreter {
+fn run_with_config<C: EvmConfig<TestTypes>>(config: RunConfig<'_>) -> TestInterpreter {
     let RunConfig { code, host, spec_id: _, tx_env, mut message, gas_limit, return_data } = config;
     let bytecode = Bytecode::new_legacy(Bytes::from(code));
     message.gas_limit = gas_limit;

--- a/crates/evm2/src/interpreter/runtime.rs
+++ b/crates/evm2/src/interpreter/runtime.rs
@@ -148,7 +148,6 @@ impl<'frame, T: EvmTypes> Interpreter<'frame, T> {
 
     /// Runs the interpreter until it stops.
     pub fn run_with(&mut self, config: &ExecutionConfig<T>, host: &mut T::Host) -> InstrStop {
-        let _gas_start = self.gas.remaining();
         self.memory.set_memory_limit(config.version.memory_limit);
 
         #[cfg(feature = "nightly")]

--- a/crates/evm2/src/interpreter/runtime.rs
+++ b/crates/evm2/src/interpreter/runtime.rs
@@ -143,11 +143,11 @@ impl<'frame, T: EvmTypes> Interpreter<'frame, T> {
     /// Runs the interpreter until it stops, using `C` as the EVM configuration.
     #[inline]
     pub fn run<C: EvmConfig<T>>(&mut self, host: &mut T::Host) -> InstrStop {
-        self.run_with(ExecutionConfig::for_config::<C>(), host)
+        self.run_with(&ExecutionConfig::for_config::<C>(), host)
     }
 
     /// Runs the interpreter until it stops.
-    pub fn run_with(&mut self, config: ExecutionConfig<T>, host: &mut T::Host) -> InstrStop {
+    pub fn run_with(&mut self, config: &ExecutionConfig<T>, host: &mut T::Host) -> InstrStop {
         let _gas_start = self.gas.remaining();
         self.memory.set_memory_limit(config.version.memory_limit);
 
@@ -160,7 +160,7 @@ impl<'frame, T: EvmTypes> Interpreter<'frame, T> {
     }
 
     #[cfg(not(feature = "nightly"))]
-    fn run_table_loop(&mut self, config: ExecutionConfig<T>, host: &mut T::Host) -> InstrStop {
+    fn run_table_loop(&mut self, config: &ExecutionConfig<T>, host: &mut T::Host) -> InstrStop {
         let mut pc = self.pc;
         let mut stack_len = self.stack_len;
         loop {
@@ -179,7 +179,7 @@ impl<'frame, T: EvmTypes> Interpreter<'frame, T> {
     /// Executes one instruction.
     #[inline]
     #[cfg(not(feature = "nightly"))]
-    pub fn step(&mut self, config: ExecutionConfig<T>, host: &mut T::Host) -> ControlFlow<(), ()> {
+    pub fn step(&mut self, config: &ExecutionConfig<T>, host: &mut T::Host) -> ControlFlow<(), ()> {
         let (pc, stack_len, flow) = self.raw_step(config, host, self.pc, self.stack_len);
         self.pc = pc;
         self.stack_len = stack_len;
@@ -190,7 +190,7 @@ impl<'frame, T: EvmTypes> Interpreter<'frame, T> {
     #[cfg(not(feature = "nightly"))]
     fn raw_step(
         &mut self,
-        config: ExecutionConfig<T>,
+        config: &ExecutionConfig<T>,
         host: &mut T::Host,
         pc: *const u8,
         stack_len: usize,
@@ -209,7 +209,7 @@ impl<'frame, T: EvmTypes> Interpreter<'frame, T> {
                 bytecode,
                 host,
                 spec: config.version.spec_id,
-                version: config.version,
+                version: &config.version,
                 raw_interp: raw,
             },
         );
@@ -219,7 +219,7 @@ impl<'frame, T: EvmTypes> Interpreter<'frame, T> {
 
     #[inline(always)]
     #[cfg(feature = "nightly")]
-    fn step_tail(&mut self, config: ExecutionConfig<T>, host: &mut T::Host) -> InstrStop {
+    fn step_tail(&mut self, config: &ExecutionConfig<T>, host: &mut T::Host) -> InstrStop {
         #[expect(clippy::unnecessary_cast, reason = "cast erases the active interpreter lifetime")]
         let raw = self as *mut Self as *mut Interpreter<'_, T>;
         let bytecode = BytecodeRef::new(&self.bytecode);
@@ -234,7 +234,7 @@ impl<'frame, T: EvmTypes> Interpreter<'frame, T> {
                 bytecode,
                 host,
                 spec: config.version.spec_id,
-                version: config.version,
+                version: &config.version,
                 raw_interp: raw,
             },
             0,

--- a/crates/evm2/src/interpreter/state.rs
+++ b/crates/evm2/src/interpreter/state.rs
@@ -18,7 +18,7 @@ pub struct State<'a, T: EvmTypes> {
     /// Active spec identifier.
     pub spec: SpecId,
     /// Active runtime version data.
-    pub version: &'static Version,
+    pub version: &'a Version,
     pub(crate) raw_interp: *mut Interpreter<'a, T>,
 }
 
@@ -59,7 +59,7 @@ impl<'a, T: EvmTypes> State<'a, T> {
 
     /// Returns the active dynamic gas parameters.
     #[inline]
-    pub const fn gas_params(&self) -> &'static GasParams {
+    pub const fn gas_params(&self) -> &GasParams {
         // Gas params are data on the active version so changes automatically affect every
         // instruction that reads them. Tracking instruction dependencies on version tables is not
         // sustainable for custom forks.

--- a/crates/evm2/src/interpreter/state.rs
+++ b/crates/evm2/src/interpreter/state.rs
@@ -59,10 +59,7 @@ impl<'a, T: EvmTypes> State<'a, T> {
 
     /// Returns the active dynamic gas parameters.
     #[inline]
-    pub const fn gas_params(&self) -> &GasParams {
-        // Gas params are data on the active version so changes automatically affect every
-        // instruction that reads them. Tracking instruction dependencies on version tables is not
-        // sustainable for custom forks.
+    pub const fn gas_params(&self) -> &'a GasParams {
         &self.version.gas_params
     }
 

--- a/crates/evm2/src/version/mod.rs
+++ b/crates/evm2/src/version/mod.rs
@@ -22,6 +22,9 @@ pub struct Version {
     /// Active base specification ID.
     pub spec_id: SpecId,
     /// Dynamic gas parameter table.
+    // Gas params are data on the active version so changes automatically affect every
+    // instruction that reads them. Tracking instruction dependencies on version tables is not
+    // sustainable for custom forks.
     pub gas_params: GasParams,
     /// Transaction gas limit cap.
     pub tx_gas_limit_cap: u64,

--- a/crates/evm2/src/version/mod.rs
+++ b/crates/evm2/src/version/mod.rs
@@ -30,6 +30,12 @@ pub struct Version {
 }
 
 impl Version {
+    /// Creates the base EVM version for `spec_id`.
+    #[inline]
+    pub const fn new(spec_id: SpecId) -> Self {
+        *Self::base(spec_id)
+    }
+
     /// Returns the base EVM version for `spec_id`.
     #[inline]
     pub const fn base(spec_id: SpecId) -> &'static Self {
@@ -117,9 +123,8 @@ macro_rules! evm_versions {
         const fn base_version_tables<T: EvmTypes, Cfg: EvmConfig<T>>() -> VersionTables<T> {
             use crate::interpreter::gas::*;
 
-            let version = Cfg::VERSION;
-            let spec_id = version.spec_id;
-            let mut v = VersionTables::empty(version);
+            let spec_id = Cfg::VERSION.spec_id;
+            let mut v = VersionTables::empty();
 
             $(
                 if spec_id.enables(SpecId::$spec) {

--- a/crates/evm2/src/version/mod.rs
+++ b/crates/evm2/src/version/mod.rs
@@ -126,7 +126,7 @@ macro_rules! evm_versions {
         const fn base_version_tables<T: EvmTypes, Cfg: EvmConfig<T>>() -> VersionTables<T> {
             use crate::interpreter::gas::*;
 
-            let spec_id = Cfg::VERSION.spec_id;
+            let spec_id = Cfg::BASE_SPEC_ID;
             let mut v = VersionTables::empty();
 
             $(

--- a/crates/evm2/src/version/tables.rs
+++ b/crates/evm2/src/version/tables.rs
@@ -1,5 +1,5 @@
 use crate::{
-    EvmConfig, EvmTypes, Version,
+    EvmConfig, EvmTypes,
     interpreter::{InstructionImplFn, instructions::table::unknown_instruction},
 };
 use core::fmt;
@@ -9,8 +9,6 @@ use core::fmt;
 /// Stores the static gas table and instruction implementations for a concrete `EvmTypes` family.
 /// These tables are compile-time inputs used to build the final interpreter dispatch table.
 pub struct VersionTables<T: EvmTypes> {
-    /// Active EVM version.
-    version: &'static Version,
     /// Static opcode gas table.
     static_gas_table: StaticGasTable,
     /// Instruction implementations.
@@ -31,18 +29,11 @@ impl<T: EvmTypes> VersionTables<T> {
 
     /// Creates empty type-specific version tables.
     #[inline]
-    pub(super) const fn empty(version: &'static Version) -> Self {
+    pub(super) const fn empty() -> Self {
         Self {
-            version,
             static_gas_table: StaticGasTable::empty(),
             instruction_impls: InstructionImplTable::empty(),
         }
-    }
-
-    /// Returns the active EVM version.
-    #[inline]
-    pub const fn version(&self) -> &'static Version {
-        self.version
     }
 
     /// Returns the static gas cost for `opcode`.


### PR DESCRIPTION
Makes Version runtime-owned by ExecutionConfig so callers can build a base Version, mutate runtime parameters, and install it without defining a custom compile-time EVM config. The dispatch table and VersionTables remain compile-time, since opcode availability, instruction implementations, and static gas are still tied to monomorphized config.

ExecutionConfig now has helpers for replacing runtime version data while preserving the selected dispatch table. Interpreter execution borrows the config instead of taking it by value, and VersionTables no longer stores or exposes Version because it only represents table shape.
