### PR TITLE
perf(evm): reduce storage access overhead

### DIFF
--- a/crates/evm2/src/ethereum/mod.rs
+++ b/crates/evm2/src/ethereum/mod.rs
@@ -376,7 +376,7 @@ fn initial_call_code<T: EvmTypes<Host = Evm<T>>>(
     if host.spec_id().enables(SpecId::PRAGUE)
         && let Some(delegated_address) = code.eip7702_address()
     {
-        host.state.warm_account(delegated_address);
+        let _ = host.state.warm_account(delegated_address);
         return InitialCallCode {
             code: host.state.get_code(delegated_address),
             code_address: delegated_address,

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -578,12 +578,15 @@ impl<T: EvmTypes<Host = Self>> Host for Evm<T> {
         load_code: bool,
         skip_cold_load: bool,
     ) -> Result<AccountLoad, InstrStop> {
-        let is_cold =
-            self.spec_id().enables(SpecId::BERLIN) && !self.state.is_account_warm(address);
+        let is_cold = if self.spec_id().enables(SpecId::BERLIN) {
+            self.state.warm_account(address)
+        } else {
+            self.state.warm_account(address);
+            false
+        };
         if skip_cold_load && is_cold {
             return Err(InstrStop::OutOfGas);
         }
-        self.state.warm_account(address);
         let info = self.state.account_info(address);
         let exists = info.is_some();
         let info = info.unwrap_or_default();
@@ -616,12 +619,9 @@ impl<T: EvmTypes<Host = Self>> Host for Evm<T> {
         skip_cold_load: bool,
     ) -> Result<SLoad, InstrStop> {
         let is_cold =
-            self.spec_id().enables(SpecId::BERLIN) && !self.state.is_storage_warm(address, key);
+            self.spec_id().enables(SpecId::BERLIN) && self.state.warm_storage(address, key);
         if skip_cold_load && is_cold {
             return Err(InstrStop::OutOfGas);
-        }
-        if is_cold {
-            let _ = self.state.warm_storage(address, key);
         }
         Ok(SLoad { value: self.state.storage(address, key), is_cold })
     }
@@ -634,12 +634,9 @@ impl<T: EvmTypes<Host = Self>> Host for Evm<T> {
         skip_cold_load: bool,
     ) -> Result<SStore, InstrStop> {
         let is_cold =
-            self.spec_id().enables(SpecId::BERLIN) && !self.state.is_storage_warm(address, key);
+            self.spec_id().enables(SpecId::BERLIN) && self.state.warm_storage(address, key);
         if skip_cold_load && is_cold {
             return Err(InstrStop::OutOfGas);
-        }
-        if is_cold {
-            let _ = self.state.warm_storage(address, key);
         }
         let mut result = self.state.set_storage(address, key, value);
         result.is_cold = is_cold;
@@ -693,11 +690,15 @@ impl<T: EvmTypes<Host = Self>> Host for Evm<T> {
         skip_cold_load: bool,
     ) -> Result<SelfDestructResult, InstrStop> {
         // TODO: evmone applies full SELFDESTRUCT revision rules in state transition.
-        let is_cold = self.spec_id().enables(SpecId::BERLIN) && !self.state.is_account_warm(target);
+        let is_cold = if self.spec_id().enables(SpecId::BERLIN) {
+            self.state.warm_account(target)
+        } else {
+            self.state.warm_account(target);
+            false
+        };
         if skip_cold_load && is_cold {
             return Err(InstrStop::OutOfGas);
         }
-        self.state.warm_account(target);
         let target_is_empty_for_new_account_gas =
             self.state.target_is_empty_for_new_account_gas(target, self.spec_id());
         let previously_destroyed = self.state.is_selfdestructed(contract);
@@ -873,6 +874,33 @@ mod tests {
 
         let result = Host::execute_message(&mut evm, &TxEnv::default(), bytecode, &message, false);
         assert!(result.stop.is_success());
+    }
+
+    #[test]
+    fn cold_storage_oog_rolls_back_warmth() {
+        let mut evm = Evm::<TestEvmTypes>::new(
+            SpecId::OSAKA,
+            BlockEnv::default(),
+            TxRegistry::new(),
+            InMemoryDB::default(),
+            Precompiles::base(SpecId::OSAKA),
+        );
+        let contract = Address::from([0x11; 20]);
+        let key = Word::ZERO;
+        let bytecode =
+            Bytecode::new_legacy(Bytes::from_static(&[op::PUSH1, 0, op::SLOAD, op::STOP]));
+        let message = Message {
+            kind: MessageKind::Call,
+            destination: contract,
+            code_address: contract,
+            gas_limit: 500,
+            ..Message::default()
+        };
+
+        let result = Host::execute_message(&mut evm, &TxEnv::default(), bytecode, &message, false);
+
+        assert_eq!(result.stop, InstrStop::OutOfGas);
+        assert!(!evm.state.is_storage_warm(contract, key));
     }
 
     #[test]

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -345,7 +345,7 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
 
         let address = self.create_address(&bytecode, message);
 
-        self.state.warm_account(address);
+        let _ = self.state.warm_account(address);
 
         if message.depth > 0 {
             self.state.increment_nonce(message.caller);
@@ -581,7 +581,7 @@ impl<T: EvmTypes<Host = Self>> Host for Evm<T> {
         let is_cold = if self.spec_id().enables(SpecId::BERLIN) {
             self.state.warm_account(address)
         } else {
-            self.state.warm_account(address);
+            let _ = self.state.warm_account(address);
             false
         };
         if skip_cold_load && is_cold {
@@ -693,7 +693,7 @@ impl<T: EvmTypes<Host = Self>> Host for Evm<T> {
         let is_cold = if self.spec_id().enables(SpecId::BERLIN) {
             self.state.warm_account(target)
         } else {
-            self.state.warm_account(target);
+            let _ = self.state.warm_account(target);
             false
         };
         if skip_cold_load && is_cold {

--- a/crates/evm2/src/evm/state.rs
+++ b/crates/evm2/src/evm/state.rs
@@ -668,30 +668,27 @@ impl<D: Database> State<D> {
     }
 
     #[must_use]
-    fn storage_initial(&mut self, address: Address, key: Word) -> Word {
-        if self.storage.get(&address).is_some_and(|storage| storage.wiped)
-            || self.accounts.get(&address).is_some_and(|account| account.original.is_none())
-        {
-            Word::ZERO
-        } else {
-            self.initial.get_storage(address, key)
-        }
-    }
-
-    #[must_use]
     fn storage_slot_mut(
         &mut self,
         address: Address,
         key: Word,
         journal_insert: bool,
     ) -> &mut Tracked<Word> {
-        let initial = self.storage_initial(address, key);
-        let storage = self.storage.entry(address).or_default();
+        let Self { initial, accounts, storage, journal, .. } = self;
+        let account_created =
+            accounts.get(&address).is_some_and(|account| account.original.is_none());
+        let storage = storage.entry(address).or_default();
+        let storage_wiped = storage.wiped;
         match storage.slots.entry(key) {
             hash_map::Entry::Occupied(entry) => entry.into_mut(),
             hash_map::Entry::Vacant(entry) => {
+                let initial = if storage_wiped || account_created {
+                    Word::ZERO
+                } else {
+                    initial.get_storage(address, key)
+                };
                 if journal_insert {
-                    self.journal.push(JournalEntry::StorageInserted { address, key });
+                    journal.push(JournalEntry::StorageInserted { address, key });
                 }
                 entry.insert(Tracked::new(initial))
             }

--- a/crates/evm2/src/evm/state.rs
+++ b/crates/evm2/src/evm/state.rs
@@ -442,6 +442,7 @@ impl<D> State<D> {
     /// for warmth introduced while executing EVM code or any other scope whose effects may be
     /// reverted to a checkpoint.
     #[inline]
+    #[must_use]
     pub fn warm_account(&mut self, address: Address) -> bool {
         if self.accessed_accounts.insert(address) {
             self.journal.push(JournalEntry::AccountWarmed { address });
@@ -475,7 +476,7 @@ impl<D> State<D> {
         let addresses = addresses.into_iter();
         self.accessed_accounts.reserve(addresses.size_hint().0);
         for address in addresses {
-            self.warm_account(address);
+            let _ = self.warm_account(address);
         }
     }
 

--- a/crates/evm2/src/evm/state.rs
+++ b/crates/evm2/src/evm/state.rs
@@ -437,13 +437,17 @@ impl<D> State<D> {
 
     /// Marks an account as warm in a revertible execution context.
     ///
-    /// If this call newly warms the account, the warm-set change is journaled and will be undone
-    /// by [`Self::rollback`]. Use this for warmth introduced while executing EVM code or any other
-    /// scope whose effects may be reverted to a checkpoint.
+    /// Returns whether the account was cold before this access. If this call newly warms the
+    /// account, the warm-set change is journaled and will be undone by [`Self::rollback`]. Use this
+    /// for warmth introduced while executing EVM code or any other scope whose effects may be
+    /// reverted to a checkpoint.
     #[inline]
-    pub fn warm_account(&mut self, address: Address) {
+    pub fn warm_account(&mut self, address: Address) -> bool {
         if self.accessed_accounts.insert(address) {
             self.journal.push(JournalEntry::AccountWarmed { address });
+            true
+        } else {
+            false
         }
     }
 
@@ -1275,7 +1279,7 @@ mod tests {
         assert!(state.journal.is_empty());
 
         let checkpoint = state.checkpoint();
-        state.warm_account(frame_account);
+        assert!(state.warm_account(frame_account));
         assert!(state.warm_storage(frame_storage, key));
         assert_eq!(state.journal.len(), 2);
 


### PR DESCRIPTION
This reduces overhead in EIP-2929 access tracking and storage overlay access.

First, account/storage warming now uses the set insertion result as the cold-access bit instead of doing a contains lookup followed by an insert for successful cold accesses. Cold accesses that cannot afford the surcharge still unwind through the existing frame rollback journal, so the speculative warmth is reverted with the failing frame. In the ERC20 transfer profile, this shifts the warm storage set work from `contains_key` to a single `insert` path.

Second, storage overlay slots now defer loading the original storage value until a vacant overlay entry is known. This avoids an unnecessary backing storage/cache lookup when a slot has already been loaded. In the ERC20 transfer profile, this removed the storage map lookup under `storage_slot_mut`; `storage_slot_mut` dropped from about 5.1% to 2.6% inclusive, while `sstore` dropped from about 9.0% to 7.7% and `sload` from about 5.5% to 3.8%.