### PR TITLE
perf(interpreter): inline raw step

### DIFF
--- a/crates/evm2/src/interpreter/runtime.rs
+++ b/crates/evm2/src/interpreter/runtime.rs
@@ -186,7 +186,7 @@ impl<'frame, T: EvmTypes> Interpreter<'frame, T> {
         flow
     }
 
-    #[inline(never)]
+    #[inline(always)]
     #[cfg(not(feature = "nightly"))]
     fn raw_step(
         &mut self,


### PR DESCRIPTION
woopsie

This changes the non-nightly interpreter's `raw_step` helper from `#[inline(never)]` to `#[inline(always)]`. The previous attribute was left over from an experiment and forces a function call on every interpreted opcode.

On `snailtracer`, this reduces the median runtime from 84.811 ms on `main` to 61.644 ms on this branch with:

```sh
cargo bench -p evm2 --bench evm snailtracer
```

Criterion reported a 27.316% improvement.
