### PR TITLE
fix: keep local labels in asm dumps

### DIFF
--- a/scripts/dump_opcode_asm.py
+++ b/scripts/dump_opcode_asm.py
@@ -157,7 +157,7 @@ def dispatch_opcode(text: str) -> int | None:
 def is_asm_symbol_label(line: str) -> bool:
     return (
         line.endswith(":\n")
-        and not line.startswith(("\t", " ", ".", "#"))
+        and not line.startswith(("\t", " ", ".", "#", "L"))
         and len(line) > 2
     )
 


### PR DESCRIPTION
Keep cargo-asm local labels inside extracted assembly blocks. On macOS-style output, labels such as Lfunc_begin and LBB do not start with a dot, so the previous symbol-boundary check stopped ADD.s at the function label before any instructions.
