### PR TITLE
perf: hoist interpreter state through dispatch loop

### DIFF
--- a/crates/evm2/src/interpreter/ctrl.rs
+++ b/crates/evm2/src/interpreter/ctrl.rs
@@ -61,15 +61,8 @@ impl<'a> BytecodeRef<'a> {
 }
 
 impl Pc {
-    /// Creates a program counter from a byte offset.
-    #[allow(dead_code)]
-    pub(crate) const fn new(bytecode: BytecodeRef<'_>, pc: usize) -> Self {
-        let base = bytecode.bytecode.as_ptr();
-        Self { pc: unsafe { base.add(pc) } }
-    }
-
     /// Creates a program counter from a byte pointer.
-    pub(crate) const fn from_ptr(pc: *const u8) -> Self {
+    pub(crate) const fn new(pc: *const u8) -> Self {
         Self { pc }
     }
 

--- a/crates/evm2/src/interpreter/instructions/table.rs
+++ b/crates/evm2/src/interpreter/instructions/table.rs
@@ -263,6 +263,7 @@ extern_table! {
         state.gas().set_remaining(remaining_gas.get());
         // SAFETY: `raw_interp` is valid for the duration of execution.
         let interp = unsafe { &mut *state.raw_interp };
+        interp.gas = state.gas;
         interp.pc = pc.as_ptr();
         interp.stack_len = stack.len;
         debug_assert!(state.result.is_err());

--- a/crates/evm2/src/interpreter/private.rs
+++ b/crates/evm2/src/interpreter/private.rs
@@ -55,7 +55,16 @@ pub fn instr_stack_setup(
     stack.instr_stack_setup(input, output)
 }
 
+/// Splits a mutable instruction state into separate gas and state references.
+///
+/// # Safety
+///
+/// The returned `gas` reference must not be accessed through the returned `state` reference while
+/// both references are live.
 #[inline]
-pub fn gas<'a, T: EvmTypes>(state: &mut State<'a, T>) -> &'a mut Gas {
-    state.gas()
+pub unsafe fn split_gas_state<'a, 'state, T: EvmTypes>(
+    state: *mut State<'state, T>,
+) -> (&'a mut Gas, &'a mut State<'state, T>) {
+    // SAFETY: The caller must ensure the returned `gas` reference is not used through `state`.
+    unsafe { (&mut (*state).gas, &mut *state) }
 }

--- a/crates/evm2/src/interpreter/runtime.rs
+++ b/crates/evm2/src/interpreter/runtime.rs
@@ -6,12 +6,9 @@ use super::{
 use crate::{EvmConfig, EvmTypes, ExecutionConfig, bytecode::Bytecode, env::TxEnv};
 use alloc::{boxed::Box, vec::Vec};
 use alloy_primitives::Bytes;
-use core::marker::PhantomData;
 #[cfg(not(feature = "nightly"))]
-use core::{
-    hint::cold_path,
-    ops::ControlFlow::{self, Break, Continue},
-};
+use core::hint::cold_path;
+use core::marker::PhantomData;
 
 /// EVM interpreter.
 #[derive(Debug)]
@@ -198,46 +195,6 @@ impl<'frame, T: EvmTypes> Interpreter<'frame, T> {
                 return self.result.unwrap_err();
             }
         }
-    }
-
-    /// Executes one instruction.
-    #[inline]
-    #[cfg(not(feature = "nightly"))]
-    pub fn step(&mut self, config: &ExecutionConfig<T>, host: &mut T::Host) -> ControlFlow<(), ()> {
-        let (pc, stack_len, flow) = self.raw_step(config, host, self.pc, self.stack_len);
-        self.pc = pc;
-        self.stack_len = stack_len;
-        flow
-    }
-
-    #[inline(always)]
-    #[cfg(not(feature = "nightly"))]
-    fn raw_step(
-        &mut self,
-        config: &ExecutionConfig<T>,
-        host: &mut T::Host,
-        pc: *const u8,
-        stack_len: usize,
-    ) -> (*const u8, usize, ControlFlow<(), ()>) {
-        #[expect(clippy::unnecessary_cast, reason = "cast erases the active interpreter lifetime")]
-        let raw = self as *mut Self as *mut Interpreter<'_, T>;
-        let bytecode = BytecodeRef::new(&self.bytecode);
-        let pc = Pc::from_ptr(pc);
-        let op = pc.op();
-        let instr = config.instructions[op as usize];
-        let mut state = State {
-            bytecode,
-            host,
-            spec: config.version.spec_id,
-            gas: self.gas,
-            result: Ok(()),
-            version: &config.version,
-            raw_interp: raw,
-        };
-        let (pc, stack_len) = instr(pc, Stack::new(&mut self.stack, stack_len), &mut state);
-        self.gas = state.gas;
-        let flow = if pc.is_null() { Break(()) } else { Continue(()) };
-        (pc, stack_len, flow)
     }
 
     #[inline(always)]

--- a/crates/evm2/src/interpreter/runtime.rs
+++ b/crates/evm2/src/interpreter/runtime.rs
@@ -169,7 +169,7 @@ impl<'frame, T: EvmTypes> Interpreter<'frame, T> {
         let raw = self as *mut Self as *mut Interpreter<'_, T>;
         let mut pc = Pc::from_ptr(self.pc);
         let mut stack_len = self.stack_len;
-        let stack = &mut self.stack;
+        let stack = &mut *self.stack;
         let bytecode = BytecodeRef::new(&self.bytecode);
         let mut state = State {
             bytecode,
@@ -206,6 +206,7 @@ impl<'frame, T: EvmTypes> Interpreter<'frame, T> {
         let pc = Pc::from_ptr(self.pc);
         let op = pc.op();
         let instr = config.instructions[op as usize];
+        let stack = &mut *self.stack;
         let remaining_gas = RemainingGas::new(self.gas.remaining());
         let mut state = State {
             bytecode,
@@ -216,7 +217,7 @@ impl<'frame, T: EvmTypes> Interpreter<'frame, T> {
             version: &config.version,
             raw_interp: raw,
         };
-        instr(pc, Stack::new(&mut self.stack, self.stack_len), remaining_gas, &mut state);
+        instr(pc, Stack::new(&mut *stack, self.stack_len), remaining_gas, &mut state);
         self.result.unwrap_err()
     }
 }

--- a/crates/evm2/src/interpreter/runtime.rs
+++ b/crates/evm2/src/interpreter/runtime.rs
@@ -168,16 +168,33 @@ impl<'frame, T: EvmTypes> Interpreter<'frame, T> {
 
     #[cfg(not(feature = "nightly"))]
     fn run_table_loop(&mut self, config: &ExecutionConfig<T>, host: &mut T::Host) -> InstrStop {
+        #[expect(clippy::unnecessary_cast, reason = "cast erases the active interpreter lifetime")]
+        let raw = self as *mut Self as *mut Interpreter<'_, T>;
         let mut pc = self.pc;
         let mut stack_len = self.stack_len;
+        let bytecode = BytecodeRef::new(&self.bytecode);
+        let mut state = State {
+            bytecode,
+            host,
+            spec: config.version.spec_id,
+            gas: self.gas,
+            result: Ok(()),
+            version: &config.version,
+            raw_interp: raw,
+        };
         loop {
-            let (next_pc, next_stack_len, flow) = self.raw_step(config, host, pc, stack_len);
+            let pc_state = Pc::from_ptr(pc);
+            let op = pc_state.op();
+            let instr = config.instructions[op as usize];
+            let (next_pc, next_stack_len) =
+                instr(pc_state, Stack::new(&mut self.stack, stack_len), &mut state);
             pc = next_pc;
             stack_len = next_stack_len;
-            if flow.is_break() {
+            if pc.is_null() {
                 cold_path();
                 self.pc = pc;
                 self.stack_len = stack_len;
+                self.gas = state.gas;
                 return self.result.unwrap_err();
             }
         }

--- a/crates/evm2/src/interpreter/runtime.rs
+++ b/crates/evm2/src/interpreter/runtime.rs
@@ -183,8 +183,7 @@ impl<'frame, T: EvmTypes> Interpreter<'frame, T> {
         loop {
             let op = pc.op();
             let instr = config.instructions[op as usize];
-            let (next_pc, next_stack_len) =
-                instr(pc, Stack::new(&mut *stack, stack_len), &mut state);
+            let (next_pc, next_stack_len) = instr(pc, Stack::new(stack, stack_len), &mut state);
             pc = Pc::new(next_pc);
             stack_len = next_stack_len;
             if next_pc.is_null() {

--- a/crates/evm2/src/interpreter/runtime.rs
+++ b/crates/evm2/src/interpreter/runtime.rs
@@ -208,18 +208,17 @@ impl<'frame, T: EvmTypes> Interpreter<'frame, T> {
         let pc = Pc::from_ptr(pc);
         let op = pc.op();
         let instr = config.instructions[op as usize];
-        let (pc, stack_len) = instr(
-            pc,
-            Stack::new(&mut self.stack, stack_len),
-            &mut State {
-                bytecode,
-                host,
-                spec: config.version.spec_id,
-                result: Ok(()),
-                version: &config.version,
-                raw_interp: raw,
-            },
-        );
+        let mut state = State {
+            bytecode,
+            host,
+            spec: config.version.spec_id,
+            gas: self.gas,
+            result: Ok(()),
+            version: &config.version,
+            raw_interp: raw,
+        };
+        let (pc, stack_len) = instr(pc, Stack::new(&mut self.stack, stack_len), &mut state);
+        self.gas = state.gas;
         let flow = if pc.is_null() { Break(()) } else { Continue(()) };
         (pc, stack_len, flow)
     }
@@ -234,19 +233,16 @@ impl<'frame, T: EvmTypes> Interpreter<'frame, T> {
         let op = pc.op();
         let instr = config.instructions[op as usize];
         let remaining_gas = RemainingGas::new(self.gas.remaining());
-        instr(
-            pc,
-            Stack::new(&mut self.stack, self.stack_len),
-            remaining_gas,
-            &mut State {
-                bytecode,
-                host,
-                spec: config.version.spec_id,
-                result: Ok(()),
-                version: &config.version,
-                raw_interp: raw,
-            },
-        );
+        let mut state = State {
+            bytecode,
+            host,
+            spec: config.version.spec_id,
+            gas: self.gas,
+            result: Ok(()),
+            version: &config.version,
+            raw_interp: raw,
+        };
+        instr(pc, Stack::new(&mut self.stack, self.stack_len), remaining_gas, &mut state);
         self.result.unwrap_err()
     }
 }

--- a/crates/evm2/src/interpreter/runtime.rs
+++ b/crates/evm2/src/interpreter/runtime.rs
@@ -167,8 +167,9 @@ impl<'frame, T: EvmTypes> Interpreter<'frame, T> {
     fn run_table_loop(&mut self, config: &ExecutionConfig<T>, host: &mut T::Host) -> InstrStop {
         #[expect(clippy::unnecessary_cast, reason = "cast erases the active interpreter lifetime")]
         let raw = self as *mut Self as *mut Interpreter<'_, T>;
-        let mut pc = self.pc;
+        let mut pc = Pc::from_ptr(self.pc);
         let mut stack_len = self.stack_len;
+        let stack = &mut self.stack;
         let bytecode = BytecodeRef::new(&self.bytecode);
         let mut state = State {
             bytecode,
@@ -180,16 +181,15 @@ impl<'frame, T: EvmTypes> Interpreter<'frame, T> {
             raw_interp: raw,
         };
         loop {
-            let pc_state = Pc::from_ptr(pc);
-            let op = pc_state.op();
+            let op = pc.op();
             let instr = config.instructions[op as usize];
             let (next_pc, next_stack_len) =
-                instr(pc_state, Stack::new(&mut self.stack, stack_len), &mut state);
-            pc = next_pc;
+                instr(pc, Stack::new(&mut *stack, stack_len), &mut state);
+            pc = Pc::from_ptr(next_pc);
             stack_len = next_stack_len;
-            if pc.is_null() {
+            if next_pc.is_null() {
                 cold_path();
-                self.pc = pc;
+                self.pc = next_pc;
                 self.stack_len = stack_len;
                 self.gas = state.gas;
                 return self.result.unwrap_err();

--- a/crates/evm2/src/interpreter/runtime.rs
+++ b/crates/evm2/src/interpreter/runtime.rs
@@ -167,7 +167,7 @@ impl<'frame, T: EvmTypes> Interpreter<'frame, T> {
     fn run_table_loop(&mut self, config: &ExecutionConfig<T>, host: &mut T::Host) -> InstrStop {
         #[expect(clippy::unnecessary_cast, reason = "cast erases the active interpreter lifetime")]
         let raw = self as *mut Self as *mut Interpreter<'_, T>;
-        let mut pc = Pc::from_ptr(self.pc);
+        let mut pc = Pc::new(self.pc);
         let mut stack_len = self.stack_len;
         let stack = &mut *self.stack;
         let bytecode = BytecodeRef::new(&self.bytecode);
@@ -185,7 +185,7 @@ impl<'frame, T: EvmTypes> Interpreter<'frame, T> {
             let instr = config.instructions[op as usize];
             let (next_pc, next_stack_len) =
                 instr(pc, Stack::new(&mut *stack, stack_len), &mut state);
-            pc = Pc::from_ptr(next_pc);
+            pc = Pc::new(next_pc);
             stack_len = next_stack_len;
             if next_pc.is_null() {
                 cold_path();
@@ -203,7 +203,7 @@ impl<'frame, T: EvmTypes> Interpreter<'frame, T> {
         #[expect(clippy::unnecessary_cast, reason = "cast erases the active interpreter lifetime")]
         let raw = self as *mut Self as *mut Interpreter<'_, T>;
         let bytecode = BytecodeRef::new(&self.bytecode);
-        let pc = Pc::from_ptr(self.pc);
+        let pc = Pc::new(self.pc);
         let op = pc.op();
         let instr = config.instructions[op as usize];
         let stack = &mut *self.stack;

--- a/crates/evm2/src/interpreter/runtime.rs
+++ b/crates/evm2/src/interpreter/runtime.rs
@@ -168,8 +168,7 @@ impl<'frame, T: EvmTypes> Interpreter<'frame, T> {
         #[expect(clippy::unnecessary_cast, reason = "cast erases the active interpreter lifetime")]
         let raw = self as *mut Self as *mut Interpreter<'_, T>;
         let mut pc = Pc::new(self.pc);
-        let mut stack_len = self.stack_len;
-        let stack = &mut *self.stack;
+        let mut stack = Stack::new(&mut self.stack, self.stack_len);
         let bytecode = BytecodeRef::new(&self.bytecode);
         let mut state = State {
             bytecode,
@@ -183,13 +182,13 @@ impl<'frame, T: EvmTypes> Interpreter<'frame, T> {
         loop {
             let op = pc.op();
             let instr = config.instructions[op as usize];
-            let (next_pc, next_stack_len) = instr(pc, Stack::new(stack, stack_len), &mut state);
+            let (next_pc, next_stack_len) = instr(pc, stack.reborrow(), &mut state);
             pc = Pc::new(next_pc);
-            stack_len = next_stack_len;
+            stack.len = next_stack_len;
             if next_pc.is_null() {
                 cold_path();
                 self.pc = next_pc;
-                self.stack_len = stack_len;
+                self.stack_len = stack.len;
                 self.gas = state.gas;
                 return self.result.unwrap_err();
             }
@@ -205,7 +204,7 @@ impl<'frame, T: EvmTypes> Interpreter<'frame, T> {
         let pc = Pc::new(self.pc);
         let op = pc.op();
         let instr = config.instructions[op as usize];
-        let stack = &mut *self.stack;
+        let stack = Stack::new(&mut self.stack, self.stack_len);
         let remaining_gas = RemainingGas::new(self.gas.remaining());
         let mut state = State {
             bytecode,
@@ -216,7 +215,7 @@ impl<'frame, T: EvmTypes> Interpreter<'frame, T> {
             version: &config.version,
             raw_interp: raw,
         };
-        instr(pc, Stack::new(&mut *stack, self.stack_len), remaining_gas, &mut state);
+        instr(pc, stack, remaining_gas, &mut state);
         self.result.unwrap_err()
     }
 }

--- a/crates/evm2/src/interpreter/stack.rs
+++ b/crates/evm2/src/interpreter/stack.rs
@@ -40,6 +40,12 @@ impl<'a> Stack<'a> {
     }
 
     #[inline]
+    #[cfg(not(feature = "nightly"))]
+    pub(crate) const fn reborrow(&mut self) -> Stack<'_> {
+        Stack { stack: self.stack, len: self.len }
+    }
+
+    #[inline]
     pub(crate) const fn as_mut(&mut self) -> StackMut<'_> {
         StackMut { stack: self.stack, len: &mut self.len }
     }

--- a/crates/evm2/src/interpreter/state.rs
+++ b/crates/evm2/src/interpreter/state.rs
@@ -17,6 +17,7 @@ pub struct State<'a, T: EvmTypes> {
     pub host: &'a mut T::Host,
     /// Active spec identifier.
     pub spec: SpecId,
+    pub(crate) gas: Gas,
     pub(crate) result: Result,
     /// Active runtime version data.
     pub version: &'a Version,
@@ -28,7 +29,7 @@ impl<'a, T: EvmTypes> State<'a, T> {
     const fn interp(&self) -> &Interpreter<'a, T> {
         // SAFETY: `raw_interp` is valid for the duration of instruction execution. Methods on
         // `State` must not borrow fields already passed separately to the instruction, such as
-        // stack and gas.
+        // stack.
         unsafe { &*self.raw_interp }
     }
 
@@ -36,15 +37,14 @@ impl<'a, T: EvmTypes> State<'a, T> {
     fn interp_mut(&mut self) -> &mut Interpreter<'a, T> {
         // SAFETY: `raw_interp` is valid for the duration of instruction execution. Methods on
         // `State` must not borrow fields already passed separately to the instruction, such as
-        // stack and gas.
+        // stack.
         unsafe { &mut *self.raw_interp }
     }
 
     /// Returns interpreter gas.
     #[inline]
-    pub(crate) fn gas(&mut self) -> &'a mut Gas {
-        // SAFETY: `raw_interp` is valid for the duration of instruction execution.
-        unsafe { &mut (*self.raw_interp).gas }
+    pub(crate) const fn gas(&mut self) -> &mut Gas {
+        &mut self.gas
     }
 
     /// Returns the cached transaction-global environment.
@@ -106,6 +106,7 @@ impl<T: EvmTypes> fmt::Debug for State<'_, T> {
             .field("memory", &self.interp().memory)
             .field("return_data", &self.return_data())
             .field("spec", &self.spec)
+            .field("gas", &self.gas)
             .field("result", &self.result)
             .field("version", &self.version)
             .field("raw_interp", &self.raw_interp)

--- a/crates/evm2/src/interpreter/state.rs
+++ b/crates/evm2/src/interpreter/state.rs
@@ -15,12 +15,12 @@ pub struct State<'a, T: EvmTypes> {
     pub bytecode: BytecodeRef<'a>,
     /// Host implementation.
     pub host: &'a mut T::Host,
-    /// Active spec identifier.
-    pub spec: SpecId,
-    pub(crate) gas: Gas,
-    pub(crate) result: Result,
     /// Active runtime version data.
     pub version: &'a Version,
+    /// Active spec identifier.
+    pub spec: SpecId,
+    pub(crate) result: Result,
+    pub(crate) gas: Gas,
     pub(crate) raw_interp: *mut Interpreter<'a, T>,
 }
 

--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -160,20 +160,24 @@ fn expand_instruction(instruction_attrs: InstructionAttrs, input: ItemFn) -> Tok
         (!instruction_attrs.no_stack_preamble).then(|| stack_setup(&inputs, &outputs));
     let cx_setup = has_cx.then(|| {
         let cx = cx_arg.unwrap_or_else(|| Ident::new("cx", ident.span()));
-        let cx_ty = if instruction_attrs.dynamic_gas {
-            quote! { evm2::interpreter::private::GasInstructionCx }
+        if instruction_attrs.dynamic_gas {
+            quote! {
+                let (__evm2_gas, __evm2_state) = unsafe {
+                    evm2::interpreter::private::split_gas_state(__evm2_state)
+                };
+                let mut #cx = evm2::interpreter::private::GasInstructionCx::<#evm_types> {
+                    pc: __evm2_pc,
+                    gas: __evm2_gas,
+                    state: __evm2_state,
+                };
+            }
         } else {
-            quote! { evm2::interpreter::private::InstructionCx }
-        };
-        let gas_field = instruction_attrs
-            .dynamic_gas
-            .then(|| quote! { gas: evm2::interpreter::private::gas(__evm2_state), });
-        quote! {
-            let mut #cx = #cx_ty::<#evm_types> {
-            pc: __evm2_pc,
-            #gas_field
-            state: __evm2_state,
-        };
+            quote! {
+                let mut #cx = evm2::interpreter::private::InstructionCx::<#evm_types> {
+                    pc: __evm2_pc,
+                    state: __evm2_state,
+                };
+            }
         }
     });
     let dynamic_gas = instruction_attrs.dynamic_gas;


### PR DESCRIPTION
Move the active gas tracker into interpreter State for instruction execution. Dispatch copies gas into State before executing and writes it back to the Interpreter on exit, avoiding per-instruction gas access through raw_interp while preserving the current ownership model.

The non-nightly table loop now inlines the raw step logic so the reusable State construction is hoisted out of the dispatch loop. The generated hot loop no longer rebuilds State or copies gas back on every opcode; gas is copied back once when execution exits. This is a code-shape cleanup only; no benchmark numbers are included.
