### PR TITLE
fix(evm): return backing database from accessor

### DIFF
--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -229,6 +229,12 @@ impl<T: EvmTypes> Evm<T> {
         self.state.initial()
     }
 
+    /// Returns the backing database mutably.
+    #[inline]
+    pub const fn database_mut(&mut self) -> &mut T::Database {
+        self.state.initial_mut()
+    }
+
     /// Returns the mutable EVM state.
     #[inline]
     pub const fn state(&self) -> &State<T::Database> {

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -225,8 +225,8 @@ impl<T: EvmTypes> Evm<T> {
 
     /// Returns the backing database.
     #[inline]
-    pub const fn database(&self) -> &State<T::Database> {
-        &self.state
+    pub const fn database(&self) -> &T::Database {
+        self.state.initial()
     }
 
     /// Returns the mutable EVM state.


### PR DESCRIPTION
Updates Evm::database() to return the backing database instead of the state overlay, matching its documentation and avoiding overlap with Evm::state().