### PR TITLE
perf: hash storage keys as fixed bytes

### DIFF
--- a/crates/evm2/src/evm/db/cache.rs
+++ b/crates/evm2/src/evm/db/cache.rs
@@ -1,10 +1,15 @@
 //! In-memory cache database.
 
 use super::{Database, EmptyDB};
-use crate::{bytecode::Bytecode, evm::state::AccountInfo, interpreter::Word};
+use crate::{
+    bytecode::Bytecode,
+    evm::state::AccountInfo,
+    interpreter::Word,
+    storage_key::{StorageKey, StorageKeyMap},
+};
 use alloy_primitives::{
     Address, B256, KECCAK256_EMPTY,
-    map::{AddressMap, B256Map, HashMap, U256Map, hash_map::Entry},
+    map::{AddressMap, B256Map, U256Map, hash_map::Entry},
 };
 
 /// A database implementation that stores initial state in memory.
@@ -22,7 +27,7 @@ pub struct Cache {
     /// Contracts keyed by code hash.
     pub contracts: B256Map<Bytecode>,
     /// Persistent storage keyed by account and slot.
-    pub storage: HashMap<(Address, Word), Word>,
+    pub(crate) storage: StorageKeyMap<Word>,
     /// Cached block hashes keyed by block number.
     pub block_hashes: U256Map<B256>,
 }
@@ -36,9 +41,37 @@ impl Default for Cache {
         Self {
             accounts: AddressMap::default(),
             contracts,
-            storage: HashMap::default(),
+            storage: StorageKeyMap::default(),
             block_hashes: U256Map::default(),
         }
+    }
+}
+
+impl Cache {
+    /// Inserts persistent storage.
+    #[inline]
+    pub fn insert_storage(&mut self, address: Address, key: Word, value: Word) {
+        self.storage.insert(StorageKey::new(address, key), value);
+    }
+
+    /// Removes persistent storage.
+    #[inline]
+    pub fn remove_storage(&mut self, address: Address, key: Word) -> Option<Word> {
+        self.storage.remove(&StorageKey::new(address, key))
+    }
+
+    /// Removes all persistent storage for an account.
+    #[inline]
+    pub fn clear_storage(&mut self, address: Address) {
+        self.storage.retain(|key, _| key.address() != address);
+    }
+
+    /// Returns persistent storage entries for an account.
+    #[inline]
+    pub fn account_storage(&self, address: Address) -> impl Iterator<Item = (Word, Word)> + '_ {
+        self.storage.iter().filter_map(move |(&key, &value)| {
+            (key.address() == address).then_some((key.key(), value))
+        })
     }
 }
 
