### PR TITLE
feat(version): gate EIP-3529 refund cap

### DIFF
--- a/crates/evm2/src/ethereum/mod.rs
+++ b/crates/evm2/src/ethereum/mod.rs
@@ -397,7 +397,7 @@ pub(super) fn settle_gas<T: EvmTypes<Host = Evm<T>>>(
     result: MessageResult,
 ) -> TxResult {
     let (gas_remaining, gas_used) =
-        final_tx_gas(&result, tx_gas_limit, spec_id.enables(SpecId::LONDON), floor_gas);
+        final_tx_gas(&result, tx_gas_limit, host.feature(EvmFeatures::EIP3529), floor_gas);
     if host.feature(EvmFeatures::FEE_CHARGE) {
         host.state.add_balance(caller, U256::from(gas_remaining) * gas_price);
         let beneficiary_gas_price = if spec_id.enables(SpecId::LONDON) {
@@ -420,11 +420,11 @@ pub(super) fn settle_gas<T: EvmTypes<Host = Evm<T>>>(
 const fn final_tx_gas(
     result: &MessageResult,
     tx_gas_limit: u64,
-    is_london: bool,
+    is_eip3529: bool,
     floor_gas: u64,
 ) -> (u64, u64) {
-    let gas_remaining = result.gas_remaining_after_final_refund(tx_gas_limit, is_london);
-    let gas_used = result.gas_used_after_final_refund(tx_gas_limit, is_london);
+    let gas_remaining = result.gas_remaining_after_final_refund(tx_gas_limit, is_eip3529);
+    let gas_used = result.gas_used_after_final_refund(tx_gas_limit, is_eip3529);
     // EIP-7623 charges at least the calldata floor after applying refunds.
     if gas_used < floor_gas {
         return (tx_gas_limit.saturating_sub(floor_gas), floor_gas);

--- a/crates/evm2/src/version/features.rs
+++ b/crates/evm2/src/version/features.rs
@@ -136,6 +136,10 @@ evm_features! {
     ///
     /// Default: on since Istanbul
     EIP2028,
+    /// Applies EIP-3529 refund reductions.
+    ///
+    /// Default: on since London
+    EIP3529,
     /// Applies EIP-3651 warm coinbase at transaction start.
     ///
     /// Default: on since Shanghai

--- a/crates/evm2/src/version/mod.rs
+++ b/crates/evm2/src/version/mod.rs
@@ -245,6 +245,7 @@ mod tests {
         assert!(osaka.feature(EvmFeatures::BLOCK_GAS_LIMIT_CHECK));
         assert!(osaka.feature(EvmFeatures::EIP2));
         assert!(osaka.feature(EvmFeatures::EIP2028));
+        assert!(osaka.feature(EvmFeatures::EIP3529));
         assert!(osaka.feature(EvmFeatures::EIP3651));
         assert!(osaka.feature(EvmFeatures::EIP3860));
         assert!(osaka.feature(EvmFeatures::EIP3541));
@@ -572,6 +573,7 @@ evm_versions! {
 
     LONDON {
         features: [
+            EIP3529,
             EIP3541,
             BASE_FEE_CHECK,
         ],


### PR DESCRIPTION
Adds an EIP3529 feature flag, enables it from London, and uses it for the final refund cap.