### PR TITLE
refactor: remove base evm types generic

### DIFF
--- a/crates/evm2/benches/evm/support.rs
+++ b/crates/evm2/benches/evm/support.rs
@@ -7,7 +7,7 @@ use evm2::{
     evm::InMemoryDB,
 };
 
-type BenchEvm = Evm<BaseEvmTypes<RecoveredTxEnvelope>>;
+type BenchEvm = Evm<BaseEvmTypes>;
 
 #[derive(Clone, Debug)]
 pub(crate) struct PreparedBench {

--- a/crates/evm2/src/evm/config.rs
+++ b/crates/evm2/src/evm/config.rs
@@ -2,6 +2,7 @@
 
 use crate::{
     SpecId, VersionTables,
+    ethereum::RecoveredTxEnvelope,
     evm::{InMemoryDB, precompile::PrecompileProvider},
     interpreter::{
         Host,
@@ -10,7 +11,6 @@ use crate::{
     spec_to_generic,
     version::Version,
 };
-use core::marker::PhantomData;
 
 /// Runtime EVM type family.
 ///
@@ -131,12 +131,12 @@ impl<T: EvmTypes> ExecutionConfig<T> {
 
 /// Base EVM types.
 #[allow(missing_copy_implementations, missing_debug_implementations)]
-pub struct BaseEvmTypes<Tx = ()>(PhantomData<fn() -> Tx>);
+pub struct BaseEvmTypes(());
 
-impl<Tx: 'static> EvmTypes for BaseEvmTypes<Tx> {
+impl EvmTypes for BaseEvmTypes {
     type ConfigSelector = BaseEvmConfigSelector;
     type SpecId = SpecId;
-    type Tx = Tx;
+    type Tx = RecoveredTxEnvelope;
     type Host = crate::evm::Evm<Self>;
     type Database = InMemoryDB;
     type Precompiles = crate::precompiles::Precompiles;

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -727,12 +727,13 @@ impl<T: EvmTypes<Host = Self>> Host for Evm<T> {
 mod tests {
     use super::*;
     use crate::{
-        BaseEvmConfig, BaseEvmTypes, Precompiles, SpecId,
+        BaseEvmConfig, Precompiles, SpecId,
         bytecode::Bytecode,
         interpreter::{MessageKind, op},
         registry::TxRequest,
     };
     use alloy_primitives::{Address, Bytes, KECCAK256_EMPTY, U256};
+    use core::marker::PhantomData;
 
     const TEST_TX_TYPE: u8 = 0x7f;
 
@@ -741,7 +742,16 @@ mod tests {
         value: u64,
     }
 
-    type TestEvmTypes<Tx = ()> = BaseEvmTypes<Tx>;
+    struct TestEvmTypes<Tx = ()>(PhantomData<fn() -> Tx>);
+
+    impl<Tx: 'static> EvmTypes for TestEvmTypes<Tx> {
+        type ConfigSelector = crate::BaseEvmConfigSelector;
+        type SpecId = SpecId;
+        type Tx = Tx;
+        type Host = Evm<Self>;
+        type Database = InMemoryDB;
+        type Precompiles = Precompiles;
+    }
 
     impl Typed2718 for TestTx {
         fn ty(&self) -> u8 {

--- a/crates/statetest/src/execute.rs
+++ b/crates/statetest/src/execute.rs
@@ -212,7 +212,7 @@ fn execute_spec(
     macro_rules! run {
         ($spec:ident) => {{
             let spec = SpecId::$spec;
-            let mut evm = Evm::<BaseEvmTypes<RecoveredTxEnvelope>>::new(
+            let mut evm = Evm::<BaseEvmTypes>::new(
                 spec,
                 block,
                 ethereum_tx_registry(),


### PR DESCRIPTION
BaseEvmTypes no longer carries a transaction type parameter. It now represents the standard Ethereum EVM type family directly by using RecoveredTxEnvelope, while tests that need custom transaction dispatch define their own EvmTypes.

This keeps the base type concrete and leaves custom transaction wiring to custom EVM type families.
