### PR TITLE
feat(version): gate EIP-2028 calldata pricing

### DIFF
--- a/crates/evm2/src/ethereum/mod.rs
+++ b/crates/evm2/src/ethereum/mod.rs
@@ -467,7 +467,7 @@ pub(super) fn intrinsic_gas(
 ) -> u64 {
     let spec = version.spec_id;
     let params = &version.gas_params;
-    let non_zero_multiplier = if spec.enables(SpecId::ISTANBUL) { 16 } else { 68 };
+    let non_zero_multiplier = if version.feature(EvmFeatures::EIP2028) { 16 } else { 68 };
     let mut gas = 21_000;
     for byte in input {
         gas += if *byte == 0 { 4 } else { non_zero_multiplier };

--- a/crates/evm2/src/version/features.rs
+++ b/crates/evm2/src/version/features.rs
@@ -132,6 +132,10 @@ evm_features! {
     ///
     /// Default: on since Homestead
     EIP2,
+    /// Applies EIP-2028 transaction calldata repricing.
+    ///
+    /// Default: on since Istanbul
+    EIP2028,
     /// Applies EIP-3541 contract code prefix rejection.
     ///
     /// Default: on since London

--- a/crates/evm2/src/version/mod.rs
+++ b/crates/evm2/src/version/mod.rs
@@ -244,6 +244,7 @@ mod tests {
         assert!(osaka.feature(EvmFeatures::BALANCE_CHECK));
         assert!(osaka.feature(EvmFeatures::BLOCK_GAS_LIMIT_CHECK));
         assert!(osaka.feature(EvmFeatures::EIP2));
+        assert!(osaka.feature(EvmFeatures::EIP2028));
         assert!(osaka.feature(EvmFeatures::EIP3541));
         assert!(osaka.feature(EvmFeatures::EIP3607));
         assert!(osaka.feature(EvmFeatures::EIP7623));
@@ -515,6 +516,9 @@ evm_versions! {
     }
 
     ISTANBUL {
+        features: [
+            EIP2028,
+        ],
         ops: [
             CHAINID: BASE,
             SELFBALANCE: LOW,


### PR DESCRIPTION
Adds an EIP2028 feature flag, enables it from Istanbul, and uses it for non-zero calldata byte pricing.