### PR TITLE
feat(version): gate EIP-3860 initcode costs

### DIFF
--- a/crates/evm2/src/ethereum/mod.rs
+++ b/crates/evm2/src/ethereum/mod.rs
@@ -208,7 +208,7 @@ pub(super) fn validate_create_initcode(
     to: TxKind,
     input: &Bytes,
 ) -> HandlerResult<()> {
-    if version.spec_id.enables(SpecId::SHANGHAI)
+    if version.feature(EvmFeatures::EIP3860)
         && to.is_create()
         && input.len() > version.max_initcode_size
     {
@@ -476,7 +476,7 @@ pub(super) fn intrinsic_gas(
     if to.is_create() && version.feature(EvmFeatures::EIP2) {
         gas += 32_000;
     }
-    if to.is_create() && spec.enables(SpecId::SHANGHAI) {
+    if to.is_create() && version.feature(EvmFeatures::EIP3860) {
         gas += u64::from(params.get(GasId::TxInitcodeCost)) * num_words(input.len()) as u64;
     }
     gas

--- a/crates/evm2/src/version/features.rs
+++ b/crates/evm2/src/version/features.rs
@@ -140,6 +140,10 @@ evm_features! {
     ///
     /// Default: on since Shanghai
     EIP3651,
+    /// Applies EIP-3860 initcode size limits and word gas.
+    ///
+    /// Default: on since Shanghai
+    EIP3860,
     /// Applies EIP-3541 contract code prefix rejection.
     ///
     /// Default: on since London

--- a/crates/evm2/src/version/mod.rs
+++ b/crates/evm2/src/version/mod.rs
@@ -245,8 +245,9 @@ mod tests {
         assert!(osaka.feature(EvmFeatures::BLOCK_GAS_LIMIT_CHECK));
         assert!(osaka.feature(EvmFeatures::EIP2));
         assert!(osaka.feature(EvmFeatures::EIP2028));
-        assert!(osaka.feature(EvmFeatures::EIP3541));
         assert!(osaka.feature(EvmFeatures::EIP3651));
+        assert!(osaka.feature(EvmFeatures::EIP3860));
+        assert!(osaka.feature(EvmFeatures::EIP3541));
         assert!(osaka.feature(EvmFeatures::EIP3607));
         assert!(osaka.feature(EvmFeatures::EIP7623));
         assert!(osaka.feature(EvmFeatures::BASE_FEE_CHECK));
@@ -592,6 +593,7 @@ evm_versions! {
     SHANGHAI {
         features: [
             EIP3651,
+            EIP3860,
         ],
         ops: [
             PUSH0: BASE,


### PR DESCRIPTION
Adds an EIP3860 feature flag, enables it from Shanghai, and uses it for initcode size limits and word gas.