@@ -105,7 +138,7 @@ impl<ExtDB> CacheDB<ExtDB> {
     #[inline]
     pub fn insert_account_storage(&mut self, address: Address, key: Word, value: Word) {
         self.cache.accounts.entry(address).or_default();
-        self.cache.storage.insert((address, key), value);
+        self.cache.insert_storage(address, key, value);
     }
 
     /// Sets a historical block hash.
@@ -140,7 +173,7 @@ impl<ExtDB: Database> Database for CacheDB<ExtDB> {
 
     #[inline]
     fn get_storage(&mut self, address: Address, key: Word) -> Word {
-        match self.cache.storage.entry((address, key)) {
+        match self.cache.storage.entry(StorageKey::new(address, key)) {
             Entry::Occupied(entry) => *entry.get(),
             Entry::Vacant(entry) => {
                 let value = self.db.get_storage(address, key);

--- a/crates/evm2/src/evm/db/cache.rs
+++ b/crates/evm2/src/evm/db/cache.rs
@@ -27,7 +27,7 @@ pub struct Cache {
     /// Contracts keyed by code hash.
     pub contracts: B256Map<Bytecode>,
     /// Persistent storage keyed by account and slot.
-    pub(crate) storage: StorageKeyMap<Word>,
+    pub storage: StorageKeyMap<Word>,
     /// Cached block hashes keyed by block number.
     pub block_hashes: U256Map<B256>,
 }
@@ -44,34 +44,6 @@ impl Default for Cache {
             storage: StorageKeyMap::default(),
             block_hashes: U256Map::default(),
         }
-    }
-}
-
-impl Cache {
-    /// Inserts persistent storage.
-    #[inline]
-    pub fn insert_storage(&mut self, address: Address, key: Word, value: Word) {
-        self.storage.insert(StorageKey::new(address, key), value);
-    }
-
-    /// Removes persistent storage.
-    #[inline]
-    pub fn remove_storage(&mut self, address: Address, key: Word) -> Option<Word> {
-        self.storage.remove(&StorageKey::new(address, key))
-    }
-
-    /// Removes all persistent storage for an account.
-    #[inline]
-    pub fn clear_storage(&mut self, address: Address) {
-        self.storage.retain(|key, _| key.address() != address);
-    }
-
-    /// Returns persistent storage entries for an account.
-    #[inline]
-    pub fn account_storage(&self, address: Address) -> impl Iterator<Item = (Word, Word)> + '_ {
-        self.storage.iter().filter_map(move |(&key, &value)| {
-            (key.address() == address).then_some((key.key(), value))
-        })
     }
 }
 
@@ -138,7 +110,7 @@ impl<ExtDB> CacheDB<ExtDB> {
     #[inline]
     pub fn insert_account_storage(&mut self, address: Address, key: Word, value: Word) {
         self.cache.accounts.entry(address).or_default();
-        self.cache.insert_storage(address, key, value);
+        self.cache.storage.insert(StorageKey::new(address, key), value);
     }
 
     /// Sets a historical block hash.

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -30,7 +30,6 @@ mod db;
 pub use db::{Cache, CacheDB, Database, EmptyDB, InMemoryDB};
 
 mod state;
-pub use crate::storage_key::{StorageKey, StorageKeyMap, StorageKeySet};
 pub use state::{
     Account, AccountInfo, JournalEntry, State, StateChanges, StateCheckpoint, StorageChangeSet,
     StorageOverlay, Tracked,

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -30,6 +30,7 @@ mod db;
 pub use db::{Cache, CacheDB, Database, EmptyDB, InMemoryDB};
 
 mod state;
+pub use crate::storage_key::{StorageKey, StorageKeyMap, StorageKeySet};
 pub use state::{
     Account, AccountInfo, JournalEntry, State, StateChanges, StateCheckpoint, StorageChangeSet,
     StorageOverlay, Tracked,

--- a/crates/evm2/src/evm/state.rs
+++ b/crates/evm2/src/evm/state.rs
@@ -5,11 +5,12 @@ use crate::{
     SpecId,
     bytecode::Bytecode,
     interpreter::{InstrStop, Word},
+    storage_key::{StorageKey, StorageKeyMap, StorageKeySet},
 };
 use alloc::{collections::BTreeMap, vec::Vec};
 use alloy_primitives::{
     Address, B256, KECCAK256_EMPTY, Log, U256,
-    map::{AddressMap, AddressSet, HashMap, HashSet, U256Map, hash_map},
+    map::{AddressMap, AddressSet, U256Map, hash_map},
 };
 
 /// A value tracked together with the value it had at the start of the current
@@ -354,9 +355,9 @@ pub struct State<D> {
     /// account was touched, changed, or should be emitted in [`StateChanges`].
     accessed_accounts: AddressSet,
     /// Transaction-scoped warm storage slot set.
-    accessed_storage: HashSet<(Address, Word)>,
+    accessed_storage: StorageKeySet,
     /// Transaction-scoped EIP-1153 transient storage keyed by account address and slot.
-    transient_storage: HashMap<(Address, Word), Word>,
+    transient_storage: StorageKeyMap<Word>,
 }
 
 impl<D> State<D> {
@@ -372,8 +373,8 @@ impl<D> State<D> {
             touched: AddressSet::default(),
             selfdestructs: AddressSet::default(),
             accessed_accounts: AddressSet::default(),
-            accessed_storage: HashSet::default(),
-            transient_storage: HashMap::default(),
+            accessed_storage: StorageKeySet::default(),
+            transient_storage: StorageKeyMap::default(),
         }
     }
 
@@ -491,7 +492,7 @@ impl<D> State<D> {
     #[inline]
     #[must_use]
     pub fn is_storage_warm(&self, address: Address, key: Word) -> bool {
-        self.accessed_storage.contains(&(address, key))
+        self.accessed_storage.contains(&StorageKey::new(address, key))
     }
 
     /// Marks a storage slot as warm in a revertible execution context.
@@ -503,7 +504,7 @@ impl<D> State<D> {
     #[inline]
     #[must_use]
     pub fn warm_storage(&mut self, address: Address, key: Word) -> bool {
-        if self.accessed_storage.insert((address, key)) {
+        if self.accessed_storage.insert(StorageKey::new(address, key)) {
             self.journal.push(JournalEntry::StorageWarmed { address, key });
             true
         } else {
@@ -525,7 +526,7 @@ impl<D> State<D> {
     #[inline]
     #[must_use]
     pub fn warm_storage_non_revertible(&mut self, address: Address, key: Word) -> bool {
-        self.accessed_storage.insert((address, key))
+        self.accessed_storage.insert(StorageKey::new(address, key))
     }
 
     /// Clears transaction-scoped substate.
@@ -842,13 +843,13 @@ impl<D: Database> State<D> {
     #[inline]
     #[must_use]
     pub fn transient_storage(&mut self, address: Address, key: Word) -> Word {
-        self.transient_storage.get(&(address, key)).copied().unwrap_or_default()
+        self.transient_storage.get(&StorageKey::new(address, key)).copied().unwrap_or_default()
     }
 
     /// Stores transient storage.
     #[inline]
     pub fn set_transient_storage(&mut self, address: Address, key: Word, value: Word) {
-        match self.transient_storage.entry((address, key)) {
+        match self.transient_storage.entry(StorageKey::new(address, key)) {
             hash_map::Entry::Occupied(mut entry) => {
                 let previous = *entry.get();
                 if previous == value {
@@ -961,17 +962,17 @@ impl<D: Database> State<D> {
                 },
                 JournalEntry::TransientStorageChange { address, key, previous } => match previous {
                     Some(previous) if !previous.is_zero() => {
-                        self.transient_storage.insert((address, key), previous);
+                        self.transient_storage.insert(StorageKey::new(address, key), previous);
                     }
                     _ => {
-                        self.transient_storage.remove(&(address, key));
+                        self.transient_storage.remove(&StorageKey::new(address, key));
                     }
                 },
                 JournalEntry::AccountWarmed { address } => {
                     self.accessed_accounts.remove(&address);
                 }
                 JournalEntry::StorageWarmed { address, key } => {
-                    self.accessed_storage.remove(&(address, key));
+                    self.accessed_storage.remove(&StorageKey::new(address, key));
                 }
             }
         }

--- a/crates/evm2/src/interpreter/instructions/host.rs
+++ b/crates/evm2/src/interpreter/instructions/host.rs
@@ -131,6 +131,7 @@ mod tests {
             instructions::tests::{RunConfig, TestHost, push, run},
             op,
         },
+        storage_key::StorageKey,
     };
     use alloc::vec::Vec;
     use alloy_primitives::{Address, B256, Bytes};
@@ -138,7 +139,7 @@ mod tests {
     #[test]
     fn sload_opcode() {
         let mut host = TestHost::default();
-        host.storage.insert((Address::ZERO, Word::from(1)), Word::from(0xbeef));
+        host.storage.insert(StorageKey::new(Address::ZERO, Word::from(1)), Word::from(0xbeef));
 
         let mut code = Vec::new();
         push(&mut code, 1);
@@ -168,7 +169,10 @@ mod tests {
         let interpreter = run(RunConfig::new(code).host(&mut host).gas_limit(30_000));
         core::assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [Word::from(0xbeef)]);
-        assert_eq!(host.storage.get(&(Address::ZERO, Word::from(1))), Some(&Word::from(0xbeef)));
+        assert_eq!(
+            host.storage.get(&StorageKey::new(Address::ZERO, Word::from(1))),
+            Some(&Word::from(0xbeef))
+        );
     }
 
     #[test]
@@ -182,7 +186,7 @@ mod tests {
         let interpreter = run(RunConfig::new(code).host(&mut host).staticcall());
         core::assert_matches!(interpreter.err, InstrStop::StateChangeDuringStaticCall);
         assert_eq!(interpreter.stack(), [Word::from(0xbeef), Word::from(1)]);
-        assert_eq!(host.storage.get(&(Address::ZERO, Word::from(1))), None);
+        assert_eq!(host.storage.get(&StorageKey::new(Address::ZERO, Word::from(1))), None);
     }
 
     #[test]
@@ -199,7 +203,7 @@ mod tests {
 
         core::assert_matches!(interpreter.err, InstrStop::StateChangeDuringStaticCall);
         assert_eq!(interpreter.stack(), [Word::from(0xbeef), Word::from(1)]);
-        assert_eq!(host.storage.get(&(Address::ZERO, Word::from(1))), None);
+        assert_eq!(host.storage.get(&StorageKey::new(Address::ZERO, Word::from(1))), None);
     }
 
     #[test]
@@ -213,7 +217,7 @@ mod tests {
         let interpreter =
             run(RunConfig::new(code).host(&mut host).spec(SpecId::ISTANBUL).gas_limit(2306));
         core::assert_matches!(interpreter.err, InstrStop::ReentrancySentryOOG);
-        assert_eq!(host.storage.get(&(Address::ZERO, Word::from(1))), None);
+        assert_eq!(host.storage.get(&StorageKey::new(Address::ZERO, Word::from(1))), None);
     }
 
     #[test]
@@ -261,7 +265,7 @@ mod tests {
     #[test]
     fn sstore_reset_to_original_records_refund() {
         let mut host = TestHost::default();
-        host.storage.insert((Address::ZERO, Word::from(0)), Word::from(5));
+        host.storage.insert(StorageKey::new(Address::ZERO, Word::from(0)), Word::from(5));
         let mut code = Vec::new();
         push(&mut code, 7);
         push(&mut code, 0);
@@ -294,7 +298,8 @@ mod tests {
     #[test]
     fn tload_opcode() {
         let mut host = TestHost::default();
-        host.transient_storage.insert((Address::ZERO, Word::from(1)), Word::from(0xcafe));
+        host.transient_storage
+            .insert(StorageKey::new(Address::ZERO, Word::from(1)), Word::from(0xcafe));
 
         let mut code = Vec::new();
         push(&mut code, 1);
@@ -324,7 +329,7 @@ mod tests {
         core::assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [Word::from(0xcafe)]);
         assert_eq!(
-            host.transient_storage.get(&(Address::ZERO, Word::from(1))),
+            host.transient_storage.get(&StorageKey::new(Address::ZERO, Word::from(1))),
             Some(&Word::from(0xcafe))
         );
 
@@ -347,7 +352,10 @@ mod tests {
             run(RunConfig::new(code).host(&mut host).spec(SpecId::CANCUN).staticcall());
         core::assert_matches!(interpreter.err, InstrStop::StateChangeDuringStaticCall);
         assert_eq!(interpreter.stack(), [Word::from(0xcafe), Word::from(1)]);
-        assert_eq!(host.transient_storage.get(&(Address::ZERO, Word::from(1))), None);
+        assert_eq!(
+            host.transient_storage.get(&StorageKey::new(Address::ZERO, Word::from(1))),
+            None
+        );
     }
 
     fn log_code<const N: usize>(offset: usize, len: usize, topics: [Word; N]) -> Vec<u8> {

--- a/crates/evm2/src/interpreter/instructions/tests.rs
+++ b/crates/evm2/src/interpreter/instructions/tests.rs
@@ -7,9 +7,10 @@ use crate::{
         Gas, Host, InstrStop, Interpreter, Memory, Message, MessageKind, MessageResult, Stack,
         Word, op,
     },
+    storage_key::{StorageKey, StorageKeyMap},
 };
 use alloc::{boxed::Box, vec::Vec};
-use alloy_primitives::{Address, B256, Bytes, Log, map::HashMap};
+use alloy_primitives::{Address, B256, Bytes, Log};
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub(crate) struct TestTypes;
@@ -33,9 +34,9 @@ pub(crate) struct TestHost {
     pub(super) is_empty: bool,
     pub(super) is_cold: bool,
     pub(super) is_touched: bool,
-    pub(super) storage: HashMap<(Address, Word), Word>,
-    pub(super) original_storage: HashMap<(Address, Word), Word>,
-    pub(super) transient_storage: HashMap<(Address, Word), Word>,
+    pub(super) storage: StorageKeyMap<Word>,
+    pub(super) original_storage: StorageKeyMap<Word>,
+    pub(super) transient_storage: StorageKeyMap<Word>,
     pub(super) logs: Vec<Log>,
     pub(super) execute_result: MessageResult,
     pub(super) selfdestruct_result: SelfDestructResult,
@@ -55,9 +56,9 @@ impl Default for TestHost {
             is_empty: false,
             is_cold: false,
             is_touched: false,
-            storage: HashMap::default(),
-            original_storage: HashMap::default(),
-            transient_storage: HashMap::default(),
+            storage: StorageKeyMap::default(),
+            original_storage: StorageKeyMap::default(),
+            transient_storage: StorageKeyMap::default(),
             logs: Vec::new(),
             execute_result: MessageResult { stop: InstrStop::Return, ..MessageResult::default() },
             selfdestruct_result: SelfDestructResult::default(),
@@ -117,7 +118,7 @@ impl Host for TestHost {
             return Err(InstrStop::OutOfGas);
         }
         Ok(SLoad {
-            value: self.storage.get(&(address, key)).copied().unwrap_or_default(),
+            value: self.storage.get(&StorageKey::new(address, key)).copied().unwrap_or_default(),
             is_cold: self.is_cold,
         })
     }
@@ -132,7 +133,7 @@ impl Host for TestHost {
         if skip_cold_load && self.is_cold {
             return Err(InstrStop::OutOfGas);
         }
-        let storage_key = (address, key);
+        let storage_key = StorageKey::new(address, key);
         let present_value = self.storage.get(&storage_key).copied().unwrap_or_default();
         let original_value = *self.original_storage.entry(storage_key).or_insert(present_value);
         if value.is_zero() {
@@ -144,11 +145,11 @@ impl Host for TestHost {
     }
 
     fn tload(&mut self, address: Address, key: Word) -> Word {
-        self.transient_storage.get(&(address, key)).copied().unwrap_or_default()
+        self.transient_storage.get(&StorageKey::new(address, key)).copied().unwrap_or_default()
     }
 
     fn tstore(&mut self, address: Address, key: Word, value: Word) {
-        self.transient_storage.insert((address, key), value);
+        self.transient_storage.insert(StorageKey::new(address, key), value);
     }
 
     fn log(&mut self, log: Log) {

--- a/crates/evm2/src/lib.rs
+++ b/crates/evm2/src/lib.rs
@@ -39,6 +39,7 @@ mod spec_id;
 pub use spec_id::SpecId;
 
 mod once_lock;
+mod storage_key;
 
 #[cfg(test)]
 mod tests;

--- a/crates/evm2/src/lib.rs
+++ b/crates/evm2/src/lib.rs
@@ -40,6 +40,7 @@ pub use spec_id::SpecId;
 
 mod once_lock;
 mod storage_key;
+pub use storage_key::{StorageKey, StorageKeyMap, StorageKeySet};
 
 #[cfg(test)]
 mod tests;

--- a/crates/evm2/src/storage_key.rs
+++ b/crates/evm2/src/storage_key.rs
@@ -1,0 +1,42 @@
+use crate::interpreter::Word;
+use alloy_primitives::{
+    Address, B256,
+    map::{FbBuildHasher, HashMap, HashSet},
+};
+use core::hash::{Hash, Hasher};
+
+pub(crate) type StorageKeyMap<V> = HashMap<StorageKey, V, FbBuildHasher<52>>;
+pub(crate) type StorageKeySet = HashSet<StorageKey, FbBuildHasher<52>>;
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) struct StorageKey {
+    address: Address,
+    key: B256,
+}
+
+impl StorageKey {
+    #[inline]
+    pub(crate) fn new(address: Address, key: Word) -> Self {
+        Self { address, key: B256::from(key) }
+    }
+
+    #[inline]
+    pub(crate) const fn address(self) -> Address {
+        self.address
+    }
+
+    #[inline]
+    pub(crate) const fn key(self) -> Word {
+        Word::from_be_bytes(self.key.0)
+    }
+}
+
+impl Hash for StorageKey {
+    #[inline]
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        let mut bytes = [0; 52];
+        bytes[..20].copy_from_slice(self.address.as_slice());
+        bytes[20..].copy_from_slice(self.key.as_slice());
+        state.write(&bytes);
+    }
+}

--- a/crates/evm2/src/storage_key.rs
+++ b/crates/evm2/src/storage_key.rs
@@ -1,9 +1,12 @@
 use crate::interpreter::Word;
 use alloy_primitives::{
-    Address, B256,
+    Address, B256, FixedBytes,
     map::{FbBuildHasher, HashMap, HashSet},
 };
-use core::hash::{Hash, Hasher};
+use core::{
+    hash::{Hash, Hasher},
+    mem,
+};
 
 /// Hash map keyed by storage account and slot.
 pub type StorageKeyMap<V> = HashMap<StorageKey, V, FbBuildHasher<52>>;
@@ -12,11 +15,14 @@ pub type StorageKeyMap<V> = HashMap<StorageKey, V, FbBuildHasher<52>>;
 pub type StorageKeySet = HashSet<StorageKey, FbBuildHasher<52>>;
 
 /// Storage key for account-address and storage-slot pairs.
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Eq)]
+#[repr(C)]
 pub struct StorageKey {
     address: Address,
     key: B256,
 }
+
+const _: () = assert!(mem::size_of::<StorageKey>() == mem::size_of::<FixedBytes<52>>());
 
 impl StorageKey {
     /// Creates a storage key from an account address and slot.
@@ -36,14 +42,26 @@ impl StorageKey {
     pub const fn key(self) -> Word {
         Word::from_be_bytes(self.key.0)
     }
+
+    #[inline]
+    const fn as_fixed_bytes(&self) -> &FixedBytes<52> {
+        // SAFETY: `StorageKey` is `repr(C)` and contains exactly an `Address` followed by a `B256`;
+        // both are transparent fixed-byte wrappers, and the size assertion above guarantees 52
+        // bytes.
+        unsafe { &*(core::ptr::from_ref(self).cast::<FixedBytes<52>>()) }
+    }
+}
+
+impl PartialEq for StorageKey {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        self.as_fixed_bytes() == other.as_fixed_bytes()
+    }
 }
 
 impl Hash for StorageKey {
     #[inline]
     fn hash<H: Hasher>(&self, state: &mut H) {
-        let mut bytes = [0; 52];
-        bytes[..20].copy_from_slice(self.address.as_slice());
-        bytes[20..].copy_from_slice(self.key.as_slice());
-        state.write(&bytes);
+        state.write(self.as_fixed_bytes().as_slice());
     }
 }

--- a/crates/evm2/src/storage_key.rs
+++ b/crates/evm2/src/storage_key.rs
@@ -5,28 +5,35 @@ use alloy_primitives::{
 };
 use core::hash::{Hash, Hasher};
 
-pub(crate) type StorageKeyMap<V> = HashMap<StorageKey, V, FbBuildHasher<52>>;
-pub(crate) type StorageKeySet = HashSet<StorageKey, FbBuildHasher<52>>;
+/// Hash map keyed by storage account and slot.
+pub type StorageKeyMap<V> = HashMap<StorageKey, V, FbBuildHasher<52>>;
 
+/// Hash set keyed by storage account and slot.
+pub type StorageKeySet = HashSet<StorageKey, FbBuildHasher<52>>;
+
+/// Storage key for account-address and storage-slot pairs.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-pub(crate) struct StorageKey {
+pub struct StorageKey {
     address: Address,
     key: B256,
 }
 
 impl StorageKey {
+    /// Creates a storage key from an account address and slot.
     #[inline]
-    pub(crate) fn new(address: Address, key: Word) -> Self {
+    pub fn new(address: Address, key: Word) -> Self {
         Self { address, key: B256::from(key) }
     }
 
+    /// Returns the account address.
     #[inline]
-    pub(crate) const fn address(self) -> Address {
+    pub const fn address(self) -> Address {
         self.address
     }
 
+    /// Returns the storage slot.
     #[inline]
-    pub(crate) const fn key(self) -> Word {
+    pub const fn key(self) -> Word {
         Word::from_be_bytes(self.key.0)
     }
 }

--- a/crates/statetest/src/execute.rs
+++ b/crates/statetest/src/execute.rs
@@ -15,11 +15,11 @@ use alloy_trie::{
 };
 use evm2::{
     BEACON_ROOTS_ADDRESS, BaseEvmTypes, Evm, EvmTypes, HISTORY_STORAGE_ADDRESS, Precompiles,
-    SpecId, TxResult,
+    SpecId, StorageKey, TxResult,
     bytecode::Bytecode,
     env::BlockEnv,
     ethereum::{RecoveredTxEnvelope, ethereum_tx_registry},
-    evm::{AccountInfo as EvmAccountInfo, InMemoryDB, StateChanges, StorageKey},
+    evm::{AccountInfo as EvmAccountInfo, InMemoryDB, StateChanges},
     registry::HandlerError,
 };
 use k256::ecdsa::SigningKey;

--- a/crates/statetest/src/execute.rs
+++ b/crates/statetest/src/execute.rs
@@ -350,13 +350,13 @@ fn apply_state_changes(pre: &InMemoryDB, changes: &StateChanges) -> InMemoryDB {
     }
     for (&address, storage) in &changes.storage {
         if storage.wipe {
-            post.cache.storage.retain(|(storage_address, _), _| *storage_address != address);
+            post.cache.clear_storage(address);
         }
         for (&key, change) in &storage.slots {
             if change.current.is_zero() {
-                post.cache.storage.remove(&(address, key));
+                post.cache.remove_storage(address, key);
             } else {
-                post.cache.storage.insert((address, key), change.current);
+                post.cache.insert_storage(address, key, change.current);
             }
         }
     }
@@ -365,7 +365,7 @@ fn apply_state_changes(pre: &InMemoryDB, changes: &StateChanges) -> InMemoryDB {
             Some(info) => post.insert_account_info(address, info.clone()),
             None => {
                 post.cache.accounts.remove(&address);
-                post.cache.storage.retain(|(storage_address, _), _| *storage_address != address);
+                post.cache.clear_storage(address);
             }
         }
     }
@@ -375,12 +375,8 @@ fn apply_state_changes(pre: &InMemoryDB, changes: &StateChanges) -> InMemoryDB {
 fn storage_for_root(state: &InMemoryDB, address: Address) -> Vec<(B256, U256)> {
     state
         .cache
-        .storage
-        .iter()
-        .filter_map(|(&(storage_address, key), &value)| {
-            (storage_address == address && !value.is_zero())
-                .then_some((B256::from(key.to_be_bytes()), value))
-        })
+        .account_storage(address)
+        .filter_map(|(key, value)| (!value.is_zero()).then_some((B256::from(key), value)))
         .collect()
 }
 

--- a/crates/statetest/src/execute.rs
+++ b/crates/statetest/src/execute.rs
@@ -19,7 +19,7 @@ use evm2::{
     bytecode::Bytecode,
     env::BlockEnv,
     ethereum::{RecoveredTxEnvelope, ethereum_tx_registry},
-    evm::{AccountInfo as EvmAccountInfo, InMemoryDB, StateChanges},
+    evm::{AccountInfo as EvmAccountInfo, InMemoryDB, StateChanges, StorageKey},
     registry::HandlerError,
 };
 use k256::ecdsa::SigningKey;
@@ -350,13 +350,13 @@ fn apply_state_changes(pre: &InMemoryDB, changes: &StateChanges) -> InMemoryDB {
     }
     for (&address, storage) in &changes.storage {
         if storage.wipe {
-            post.cache.clear_storage(address);
+            post.cache.storage.retain(|key, _| key.address() != address);
         }
         for (&key, change) in &storage.slots {
             if change.current.is_zero() {
-                post.cache.remove_storage(address, key);
+                post.cache.storage.remove(&StorageKey::new(address, key));
             } else {
-                post.cache.insert_storage(address, key, change.current);
+                post.cache.storage.insert(StorageKey::new(address, key), change.current);
             }
         }
     }
@@ -365,7 +365,7 @@ fn apply_state_changes(pre: &InMemoryDB, changes: &StateChanges) -> InMemoryDB {
             Some(info) => post.insert_account_info(address, info.clone()),
             None => {
                 post.cache.accounts.remove(&address);
-                post.cache.clear_storage(address);
+                post.cache.storage.retain(|key, _| key.address() != address);
             }
         }
     }
@@ -375,8 +375,11 @@ fn apply_state_changes(pre: &InMemoryDB, changes: &StateChanges) -> InMemoryDB {
 fn storage_for_root(state: &InMemoryDB, address: Address) -> Vec<(B256, U256)> {
     state
         .cache
-        .account_storage(address)
-        .filter_map(|(key, value)| (!value.is_zero()).then_some((B256::from(key), value)))
+        .storage
+        .iter()
+        .filter_map(|(&key, &value)| {
+            (key.address() == address && !value.is_zero()).then_some((B256::from(key.key()), value))
+        })
         .collect()
 }
 


### PR DESCRIPTION
This replaces tuple-based storage map keys with a storage key wrapper that uses the fixed-byte hasher path for the concatenated account address and slot. The wrapper stores the address and slot hash directly, while its Hash implementation writes the 52-byte address-plus-slot view expected by FbBuildHasher<52>.
