### PR TITLE
feat(version): add evm feature bitmap

### DIFF
--- a/crates/evm2/src/constants.rs
+++ b/crates/evm2/src/constants.rs
@@ -10,6 +10,18 @@ pub(crate) const MAX_CODE_SIZE: usize = 0x6000;
 /// EIP-3860 - Limit and meter initcode.
 pub(crate) const MAX_INITCODE_SIZE: usize = 2 * MAX_CODE_SIZE;
 
+/// Maximum deployed contract bytecode size since Amsterdam.
+pub(crate) const MAX_CODE_SIZE_AMSTERDAM: usize = 0xC000;
+
+/// Maximum contract creation initcode size since Amsterdam.
+pub(crate) const MAX_INITCODE_SIZE_AMSTERDAM: usize = 0x12000;
+
+/// Cancun blob base fee update fraction.
+pub(crate) const BLOB_BASE_FEE_UPDATE_FRACTION_CANCUN: u64 = 3_338_477;
+
+/// Prague blob base fee update fraction.
+pub(crate) const BLOB_BASE_FEE_UPDATE_FRACTION_PRAGUE: u64 = 5_007_716;
+
 /// Maximum message call depth.
 pub(crate) const CALL_DEPTH_LIMIT: u16 = 1024;
 

--- a/crates/evm2/src/ethereum/eip1559.rs
+++ b/crates/evm2/src/ethereum/eip1559.rs
@@ -29,10 +29,10 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     let gas_price =
         effective_gas_price(max_fee_per_gas, max_priority_fee_per_gas, req.host.block.basefee);
 
-    validate_priority_fee(max_fee_per_gas, max_priority_fee_per_gas)?;
-    validate_gas_price(spec_id, gas_price, req.host.block.basefee)?;
+    validate_priority_fee(req.host.version(), max_fee_per_gas, max_priority_fee_per_gas)?;
+    validate_gas_price(req.host.version(), gas_price, req.host.block.basefee)?;
     validate_tx_gas_limit_cap(req.host.version(), tx.gas_limit)?;
-    validate_block_gas_limit(tx.gas_limit, req.host.block.gas_limit)?;
+    validate_block_gas_limit(req.host.version(), tx.gas_limit, req.host.block.gas_limit)?;
     validate_create_initcode(spec_id, tx.to, &tx.input)?;
     validate_nonce_not_overflow(tx.nonce)?;
     let (access_list_accounts, access_list_storage_keys) = access_list_counts(&tx.access_list);

