### PR TITLE
feat(version): gate EIP-2 create gas with feature

### DIFF
--- a/crates/evm2/src/ethereum/mod.rs
+++ b/crates/evm2/src/ethereum/mod.rs
@@ -474,7 +474,7 @@ pub(super) fn intrinsic_gas(
     }
     gas += access_list_accounts * u64::from(params.get(GasId::TxAccessListAddressCost));
     gas += access_list_storage_keys * u64::from(params.get(GasId::TxAccessListStorageKeyCost));
-    if to.is_create() && spec.enables(SpecId::HOMESTEAD) {
+    if to.is_create() && version.feature(EvmFeatures::EIP2) {
         gas += 32_000;
     }
     if to.is_create() && spec.enables(SpecId::SHANGHAI) {

--- a/crates/evm2/src/version/features.rs
+++ b/crates/evm2/src/version/features.rs
@@ -128,6 +128,10 @@ evm_features! {
     ///
     /// Default: on
     BLOCK_GAS_LIMIT_CHECK,
+    /// Applies EIP-2 create transaction intrinsic gas.
+    ///
+    /// Default: on since Homestead
+    EIP2,
     /// Applies EIP-3541 contract code prefix rejection.
     ///
     /// Default: on since London

--- a/crates/evm2/src/version/mod.rs
+++ b/crates/evm2/src/version/mod.rs
@@ -243,6 +243,7 @@ mod tests {
         assert!(osaka.feature(EvmFeatures::NONCE_CHECK));
         assert!(osaka.feature(EvmFeatures::BALANCE_CHECK));
         assert!(osaka.feature(EvmFeatures::BLOCK_GAS_LIMIT_CHECK));
+        assert!(osaka.feature(EvmFeatures::EIP2));
         assert!(osaka.feature(EvmFeatures::EIP3541));
         assert!(osaka.feature(EvmFeatures::EIP3607));
         assert!(osaka.feature(EvmFeatures::EIP7623));
@@ -457,6 +458,9 @@ evm_versions! {
     }
 
     HOMESTEAD {
+        features: [
+            EIP2,
+        ],
         ops: [
             DELEGATECALL: 40,
         ],


### PR DESCRIPTION
Adds an EIP2 feature flag, enables it from Homestead, and uses it for create transaction intrinsic gas.