### PR TITLE
feat(version): gate EIP-3651 warm coinbase

### DIFF
--- a/crates/evm2/src/ethereum/eip1559.rs
+++ b/crates/evm2/src/ethereum/eip1559.rs
@@ -53,7 +53,7 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     let max_gas_cost = U256::from(tx.gas_limit) * max_fee_per_gas;
     validate_sender(req.host, caller, tx.nonce, max_gas_cost.saturating_add(tx.value))?;
 
-    warm_base_accounts(req.host, spec_id, caller, tx.to);
+    warm_base_accounts(req.host, caller, tx.to);
     warm_access_list(req.host, &tx.access_list);
 
     let effective_gas_cost = U256::from(tx.gas_limit) * gas_price;

--- a/crates/evm2/src/ethereum/eip2930.rs
+++ b/crates/evm2/src/ethereum/eip2930.rs
@@ -48,7 +48,7 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     let max_gas_cost = U256::from(tx.gas_limit) * gas_price;
     validate_sender(req.host, caller, tx.nonce, max_gas_cost.saturating_add(tx.value))?;
 
-    warm_base_accounts(req.host, spec_id, caller, tx.to);
+    warm_base_accounts(req.host, caller, tx.to);
     warm_access_list(req.host, &tx.access_list);
 
     charge_upfront(req.host, caller, max_gas_cost);

--- a/crates/evm2/src/ethereum/eip4844.rs
+++ b/crates/evm2/src/ethereum/eip4844.rs
@@ -65,7 +65,7 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
         max_gas_cost.saturating_add(max_blob_gas_cost).saturating_add(tx.value),
     )?;
 
-    warm_base_accounts(req.host, spec_id, caller, tx.to.into());
+    warm_base_accounts(req.host, caller, tx.to.into());
     warm_access_list(req.host, &tx.access_list);
 
     let effective_gas_cost = U256::from(tx.gas_limit) * gas_price;

--- a/crates/evm2/src/ethereum/eip7702.rs
+++ b/crates/evm2/src/ethereum/eip7702.rs
@@ -59,7 +59,7 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     let max_gas_cost = U256::from(tx.gas_limit) * max_fee_per_gas;
     validate_sender(req.host, caller, tx.nonce, max_gas_cost.saturating_add(tx.value))?;
 
-    warm_base_accounts(req.host, spec_id, caller, tx.to.into());
+    warm_base_accounts(req.host, caller, tx.to.into());
     warm_access_list(req.host, &tx.access_list);
 
     let effective_gas_cost = U256::from(tx.gas_limit) * gas_price;

--- a/crates/evm2/src/ethereum/legacy.rs
+++ b/crates/evm2/src/ethereum/legacy.rs
@@ -36,7 +36,7 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     let max_gas_cost = U256::from(tx.gas_limit) * gas_price;
     validate_sender(req.host, caller, tx.nonce, max_gas_cost.saturating_add(tx.value))?;
 
-    warm_base_accounts(req.host, spec_id, caller, tx.to);
+    warm_base_accounts(req.host, caller, tx.to);
 
     charge_upfront(req.host, caller, max_gas_cost);
     req.host.state.increment_nonce(caller);

--- a/crates/evm2/src/ethereum/mod.rs
+++ b/crates/evm2/src/ethereum/mod.rs
@@ -268,12 +268,11 @@ pub(super) fn validate_sender<T: EvmTypes<Host = Evm<T>>>(
 
 pub(super) fn warm_base_accounts<T: EvmTypes<Host = Evm<T>>>(
     host: &mut Evm<T>,
-    spec_id: SpecId,
     caller: Address,
     to: TxKind,
 ) {
     host.state.warm_account_non_revertible(caller);
-    if spec_id.enables(SpecId::SHANGHAI) {
+    if host.feature(EvmFeatures::EIP3651) {
         host.state.warm_account_non_revertible(host.block.beneficiary);
     }
     if let TxKind::Call(to) = to {

--- a/crates/evm2/src/version/features.rs
+++ b/crates/evm2/src/version/features.rs
@@ -136,6 +136,10 @@ evm_features! {
     ///
     /// Default: on since Istanbul
     EIP2028,
+    /// Applies EIP-3651 warm coinbase at transaction start.
+    ///
+    /// Default: on since Shanghai
+    EIP3651,
     /// Applies EIP-3541 contract code prefix rejection.
     ///
     /// Default: on since London

--- a/crates/evm2/src/version/mod.rs
+++ b/crates/evm2/src/version/mod.rs
@@ -246,6 +246,7 @@ mod tests {
         assert!(osaka.feature(EvmFeatures::EIP2));
         assert!(osaka.feature(EvmFeatures::EIP2028));
         assert!(osaka.feature(EvmFeatures::EIP3541));
+        assert!(osaka.feature(EvmFeatures::EIP3651));
         assert!(osaka.feature(EvmFeatures::EIP3607));
         assert!(osaka.feature(EvmFeatures::EIP7623));
         assert!(osaka.feature(EvmFeatures::BASE_FEE_CHECK));
@@ -589,6 +590,9 @@ evm_versions! {
     MERGE {}
 
     SHANGHAI {
+        features: [
+            EIP3651,
+        ],
         ops: [
             PUSH0: BASE,
         ],


### PR DESCRIPTION
Adds an EIP3651 feature flag, enables it from Shanghai, and uses it to warm the coinbase at transaction start.