### PR TITLE
fix: keep local labels in asm dumps

### DIFF
--- a/crates/evm2/src/evm/db/cache.rs
+++ b/crates/evm2/src/evm/db/cache.rs
@@ -132,15 +132,10 @@ impl<ExtDB: Database> Database for CacheDB<ExtDB> {
 
     #[inline]
     fn get_code_by_hash(&mut self, code_hash: B256) -> Bytecode {
-        if let Some(code) = self.cache.contracts.get(&code_hash) {
-            return code.clone();
+        match self.cache.contracts.entry(code_hash) {
+            Entry::Occupied(entry) => entry.get().clone(),
+            Entry::Vacant(entry) => entry.insert(self.db.get_code_by_hash(code_hash)).clone(),
         }
-
-        let code = self.db.get_code_by_hash(code_hash);
-        if !code.is_empty() {
-            self.cache.contracts.entry(code_hash).or_insert_with(|| code.clone());
-        }
-        code
     }
 
     #[inline]

--- a/scripts/dump_opcode_asm.py
+++ b/scripts/dump_opcode_asm.py
@@ -157,7 +157,7 @@ def dispatch_opcode(text: str) -> int | None:
 def is_asm_symbol_label(line: str) -> bool:
     return (
         line.endswith(":\n")
-        and not line.startswith(("\t", " ", ".", "#"))
+        and not line.startswith(("\t", " ", ".", "#", "L"))
         and len(line) > 2
     )
 


### PR DESCRIPTION
Keep cargo-asm local labels inside extracted assembly blocks. On macOS-style output, labels such as Lfunc_begin and LBB do not start with a dot, so the previous symbol-boundary check stopped ADD.s at the function label before any instructions.