--- a/crates/evm2/src/ethereum/eip1559.rs
+++ b/crates/evm2/src/ethereum/eip1559.rs
@@ -1,9 +1,10 @@
 use super::{
     access_list_counts, charge_upfront, effective_gas_price, floor_gas, initial_message,
     intrinsic_gas, rollback_failed_execution, settle_gas, validate_block_gas_limit,
-    validate_create_initcode, validate_floor_gas, validate_gas_price, validate_intrinsic_gas,
-    validate_nonce_not_overflow, validate_priority_fee, validate_regular_gas_limit_cap,
-    validate_sender, validate_tx_gas_limit_cap, warm_access_list, warm_base_accounts,
+    validate_chain_id, validate_create_initcode, validate_floor_gas, validate_gas_price,
+    validate_intrinsic_gas, validate_nonce_not_overflow, validate_priority_fee,
+    validate_regular_gas_limit_cap, validate_sender, validate_tx_gas_limit_cap, warm_access_list,
+    warm_base_accounts,
 };
 use crate::{
     Evm, EvmTypes, SpecId, TxResult,
@@ -31,9 +32,10 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
 
     validate_priority_fee(req.host.version(), max_fee_per_gas, max_priority_fee_per_gas)?;
     validate_gas_price(req.host.version(), gas_price, req.host.block.basefee)?;
+    validate_chain_id(req.host.version(), Some(tx.chain_id), false)?;
     validate_tx_gas_limit_cap(req.host.version(), tx.gas_limit)?;
     validate_block_gas_limit(req.host.version(), tx.gas_limit, req.host.block.gas_limit)?;
-    validate_create_initcode(spec_id, tx.to, &tx.input)?;
+    validate_create_initcode(req.host.version(), tx.to, &tx.input)?;
     validate_nonce_not_overflow(tx.nonce)?;
     let (access_list_accounts, access_list_storage_keys) = access_list_counts(&tx.access_list);
     let intrinsic = intrinsic_gas(
@@ -60,8 +62,12 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     let execution_checkpoint = req.host.state.checkpoint();
 
     let gas_limit = tx.gas_limit - intrinsic;
-    let tx_env =
-        TxEnv { origin: caller, gas_price, chain_id: U256::from(tx.chain_id), ..TxEnv::default() };
+    let tx_env = TxEnv {
+        origin: caller,
+        gas_price,
+        chain_id: U256::from(req.host.version().chain_id),
+        ..TxEnv::default()
+    };
     let (bytecode, message) =
         initial_message(req.host, caller, tx.nonce, tx.to, &tx.input, tx.value, gas_limit);
     let mut result = req.host.execute_message(&tx_env, bytecode, &message, false);

--- a/crates/evm2/src/ethereum/eip2930.rs
+++ b/crates/evm2/src/ethereum/eip2930.rs
@@ -1,9 +1,9 @@
 use super::{
     access_list_counts, charge_upfront, floor_gas, initial_message, intrinsic_gas,
-    rollback_failed_execution, settle_gas, validate_block_gas_limit, validate_create_initcode,
-    validate_floor_gas, validate_gas_price, validate_intrinsic_gas, validate_nonce_not_overflow,
-    validate_regular_gas_limit_cap, validate_sender, validate_tx_gas_limit_cap, warm_access_list,
-    warm_base_accounts,
+    rollback_failed_execution, settle_gas, validate_block_gas_limit, validate_chain_id,
+    validate_create_initcode, validate_floor_gas, validate_gas_price, validate_intrinsic_gas,
+    validate_nonce_not_overflow, validate_regular_gas_limit_cap, validate_sender,
+    validate_tx_gas_limit_cap, warm_access_list, warm_base_accounts,
 };
 use crate::{
     Evm, EvmTypes, SpecId, TxResult,
@@ -27,9 +27,10 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     let gas_price = U256::from(tx.gas_price);
 
     validate_gas_price(req.host.version(), gas_price, req.host.block.basefee)?;
+    validate_chain_id(req.host.version(), Some(tx.chain_id), false)?;
     validate_tx_gas_limit_cap(req.host.version(), tx.gas_limit)?;
     validate_block_gas_limit(req.host.version(), tx.gas_limit, req.host.block.gas_limit)?;
-    validate_create_initcode(spec_id, tx.to, &tx.input)?;
+    validate_create_initcode(req.host.version(), tx.to, &tx.input)?;
     validate_nonce_not_overflow(tx.nonce)?;
     let (access_list_accounts, access_list_storage_keys) = access_list_counts(&tx.access_list);
     let intrinsic = intrinsic_gas(
@@ -55,8 +56,12 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     let execution_checkpoint = req.host.state.checkpoint();
 
     let gas_limit = tx.gas_limit - intrinsic;
-    let tx_env =
-        TxEnv { origin: caller, gas_price, chain_id: U256::from(tx.chain_id), ..TxEnv::default() };
+    let tx_env = TxEnv {
+        origin: caller,
+        gas_price,
+        chain_id: U256::from(req.host.version().chain_id),
+        ..TxEnv::default()
+    };
     let (bytecode, message) =
         initial_message(req.host, caller, tx.nonce, tx.to, &tx.input, tx.value, gas_limit);
     let mut result = req.host.execute_message(&tx_env, bytecode, &message, false);

--- a/crates/evm2/src/ethereum/eip2930.rs
+++ b/crates/evm2/src/ethereum/eip2930.rs
@@ -26,9 +26,9 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     let tx = req.tx.inner();
     let gas_price = U256::from(tx.gas_price);
 
-    validate_gas_price(spec_id, gas_price, req.host.block.basefee)?;
+    validate_gas_price(req.host.version(), gas_price, req.host.block.basefee)?;
     validate_tx_gas_limit_cap(req.host.version(), tx.gas_limit)?;
-    validate_block_gas_limit(tx.gas_limit, req.host.block.gas_limit)?;
+    validate_block_gas_limit(req.host.version(), tx.gas_limit, req.host.block.gas_limit)?;
     validate_create_initcode(spec_id, tx.to, &tx.input)?;
     validate_nonce_not_overflow(tx.nonce)?;
     let (access_list_accounts, access_list_storage_keys) = access_list_counts(&tx.access_list);

--- a/crates/evm2/src/ethereum/eip4844.rs
+++ b/crates/evm2/src/ethereum/eip4844.rs
@@ -34,12 +34,12 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
         effective_gas_price(max_fee_per_gas, max_priority_fee_per_gas, req.host.block.basefee);
     let max_fee_per_blob_gas = U256::from(tx.max_fee_per_blob_gas);
 
-    validate_priority_fee(max_fee_per_gas, max_priority_fee_per_gas)?;
-    validate_gas_price(spec_id, gas_price, req.host.block.basefee)?;
+    validate_priority_fee(req.host.version(), max_fee_per_gas, max_priority_fee_per_gas)?;
+    validate_gas_price(req.host.version(), gas_price, req.host.block.basefee)?;
     validate_blob_fee(max_fee_per_blob_gas, req.host.block.blob_basefee)?;
     validate_blobs(&tx.blob_versioned_hashes, max_blobs_per_tx(spec_id))?;
     validate_tx_gas_limit_cap(req.host.version(), tx.gas_limit)?;
-    validate_block_gas_limit(tx.gas_limit, req.host.block.gas_limit)?;
+    validate_block_gas_limit(req.host.version(), tx.gas_limit, req.host.block.gas_limit)?;
     validate_create_initcode(spec_id, tx.to.into(), &tx.input)?;
     validate_nonce_not_overflow(tx.nonce)?;
     let (access_list_accounts, access_list_storage_keys) = access_list_counts(&tx.access_list);

--- a/crates/evm2/src/ethereum/eip4844.rs
+++ b/crates/evm2/src/ethereum/eip4844.rs
@@ -1,9 +1,10 @@
 use super::{
     access_list_counts, charge_upfront, effective_gas_price, floor_gas, initial_message,
     intrinsic_gas, rollback_failed_execution, settle_gas, validate_block_gas_limit,
-    validate_create_initcode, validate_floor_gas, validate_gas_price, validate_intrinsic_gas,
-    validate_nonce_not_overflow, validate_priority_fee, validate_regular_gas_limit_cap,
-    validate_sender, validate_tx_gas_limit_cap, warm_access_list, warm_base_accounts,
+    validate_chain_id, validate_create_initcode, validate_floor_gas, validate_gas_price,
+    validate_intrinsic_gas, validate_nonce_not_overflow, validate_priority_fee,
+    validate_regular_gas_limit_cap, validate_sender, validate_tx_gas_limit_cap, warm_access_list,
+    warm_base_accounts,
 };
 use crate::{
     Evm, EvmTypes, SpecId, TxResult,
@@ -13,9 +14,7 @@ use crate::{
     utils::b256_to_word,
 };
 use alloy_consensus::transaction::{Recovered, TxEip4844Variant};
-use alloy_eips::eip4844::{
-    DATA_GAS_PER_BLOB, MAX_BLOBS_PER_BLOCK_DENCUN, VERSIONED_HASH_VERSION_KZG,
-};
+use alloy_eips::eip4844::{DATA_GAS_PER_BLOB, VERSIONED_HASH_VERSION_KZG};
 use alloy_primitives::U256;
 
 pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
@@ -36,11 +35,12 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
 
     validate_priority_fee(req.host.version(), max_fee_per_gas, max_priority_fee_per_gas)?;
     validate_gas_price(req.host.version(), gas_price, req.host.block.basefee)?;
+    validate_chain_id(req.host.version(), Some(tx.chain_id), false)?;
     validate_blob_fee(max_fee_per_blob_gas, req.host.block.blob_basefee)?;
-    validate_blobs(&tx.blob_versioned_hashes, max_blobs_per_tx(spec_id))?;
+    validate_blobs(&tx.blob_versioned_hashes, req.host.version().max_blobs_per_tx)?;
     validate_tx_gas_limit_cap(req.host.version(), tx.gas_limit)?;
     validate_block_gas_limit(req.host.version(), tx.gas_limit, req.host.block.gas_limit)?;
-    validate_create_initcode(spec_id, tx.to.into(), &tx.input)?;
+    validate_create_initcode(req.host.version(), tx.to.into(), &tx.input)?;
     validate_nonce_not_overflow(tx.nonce)?;
     let (access_list_accounts, access_list_storage_keys) = access_list_counts(&tx.access_list);
     let intrinsic = intrinsic_gas(
@@ -78,7 +78,7 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     let tx_env = TxEnv {
         origin: caller,
         gas_price,
-        chain_id: U256::from(tx.chain_id),
+        chain_id: U256::from(req.host.version().chain_id),
         blob_hashes: tx.blob_versioned_hashes.iter().copied().map(b256_to_word).collect(),
     };
     let (bytecode, message) =
@@ -110,14 +110,4 @@ fn validate_blobs(blobs: &[alloy_primitives::B256], max_blobs: usize) -> Handler
         return Err(HandlerError::BlobVersionNotSupported);
     }
     Ok(())
-}
-
-const fn max_blobs_per_tx(spec_id: SpecId) -> usize {
-    // EIP-7594 Osaka tests keep the per-transaction blob cap at the Cancun cap, while
-    // Prague allows nine blobs per transaction.
-    if spec_id.enables(SpecId::PRAGUE) && !spec_id.enables(SpecId::OSAKA) {
-        9
-    } else {
-        MAX_BLOBS_PER_BLOCK_DENCUN
-    }
 }

--- a/crates/evm2/src/ethereum/eip7702.rs
+++ b/crates/evm2/src/ethereum/eip7702.rs
@@ -35,10 +35,10 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     let gas_price =
         effective_gas_price(max_fee_per_gas, max_priority_fee_per_gas, req.host.block.basefee);
 
-    validate_priority_fee(max_fee_per_gas, max_priority_fee_per_gas)?;
-    validate_gas_price(spec_id, gas_price, req.host.block.basefee)?;
+    validate_priority_fee(req.host.version(), max_fee_per_gas, max_priority_fee_per_gas)?;
+    validate_gas_price(req.host.version(), gas_price, req.host.block.basefee)?;
     validate_tx_gas_limit_cap(req.host.version(), tx.gas_limit)?;
-    validate_block_gas_limit(tx.gas_limit, req.host.block.gas_limit)?;
+    validate_block_gas_limit(req.host.version(), tx.gas_limit, req.host.block.gas_limit)?;
     validate_create_initcode(spec_id, tx.to.into(), &tx.input)?;
     validate_nonce_not_overflow(tx.nonce)?;
     let (access_list_accounts, access_list_storage_keys) = access_list_counts(&tx.access_list);

--- a/crates/evm2/src/ethereum/eip7702.rs
+++ b/crates/evm2/src/ethereum/eip7702.rs
@@ -1,9 +1,10 @@
 use super::{
     access_list_counts, charge_upfront, effective_gas_price, floor_gas, initial_message,
     intrinsic_gas, rollback_failed_execution, settle_gas, validate_block_gas_limit,
-    validate_create_initcode, validate_floor_gas, validate_gas_price, validate_intrinsic_gas,
-    validate_nonce_not_overflow, validate_priority_fee, validate_regular_gas_limit_cap,
-    validate_sender, validate_tx_gas_limit_cap, warm_access_list, warm_base_accounts,
+    validate_chain_id, validate_create_initcode, validate_floor_gas, validate_gas_price,
+    validate_intrinsic_gas, validate_nonce_not_overflow, validate_priority_fee,
+    validate_regular_gas_limit_cap, validate_sender, validate_tx_gas_limit_cap, warm_access_list,
+    warm_base_accounts,
 };
 use crate::{
     Evm, EvmTypes, SpecId, TxResult,
@@ -37,9 +38,10 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
 
     validate_priority_fee(req.host.version(), max_fee_per_gas, max_priority_fee_per_gas)?;
     validate_gas_price(req.host.version(), gas_price, req.host.block.basefee)?;
+    validate_chain_id(req.host.version(), Some(tx.chain_id), false)?;
     validate_tx_gas_limit_cap(req.host.version(), tx.gas_limit)?;
     validate_block_gas_limit(req.host.version(), tx.gas_limit, req.host.block.gas_limit)?;
-    validate_create_initcode(spec_id, tx.to.into(), &tx.input)?;
+    validate_create_initcode(req.host.version(), tx.to.into(), &tx.input)?;
     validate_nonce_not_overflow(tx.nonce)?;
     let (access_list_accounts, access_list_storage_keys) = access_list_counts(&tx.access_list);
     let intrinsic = intrinsic_gas(
@@ -63,12 +65,17 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     let effective_gas_cost = U256::from(tx.gas_limit) * gas_price;
     charge_upfront(req.host, caller, effective_gas_cost);
     req.host.state.increment_nonce(caller);
-    let eip7702_refund = apply_auth_list(req.host, tx.chain_id, &tx.authorization_list);
+    let chain_id = req.host.version().chain_id;
+    let eip7702_refund = apply_auth_list(req.host, chain_id, &tx.authorization_list);
     let execution_checkpoint = req.host.state.checkpoint();
 
     let gas_limit = tx.gas_limit - intrinsic;
-    let tx_env =
-        TxEnv { origin: caller, gas_price, chain_id: U256::from(tx.chain_id), ..TxEnv::default() };
+    let tx_env = TxEnv {
+        origin: caller,
+        gas_price,
+        chain_id: U256::from(req.host.version().chain_id),
+        ..TxEnv::default()
+    };
     let (bytecode, message) =
         initial_message(req.host, caller, tx.nonce, tx.to.into(), &tx.input, tx.value, gas_limit);
     let mut result = req.host.execute_message(&tx_env, bytecode, &message, false);

--- a/crates/evm2/src/ethereum/legacy.rs
+++ b/crates/evm2/src/ethereum/legacy.rs
@@ -1,7 +1,7 @@
 use super::{
     charge_upfront, floor_gas, initial_message, intrinsic_gas, rollback_failed_execution,
-    settle_gas, validate_block_gas_limit, validate_create_initcode, validate_floor_gas,
-    validate_gas_price, validate_intrinsic_gas, validate_nonce_not_overflow,
+    settle_gas, validate_block_gas_limit, validate_chain_id, validate_create_initcode,
+    validate_floor_gas, validate_gas_price, validate_intrinsic_gas, validate_nonce_not_overflow,
     validate_regular_gas_limit_cap, validate_sender, validate_tx_gas_limit_cap, warm_base_accounts,
 };
 use crate::{
@@ -22,9 +22,10 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     let gas_price = U256::from(tx.gas_price);
 
     validate_gas_price(req.host.version(), gas_price, req.host.block.basefee)?;
+    validate_chain_id(req.host.version(), tx.chain_id, true)?;
     validate_tx_gas_limit_cap(req.host.version(), tx.gas_limit)?;
     validate_block_gas_limit(req.host.version(), tx.gas_limit, req.host.block.gas_limit)?;
-    validate_create_initcode(spec_id, tx.to, &tx.input)?;
+    validate_create_initcode(req.host.version(), tx.to, &tx.input)?;
     validate_nonce_not_overflow(tx.nonce)?;
     let intrinsic = intrinsic_gas(req.host.version(), tx.to, &tx.input, 0, 0);
     validate_intrinsic_gas(tx.gas_limit, intrinsic)?;
@@ -45,7 +46,7 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     let tx_env = TxEnv {
         origin: caller,
         gas_price,
-        chain_id: tx.chain_id.map(U256::from).unwrap_or(U256::ONE),
+        chain_id: U256::from(req.host.version().chain_id),
         ..TxEnv::default()
     };
     let (bytecode, message) =

--- a/crates/evm2/src/ethereum/legacy.rs
+++ b/crates/evm2/src/ethereum/legacy.rs
@@ -21,9 +21,9 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     let spec_id = req.host.spec_id();
     let gas_price = U256::from(tx.gas_price);
 
-    validate_gas_price(spec_id, gas_price, req.host.block.basefee)?;
+    validate_gas_price(req.host.version(), gas_price, req.host.block.basefee)?;
     validate_tx_gas_limit_cap(req.host.version(), tx.gas_limit)?;
-    validate_block_gas_limit(tx.gas_limit, req.host.block.gas_limit)?;
+    validate_block_gas_limit(req.host.version(), tx.gas_limit, req.host.block.gas_limit)?;
     validate_create_initcode(spec_id, tx.to, &tx.input)?;
     validate_nonce_not_overflow(tx.nonce)?;
     let intrinsic = intrinsic_gas(req.host.version(), tx.to, &tx.input, 0, 0);

--- a/crates/evm2/src/ethereum/mod.rs
+++ b/crates/evm2/src/ethereum/mod.rs
@@ -108,10 +108,7 @@ pub(super) fn validate_gas_price(
     gas_price: U256,
     basefee: U256,
 ) -> HandlerResult<()> {
-    if version.features.contains(EvmFeatures::BASE_FEE_CHECK)
-        && version.spec_id.enables(SpecId::LONDON)
-        && gas_price < basefee
-    {
+    if version.features.contains(EvmFeatures::BASE_FEE_CHECK) && gas_price < basefee {
         return Err(HandlerError::FeeCapLessThanBaseFee {
             max_fee_per_gas: gas_price,
             base_fee: basefee,

--- a/crates/evm2/src/ethereum/mod.rs
+++ b/crates/evm2/src/ethereum/mod.rs
@@ -108,7 +108,7 @@ pub(super) fn validate_gas_price(
     gas_price: U256,
     basefee: U256,
 ) -> HandlerResult<()> {
-    if version.features.contains(EvmFeatures::BASE_FEE_CHECK) && gas_price < basefee {
+    if version.feature(EvmFeatures::BASE_FEE_CHECK) && gas_price < basefee {
         return Err(HandlerError::FeeCapLessThanBaseFee {
             max_fee_per_gas: gas_price,
             base_fee: basefee,
@@ -122,7 +122,7 @@ pub(super) fn validate_priority_fee(
     max_fee_per_gas: U256,
     max_priority_fee_per_gas: U256,
 ) -> HandlerResult<()> {
-    if version.features.contains(EvmFeatures::PRIORITY_FEE_CHECK)
+    if version.feature(EvmFeatures::PRIORITY_FEE_CHECK)
         && max_priority_fee_per_gas > max_fee_per_gas
     {
         return Err(HandlerError::PriorityFeeGreaterThanMaxFee);
@@ -143,7 +143,7 @@ pub(super) fn validate_block_gas_limit(
     tx_gas_limit: u64,
     block_gas_limit: U256,
 ) -> HandlerResult<()> {
-    if version.features.contains(EvmFeatures::BLOCK_GAS_LIMIT_CHECK)
+    if version.feature(EvmFeatures::BLOCK_GAS_LIMIT_CHECK)
         && U256::from(tx_gas_limit) > block_gas_limit
     {
         return Err(HandlerError::GasLimitMoreThanBlock {
@@ -162,7 +162,7 @@ pub(super) const fn validate_tx_gas_limit_cap(
     // replaces this with a regular-gas cap while allowing extra transaction gas to serve as
     // the state-gas reservoir.
     let cap = version.tx_gas_limit_cap;
-    if !version.features.contains(EvmFeatures::EIP8037) && tx_gas_limit > cap {
+    if !version.feature(EvmFeatures::EIP8037) && tx_gas_limit > cap {
         return Err(HandlerError::TxGasLimitGreaterThanCap { gas_limit: tx_gas_limit, cap });
     }
     Ok(())
@@ -175,7 +175,7 @@ pub(super) const fn validate_regular_gas_limit_cap(
     floor_gas: u64,
 ) -> HandlerResult<()> {
     let cap = version.tx_gas_limit_cap;
-    if version.features.contains(EvmFeatures::EIP8037) && tx_gas_limit > cap {
+    if version.feature(EvmFeatures::EIP8037) && tx_gas_limit > cap {
         let required_regular_gas = if intrinsic > floor_gas { intrinsic } else { floor_gas };
         if required_regular_gas > cap {
             return Err(HandlerError::TxGasLimitGreaterThanCap {
@@ -229,20 +229,19 @@ pub(super) fn validate_sender<T: EvmTypes<Host = Evm<T>>>(
     max_upfront: U256,
 ) -> HandlerResult<AccountInfo> {
     let sender_info = host.state.account_info(caller).unwrap_or_default();
-    let features = host.version().features;
-    if features.contains(EvmFeatures::EIP3607) && sender_info.code_hash != KECCAK256_EMPTY {
+    if host.feature(EvmFeatures::EIP3607) && sender_info.code_hash != KECCAK256_EMPTY {
         let code = host.state.get_code(caller);
         if !code.is_empty() && !code.is_eip7702() {
             return Err(HandlerError::RejectCallerWithCode);
         }
     }
-    if features.contains(EvmFeatures::NONCE_CHECK) && sender_info.nonce != nonce {
+    if host.feature(EvmFeatures::NONCE_CHECK) && sender_info.nonce != nonce {
         return Err(HandlerError::InvalidNonce { expected: sender_info.nonce, got: nonce });
     }
-    if features.contains(EvmFeatures::BALANCE_CHECK) && sender_info.balance < max_upfront {
+    if host.feature(EvmFeatures::BALANCE_CHECK) && sender_info.balance < max_upfront {
         return Err(HandlerError::InsufficientFunds);
     }
-    if !features.contains(EvmFeatures::BALANCE_CHECK) && sender_info.balance < max_upfront {
+    if !host.feature(EvmFeatures::BALANCE_CHECK) && sender_info.balance < max_upfront {
         host.state.add_balance(caller, max_upfront - sender_info.balance);
     }
     Ok(sender_info)
@@ -282,7 +281,7 @@ pub(super) fn charge_upfront<T: EvmTypes<Host = Evm<T>>>(
     caller: Address,
     max_gas_cost: U256,
 ) {
-    if !host.version().features.contains(EvmFeatures::FEE_CHARGE) {
+    if !host.feature(EvmFeatures::FEE_CHARGE) {
         return;
     }
     host.state.add_balance(caller, Word::ZERO.wrapping_sub(max_gas_cost));
@@ -381,7 +380,7 @@ pub(super) fn settle_gas<T: EvmTypes<Host = Evm<T>>>(
 ) -> TxResult {
     let (gas_remaining, gas_used) =
         final_tx_gas(&result, tx_gas_limit, spec_id.enables(SpecId::LONDON), floor_gas);
-    if host.version().features.contains(EvmFeatures::FEE_CHARGE) {
+    if host.feature(EvmFeatures::FEE_CHARGE) {
         host.state.add_balance(caller, U256::from(gas_remaining) * gas_price);
         let beneficiary_gas_price = if spec_id.enables(SpecId::LONDON) {
             gas_price.saturating_sub(host.block.basefee)
@@ -421,7 +420,7 @@ pub(super) fn access_list_counts(access_list: &AccessList) -> (u64, u64) {
 
 /// Calculates transaction calldata floor gas.
 pub(super) fn floor_gas(version: &Version, input: &Bytes) -> u64 {
-    if !version.features.contains(EvmFeatures::EIP7623) {
+    if !version.feature(EvmFeatures::EIP7623) {
         return 0;
     }
     let params = &version.gas_params;

--- a/crates/evm2/src/ethereum/mod.rs
+++ b/crates/evm2/src/ethereum/mod.rs
@@ -9,7 +9,6 @@ mod legacy;
 use crate::{
     Evm, EvmFeatures, EvmTypes, SpecId, TxResult, Version,
     bytecode::Bytecode,
-    constants::MAX_INITCODE_SIZE,
     evm::{AccountInfo, StateCheckpoint, precompile::PrecompileProvider},
     interpreter::{Message, MessageKind, MessageResult, Word},
     registry::{HandlerError, HandlerResult, TxRegistry},
@@ -187,14 +186,34 @@ pub(super) const fn validate_regular_gas_limit_cap(
     Ok(())
 }
 
+pub(super) const fn validate_chain_id(
+    version: &Version,
+    chain_id: Option<u64>,
+    allow_missing: bool,
+) -> HandlerResult<()> {
+    if !version.feature(EvmFeatures::TX_CHAIN_ID_CHECK) {
+        return Ok(());
+    }
+    let Some(chain_id) = chain_id else {
+        return if allow_missing { Ok(()) } else { Err(HandlerError::MissingChainId) };
+    };
+    if chain_id != version.chain_id {
+        return Err(HandlerError::InvalidChainId { expected: version.chain_id, got: chain_id });
+    }
+    Ok(())
+}
+
 pub(super) fn validate_create_initcode(
-    spec_id: SpecId,
+    version: &Version,
     to: TxKind,
     input: &Bytes,
 ) -> HandlerResult<()> {
-    if spec_id.enables(SpecId::SHANGHAI) && to.is_create() && input.len() > MAX_INITCODE_SIZE {
+    if version.spec_id.enables(SpecId::SHANGHAI)
+        && to.is_create()
+        && input.len() > version.max_initcode_size
+    {
         return Err(HandlerError::CreateInitCodeSizeLimit {
-            limit: MAX_INITCODE_SIZE,
+            limit: version.max_initcode_size,
             got: input.len(),
         });
     }
@@ -538,6 +557,18 @@ mod tests {
         );
         prague.features.remove(EvmFeatures::BLOCK_GAS_LIMIT_CHECK);
         assert_eq!(validate_block_gas_limit(&prague, 2, U256::ONE), Ok(()));
+
+        let mut version = Version::new(SpecId::OSAKA);
+        version.chain_id = 10;
+        assert_eq!(validate_chain_id(&version, Some(10), false), Ok(()));
+        assert_eq!(
+            validate_chain_id(&version, Some(1), false),
+            Err(HandlerError::InvalidChainId { expected: 10, got: 1 })
+        );
+        assert_eq!(validate_chain_id(&version, None, false), Err(HandlerError::MissingChainId));
+        assert_eq!(validate_chain_id(&version, None, true), Ok(()));
+        version.features.remove(EvmFeatures::TX_CHAIN_ID_CHECK);
+        assert_eq!(validate_chain_id(&version, Some(1), false), Ok(()));
     }
 
     #[test]

--- a/crates/evm2/src/ethereum/mod.rs
+++ b/crates/evm2/src/ethereum/mod.rs
@@ -7,7 +7,7 @@ mod eip7702;
 mod legacy;
 
 use crate::{
-    Evm, EvmTypes, SpecId, TxResult, Version,
+    Evm, EvmFeatures, EvmTypes, SpecId, TxResult, Version,
     bytecode::Bytecode,
     constants::MAX_INITCODE_SIZE,
     evm::{AccountInfo, StateCheckpoint, precompile::PrecompileProvider},
@@ -104,11 +104,14 @@ pub fn ethereum_tx_registry<T: EvmTypes<Host = Evm<T>>>()
 }
 
 pub(super) fn validate_gas_price(
-    spec_id: SpecId,
+    version: &Version,
     gas_price: U256,
     basefee: U256,
 ) -> HandlerResult<()> {
-    if spec_id.enables(SpecId::LONDON) && gas_price < basefee {
+    if version.features.contains(EvmFeatures::BASE_FEE_CHECK)
+        && version.spec_id.enables(SpecId::LONDON)
+        && gas_price < basefee
+    {
         return Err(HandlerError::FeeCapLessThanBaseFee {
             max_fee_per_gas: gas_price,
             base_fee: basefee,
@@ -118,10 +121,13 @@ pub(super) fn validate_gas_price(
 }
 
 pub(super) fn validate_priority_fee(
+    version: &Version,
     max_fee_per_gas: U256,
     max_priority_fee_per_gas: U256,
 ) -> HandlerResult<()> {
-    if max_priority_fee_per_gas > max_fee_per_gas {
+    if version.features.contains(EvmFeatures::PRIORITY_FEE_CHECK)
+        && max_priority_fee_per_gas > max_fee_per_gas
+    {
         return Err(HandlerError::PriorityFeeGreaterThanMaxFee);
     }
     Ok(())
@@ -136,10 +142,13 @@ pub(super) fn effective_gas_price(
 }
 
 pub(super) fn validate_block_gas_limit(
+    version: &Version,
     tx_gas_limit: u64,
     block_gas_limit: U256,
 ) -> HandlerResult<()> {
-    if U256::from(tx_gas_limit) > block_gas_limit {
+    if version.features.contains(EvmFeatures::BLOCK_GAS_LIMIT_CHECK)
+        && U256::from(tx_gas_limit) > block_gas_limit
+    {
         return Err(HandlerError::GasLimitMoreThanBlock {
             gas_limit: tx_gas_limit,
             block_gas_limit,
@@ -156,7 +165,7 @@ pub(super) const fn validate_tx_gas_limit_cap(
     // replaces this with a regular-gas cap while allowing extra transaction gas to serve as
     // the state-gas reservoir.
     let cap = version.tx_gas_limit_cap;
-    if matches!(version.spec_id, SpecId::OSAKA) && tx_gas_limit > cap {
+    if !version.features.contains(EvmFeatures::EIP8037) && tx_gas_limit > cap {
         return Err(HandlerError::TxGasLimitGreaterThanCap { gas_limit: tx_gas_limit, cap });
     }
     Ok(())
@@ -169,7 +178,7 @@ pub(super) const fn validate_regular_gas_limit_cap(
     floor_gas: u64,
 ) -> HandlerResult<()> {
     let cap = version.tx_gas_limit_cap;
-    if version.spec_id.enables(SpecId::AMSTERDAM) && tx_gas_limit > cap {
+    if version.features.contains(EvmFeatures::EIP8037) && tx_gas_limit > cap {
         let required_regular_gas = if intrinsic > floor_gas { intrinsic } else { floor_gas };
         if required_regular_gas > cap {
             return Err(HandlerError::TxGasLimitGreaterThanCap {
@@ -223,17 +232,21 @@ pub(super) fn validate_sender<T: EvmTypes<Host = Evm<T>>>(
     max_upfront: U256,
 ) -> HandlerResult<AccountInfo> {
     let sender_info = host.state.account_info(caller).unwrap_or_default();
-    if sender_info.code_hash != KECCAK256_EMPTY {
+    let features = host.version().features;
+    if features.contains(EvmFeatures::EIP3607) && sender_info.code_hash != KECCAK256_EMPTY {
         let code = host.state.get_code(caller);
         if !code.is_empty() && !code.is_eip7702() {
             return Err(HandlerError::RejectCallerWithCode);
         }
     }
-    if sender_info.nonce != nonce {
+    if features.contains(EvmFeatures::NONCE_CHECK) && sender_info.nonce != nonce {
         return Err(HandlerError::InvalidNonce { expected: sender_info.nonce, got: nonce });
     }
-    if sender_info.balance < max_upfront {
+    if features.contains(EvmFeatures::BALANCE_CHECK) && sender_info.balance < max_upfront {
         return Err(HandlerError::InsufficientFunds);
+    }
+    if !features.contains(EvmFeatures::BALANCE_CHECK) && sender_info.balance < max_upfront {
+        host.state.add_balance(caller, max_upfront - sender_info.balance);
     }
     Ok(sender_info)
 }
@@ -272,6 +285,9 @@ pub(super) fn charge_upfront<T: EvmTypes<Host = Evm<T>>>(
     caller: Address,
     max_gas_cost: U256,
 ) {
+    if !host.version().features.contains(EvmFeatures::FEE_CHARGE) {
+        return;
+    }
     host.state.add_balance(caller, Word::ZERO.wrapping_sub(max_gas_cost));
 }
 
@@ -368,13 +384,16 @@ pub(super) fn settle_gas<T: EvmTypes<Host = Evm<T>>>(
 ) -> TxResult {
     let (gas_remaining, gas_used) =
         final_tx_gas(&result, tx_gas_limit, spec_id.enables(SpecId::LONDON), floor_gas);
-    host.state.add_balance(caller, U256::from(gas_remaining) * gas_price);
-    let beneficiary_gas_price = if spec_id.enables(SpecId::LONDON) {
-        gas_price.saturating_sub(host.block.basefee)
-    } else {
-        gas_price
-    };
-    host.state.add_balance(host.block.beneficiary, U256::from(gas_used) * beneficiary_gas_price);
+    if host.version().features.contains(EvmFeatures::FEE_CHARGE) {
+        host.state.add_balance(caller, U256::from(gas_remaining) * gas_price);
+        let beneficiary_gas_price = if spec_id.enables(SpecId::LONDON) {
+            gas_price.saturating_sub(host.block.basefee)
+        } else {
+            gas_price
+        };
+        host.state
+            .add_balance(host.block.beneficiary, U256::from(gas_used) * beneficiary_gas_price);
+    }
     TxResult {
         status: result.stop.is_success(),
         gas_used,
@@ -405,6 +424,9 @@ pub(super) fn access_list_counts(access_list: &AccessList) -> (u64, u64) {
 
 /// Calculates transaction calldata floor gas.
 pub(super) fn floor_gas(version: &Version, input: &Bytes) -> u64 {
+    if !version.features.contains(EvmFeatures::EIP7623) {
+        return 0;
+    }
     let params = &version.gas_params;
     let floor_cost_per_token = u64::from(params.get(GasId::TxFloorCostPerToken));
     if floor_cost_per_token == 0 {
@@ -450,7 +472,7 @@ pub(super) fn intrinsic_gas(
 mod tests {
     use super::*;
     use crate::{
-        BaseEvmTypes, Precompiles,
+        BaseEvmTypes, ExecutionConfig, Precompiles,
         env::{BlockEnv, TxEnv},
         evm::InMemoryDB,
         interpreter::{Host, InstrStop, op},
@@ -485,9 +507,69 @@ mod tests {
     #[test]
     fn floor_gas_charges_prague_calldata_tokens() {
         let input = Bytes::from_static(&[0, 1, 2]);
+        let mut prague_without_eip7623 = Version::new(SpecId::PRAGUE);
+        prague_without_eip7623.features.remove(EvmFeatures::EIP7623);
 
         assert_eq!(floor_gas(Version::base(SpecId::SHANGHAI), &input), 0);
         assert_eq!(floor_gas(Version::base(SpecId::PRAGUE), &input), 21_000 + 9 * 10);
+        assert_eq!(floor_gas(&prague_without_eip7623, &input), 0);
+    }
+
+    #[test]
+    fn features_gate_transaction_validation() {
+        let mut london = Version::new(SpecId::LONDON);
+        assert_eq!(
+            validate_gas_price(&london, U256::ZERO, U256::ONE),
+            Err(HandlerError::FeeCapLessThanBaseFee {
+                max_fee_per_gas: U256::ZERO,
+                base_fee: U256::ONE,
+            })
+        );
+        london.features.remove(EvmFeatures::BASE_FEE_CHECK);
+        assert_eq!(validate_gas_price(&london, U256::ZERO, U256::ONE), Ok(()));
+
+        let mut prague = Version::new(SpecId::PRAGUE);
+        assert_eq!(
+            validate_priority_fee(&prague, U256::ONE, U256::from(2)),
+            Err(HandlerError::PriorityFeeGreaterThanMaxFee)
+        );
+        prague.features.remove(EvmFeatures::PRIORITY_FEE_CHECK);
+        assert_eq!(validate_priority_fee(&prague, U256::ONE, U256::from(2)), Ok(()));
+
+        assert_eq!(
+            validate_block_gas_limit(&prague, 2, U256::ONE),
+            Err(HandlerError::GasLimitMoreThanBlock { gas_limit: 2, block_gas_limit: U256::ONE })
+        );
+        prague.features.remove(EvmFeatures::BLOCK_GAS_LIMIT_CHECK);
+        assert_eq!(validate_block_gas_limit(&prague, 2, U256::ONE), Ok(()));
+    }
+
+    #[test]
+    fn features_gate_sender_validation() {
+        let caller = Address::with_last_byte(0xaa);
+        let mut database = InMemoryDB::default();
+        database.insert_account_info(
+            caller,
+            AccountInfo::default()
+                .with_nonce(7)
+                .with_code(Bytecode::new_legacy(Bytes::from_static(&[op::STOP]))),
+        );
+
+        let mut version = Version::new(SpecId::OSAKA);
+        version.features.remove(EvmFeatures::EIP3607);
+        version.features.remove(EvmFeatures::NONCE_CHECK);
+        version.features.remove(EvmFeatures::BALANCE_CHECK);
+        let mut evm = Evm::<BaseEvmTypes>::new_with_execution_config(
+            ExecutionConfig::for_spec_and_version(SpecId::OSAKA, version),
+            SpecId::OSAKA,
+            BlockEnv::default(),
+            TxRegistry::new(),
+            database,
+            Precompiles::base(SpecId::OSAKA),
+        );
+
+        assert!(validate_sender(&mut evm, caller, 0, U256::from(100)).is_ok());
+        assert_eq!(evm.state.account_info(caller).unwrap().balance, U256::from(100));
     }
 
     #[test]
@@ -593,6 +675,16 @@ mod tests {
             Err(HandlerError::TxGasLimitGreaterThanCap {
                 gas_limit: amsterdam.tx_gas_limit_cap + 1,
                 cap: amsterdam.tx_gas_limit_cap
+            })
+        );
+
+        let mut amsterdam_without_eip8037 = Version::new(SpecId::AMSTERDAM);
+        amsterdam_without_eip8037.features.remove(EvmFeatures::EIP8037);
+        assert_eq!(
+            validate_tx_gas_limit_cap(&amsterdam_without_eip8037, tx_gas_limit),
+            Err(HandlerError::TxGasLimitGreaterThanCap {
+                gas_limit: tx_gas_limit,
+                cap: amsterdam_without_eip8037.tx_gas_limit_cap,
             })
         );
     }

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -364,7 +364,6 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
             {
                 Some(InstrStop::CreateContractSizeLimit)
             } else if self.version().features.contains(EvmFeatures::EIP3541)
-                && self.spec_id().enables(SpecId::LONDON)
                 && output.first().is_some_and(|byte| *byte == 0xef)
             {
                 Some(InstrStop::CreateContractStartingWithEF)

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -11,7 +11,7 @@ use crate::{
         Word,
     },
     registry::{HandlerResult, TxRegistry},
-    version::GasId,
+    version::{EvmFeatures, GasId},
 };
 use alloy_eips::eip2718::Typed2718;
 use alloy_primitives::{Address, B256, Bytes, Log};
@@ -363,7 +363,8 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
                 && output.len() > MAX_CODE_SIZE
             {
                 Some(InstrStop::CreateContractSizeLimit)
-            } else if self.spec_id().enables(SpecId::LONDON)
+            } else if self.version().features.contains(EvmFeatures::EIP3541)
+                && self.spec_id().enables(SpecId::LONDON)
                 && output.first().is_some_and(|byte| *byte == 0xef)
             {
                 Some(InstrStop::CreateContractStartingWithEF)

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -4,7 +4,7 @@ use self::precompile::{PrecompileOutput, PrecompileProvider};
 use crate::{
     EvmConfigSelector, EvmTypes, ExecutionConfig, PrecompileError, PrecompileHalt, SpecId,
     bytecode::Bytecode,
-    constants::{CALL_DEPTH_LIMIT, MAX_CODE_SIZE},
+    constants::CALL_DEPTH_LIMIT,
     env::{BlockEnv, TxEnv},
     interpreter::{
         Gas, Host, InstrStop, Interpreter, InterpreterPool, Message, MessageKind, MessageResult,
@@ -375,7 +375,7 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
 
         if stop.is_success() {
             let stop = if self.spec_id().enables(SpecId::SPURIOUS_DRAGON)
-                && output.len() > MAX_CODE_SIZE
+                && output.len() > self.version().max_code_size
             {
                 Some(InstrStop::CreateContractSizeLimit)
             } else if self.feature(EvmFeatures::EIP3541)

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -213,46 +213,61 @@ impl<T: EvmTypes> Evm<T> {
 
 impl<T: EvmTypes> Evm<T> {
     /// Returns the transaction handler registry.
+    #[inline]
     pub const fn registry(&self) -> &TxRegistry<T::Tx, TxResult, Self> {
         &self.registry
     }
 
     /// Returns the backing database.
+    #[inline]
     pub const fn database(&self) -> &State<T::Database> {
         &self.state
     }
 
     /// Returns the mutable EVM state.
+    #[inline]
     pub const fn state(&self) -> &State<T::Database> {
         &self.state
     }
 
     /// Returns logs emitted by the current in-flight transaction.
+    #[inline]
     pub fn logs(&self) -> &[Log] {
         self.state.logs()
     }
 
     /// Returns the precompile provider.
+    #[inline]
     pub const fn precompiles(&self) -> &T::Precompiles {
         &self.precompiles
     }
 
     /// Returns the precompile provider mutably.
+    #[inline]
     pub const fn precompiles_mut(&mut self) -> &mut T::Precompiles {
         &mut self.precompiles
     }
 
     /// Returns the active EVM version.
+    #[inline]
     pub const fn version(&self) -> &crate::Version {
         self.execution_config.version()
     }
 
+    /// Returns `true` if the active EVM feature set contains `feature`.
+    #[inline]
+    pub const fn feature(&self, feature: EvmFeatures) -> bool {
+        self.version().feature(feature)
+    }
+
     /// Returns the active base specification ID.
+    #[inline]
     pub const fn spec_id(&self) -> SpecId {
         self.version().spec_id
     }
 
     /// Returns the selector-specific runtime specification ID.
+    #[inline]
     pub const fn config_spec_id(&self) -> T::SpecId {
         self.spec_id
     }
@@ -363,7 +378,7 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
                 && output.len() > MAX_CODE_SIZE
             {
                 Some(InstrStop::CreateContractSizeLimit)
-            } else if self.version().features.contains(EvmFeatures::EIP3541)
+            } else if self.feature(EvmFeatures::EIP3541)
                 && output.first().is_some_and(|byte| *byte == 0xef)
             {
                 Some(InstrStop::CreateContractStartingWithEF)

--- a/crates/evm2/src/evm/registry.rs
+++ b/crates/evm2/src/evm/registry.rs
@@ -80,6 +80,17 @@ pub enum HandlerError {
         /// Transaction nonce.
         got: u64,
     },
+    /// Transaction chain ID does not match the active chain.
+    #[error("invalid chain id: expected {expected}, got {got}")]
+    InvalidChainId {
+        /// Active chain ID.
+        expected: u64,
+        /// Transaction chain ID.
+        got: u64,
+    },
+    /// Transaction chain ID is required.
+    #[error("missing chain id")]
+    MissingChainId,
     /// Transaction gas limit is lower than intrinsic gas.
     #[error("intrinsic gas too low: required {required}, got {got}")]
     IntrinsicGasTooLow {

--- a/crates/evm2/src/interpreter/instructions/host.rs
+++ b/crates/evm2/src/interpreter/instructions/host.rs
@@ -64,7 +64,7 @@ pub(crate) fn sstore(cx: _) -> Result {
     // EIP-8037 / Amsterdam: creating a new storage slot (original == present == 0,
     // new != 0) also consumes state gas from the reservoir before spilling into
     // regular gas.
-    if cx.state.version.features.contains(EvmFeatures::EIP8037) {
+    if cx.state.version.feature(EvmFeatures::EIP8037) {
         cx.gas.spend_state(gas_params.sstore_state_gas(&state_load))?;
     }
 

--- a/crates/evm2/src/interpreter/instructions/host.rs
+++ b/crates/evm2/src/interpreter/instructions/host.rs
@@ -1,5 +1,5 @@
 use crate::{
-    EvmTypes, SpecId,
+    EvmFeatures, EvmTypes, SpecId,
     interpreter::{Host, InstrStop, InstructionCx, Result, StackMut, Word, memory::resize_memory},
     utils::word_to_usize,
     version::GasId,
@@ -64,7 +64,7 @@ pub(crate) fn sstore(cx: _) -> Result {
     // EIP-8037 / Amsterdam: creating a new storage slot (original == present == 0,
     // new != 0) also consumes state gas from the reservoir before spilling into
     // regular gas.
-    if cx.state.spec.enables(SpecId::AMSTERDAM) {
+    if cx.state.version.features.contains(EvmFeatures::EIP8037) {
         cx.gas.spend_state(gas_params.sstore_state_gas(&state_load))?;
     }
 

--- a/crates/evm2/src/interpreter/instructions/system.rs
+++ b/crates/evm2/src/interpreter/instructions/system.rs
@@ -2,10 +2,7 @@
 
 use crate::{
     EvmTypes, SpecId,
-    constants::{
-        CALL_DEPTH_LIMIT, EIP7702_BYTECODE_LEN, EIP7702_MAGIC_BYTES, EIP7702_VERSION,
-        MAX_INITCODE_SIZE,
-    },
+    constants::{CALL_DEPTH_LIMIT, EIP7702_BYTECODE_LEN, EIP7702_MAGIC_BYTES, EIP7702_VERSION},
     interpreter::{
         Host, InstrStop, InstructionCx, Message, MessageKind, MessageResult, Result, StackMut,
         Word, memory::resize_memory,
@@ -275,7 +272,7 @@ fn create_inner<T: EvmTypes>(
 
     let len = word_to_usize(len)?;
     if cx.state.spec.enables(SpecId::SHANGHAI) {
-        if len > MAX_INITCODE_SIZE {
+        if len > cx.state.version.max_initcode_size {
             return Err(InstrStop::CreateInitCodeSizeLimit);
         }
         cx.gas.spend(cx.state.gas_params().initcode_cost(len))?;

--- a/crates/evm2/src/interpreter/instructions/tests.rs
+++ b/crates/evm2/src/interpreter/instructions/tests.rs
@@ -25,6 +25,7 @@ impl EvmTypes for TestTypes {
 
 #[derive(Debug)]
 pub(crate) struct TestHost {
+    pub(super) spec_id: SpecId,
     pub(super) block: BlockEnv,
     pub(super) code_hash: B256,
     pub(super) code: Bytes,
@@ -46,6 +47,7 @@ pub(crate) struct TestHost {
 impl Default for TestHost {
     fn default() -> Self {
         Self {
+            spec_id: SpecId::OSAKA,
             block: BlockEnv::default(),
             code_hash: B256::ZERO,
             code: Bytes::new(),
@@ -68,7 +70,7 @@ impl Default for TestHost {
 
 impl Host for TestHost {
     fn spec_id(&self) -> SpecId {
-        SpecId::OSAKA
+        self.spec_id
     }
 
     fn block_env(&mut self) -> &BlockEnv {
@@ -285,13 +287,14 @@ pub(super) fn run(config: RunConfig<'_>) -> TestInterpreter {
 }
 
 fn run_with_config<C: EvmConfig<TestTypes>>(config: RunConfig<'_>) -> TestInterpreter {
-    let RunConfig { code, host, spec_id: _, tx_env, mut message, gas_limit, return_data } = config;
+    let RunConfig { code, host, spec_id, tx_env, mut message, gas_limit, return_data } = config;
     let bytecode = Bytecode::new_legacy(Bytes::from(code));
     message.gas_limit = gas_limit;
     let mut inner = Interpreter::<TestTypes>::new(bytecode, &tx_env, &message, false);
     inner.return_data = return_data;
     let mut default_host = TestHost::default();
     let host = host.unwrap_or(&mut default_host);
+    host.spec_id = spec_id;
     let err = inner.run::<C>(host);
     let stack_len = inner.stack_len();
     TestInterpreter {

--- a/crates/evm2/src/lib.rs
+++ b/crates/evm2/src/lib.rs
@@ -32,7 +32,7 @@ pub use precompiles::{
 };
 
 pub mod version;
-pub use version::{Version, VersionTables};
+pub use version::{EvmFeatures, Version, VersionTables};
 
 mod spec_id;
 pub use spec_id::SpecId;

--- a/crates/evm2/src/version/features.rs
+++ b/crates/evm2/src/version/features.rs
@@ -120,55 +120,55 @@ impl core::ops::Not for EvmFeatures {
 evm_features! {
     /// Checks transaction chain IDs.
     ///
-    /// Default: on.
+    /// Default: on
     TX_CHAIN_ID_CHECK = 0,
     /// Checks transaction nonces against account nonces.
     ///
-    /// Default: on.
+    /// Default: on
     NONCE_CHECK = 1,
     /// Checks that senders can pay transaction costs.
     ///
-    /// Default: on.
+    /// Default: on
     BALANCE_CHECK = 2,
     /// Checks that transaction gas limits do not exceed the block gas limit.
     ///
-    /// Default: on.
+    /// Default: on
     BLOCK_GAS_LIMIT_CHECK = 3,
     /// Applies EIP-3541 contract code prefix rejection.
     ///
-    /// Default: on.
+    /// Default: on
     EIP3541 = 4,
     /// Applies EIP-3607 sender code rejection.
     ///
-    /// Default: on.
+    /// Default: on
     EIP3607 = 5,
     /// Applies EIP-7623 calldata cost floor.
     ///
-    /// Default: on.
+    /// Default: on
     EIP7623 = 6,
     /// Checks EIP-1559 transaction fee caps against the block base fee.
     ///
-    /// Default: on.
+    /// Default: on
     BASE_FEE_CHECK = 7,
     /// Checks EIP-1559 max priority fee against max fee.
     ///
-    /// Default: on.
+    /// Default: on
     PRIORITY_FEE_CHECK = 8,
     /// Charges transaction fees.
     ///
-    /// Default: on.
+    /// Default: on
     FEE_CHARGE = 9,
     /// Applies EIP-8037 state creation gas accounting.
     ///
-    /// Default: on if Amsterdam.
+    /// Default: on if amsterdam
     EIP8037 = 10,
     /// Applies EIP-7708 ETH transfer logs.
     ///
-    /// Default: on.
+    /// Default: on
     EIP7708 = 11,
     /// Applies delayed burn logging for EIP-7708 selfdestructs.
     ///
-    /// Default: on.
+    /// Default: on
     EIP7708_DELAYED_BURN = 12,
 }
 

--- a/crates/evm2/src/version/features.rs
+++ b/crates/evm2/src/version/features.rs
@@ -5,8 +5,11 @@
 pub struct EvmFeatures(u64);
 
 impl EvmFeatures {
-    /// Empty feature bitmap.
-    pub const EMPTY: Self = Self(0);
+    /// Creates an empty feature bitmap.
+    #[inline]
+    pub const fn empty() -> Self {
+        Self(0)
+    }
 
     const fn from_bit(bit: u32) -> Self {
         Self(1 << bit)

--- a/crates/evm2/src/version/features.rs
+++ b/crates/evm2/src/version/features.rs
@@ -4,17 +4,6 @@
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
 pub struct EvmFeatures(u64);
 
-macro_rules! evm_features {
-    ($($(#[$attr:meta])* $name:ident = $bit:literal,)*) => {
-        impl EvmFeatures {
-            $(
-                $(#[$attr])*
-                pub const $name: Self = Self::from_bit($bit);
-            )*
-        }
-    };
-}
-
 impl EvmFeatures {
     /// Empty feature bitmap.
     pub const EMPTY: Self = Self(0);
@@ -117,59 +106,73 @@ impl core::ops::Not for EvmFeatures {
     }
 }
 
+macro_rules! evm_features {
+    (@impl $bit:expr;) => {};
+    (@impl $bit:expr; $(#[$attr:meta])* $name:ident, $($rest:tt)*) => {
+        impl EvmFeatures {
+            $(#[$attr])*
+            pub const $name: Self = Self::from_bit($bit);
+        }
+        evm_features!(@impl $bit + 1; $($rest)*);
+    };
+    ($($tokens:tt)*) => {
+        evm_features!(@impl 0; $($tokens)*);
+    };
+}
+
 evm_features! {
     /// Checks transaction chain IDs.
     ///
     /// Default: on
-    TX_CHAIN_ID_CHECK = 0,
+    TX_CHAIN_ID_CHECK,
     /// Checks transaction nonces against account nonces.
     ///
     /// Default: on
-    NONCE_CHECK = 1,
+    NONCE_CHECK,
     /// Checks that senders can pay transaction costs.
     ///
     /// Default: on
-    BALANCE_CHECK = 2,
+    BALANCE_CHECK,
     /// Checks that transaction gas limits do not exceed the block gas limit.
     ///
     /// Default: on
-    BLOCK_GAS_LIMIT_CHECK = 3,
+    BLOCK_GAS_LIMIT_CHECK,
     /// Applies EIP-3541 contract code prefix rejection.
     ///
-    /// Default: on
-    EIP3541 = 4,
+    /// Default: on since London
+    EIP3541,
     /// Applies EIP-3607 sender code rejection.
     ///
     /// Default: on
-    EIP3607 = 5,
+    EIP3607,
     /// Applies EIP-7623 calldata cost floor.
     ///
-    /// Default: on
-    EIP7623 = 6,
+    /// Default: on since Prague
+    EIP7623,
     /// Checks EIP-1559 transaction fee caps against the block base fee.
     ///
-    /// Default: on
-    BASE_FEE_CHECK = 7,
+    /// Default: on since London
+    BASE_FEE_CHECK,
     /// Checks EIP-1559 max priority fee against max fee.
     ///
     /// Default: on
-    PRIORITY_FEE_CHECK = 8,
+    PRIORITY_FEE_CHECK,
     /// Charges transaction fees.
     ///
     /// Default: on
-    FEE_CHARGE = 9,
+    FEE_CHARGE,
     /// Applies EIP-8037 state creation gas accounting.
     ///
-    /// Default: on if amsterdam
-    EIP8037 = 10,
+    /// Default: on since Amsterdam
+    EIP8037,
     /// Applies EIP-7708 ETH transfer logs.
     ///
-    /// Default: on
-    EIP7708 = 11,
+    /// Default: on since Amsterdam
+    EIP7708,
     /// Applies delayed burn logging for EIP-7708 selfdestructs.
     ///
-    /// Default: on
-    EIP7708_DELAYED_BURN = 12,
+    /// Default: on since Amsterdam
+    EIP7708_DELAYED_BURN,
 }
 
 #[cfg(test)]

--- a/crates/evm2/src/version/features.rs
+++ b/crates/evm2/src/version/features.rs
@@ -8,20 +8,8 @@ impl EvmFeatures {
     /// Empty feature bitmap.
     pub const EMPTY: Self = Self(0);
 
-    /// Creates a feature bitmap from raw bits.
-    #[inline]
-    pub const fn from_bits(bits: u64) -> Self {
-        Self(bits)
-    }
-
     const fn from_bit(bit: u32) -> Self {
         Self(1 << bit)
-    }
-
-    /// Returns the raw feature bits.
-    #[inline]
-    pub const fn bits(self) -> u64 {
-        self.0
     }
 
     /// Returns `true` if no feature bits are set.
@@ -189,9 +177,6 @@ mod tests {
         assert!(!features.contains(EvmFeatures::NONCE_CHECK));
 
         features.set(EvmFeatures::BASE_FEE_CHECK, true);
-        assert_eq!(
-            EvmFeatures::from_bits(features.bits()),
-            EvmFeatures::TX_CHAIN_ID_CHECK | EvmFeatures::BASE_FEE_CHECK
-        );
+        assert_eq!(features, EvmFeatures::TX_CHAIN_ID_CHECK | EvmFeatures::BASE_FEE_CHECK);
     }
 }

--- a/crates/evm2/src/version/features.rs
+++ b/crates/evm2/src/version/features.rs
@@ -1,0 +1,194 @@
+//! EVM configuration feature bitmap.
+
+/// EVM configuration feature bitmap.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub struct EvmFeatures(u64);
+
+macro_rules! evm_features {
+    ($($(#[$attr:meta])* $name:ident = $bit:literal,)*) => {
+        impl EvmFeatures {
+            $(
+                $(#[$attr])*
+                pub const $name: Self = Self::from_bit($bit);
+            )*
+        }
+    };
+}
+
+impl EvmFeatures {
+    /// Empty feature bitmap.
+    pub const EMPTY: Self = Self(0);
+
+    /// Creates a feature bitmap from raw bits.
+    #[inline]
+    pub const fn from_bits(bits: u64) -> Self {
+        Self(bits)
+    }
+
+    const fn from_bit(bit: u32) -> Self {
+        Self(1 << bit)
+    }
+
+    /// Returns the raw feature bits.
+    #[inline]
+    pub const fn bits(self) -> u64 {
+        self.0
+    }
+
+    /// Returns `true` if no feature bits are set.
+    #[inline]
+    pub const fn is_empty(self) -> bool {
+        self.0 == 0
+    }
+
+    /// Returns `true` if all `other` feature bits are set.
+    #[inline]
+    pub const fn contains(self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+
+    /// Returns `true` if any `other` feature bits are set.
+    #[inline]
+    pub const fn intersects(self, other: Self) -> bool {
+        self.0 & other.0 != 0
+    }
+
+    /// Inserts feature bits.
+    #[inline]
+    pub const fn insert(&mut self, other: Self) {
+        self.0 |= other.0;
+    }
+
+    /// Removes feature bits.
+    #[inline]
+    pub const fn remove(&mut self, other: Self) {
+        self.0 &= !other.0;
+    }
+
+    /// Sets or clears feature bits.
+    #[inline]
+    pub const fn set(&mut self, other: Self, on: bool) {
+        if on {
+            self.insert(other);
+        } else {
+            self.remove(other);
+        }
+    }
+}
+
+impl core::ops::BitOr for EvmFeatures {
+    type Output = Self;
+
+    #[inline]
+    fn bitor(self, rhs: Self) -> Self::Output {
+        Self(self.0 | rhs.0)
+    }
+}
+
+impl core::ops::BitOrAssign for EvmFeatures {
+    #[inline]
+    fn bitor_assign(&mut self, rhs: Self) {
+        self.insert(rhs);
+    }
+}
+
+impl core::ops::BitAnd for EvmFeatures {
+    type Output = Self;
+
+    #[inline]
+    fn bitand(self, rhs: Self) -> Self::Output {
+        Self(self.0 & rhs.0)
+    }
+}
+
+impl core::ops::BitAndAssign for EvmFeatures {
+    #[inline]
+    fn bitand_assign(&mut self, rhs: Self) {
+        self.0 &= rhs.0;
+    }
+}
+
+impl core::ops::Not for EvmFeatures {
+    type Output = Self;
+
+    #[inline]
+    fn not(self) -> Self::Output {
+        Self(!self.0)
+    }
+}
+
+evm_features! {
+    /// Checks transaction chain IDs.
+    ///
+    /// Default: on.
+    TX_CHAIN_ID_CHECK = 0,
+    /// Checks transaction nonces against account nonces.
+    ///
+    /// Default: on.
+    NONCE_CHECK = 1,
+    /// Checks that senders can pay transaction costs.
+    ///
+    /// Default: on.
+    BALANCE_CHECK = 2,
+    /// Checks that transaction gas limits do not exceed the block gas limit.
+    ///
+    /// Default: on.
+    BLOCK_GAS_LIMIT_CHECK = 3,
+    /// Applies EIP-3541 contract code prefix rejection.
+    ///
+    /// Default: on.
+    EIP3541 = 4,
+    /// Applies EIP-3607 sender code rejection.
+    ///
+    /// Default: on.
+    EIP3607 = 5,
+    /// Applies EIP-7623 calldata cost floor.
+    ///
+    /// Default: on.
+    EIP7623 = 6,
+    /// Checks EIP-1559 transaction fee caps against the block base fee.
+    ///
+    /// Default: on.
+    BASE_FEE_CHECK = 7,
+    /// Checks EIP-1559 max priority fee against max fee.
+    ///
+    /// Default: on.
+    PRIORITY_FEE_CHECK = 8,
+    /// Charges transaction fees.
+    ///
+    /// Default: on.
+    FEE_CHARGE = 9,
+    /// Applies EIP-8037 state creation gas accounting.
+    ///
+    /// Default: on if Amsterdam.
+    EIP8037 = 10,
+    /// Applies EIP-7708 ETH transfer logs.
+    ///
+    /// Default: on.
+    EIP7708 = 11,
+    /// Applies delayed burn logging for EIP-7708 selfdestructs.
+    ///
+    /// Default: on.
+    EIP7708_DELAYED_BURN = 12,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn feature_bitmap_api() {
+        let mut features = EvmFeatures::TX_CHAIN_ID_CHECK | EvmFeatures::NONCE_CHECK;
+        assert!(features.contains(EvmFeatures::TX_CHAIN_ID_CHECK));
+        assert!(features.intersects(EvmFeatures::NONCE_CHECK));
+
+        features.remove(EvmFeatures::NONCE_CHECK);
+        assert!(!features.contains(EvmFeatures::NONCE_CHECK));
+
+        features.set(EvmFeatures::BASE_FEE_CHECK, true);
+        assert_eq!(
+            EvmFeatures::from_bits(features.bits()),
+            EvmFeatures::TX_CHAIN_ID_CHECK | EvmFeatures::BASE_FEE_CHECK
+        );
+    }
+}

--- a/crates/evm2/src/version/mod.rs
+++ b/crates/evm2/src/version/mod.rs
@@ -19,10 +19,12 @@ pub use features::EvmFeatures;
 mod tables;
 pub use tables::VersionTables;
 
-/// Runtime version data.
+/// Runtime configuration data.
 ///
-/// Holds the active base `SpecId` and dynamic gas parameter table so instructions can read
-/// version-dependent runtime parameters without monomorphization.
+/// The name is a bit misleading: this is a catch-all runtime configuration object. It stores fork
+/// configuration such as the active base `SpecId` and EVM features, and also stores regular runtime
+/// configuration values such as chain ID, memory limits, code size limits, gas caps, and gas
+/// parameters.
 #[derive(Clone, Copy, Debug)]
 #[non_exhaustive]
 pub struct Version {

--- a/crates/evm2/src/version/mod.rs
+++ b/crates/evm2/src/version/mod.rs
@@ -49,6 +49,12 @@ impl Version {
     pub const fn base(spec_id: SpecId) -> &'static Self {
         &BASE_VERSIONS[spec_id as usize]
     }
+
+    /// Returns `true` if the active feature set contains `feature`.
+    #[inline]
+    pub const fn feature(&self, feature: EvmFeatures) -> bool {
+        self.features.contains(feature)
+    }
 }
 
 const fn base_tx_gas_limit_cap(spec_id: SpecId) -> u64 {
@@ -184,25 +190,25 @@ mod tests {
     #[test]
     fn base_versions_set_revm_cfg_env_defaults() {
         let osaka = Version::base(SpecId::OSAKA);
-        assert!(osaka.features.contains(EvmFeatures::TX_CHAIN_ID_CHECK));
-        assert!(osaka.features.contains(EvmFeatures::NONCE_CHECK));
-        assert!(osaka.features.contains(EvmFeatures::BALANCE_CHECK));
-        assert!(osaka.features.contains(EvmFeatures::BLOCK_GAS_LIMIT_CHECK));
-        assert!(osaka.features.contains(EvmFeatures::EIP3541));
-        assert!(osaka.features.contains(EvmFeatures::EIP3607));
-        assert!(osaka.features.contains(EvmFeatures::EIP7623));
-        assert!(osaka.features.contains(EvmFeatures::BASE_FEE_CHECK));
-        assert!(osaka.features.contains(EvmFeatures::PRIORITY_FEE_CHECK));
-        assert!(osaka.features.contains(EvmFeatures::FEE_CHARGE));
-        assert!(!osaka.features.contains(EvmFeatures::EIP7708));
-        assert!(!osaka.features.contains(EvmFeatures::EIP7708_DELAYED_BURN));
-        assert!(!osaka.features.contains(EvmFeatures::EIP8037));
+        assert!(osaka.feature(EvmFeatures::TX_CHAIN_ID_CHECK));
+        assert!(osaka.feature(EvmFeatures::NONCE_CHECK));
+        assert!(osaka.feature(EvmFeatures::BALANCE_CHECK));
+        assert!(osaka.feature(EvmFeatures::BLOCK_GAS_LIMIT_CHECK));
+        assert!(osaka.feature(EvmFeatures::EIP3541));
+        assert!(osaka.feature(EvmFeatures::EIP3607));
+        assert!(osaka.feature(EvmFeatures::EIP7623));
+        assert!(osaka.feature(EvmFeatures::BASE_FEE_CHECK));
+        assert!(osaka.feature(EvmFeatures::PRIORITY_FEE_CHECK));
+        assert!(osaka.feature(EvmFeatures::FEE_CHARGE));
+        assert!(!osaka.feature(EvmFeatures::EIP7708));
+        assert!(!osaka.feature(EvmFeatures::EIP7708_DELAYED_BURN));
+        assert!(!osaka.feature(EvmFeatures::EIP8037));
 
         let amsterdam = Version::base(SpecId::AMSTERDAM);
-        assert!(amsterdam.features.contains(EvmFeatures::TX_CHAIN_ID_CHECK));
-        assert!(amsterdam.features.contains(EvmFeatures::EIP8037));
-        assert!(amsterdam.features.contains(EvmFeatures::EIP7708));
-        assert!(amsterdam.features.contains(EvmFeatures::EIP7708_DELAYED_BURN));
+        assert!(amsterdam.feature(EvmFeatures::TX_CHAIN_ID_CHECK));
+        assert!(amsterdam.feature(EvmFeatures::EIP8037));
+        assert!(amsterdam.feature(EvmFeatures::EIP7708));
+        assert!(amsterdam.feature(EvmFeatures::EIP7708_DELAYED_BURN));
     }
 }
 

--- a/crates/evm2/src/version/mod.rs
+++ b/crates/evm2/src/version/mod.rs
@@ -62,7 +62,7 @@ static BASE_VERSIONS: [Version; SpecId::COUNT] = {
         Version {
             spec_id: SpecId::FRONTIER,
             gas_params: GasParams::empty(),
-            features: EvmFeatures::EMPTY,
+            features: EvmFeatures::empty(),
             tx_gas_limit_cap: u64::MAX,
             memory_limit: DEFAULT_MEMORY_LIMIT,
         }
@@ -127,7 +127,7 @@ macro_rules! evm_versions {
     ($($spec:ident { $($section:ident: [$($tokens:tt)*],)* })*) => {
         /// Creates the base feature set for `spec_id`.
         const fn base_features(spec_id: SpecId) -> EvmFeatures {
-            let mut features = EvmFeatures::EMPTY;
+            let mut features = EvmFeatures::empty();
 
             $(
                 if spec_id.enables(SpecId::$spec) {

--- a/crates/evm2/src/version/mod.rs
+++ b/crates/evm2/src/version/mod.rs
@@ -9,6 +9,9 @@ use alloy_eips::eip7825::MAX_TX_GAS_LIMIT_OSAKA;
 mod gas_params;
 pub use gas_params::{GasId, GasParams};
 
+mod features;
+pub use features::EvmFeatures;
+
 mod tables;
 pub use tables::VersionTables;
 
@@ -26,6 +29,8 @@ pub struct Version {
     // instruction that reads them. Tracking instruction dependencies on version tables is not
     // sustainable for custom forks.
     pub gas_params: GasParams,
+    /// EVM feature set.
+    pub features: EvmFeatures,
     /// Transaction gas limit cap.
     pub tx_gas_limit_cap: u64,
     /// Hard memory limit in bytes.
@@ -57,6 +62,7 @@ static BASE_VERSIONS: [Version; SpecId::COUNT] = {
         Version {
             spec_id: SpecId::FRONTIER,
             gas_params: GasParams::empty(),
+            features: EvmFeatures::EMPTY,
             tx_gas_limit_cap: u64::MAX,
             memory_limit: DEFAULT_MEMORY_LIMIT,
         }
@@ -67,6 +73,7 @@ static BASE_VERSIONS: [Version; SpecId::COUNT] = {
         versions[i] = Version {
             spec_id,
             gas_params: base_gas_params(spec_id),
+            features: base_features(spec_id),
             tx_gas_limit_cap: base_tx_gas_limit_cap(spec_id),
             memory_limit: DEFAULT_MEMORY_LIMIT,
         };
@@ -74,6 +81,24 @@ static BASE_VERSIONS: [Version; SpecId::COUNT] = {
     }
     versions
 };
+
+const fn base_features(spec_id: SpecId) -> EvmFeatures {
+    let mut features = EvmFeatures::EMPTY;
+    features.insert(EvmFeatures::TX_CHAIN_ID_CHECK);
+    features.insert(EvmFeatures::NONCE_CHECK);
+    features.insert(EvmFeatures::BALANCE_CHECK);
+    features.insert(EvmFeatures::BLOCK_GAS_LIMIT_CHECK);
+    features.insert(EvmFeatures::EIP3541);
+    features.insert(EvmFeatures::EIP3607);
+    features.insert(EvmFeatures::EIP7623);
+    features.insert(EvmFeatures::BASE_FEE_CHECK);
+    features.insert(EvmFeatures::PRIORITY_FEE_CHECK);
+    features.insert(EvmFeatures::FEE_CHARGE);
+    features.insert(EvmFeatures::EIP7708);
+    features.insert(EvmFeatures::EIP7708_DELAYED_BURN);
+    features.set(EvmFeatures::EIP8037, spec_id.enables(SpecId::AMSTERDAM));
+    features
+}
 
 macro_rules! apply_base_gas_params {
     ($gp:ident, ops: [$($tokens:tt)*]) => {};
@@ -140,6 +165,35 @@ macro_rules! evm_versions {
             v
         }
     };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn base_versions_set_revm_cfg_env_defaults() {
+        let osaka = Version::base(SpecId::OSAKA);
+        assert!(osaka.features.contains(EvmFeatures::TX_CHAIN_ID_CHECK));
+        assert!(osaka.features.contains(EvmFeatures::NONCE_CHECK));
+        assert!(osaka.features.contains(EvmFeatures::BALANCE_CHECK));
+        assert!(osaka.features.contains(EvmFeatures::BLOCK_GAS_LIMIT_CHECK));
+        assert!(osaka.features.contains(EvmFeatures::EIP3541));
+        assert!(osaka.features.contains(EvmFeatures::EIP3607));
+        assert!(osaka.features.contains(EvmFeatures::EIP7623));
+        assert!(osaka.features.contains(EvmFeatures::BASE_FEE_CHECK));
+        assert!(osaka.features.contains(EvmFeatures::PRIORITY_FEE_CHECK));
+        assert!(osaka.features.contains(EvmFeatures::FEE_CHARGE));
+        assert!(osaka.features.contains(EvmFeatures::EIP7708));
+        assert!(osaka.features.contains(EvmFeatures::EIP7708_DELAYED_BURN));
+        assert!(!osaka.features.contains(EvmFeatures::EIP8037));
+
+        let amsterdam = Version::base(SpecId::AMSTERDAM);
+        assert!(amsterdam.features.contains(EvmFeatures::TX_CHAIN_ID_CHECK));
+        assert!(amsterdam.features.contains(EvmFeatures::EIP8037));
+        assert!(amsterdam.features.contains(EvmFeatures::EIP7708));
+        assert!(amsterdam.features.contains(EvmFeatures::EIP7708_DELAYED_BURN));
+    }
 }
 
 const AMSTERDAM_CPSB: u32 = 1174;

--- a/crates/evm2/src/version/mod.rs
+++ b/crates/evm2/src/version/mod.rs
@@ -2,9 +2,13 @@
 
 use crate::{
     EvmConfig, EvmTypes, SpecId,
+    constants::{
+        BLOB_BASE_FEE_UPDATE_FRACTION_CANCUN, BLOB_BASE_FEE_UPDATE_FRACTION_PRAGUE, MAX_CODE_SIZE,
+        MAX_CODE_SIZE_AMSTERDAM, MAX_INITCODE_SIZE, MAX_INITCODE_SIZE_AMSTERDAM,
+    },
     interpreter::{instructions as instr, opcode::op},
 };
-use alloy_eips::eip7825::MAX_TX_GAS_LIMIT_OSAKA;
+use alloy_eips::{eip4844::MAX_BLOBS_PER_BLOCK_DENCUN, eip7825::MAX_TX_GAS_LIMIT_OSAKA};
 
 mod gas_params;
 pub use gas_params::{GasId, GasParams};
@@ -31,10 +35,20 @@ pub struct Version {
     pub gas_params: GasParams,
     /// EVM feature set.
     pub features: EvmFeatures,
+    /// Chain ID returned by the `CHAINID` opcode and used for transaction chain ID validation.
+    pub chain_id: u64,
     /// Transaction gas limit cap.
     pub tx_gas_limit_cap: u64,
     /// Hard memory limit in bytes.
     pub memory_limit: u64,
+    /// Maximum deployed contract bytecode size.
+    pub max_code_size: usize,
+    /// Maximum contract creation initcode size.
+    pub max_initcode_size: usize,
+    /// Maximum blobs allowed in a single blob transaction.
+    pub max_blobs_per_tx: usize,
+    /// Blob base fee update fraction.
+    pub blob_base_fee_update_fraction: u64,
 }
 
 impl Version {
@@ -61,7 +75,34 @@ const fn base_tx_gas_limit_cap(spec_id: SpecId) -> u64 {
     if spec_id.enables(SpecId::OSAKA) { MAX_TX_GAS_LIMIT_OSAKA } else { u64::MAX }
 }
 
+const fn base_max_code_size(spec_id: SpecId) -> usize {
+    if spec_id.enables(SpecId::AMSTERDAM) { MAX_CODE_SIZE_AMSTERDAM } else { MAX_CODE_SIZE }
+}
+
+const fn base_max_initcode_size(spec_id: SpecId) -> usize {
+    if spec_id.enables(SpecId::AMSTERDAM) { MAX_INITCODE_SIZE_AMSTERDAM } else { MAX_INITCODE_SIZE }
+}
+
+const fn base_max_blobs_per_tx(spec_id: SpecId) -> usize {
+    // EIP-7594 Osaka tests keep the per-transaction blob cap at the Cancun cap, while
+    // Prague allows nine blobs per transaction.
+    if spec_id.enables(SpecId::PRAGUE) && !spec_id.enables(SpecId::OSAKA) {
+        9
+    } else {
+        MAX_BLOBS_PER_BLOCK_DENCUN
+    }
+}
+
+const fn base_blob_base_fee_update_fraction(spec_id: SpecId) -> u64 {
+    if spec_id.enables(SpecId::PRAGUE) {
+        BLOB_BASE_FEE_UPDATE_FRACTION_PRAGUE
+    } else {
+        BLOB_BASE_FEE_UPDATE_FRACTION_CANCUN
+    }
+}
+
 const DEFAULT_MEMORY_LIMIT: u64 = (1 << 32) - 1;
+const DEFAULT_CHAIN_ID: u64 = 1;
 
 static BASE_VERSIONS: [Version; SpecId::COUNT] = {
     let mut versions = [const {
@@ -69,8 +110,13 @@ static BASE_VERSIONS: [Version; SpecId::COUNT] = {
             spec_id: SpecId::FRONTIER,
             gas_params: GasParams::empty(),
             features: EvmFeatures::empty(),
+            chain_id: DEFAULT_CHAIN_ID,
             tx_gas_limit_cap: u64::MAX,
             memory_limit: DEFAULT_MEMORY_LIMIT,
+            max_code_size: MAX_CODE_SIZE,
+            max_initcode_size: MAX_INITCODE_SIZE,
+            max_blobs_per_tx: MAX_BLOBS_PER_BLOCK_DENCUN,
+            blob_base_fee_update_fraction: BLOB_BASE_FEE_UPDATE_FRACTION_CANCUN,
         }
     }; SpecId::COUNT];
     let mut i = 0;
@@ -80,8 +126,13 @@ static BASE_VERSIONS: [Version; SpecId::COUNT] = {
             spec_id,
             gas_params: base_gas_params(spec_id),
             features: base_features(spec_id),
+            chain_id: DEFAULT_CHAIN_ID,
             tx_gas_limit_cap: base_tx_gas_limit_cap(spec_id),
             memory_limit: DEFAULT_MEMORY_LIMIT,
+            max_code_size: base_max_code_size(spec_id),
+            max_initcode_size: base_max_initcode_size(spec_id),
+            max_blobs_per_tx: base_max_blobs_per_tx(spec_id),
+            blob_base_fee_update_fraction: base_blob_base_fee_update_fraction(spec_id),
         };
         i += 1;
     }
@@ -203,12 +254,34 @@ mod tests {
         assert!(!osaka.feature(EvmFeatures::EIP7708));
         assert!(!osaka.feature(EvmFeatures::EIP7708_DELAYED_BURN));
         assert!(!osaka.feature(EvmFeatures::EIP8037));
+        assert_eq!(osaka.chain_id, DEFAULT_CHAIN_ID);
+        assert_eq!(osaka.tx_gas_limit_cap, MAX_TX_GAS_LIMIT_OSAKA);
+        assert_eq!(osaka.memory_limit, DEFAULT_MEMORY_LIMIT);
+        assert_eq!(osaka.max_code_size, MAX_CODE_SIZE);
+        assert_eq!(osaka.max_initcode_size, MAX_INITCODE_SIZE);
+        assert_eq!(osaka.max_blobs_per_tx, MAX_BLOBS_PER_BLOCK_DENCUN);
+        assert_eq!(osaka.blob_base_fee_update_fraction, BLOB_BASE_FEE_UPDATE_FRACTION_PRAGUE);
 
         let amsterdam = Version::base(SpecId::AMSTERDAM);
         assert!(amsterdam.feature(EvmFeatures::TX_CHAIN_ID_CHECK));
         assert!(amsterdam.feature(EvmFeatures::EIP8037));
         assert!(amsterdam.feature(EvmFeatures::EIP7708));
         assert!(amsterdam.feature(EvmFeatures::EIP7708_DELAYED_BURN));
+        assert_eq!(amsterdam.chain_id, DEFAULT_CHAIN_ID);
+        assert_eq!(amsterdam.tx_gas_limit_cap, MAX_TX_GAS_LIMIT_OSAKA);
+        assert_eq!(amsterdam.memory_limit, DEFAULT_MEMORY_LIMIT);
+        assert_eq!(amsterdam.max_code_size, MAX_CODE_SIZE_AMSTERDAM);
+        assert_eq!(amsterdam.max_initcode_size, MAX_INITCODE_SIZE_AMSTERDAM);
+        assert_eq!(amsterdam.max_blobs_per_tx, MAX_BLOBS_PER_BLOCK_DENCUN);
+        assert_eq!(amsterdam.blob_base_fee_update_fraction, BLOB_BASE_FEE_UPDATE_FRACTION_PRAGUE);
+
+        let cancun = Version::base(SpecId::CANCUN);
+        assert_eq!(cancun.max_blobs_per_tx, MAX_BLOBS_PER_BLOCK_DENCUN);
+        assert_eq!(cancun.blob_base_fee_update_fraction, BLOB_BASE_FEE_UPDATE_FRACTION_CANCUN);
+
+        let prague = Version::base(SpecId::PRAGUE);
+        assert_eq!(prague.max_blobs_per_tx, 9);
+        assert_eq!(prague.blob_base_fee_update_fraction, BLOB_BASE_FEE_UPDATE_FRACTION_PRAGUE);
     }
 }
 

--- a/crates/evm2/src/version/mod.rs
+++ b/crates/evm2/src/version/mod.rs
@@ -82,25 +82,8 @@ static BASE_VERSIONS: [Version; SpecId::COUNT] = {
     versions
 };
 
-const fn base_features(spec_id: SpecId) -> EvmFeatures {
-    let mut features = EvmFeatures::EMPTY;
-    features.insert(EvmFeatures::TX_CHAIN_ID_CHECK);
-    features.insert(EvmFeatures::NONCE_CHECK);
-    features.insert(EvmFeatures::BALANCE_CHECK);
-    features.insert(EvmFeatures::BLOCK_GAS_LIMIT_CHECK);
-    features.insert(EvmFeatures::EIP3541);
-    features.insert(EvmFeatures::EIP3607);
-    features.insert(EvmFeatures::EIP7623);
-    features.insert(EvmFeatures::BASE_FEE_CHECK);
-    features.insert(EvmFeatures::PRIORITY_FEE_CHECK);
-    features.insert(EvmFeatures::FEE_CHARGE);
-    features.insert(EvmFeatures::EIP7708);
-    features.insert(EvmFeatures::EIP7708_DELAYED_BURN);
-    features.set(EvmFeatures::EIP8037, spec_id.enables(SpecId::AMSTERDAM));
-    features
-}
-
 macro_rules! apply_base_gas_params {
+    ($gp:ident, features: [$($tokens:tt)*]) => {};
     ($gp:ident, ops: [$($tokens:tt)*]) => {};
     ($gp:ident, static_gas: [$($tokens:tt)*]) => {};
     ($gp:ident, dynamic_gas: [$($id:ident: $value:expr,)*]) => {
@@ -110,7 +93,19 @@ macro_rules! apply_base_gas_params {
     };
 }
 
+macro_rules! apply_base_features {
+    ($features:ident, features: [$($feature:ident,)*]) => {
+        $(
+            $features.insert(EvmFeatures::$feature);
+        )*
+    };
+    ($features:ident, ops: [$($tokens:tt)*]) => {};
+    ($features:ident, static_gas: [$($tokens:tt)*]) => {};
+    ($features:ident, dynamic_gas: [$($tokens:tt)*]) => {};
+}
+
 macro_rules! apply_version_tables {
+    ($v:ident, $ty:ident, features: [$($tokens:tt)*]) => {};
     ($v:ident, $ty:ident, ops: [$($name:ident: $cost:expr,)*]) => {
         $(
             $v.set_instruction(
@@ -130,6 +125,21 @@ macro_rules! apply_version_tables {
 
 macro_rules! evm_versions {
     ($($spec:ident { $($section:ident: [$($tokens:tt)*],)* })*) => {
+        /// Creates the base feature set for `spec_id`.
+        const fn base_features(spec_id: SpecId) -> EvmFeatures {
+            let mut features = EvmFeatures::EMPTY;
+
+            $(
+                if spec_id.enables(SpecId::$spec) {
+                    $(
+                        apply_base_features!(features, $section: [$($tokens)*]);
+                    )*
+                }
+            )*
+
+            features
+        }
+
         /// Creates the base dynamic gas parameters for `spec_id`.
         const fn base_gas_params(spec_id: SpecId) -> GasParams {
             use crate::interpreter::gas::*;
@@ -184,8 +194,8 @@ mod tests {
         assert!(osaka.features.contains(EvmFeatures::BASE_FEE_CHECK));
         assert!(osaka.features.contains(EvmFeatures::PRIORITY_FEE_CHECK));
         assert!(osaka.features.contains(EvmFeatures::FEE_CHARGE));
-        assert!(osaka.features.contains(EvmFeatures::EIP7708));
-        assert!(osaka.features.contains(EvmFeatures::EIP7708_DELAYED_BURN));
+        assert!(!osaka.features.contains(EvmFeatures::EIP7708));
+        assert!(!osaka.features.contains(EvmFeatures::EIP7708_DELAYED_BURN));
         assert!(!osaka.features.contains(EvmFeatures::EIP8037));
 
         let amsterdam = Version::base(SpecId::AMSTERDAM);
@@ -200,6 +210,15 @@ const AMSTERDAM_CPSB: u32 = 1174;
 
 evm_versions! {
     FRONTIER {
+        features: [
+            TX_CHAIN_ID_CHECK,
+            NONCE_CHECK,
+            BALANCE_CHECK,
+            BLOCK_GAS_LIMIT_CHECK,
+            EIP3607,
+            PRIORITY_FEE_CHECK,
+            FEE_CHARGE,
+        ],
         ops: [
             STOP: ZERO,
             ADD: VERYLOW,
@@ -465,6 +484,10 @@ evm_versions! {
     }
 
     LONDON {
+        features: [
+            EIP3541,
+            BASE_FEE_CHECK,
+        ],
         ops: [
             BASEFEE: BASE,
         ],
@@ -504,6 +527,9 @@ evm_versions! {
     }
 
     PRAGUE {
+        features: [
+            EIP7623,
+        ],
         dynamic_gas: [
             TxEip7702PerEmptyAccountCost: EIP7702_PER_EMPTY_ACCOUNT_COST,
             TxEip7702AuthRefund: EIP7702_PER_EMPTY_ACCOUNT_COST - EIP7702_PER_AUTH_BASE_COST,
@@ -519,6 +545,11 @@ evm_versions! {
     }
 
     AMSTERDAM {
+        features: [
+            EIP8037,
+            EIP7708,
+            EIP7708_DELAYED_BURN,
+        ],
         ops: [
             DUPN: VERYLOW,
             SWAPN: VERYLOW,


### PR DESCRIPTION
Adds an `EvmFeatures` bitmap to runtime `Version` data so revm-style cfg toggles can be carried dynamically with the selected version. The feature constants are declared through a macro, documented with their default state, and use positive names so callers can opt out by removing a bit from the set.

The transaction and execution paths now consult those features for the existing revm-equivalent gates: base fee and priority fee checks, block gas limit checks, sender code/nonce/balance validation, fee charging, EIP-7623 floor gas, EIP-3541 contract code rejection, and EIP-8037 state gas behavior. The base feature set matches revm defaults, with EIP-8037 enabled for Amsterdam and later.
