### PR TITLE
perf: add revm fixture benches

### DIFF
--- a/crates/evm2/Cargo.toml
+++ b/crates/evm2/Cargo.toml
@@ -77,6 +77,7 @@ aws-lc-rs = { workspace = true, optional = true }
 [dev-dependencies]
 alloy-primitives = { workspace = true, features = ["serde", "std"] }
 criterion = { package = "codspeed-criterion-compat", version = "4", default-features = false, features = ["cargo_bench_support"] }
+revm = { version = "38", default-features = true, features = ["test-types"] }
 serde = { workspace = true, features = ["derive", "std"] }
 serde_json = { workspace = true, features = ["std"] }
 rand = { workspace = true, features = ["std"] }

--- a/crates/evm2/benches/evm.rs
+++ b/crates/evm2/benches/evm.rs
@@ -6,6 +6,8 @@ use criterion::{Criterion, criterion_group, criterion_main};
 mod cases;
 #[path = "evm/fixture.rs"]
 mod fixture;
+#[path = "evm/revm.rs"]
+mod revm;
 #[path = "evm/support.rs"]
 mod support;
 
@@ -14,6 +16,10 @@ fn evm(c: &mut Criterion) {
     let suites = fixture::Suites::load(cases::all().iter().map(|bench| bench.fixture_path));
     for bench in cases::all() {
         let prepared = support::PreparedBench::load(bench, &suites);
+        prepared.sanity_check();
+        prepared.bench(&mut group);
+
+        let prepared = revm::PreparedBench::load(bench, &suites);
         prepared.sanity_check();
         prepared.bench(&mut group);
     }

--- a/crates/evm2/benches/evm/fixture.rs
+++ b/crates/evm2/benches/evm/fixture.rs
@@ -1,5 +1,5 @@
 use alloy_consensus::{TxLegacy, transaction::Recovered};
-use alloy_primitives::{Address, Bytes, TxKind, U256};
+use alloy_primitives::{Address, B256, Bytes, TxKind, U256};
 use evm2::{
     SpecId, Version,
     bytecode::Bytecode,
@@ -7,7 +7,8 @@ use evm2::{
     ethereum::RecoveredTxEnvelope,
     evm::{AccountInfo, InMemoryDB},
 };
-use serde::{Deserialize, Deserializer, de};
+use serde::{Deserialize, Deserializer, Serialize, de};
+use serde_json::json;
 use std::{
     collections::{BTreeMap, HashMap},
     fs,
@@ -92,6 +93,72 @@ impl Case {
     pub(crate) fn tx(&self, spec: SpecId) -> RecoveredTxEnvelope {
         self.transaction.first().expect("fixture must contain a transaction").envelope(spec)
     }
+
+    pub(crate) fn revm_case(&self, name: &str, spec: SpecId) -> revm_fixture::Case {
+        let transaction = self.transaction.first().expect("fixture must contain a transaction");
+        let gas_limit = transaction.capped_gas_limit(spec);
+        let value = transaction.value.unwrap_or_default();
+        let current_random = self.env.current_random.map(b256_from_u256);
+        let fixture = json!({
+            name: {
+                "env": {
+                    "currentChainID": null,
+                    "currentCoinbase": self.env.current_coinbase,
+                    "currentDifficulty": self.env.current_difficulty,
+                    "currentGasLimit": self.env.current_gas_limit,
+                    "currentNumber": self.env.current_number,
+                    "currentTimestamp": self.env.current_timestamp,
+                    "currentBaseFee": self.env.current_base_fee,
+                    "previousHash": null,
+                    "currentRandom": current_random,
+                    "currentBeaconRoot": null,
+                    "currentWithdrawalsRoot": null,
+                    "currentExcessBlobGas": null,
+                    "slotNumber": self.env.slot_number,
+                },
+                "pre": self.pre,
+                "post": {
+                    revm_spec_name(spec): [{
+                        "expectException": null,
+                        "indexes": {
+                            "data": 0,
+                            "gas": 0,
+                            "value": 0,
+                        },
+                        "hash": B256::ZERO,
+                        "logs": B256::ZERO,
+                    }],
+                },
+                "transaction": {
+                    "data": [transaction.data.clone()],
+                    "gasLimit": [U256::from(gas_limit)],
+                    "gasPrice": transaction.gas_price,
+                    "nonce": transaction.nonce,
+                    "secretKey": B256::ZERO,
+                    "sender": transaction.sender,
+                    "to": transaction.to,
+                    "value": [value],
+                },
+            },
+        });
+        let mut suite: ::revm::statetest_types::TestSuite = serde_json::from_value(fixture)
+            .expect("converted fixture must parse as revm statetest");
+        let mut unit = suite.0.remove(name).expect("converted suite must contain benchmark case");
+        let test = unit
+            .post
+            .values_mut()
+            .next()
+            .and_then(|tests| tests.pop())
+            .expect("converted suite must contain a post test");
+        revm_fixture::Case { unit, test }
+    }
+}
+
+pub(crate) mod revm_fixture {
+    pub(crate) struct Case {
+        pub(crate) unit: ::revm::statetest_types::TestUnit,
+        pub(crate) test: ::revm::statetest_types::Test,
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -127,7 +194,7 @@ impl Env {
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 struct Account {
     balance: U256,
     code: Bytes,
@@ -152,8 +219,7 @@ struct Transaction {
 
 impl Transaction {
     fn envelope(&self, spec: SpecId) -> RecoveredTxEnvelope {
-        let version = Version::base(spec);
-        let gas_limit = u64_value(self.gas_limit).min(version.tx_gas_limit_cap);
+        let gas_limit = self.capped_gas_limit(spec);
         let tx = TxLegacy {
             chain_id: None,
             nonce: u64_value(self.nonce),
@@ -164,6 +230,36 @@ impl Transaction {
             input: self.data.clone(),
         };
         RecoveredTxEnvelope::Legacy(Recovered::new_unchecked(tx, self.sender))
+    }
+
+    fn capped_gas_limit(&self, spec: SpecId) -> u64 {
+        let version = Version::base(spec);
+        u64_value(self.gas_limit).min(version.tx_gas_limit_cap)
+    }
+}
+
+fn b256_from_u256(value: U256) -> B256 {
+    B256::from(value.to_be_bytes())
+}
+
+fn revm_spec_name(spec: SpecId) -> &'static str {
+    match spec {
+        SpecId::FRONTIER => "Frontier",
+        SpecId::HOMESTEAD => "Homestead",
+        SpecId::TANGERINE => "EIP150",
+        SpecId::SPURIOUS_DRAGON => "EIP158",
+        SpecId::BYZANTIUM => "Byzantium",
+        SpecId::PETERSBURG => "ConstantinopleFix",
+        SpecId::ISTANBUL => "Istanbul",
+        SpecId::BERLIN => "Berlin",
+        SpecId::LONDON => "London",
+        SpecId::MERGE => "Merge",
+        SpecId::SHANGHAI => "Shanghai",
+        SpecId::CANCUN => "Cancun",
+        SpecId::PRAGUE => "Prague",
+        SpecId::OSAKA => "Osaka",
+        SpecId::AMSTERDAM => "Amsterdam",
+        _ => panic!("unsupported benchmark spec: {spec:?}"),
     }
 }
 

--- a/crates/evm2/benches/evm/revm.rs
+++ b/crates/evm2/benches/evm/revm.rs
@@ -1,0 +1,135 @@
+use crate::{cases::Bench, fixture::Suites};
+use criterion::{BatchSize, BenchmarkGroup, black_box, measurement::WallTime};
+use evm2::SpecId;
+use revm::{
+    ExecuteEvm, MainBuilder, MainContext,
+    context::{CfgEnv, Context, TxEnv},
+    database::{EmptyDB, InMemoryDB},
+    primitives::hardfork::SpecId as RevmSpecId,
+    statetest_types::TestUnit,
+};
+
+type BenchEvm = revm::MainnetEvm<revm::handler::MainnetContext<InMemoryDB>>;
+
+pub(crate) struct PreparedBench {
+    name: &'static str,
+    spec: RevmSpecId,
+    unit: TestUnit,
+    tx: TxEnv,
+}
+
+impl PreparedBench {
+    pub(crate) fn load(bench: &Bench, suites: &Suites) -> Self {
+        let suite = suites.get(bench.fixture_path);
+        let case = suite.case(bench.name).revm_case(bench.name, bench.spec);
+        let tx =
+            case.test.tx_env(&case.unit).expect("converted revm benchmark transaction must build");
+        Self { name: bench.name, spec: revm_spec_id(bench.spec), unit: case.unit, tx }
+    }
+
+    pub(crate) fn sanity_check(&self) {
+        let mut runner = Runner::new(self);
+        runner.run().unwrap_or_else(|err| {
+            panic!("{} revm benchmark transaction must execute: {err:?}", self.name)
+        });
+    }
+
+    pub(crate) fn bench(&self, group: &mut BenchmarkGroup<'_, WallTime>) {
+        group.bench_function(format!("{}/revm/transact", self.name), |b| {
+            b.iter_batched(
+                || Runner::new(self),
+                |mut runner| {
+                    black_box(runner.run().unwrap_or_else(|err| {
+                        panic!("{} revm benchmark transaction must execute: {err:?}", self.name)
+                    }))
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
+}
+
+struct Runner {
+    evm: BenchEvm,
+    tx: TxEnv,
+}
+
+impl Runner {
+    fn new(prepared: &PreparedBench) -> Self {
+        Self { evm: new_evm(prepared), tx: prepared.tx.clone() }
+    }
+
+    fn run(
+        &mut self,
+    ) -> Result<
+        revm::context_interface::result::ExecResultAndState<
+            revm::context_interface::result::ExecutionResult<
+                revm::context_interface::result::HaltReason,
+            >,
+            revm::state::EvmState,
+        >,
+        revm::context_interface::result::EVMError<
+            <InMemoryDB as revm::Database>::Error,
+            revm::context_interface::result::InvalidTransaction,
+        >,
+    > {
+        self.evm.transact(self.tx.clone())
+    }
+}
+
+fn new_evm(prepared: &PreparedBench) -> BenchEvm {
+    let mut cfg = CfgEnv::new();
+    cfg.set_spec_and_mainnet_gas_params(prepared.spec);
+    cfg = cfg.disable_tx_chain_id_check();
+    cfg.chain_id =
+        prepared.unit.env.current_chain_id.map(|chain_id| chain_id.to()).unwrap_or_default();
+    let block = prepared.unit.block_env(&mut cfg);
+    Context::mainnet()
+        .with_cfg(cfg)
+        .with_block(block)
+        .with_db(database(&prepared.unit))
+        .build_mainnet()
+}
+
+fn database(unit: &TestUnit) -> InMemoryDB {
+    let mut db = InMemoryDB::new(EmptyDB::new());
+    for (address, account) in &unit.pre {
+        let mut info = revm::state::AccountInfo {
+            balance: account.balance,
+            nonce: account.nonce,
+            code: Some(
+                revm::state::Bytecode::new_raw_checked(account.code.clone())
+                    .unwrap_or_else(|_| revm::state::Bytecode::new_legacy(account.code.clone())),
+            ),
+            ..Default::default()
+        };
+        db.insert_contract(&mut info);
+        db.insert_account_info(*address, info);
+        for (key, value) in &account.storage {
+            db.insert_account_storage(*address, *key, *value)
+                .expect("converted revm benchmark storage must insert");
+        }
+    }
+    db
+}
+
+fn revm_spec_id(spec: SpecId) -> RevmSpecId {
+    match spec {
+        SpecId::FRONTIER => RevmSpecId::FRONTIER,
+        SpecId::HOMESTEAD => RevmSpecId::HOMESTEAD,
+        SpecId::TANGERINE => RevmSpecId::TANGERINE,
+        SpecId::SPURIOUS_DRAGON => RevmSpecId::SPURIOUS_DRAGON,
+        SpecId::BYZANTIUM => RevmSpecId::BYZANTIUM,
+        SpecId::PETERSBURG => RevmSpecId::PETERSBURG,
+        SpecId::ISTANBUL => RevmSpecId::ISTANBUL,
+        SpecId::BERLIN => RevmSpecId::BERLIN,
+        SpecId::LONDON => RevmSpecId::LONDON,
+        SpecId::MERGE => RevmSpecId::MERGE,
+        SpecId::SHANGHAI => RevmSpecId::SHANGHAI,
+        SpecId::CANCUN => RevmSpecId::CANCUN,
+        SpecId::PRAGUE => RevmSpecId::PRAGUE,
+        SpecId::OSAKA => RevmSpecId::OSAKA,
+        SpecId::AMSTERDAM => RevmSpecId::AMSTERDAM,
+        _ => panic!("unsupported benchmark spec: {spec:?}"),
+    }
+}

--- a/crates/evm2/src/interpreter/instructions/table.rs
+++ b/crates/evm2/src/interpreter/instructions/table.rs
@@ -1,5 +1,7 @@
 //! Instruction dispatch tables.
 
+#[cfg(not(feature = "nightly"))]
+use crate::interpreter::Gas;
 #[cfg(feature = "nightly")]
 use crate::interpreter::gas::RemainingGas;
 use crate::{


### PR DESCRIPTION
This adds revm-backed Criterion cases next to the existing evm2 transaction benches, using the same local fixture files by converting them into revm state-test-shaped inputs at bench setup time.

The revm path builds its own mainnet EVM from the converted state test data and keeps benchmark names under the existing evm group as case/revm/transact.
