### PR TITLE
refactor(ethereum): gate tx registry by spec

### DIFF
--- a/crates/evm2/benches/evm/support.rs
+++ b/crates/evm2/benches/evm/support.rs
@@ -72,5 +72,5 @@ impl Runner {
 }
 
 fn new_evm(spec: SpecId, block: BlockEnv, db: InMemoryDB) -> BenchEvm {
-    Evm::new(spec, block, ethereum_tx_registry(), db, Precompiles::base(spec))
+    Evm::new(spec, block, ethereum_tx_registry(spec), db, Precompiles::base(spec))
 }

--- a/crates/evm2/src/ethereum/eip1559.rs
+++ b/crates/evm2/src/ethereum/eip1559.rs
@@ -7,10 +7,10 @@ use super::{
     warm_base_accounts,
 };
 use crate::{
-    Evm, EvmTypes, SpecId, TxResult,
+    Evm, EvmTypes, TxResult,
     env::TxEnv,
     interpreter::Host,
-    registry::{HandlerError, HandlerResult, TxRequest},
+    registry::{HandlerResult, TxRequest},
 };
 use alloy_consensus::{TxEip1559, transaction::Recovered};
 use alloy_primitives::U256;
@@ -19,10 +19,6 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     req: TxRequest<'_, Recovered<TxEip1559>, Evm<T>>,
 ) -> HandlerResult<TxResult> {
     let spec_id = req.host.spec_id();
-    if !spec_id.enables(SpecId::LONDON) {
-        return Err(HandlerError::Eip1559NotSupported);
-    }
-
     let caller = req.tx.signer();
     let tx = req.tx.inner();
     let max_fee_per_gas = U256::from(tx.max_fee_per_gas);

--- a/crates/evm2/src/ethereum/eip2930.rs
+++ b/crates/evm2/src/ethereum/eip2930.rs
@@ -6,10 +6,10 @@ use super::{
     validate_tx_gas_limit_cap, warm_access_list, warm_base_accounts,
 };
 use crate::{
-    Evm, EvmTypes, SpecId, TxResult,
+    Evm, EvmTypes, TxResult,
     env::TxEnv,
     interpreter::Host,
-    registry::{HandlerError, HandlerResult, TxRequest},
+    registry::{HandlerResult, TxRequest},
 };
 use alloy_consensus::{TxEip2930, transaction::Recovered};
 use alloy_primitives::U256;
@@ -18,10 +18,6 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     req: TxRequest<'_, Recovered<TxEip2930>, Evm<T>>,
 ) -> HandlerResult<TxResult> {
     let spec_id = req.host.spec_id();
-    if !spec_id.enables(SpecId::BERLIN) {
-        return Err(HandlerError::Eip2930NotSupported);
-    }
-
     let caller = req.tx.signer();
     let tx = req.tx.inner();
     let gas_price = U256::from(tx.gas_price);

--- a/crates/evm2/src/ethereum/eip4844.rs
+++ b/crates/evm2/src/ethereum/eip4844.rs
@@ -7,7 +7,7 @@ use super::{
     warm_base_accounts,
 };
 use crate::{
-    Evm, EvmTypes, SpecId, TxResult,
+    Evm, EvmTypes, TxResult,
     env::TxEnv,
     interpreter::Host,
     registry::{HandlerError, HandlerResult, TxRequest},
@@ -21,10 +21,6 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     req: TxRequest<'_, Recovered<TxEip4844Variant>, Evm<T>>,
 ) -> HandlerResult<TxResult> {
     let spec_id = req.host.spec_id();
-    if !spec_id.enables(SpecId::CANCUN) {
-        return Err(HandlerError::Eip4844NotSupported);
-    }
-
     let caller = req.tx.signer();
     let tx = req.tx.inner().tx();
     let max_fee_per_gas = U256::from(tx.max_fee_per_gas);

--- a/crates/evm2/src/ethereum/eip7702.rs
+++ b/crates/evm2/src/ethereum/eip7702.rs
@@ -7,7 +7,7 @@ use super::{
     warm_base_accounts,
 };
 use crate::{
-    Evm, EvmTypes, SpecId, TxResult,
+    Evm, EvmTypes, TxResult,
     bytecode::Bytecode,
     env::TxEnv,
     interpreter::Host,
@@ -22,10 +22,6 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     req: TxRequest<'_, Recovered<TxEip7702>, Evm<T>>,
 ) -> HandlerResult<TxResult> {
     let spec_id = req.host.spec_id();
-    if !spec_id.enables(SpecId::PRAGUE) {
-        return Err(HandlerError::Eip7702NotSupported);
-    }
-
     let caller = req.tx.signer();
     let tx = req.tx.inner();
     if tx.authorization_list.is_empty() {

--- a/crates/evm2/src/ethereum/mod.rs
+++ b/crates/evm2/src/ethereum/mod.rs
@@ -91,15 +91,27 @@ impl Typed2718 for RecoveredTxEnvelope {
     }
 }
 
-/// Returns the Ethereum transaction registry.
-pub fn ethereum_tx_registry<T: EvmTypes<Host = Evm<T>>>()
--> TxRegistry<RecoveredTxEnvelope, TxResult, Evm<T>> {
-    TxRegistry::new()
-        .with_handler(0, RecoveredTxEnvelope::as_legacy, legacy::handle::<T>)
-        .with_handler(1, RecoveredTxEnvelope::as_eip2930, eip2930::handle::<T>)
-        .with_handler(2, RecoveredTxEnvelope::as_eip1559, eip1559::handle::<T>)
-        .with_handler(3, RecoveredTxEnvelope::as_eip4844, eip4844::handle::<T>)
-        .with_handler(4, RecoveredTxEnvelope::as_eip7702, eip7702::handle::<T>)
+/// Returns the Ethereum transaction registry for `spec_id`.
+pub fn ethereum_tx_registry<T: EvmTypes<Host = Evm<T>>>(
+    spec_id: SpecId,
+) -> TxRegistry<RecoveredTxEnvelope, TxResult, Evm<T>> {
+    let mut registry =
+        TxRegistry::new().with_handler(0, RecoveredTxEnvelope::as_legacy, legacy::handle::<T>);
+
+    if spec_id.enables(SpecId::BERLIN) {
+        registry.register(1, RecoveredTxEnvelope::as_eip2930, eip2930::handle::<T>);
+    }
+    if spec_id.enables(SpecId::LONDON) {
+        registry.register(2, RecoveredTxEnvelope::as_eip1559, eip1559::handle::<T>);
+    }
+    if spec_id.enables(SpecId::CANCUN) {
+        registry.register(3, RecoveredTxEnvelope::as_eip4844, eip4844::handle::<T>);
+    }
+    if spec_id.enables(SpecId::PRAGUE) {
+        registry.register(4, RecoveredTxEnvelope::as_eip7702, eip7702::handle::<T>);
+    }
+
+    registry
 }
 
 pub(super) fn validate_gas_price(
@@ -464,7 +476,6 @@ pub(super) fn intrinsic_gas(
     access_list_accounts: u64,
     access_list_storage_keys: u64,
 ) -> u64 {
-    let spec = version.spec_id;
     let params = &version.gas_params;
     let non_zero_multiplier = if version.feature(EvmFeatures::EIP2028) { 16 } else { 68 };
     let mut gas = 21_000;

--- a/crates/evm2/src/evm/registry.rs
+++ b/crates/evm2/src/evm/registry.rs
@@ -146,21 +146,9 @@ pub enum HandlerError {
         /// Block base fee.
         base_fee: U256,
     },
-    /// EIP-2930 transaction is not enabled in the active specification.
-    #[error("EIP-2930 transaction not supported")]
-    Eip2930NotSupported,
-    /// EIP-1559 transaction is not enabled in the active specification.
-    #[error("EIP-1559 transaction not supported")]
-    Eip1559NotSupported,
-    /// EIP-7702 transaction is not enabled in the active specification.
-    #[error("EIP-7702 transaction not supported")]
-    Eip7702NotSupported,
     /// EIP-7702 authorization list is empty.
     #[error("EIP-7702 authorization list is empty")]
     EmptyAuthorizationList,
-    /// EIP-4844 transaction is not enabled in the active specification.
-    #[error("EIP-4844 transaction not supported")]
-    Eip4844NotSupported,
     /// EIP-4844 blob fee cap is lower than the block blob base fee.
     #[error(
         "blob fee cap less than blob base fee: max_fee_per_blob_gas {max_fee_per_blob_gas}, blob_base_fee {blob_base_fee}"

--- a/crates/statetest/src/execute.rs
+++ b/crates/statetest/src/execute.rs
@@ -215,7 +215,7 @@ fn execute_spec(
             let mut evm = Evm::<BaseEvmTypes<RecoveredTxEnvelope>>::new(
                 spec,
                 block,
-                ethereum_tx_registry(),
+                ethereum_tx_registry(spec),
                 database.clone(),
                 Precompiles::base(spec),
             );


### PR DESCRIPTION
Build the Ethereum transaction registry according to the active SpecId so unsupported typed transactions are rejected by the registry instead of handler-level EIP checks.

Also removes the now-unused unsupported EIP handler errors.