### PR TITLE
refactor(evm): load bytecode by hash

### DIFF
--- a/crates/evm2/src/evm/db.rs
+++ b/crates/evm2/src/evm/db.rs
@@ -13,8 +13,8 @@ pub trait Database {
     /// Loads account information.
     fn get_account(&mut self, address: Address) -> Option<AccountInfo>;
 
-    /// Loads account code.
-    fn get_account_code(&mut self, address: Address) -> Bytecode;
+    /// Loads bytecode by code hash.
+    fn get_code_by_hash(&mut self, code_hash: B256) -> Bytecode;
 
     /// Loads a persistent storage slot.
     fn get_storage(&mut self, address: Address, key: Word) -> Word;
@@ -34,7 +34,7 @@ impl Database for EmptyDB {
     }
 
     #[inline]
-    fn get_account_code(&mut self, _address: Address) -> Bytecode {
+    fn get_code_by_hash(&mut self, _code_hash: B256) -> Bytecode {
         Bytecode::default()
     }
 

--- a/crates/evm2/src/evm/db/cache.rs
+++ b/crates/evm2/src/evm/db/cache.rs
@@ -131,17 +131,13 @@ impl<ExtDB: Database> Database for CacheDB<ExtDB> {
     }
 
     #[inline]
-    fn get_account_code(&mut self, address: Address) -> Bytecode {
-        let code_hash = self.get_account(address).map(|info| info.code_hash);
-        if let Some(code_hash) = code_hash
-            && let Some(code) = self.cache.contracts.get(&code_hash)
-        {
+    fn get_code_by_hash(&mut self, code_hash: B256) -> Bytecode {
+        if let Some(code) = self.cache.contracts.get(&code_hash) {
             return code.clone();
         }
 
-        let code = self.db.get_account_code(address);
+        let code = self.db.get_code_by_hash(code_hash);
         if !code.is_empty() {
-            let code_hash = code_hash.unwrap_or_else(|| code.hash_slow());
             self.cache.contracts.entry(code_hash).or_insert_with(|| code.clone());
         }
         code
@@ -193,9 +189,13 @@ mod tests {
             self.account.clone()
         }
 
-        fn get_account_code(&mut self, _address: Address) -> Bytecode {
+        fn get_code_by_hash(&mut self, code_hash: B256) -> Bytecode {
             self.code_loads += 1;
-            self.account.as_ref().and_then(|info| info.code.clone()).unwrap_or_default()
+            self.account
+                .as_ref()
+                .filter(|info| info.code_hash == code_hash)
+                .and_then(|info| info.code.clone())
+                .unwrap_or_default()
         }
 
         fn get_storage(&mut self, _address: Address, _key: Word) -> Word {
@@ -223,8 +223,10 @@ mod tests {
         };
         let mut cache = CacheDB::new(db);
 
-        assert_eq!(cache.get_account_code(address), code);
-        assert_eq!(cache.get_account_code(address), code);
+        let code_hash = code.hash_slow();
+        assert_eq!(cache.get_account(address).map(|info| info.code_hash), Some(code_hash));
+        assert_eq!(cache.get_code_by_hash(code_hash), code);
+        assert_eq!(cache.get_code_by_hash(code_hash), code);
         assert_eq!(cache.db.account_loads, 1);
         assert_eq!(cache.db.code_loads, 0);
 

--- a/crates/evm2/src/evm/state.rs
+++ b/crates/evm2/src/evm/state.rs
@@ -645,16 +645,20 @@ impl<D: Database> State<D> {
     #[inline]
     #[must_use]
     pub fn get_code(&mut self, address: Address) -> Bytecode {
-        let Some(account) = self.find(address) else {
+        let Some((code_hash, code)) = self.find(address).map(|account| {
+            let code_hash = account.code_hash;
+            let code = account.code.clone();
+            (code_hash, code)
+        }) else {
             return Bytecode::default();
         };
-        if account.code_hash == KECCAK256_EMPTY {
+        if code_hash == KECCAK256_EMPTY {
             return Bytecode::default();
         }
-        if !account.code.is_empty() {
-            return account.code.clone();
+        if !code.is_empty() {
+            return code;
         }
-        self.initial.get_account_code(address)
+        self.initial.get_code_by_hash(code_hash)
     }
 
     #[must_use]


### PR DESCRIPTION
Adds a Database::get_code_by_hash hook and updates State::get_code to fetch missing bytecode using the account's known code hash instead of reloading code by address.