### PR TITLE
refactor(interpreter): split instruction table impls

### DIFF
--- a/crates/evm2/src/evm/config.rs
+++ b/crates/evm2/src/evm/config.rs
@@ -6,7 +6,7 @@ use crate::{
     evm::{InMemoryDB, precompile::PrecompileProvider},
     interpreter::{
         Host,
-        instructions::table::{InstructionTable, InstructionTables},
+        instructions::table::{InstrTable, InstrTables},
     },
     spec_to_generic,
     version::Version,
@@ -73,7 +73,7 @@ pub trait EvmConfigSelector<T: EvmTypes>: Sized {
 pub struct ExecutionConfig<T: EvmTypes> {
     pub(crate) version: Version,
     #[debug(skip)]
-    pub(crate) instructions: &'static InstructionTable<T>,
+    pub(crate) instructions: &'static InstrTable<T>,
 }
 
 impl<T: EvmTypes> Clone for ExecutionConfig<T> {
@@ -91,7 +91,7 @@ impl<T: EvmTypes> ExecutionConfig<T> {
     pub const fn for_config<C: EvmConfig<T>>() -> Self {
         Self {
             version: Version::new(C::BASE_SPEC_ID),
-            instructions: <T as InstructionTables<C>>::INSTRUCTIONS,
+            instructions: <T as InstrTables<C>>::INSTRUCTIONS,
         }
     }
 

--- a/crates/evm2/src/interpreter/instructions/table.rs
+++ b/crates/evm2/src/interpreter/instructions/table.rs
@@ -55,30 +55,30 @@ macro_rules! for_each_opcode_value {
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "tco")] {
-        #[path = "table/tco.rs"]
-        mod imp;
+        mod tco;
+        use tco as imp;
     } else {
-        #[path = "table/normal.rs"]
-        mod imp;
+        mod normal;
+        use normal as imp;
     }
 }
 
-/// Normal instruction function pointer.
-pub(crate) type InstructionFn<T> = imp::RawInstructionFn<T>;
+/// Instruction function pointer.
+pub(crate) type InstrFn<T> = imp::RawInstrFn<T>;
 
-/// Normal instruction dispatch table.
-pub(crate) type InstructionTable<T> = imp::RawInstructionTable<T>;
+/// Instruction dispatch table.
+pub(crate) type InstrTable<T> = imp::RawInstrTable<T>;
 
 pub(crate) use imp::make_instruction_table;
 
-pub(crate) trait InstructionTables<C>: EvmTypes
+pub(crate) trait InstrTables<C>: EvmTypes
 where
     C: EvmConfig<Self>,
 {
-    const INSTRUCTIONS: &'static InstructionTable<Self> = &make_instruction_table::<Self, C>();
+    const INSTRUCTIONS: &'static InstrTable<Self> = &make_instruction_table::<Self, C>();
 }
 
-impl<T, C> InstructionTables<C> for T
+impl<T, C> InstrTables<C> for T
 where
     T: EvmTypes,
     C: EvmConfig<T>,

--- a/crates/evm2/src/interpreter/instructions/table.rs
+++ b/crates/evm2/src/interpreter/instructions/table.rs
@@ -55,23 +55,21 @@ macro_rules! for_each_opcode_value {
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "tco")] {
-        mod tco;
-        pub(crate) use tco::{TailInstructionFn, TailInstructionTable, make_instruction_table};
+        #[path = "table/tco.rs"]
+        mod imp;
     } else {
-        mod normal;
-        pub(crate) use normal::{
-            NormalInstructionFn as TailInstructionFn,
-            NormalInstructionTable as TailInstructionTable,
-            make_instruction_table,
-        };
+        #[path = "table/normal.rs"]
+        mod imp;
     }
 }
 
 /// Normal instruction function pointer.
-pub(crate) type InstructionFn<T> = TailInstructionFn<T>;
+pub(crate) type InstructionFn<T> = imp::RawInstructionFn<T>;
 
 /// Normal instruction dispatch table.
-pub(crate) type InstructionTable<T> = TailInstructionTable<T>;
+pub(crate) type InstructionTable<T> = imp::RawInstructionTable<T>;
+
+pub(crate) use imp::make_instruction_table;
 
 pub(crate) trait InstructionTables<C>: EvmTypes
 where

--- a/crates/evm2/src/interpreter/instructions/table.rs
+++ b/crates/evm2/src/interpreter/instructions/table.rs
@@ -56,12 +56,22 @@ macro_rules! for_each_opcode_value {
 cfg_if::cfg_if! {
     if #[cfg(feature = "tco")] {
         mod tco;
-        pub(crate) use tco::*;
+        pub(crate) use tco::{TailInstructionFn, TailInstructionTable, make_instruction_table};
     } else {
         mod normal;
-        pub(crate) use normal::*;
+        pub(crate) use normal::{
+            NormalInstructionFn as TailInstructionFn,
+            NormalInstructionTable as TailInstructionTable,
+            make_instruction_table,
+        };
     }
 }
+
+/// Normal instruction function pointer.
+pub(crate) type InstructionFn<T> = TailInstructionFn<T>;
+
+/// Normal instruction dispatch table.
+pub(crate) type InstructionTable<T> = TailInstructionTable<T>;
 
 pub(crate) trait InstructionTables<C>: EvmTypes
 where

--- a/crates/evm2/src/interpreter/instructions/table.rs
+++ b/crates/evm2/src/interpreter/instructions/table.rs
@@ -1,57 +1,9 @@
 //! Instruction dispatch tables.
 
-#[cfg(not(feature = "tco"))]
-use crate::interpreter::gas::Gas;
-#[cfg(feature = "tco")]
-use crate::interpreter::gas::RemainingGas;
 use crate::{
     EvmConfig, EvmTypes,
-    interpreter::{InstrStop, InterpreterState, Pc, Result, Stack, StackMut, op},
+    interpreter::{InstrStop, InterpreterState, Pc, Result, StackMut, op},
 };
-use core::hint::cold_path;
-
-/// Normal instruction return value.
-#[cfg(not(feature = "tco"))]
-pub(crate) type InstructionFnRet = (*const u8, usize);
-
-/// Normal instruction function pointer.
-#[cfg(not(feature = "tco"))]
-pub(crate) type InstructionFn<T> = extern_table!(
-    fn(pc: Pc, stack: Stack<'_>, state: &mut InterpreterState<'_, T>) -> InstructionFnRet
-);
-
-#[cfg(feature = "tco")]
-pub(crate) type InstructionFn<T> = TailInstructionFn<T>;
-
-/// Normal instruction dispatch table.
-#[cfg(not(feature = "tco"))]
-pub(crate) type InstructionTable<T> = [InstructionFn<T>; 256];
-#[cfg(feature = "tco")]
-pub(crate) type InstructionTable<T> = TailInstructionTable<T>;
-
-/// Tail instruction function pointer.
-#[cfg(feature = "tco")]
-pub(crate) type TailInstructionFn<T> = extern_table!(
-    fn(pc: Pc, stack: Stack<'_>, remaining_gas: RemainingGas, state: &mut InterpreterState<'_, T>)
-);
-
-/// Tail instruction dispatch table.
-#[cfg(feature = "tco")]
-pub(crate) type TailInstructionTable<T> = [TailInstructionFn<T>; 256];
-
-pub(crate) trait InstructionTables<C>: EvmTypes
-where
-    C: EvmConfig<Self>,
-{
-    const INSTRUCTIONS: &'static InstructionTable<Self> = &make_instruction_table::<Self, C>();
-}
-
-impl<T, C> InstructionTables<C> for T
-where
-    T: EvmTypes,
-    C: EvmConfig<T>,
-{
-}
 
 #[cold]
 pub(crate) const fn unknown_instruction<T: EvmTypes>(
@@ -60,29 +12,6 @@ pub(crate) const fn unknown_instruction<T: EvmTypes>(
     _state: &mut InterpreterState<'_, T>,
 ) -> Result {
     Err(InstrStop::OpcodeNotFound)
-}
-
-#[cfg(not(feature = "tco"))]
-macro_rules! assign_instruction_table_entries {
-    ([$table:expr, $evm_types:ty, $config:ty, $dispatch:ident, $instr_fn:ty] $($op:literal,)*) => {
-        $(
-            $table[$op] = $dispatch::<$evm_types, $config, $op> as $instr_fn;
-        )*
-    };
-}
-
-#[cfg(feature = "tco")]
-macro_rules! assign_instruction_table_entries {
-    ([$table:expr, $evm_types:ty, $config:ty, $dispatch:ident, $instr_fn:ty] $($op:literal,)*) => {
-        $(
-            let instruction = <$config as EvmConfig<$evm_types>>::VERSION_TABLES.instruction($op);
-            $table[$op] = if instruction.dynamic_gas {
-                $dispatch::<$evm_types, $config, $op, true> as $instr_fn
-            } else {
-                $dispatch::<$evm_types, $config, $op, false> as $instr_fn
-            };
-        )*
-    };
 }
 
 macro_rules! for_each_opcode_value {
@@ -124,194 +53,37 @@ macro_rules! for_each_opcode_value {
     };
 }
 
-pub(crate) const fn make_instruction_table<T, C>() -> InstructionTable<T>
+cfg_if::cfg_if! {
+    if #[cfg(feature = "tco")] {
+        mod tco;
+        pub(crate) use tco::*;
+    } else {
+        mod normal;
+        pub(crate) use normal::*;
+    }
+}
+
+pub(crate) trait InstructionTables<C>: EvmTypes
+where
+    C: EvmConfig<Self>,
+{
+    const INSTRUCTIONS: &'static InstructionTable<Self> = &make_instruction_table::<Self, C>();
+}
+
+impl<T, C> InstructionTables<C> for T
 where
     T: EvmTypes,
     C: EvmConfig<T>,
 {
-    #[cfg(feature = "tco")]
-    use tail_dispatch as dispatch;
-
-    #[cfg(not(feature = "tco"))]
-    let mut table = [dispatch::<T, C, 0> as InstructionFn<T>; 256];
-    #[cfg(feature = "tco")]
-    let mut table = [dispatch::<T, C, 0, true> as InstructionFn<T>; 256];
-    for_each_opcode_value!([table, T, C, dispatch, InstructionFn<T>] assign_instruction_table_entries);
-
-    // Make all unknown entries point to the same dispatch function.
-    let mut i = 0;
-    #[cfg(not(feature = "tco"))]
-    let mut unknown_idx = None;
-    while i < 256 {
-        if C::VERSION_TABLES.is_unknown_opcode(i as u8) {
-            #[cfg(not(feature = "tco"))]
-            {
-                if unknown_idx.is_none() {
-                    unknown_idx = Some(i);
-                }
-                table[i] = table[unknown_idx.unwrap()];
-            }
-            #[cfg(feature = "tco")]
-            {
-                table[i] = tail_unknown_dispatch::<T, C> as InstructionFn<T>;
-            }
-        }
-        i += 1;
-    }
-
-    table
-}
-
-extern_table! {
-    #[cfg(not(feature = "tco"))]
-    fn dispatch<T: EvmTypes, C: EvmConfig<T>, const OP: u8>(
-        pc: Pc,
-        stack: Stack<'_>,
-        state: &mut InterpreterState<'_, T>,
-    ) -> InstructionFnRet {
-        dispatch_mono::<T, C>(OP, pc, stack, state)
-    }
-}
-
-#[cfg(not(feature = "tco"))]
-#[inline(always)]
-fn dispatch_mono<T: EvmTypes, C: EvmConfig<T>>(
-    op: u8,
-    mut pc: Pc,
-    mut stack: Stack<'_>,
-    state: &mut InterpreterState<'_, T>,
-) -> InstructionFnRet {
-    let instr = C::VERSION_TABLES.instruction(op).instr;
-    let r;
-    match pre_step::<T, C>(state.gas_mut(), op) {
-        Ok(()) => {
-            r = instr(&mut pc, stack.as_mut(), state);
-            inc_pc(&mut pc, op);
-        }
-        Err(e) => r = Err(e),
-    }
-    if r.is_err() {
-        cold_path();
-        state.set_result(r);
-        return (core::ptr::null(), stack.len);
-    }
-    (pc.as_ptr(), stack.len)
-}
-
-extern_table! {
-    #[cfg(feature = "tco")]
-    fn tail_dispatch<T: EvmTypes, C: EvmConfig<T>, const OP: u8, const DYNAMIC_GAS: bool>(
-        pc: Pc,
-        stack: Stack<'_>,
-        remaining_gas: RemainingGas,
-        state: &mut InterpreterState<'_, T>,
-    ) {
-        assume!(pc.op() == OP);
-        tail_return!(tail_dispatch_mono::<T, C, DYNAMIC_GAS>(pc, stack, remaining_gas, state));
-    }
-}
-
-extern_table! {
-    #[cfg(feature = "tco")]
-    #[cold]
-    fn tail_unknown_dispatch<T: EvmTypes, C: EvmConfig<T>>(
-        pc: Pc,
-        stack: Stack<'_>,
-        remaining_gas: RemainingGas,
-        state: &mut InterpreterState<'_, T>,
-    ) {
-        assume!(C::VERSION_TABLES.is_unknown_opcode(pc.op()));
-        state.set_result(Err(InstrStop::OpcodeNotFound));
-        tail_return!(tail_call_restore::<T>(pc, stack, remaining_gas, state));
-    }
-}
-
-extern_table! {
-    #[cfg(feature = "tco")]
-    #[inline(always)]
-    fn tail_dispatch_mono<T: EvmTypes, C: EvmConfig<T>, const DYNAMIC_GAS: bool>(
-        mut pc: Pc,
-        mut stack: Stack<'_>,
-        mut remaining_gas: RemainingGas,
-        state: &mut InterpreterState<'_, T>,
-    ) {
-        let op = pc.op();
-        let instr = C::VERSION_TABLES.instruction(op).instr;
-        if let Err(e) = pre_step::<T, C>(&mut remaining_gas, op) {
-            cold_path();
-            state.set_result(Err(e));
-            tail_return!(tail_call_restore::<T>(pc, stack, remaining_gas, state));
-        }
-        if DYNAMIC_GAS {
-            state.gas_mut().set_remaining(remaining_gas.get());
-        }
-        let r = instr(&mut pc, stack.as_mut(), state);
-        if DYNAMIC_GAS {
-            remaining_gas.set(state.gas_mut().remaining());
-        }
-        if let Err(e) = r {
-            cold_path();
-            state.set_result(Err(e));
-            tail_return!(tail_call_restore::<T>(pc, stack, remaining_gas, state));
-        }
-        inc_pc(&mut pc, op);
-        tail_return!(tail_call_next::<T, C>(pc, stack, remaining_gas, state));
-    }
-}
-
-extern_table! {
-    #[cfg(feature = "tco")]
-    #[inline]
-    fn tail_call_next<T: EvmTypes, C: EvmConfig<T>>(
-        pc: Pc,
-        stack: Stack<'_>,
-        remaining_gas: RemainingGas,
-        state: &mut InterpreterState<'_, T>,
-    ) {
-        let instr = <T as InstructionTables<C>>::INSTRUCTIONS[pc.op() as usize];
-        tail_return!(instr(pc, stack, remaining_gas, state));
-    }
-}
-
-extern_table! {
-    #[cfg(feature = "tco")]
-    #[inline(never)] // TODO
-    #[cold]
-    fn tail_call_restore<T: EvmTypes>(
-        pc: Pc,
-        stack: Stack<'_>,
-        remaining_gas: RemainingGas,
-        state: &mut InterpreterState<'_, T>,
-    ) {
-        state.gas_mut().set_remaining(remaining_gas.get());
-        state.set_pc_stack_len(pc.as_ptr(), stack.len);
-        debug_assert!(state.result().is_err());
-        // Exits by returning normally.
-    }
 }
 
 #[inline]
-#[cfg(not(feature = "tco"))]
-const fn pre_step<T: EvmTypes, C: EvmConfig<T>>(gas: &mut Gas, op: u8) -> Result {
-    gas.spend(C::VERSION_TABLES.static_gas(op) as _)
-}
-
-#[inline]
-#[cfg(feature = "tco")]
-const fn pre_step<T: EvmTypes, C: EvmConfig<T>>(
-    remaining_gas: &mut RemainingGas,
-    op: u8,
-) -> Result {
-    remaining_gas.spend(C::VERSION_TABLES.static_gas(op) as _)
-}
-
-#[inline]
-const fn inc_pc(pc: &mut Pc, op: u8) {
+pub(super) const fn inc_pc(pc: &mut Pc, op: u8) {
     unsafe { pc.advance_unchecked(instruction_len(op)) };
 }
 
 #[inline(always)]
-const fn instruction_len(op: u8) -> usize {
+pub(super) const fn instruction_len(op: u8) -> usize {
     match op {
         op::JUMP | op::JUMPI => 0, // Set inside.
         op::PUSH1..=op::PUSH32 => (op - op::PUSH1 + 2) as usize,

--- a/crates/evm2/src/interpreter/instructions/table/normal.rs
+++ b/crates/evm2/src/interpreter/instructions/table/normal.rs
@@ -5,15 +5,14 @@ use crate::{
 use core::hint::cold_path;
 
 /// Normal instruction return value.
-pub(crate) type InstructionFnRet = (*const u8, usize);
+pub(crate) type InstrFnRet = (*const u8, usize);
 
 /// Normal instruction function pointer.
-pub(super) type RawInstructionFn<T> = extern_table!(
-    fn(pc: Pc, stack: Stack<'_>, state: &mut InterpreterState<'_, T>) -> InstructionFnRet
-);
+pub(super) type RawInstrFn<T> =
+    extern_table!(fn(pc: Pc, stack: Stack<'_>, state: &mut InterpreterState<'_, T>) -> InstrFnRet);
 
 /// Normal instruction dispatch table.
-pub(super) type RawInstructionTable<T> = [RawInstructionFn<T>; 256];
+pub(super) type RawInstrTable<T> = [RawInstrFn<T>; 256];
 
 macro_rules! assign_instruction_table_entries {
     ([$table:expr, $evm_types:ty, $config:ty, $dispatch:ident, $instr_fn:ty] $($op:literal,)*) => {
@@ -23,13 +22,13 @@ macro_rules! assign_instruction_table_entries {
     };
 }
 
-pub(crate) const fn make_instruction_table<T, C>() -> RawInstructionTable<T>
+pub(crate) const fn make_instruction_table<T, C>() -> RawInstrTable<T>
 where
     T: EvmTypes,
     C: EvmConfig<T>,
 {
-    let mut table = [dispatch::<T, C, 0> as super::InstructionFn<T>; 256];
-    for_each_opcode_value!([table, T, C, dispatch, super::InstructionFn<T>] assign_instruction_table_entries);
+    let mut table = [dispatch::<T, C, 0> as super::InstrFn<T>; 256];
+    for_each_opcode_value!([table, T, C, dispatch, super::InstrFn<T>] assign_instruction_table_entries);
 
     // Make all unknown entries point to the same dispatch function.
     let mut i = 0;
@@ -52,7 +51,7 @@ extern_table! {
         pc: Pc,
         stack: Stack<'_>,
         state: &mut InterpreterState<'_, T>,
-    ) -> InstructionFnRet {
+    ) -> InstrFnRet {
         dispatch_mono::<T, C>(OP, pc, stack, state)
     }
 }
@@ -63,7 +62,7 @@ fn dispatch_mono<T: EvmTypes, C: EvmConfig<T>>(
     mut pc: Pc,
     mut stack: Stack<'_>,
     state: &mut InterpreterState<'_, T>,
-) -> InstructionFnRet {
+) -> InstrFnRet {
     let instr = C::VERSION_TABLES.instruction(op).instr;
     let r;
     match pre_step::<T, C>(state.gas_mut(), op) {

--- a/crates/evm2/src/interpreter/instructions/table/normal.rs
+++ b/crates/evm2/src/interpreter/instructions/table/normal.rs
@@ -1,0 +1,87 @@
+use crate::{
+    EvmConfig, EvmTypes,
+    interpreter::{InterpreterState, Pc, Result, Stack, gas::Gas},
+};
+use core::hint::cold_path;
+
+/// Normal instruction return value.
+pub(crate) type InstructionFnRet = (*const u8, usize);
+
+/// Normal instruction function pointer.
+pub(crate) type InstructionFn<T> = extern_table!(
+    fn(pc: Pc, stack: Stack<'_>, state: &mut InterpreterState<'_, T>) -> InstructionFnRet
+);
+
+/// Normal instruction dispatch table.
+pub(crate) type InstructionTable<T> = [InstructionFn<T>; 256];
+
+macro_rules! assign_instruction_table_entries {
+    ([$table:expr, $evm_types:ty, $config:ty, $dispatch:ident, $instr_fn:ty] $($op:literal,)*) => {
+        $(
+            $table[$op] = $dispatch::<$evm_types, $config, $op> as $instr_fn;
+        )*
+    };
+}
+
+pub(crate) const fn make_instruction_table<T, C>() -> InstructionTable<T>
+where
+    T: EvmTypes,
+    C: EvmConfig<T>,
+{
+    let mut table = [dispatch::<T, C, 0> as InstructionFn<T>; 256];
+    for_each_opcode_value!([table, T, C, dispatch, InstructionFn<T>] assign_instruction_table_entries);
+
+    // Make all unknown entries point to the same dispatch function.
+    let mut i = 0;
+    let mut unknown_idx = None;
+    while i < 256 {
+        if C::VERSION_TABLES.is_unknown_opcode(i as u8) {
+            if unknown_idx.is_none() {
+                unknown_idx = Some(i);
+            }
+            table[i] = table[unknown_idx.unwrap()];
+        }
+        i += 1;
+    }
+
+    table
+}
+
+extern_table! {
+    fn dispatch<T: EvmTypes, C: EvmConfig<T>, const OP: u8>(
+        pc: Pc,
+        stack: Stack<'_>,
+        state: &mut InterpreterState<'_, T>,
+    ) -> InstructionFnRet {
+        dispatch_mono::<T, C>(OP, pc, stack, state)
+    }
+}
+
+#[inline(always)]
+fn dispatch_mono<T: EvmTypes, C: EvmConfig<T>>(
+    op: u8,
+    mut pc: Pc,
+    mut stack: Stack<'_>,
+    state: &mut InterpreterState<'_, T>,
+) -> InstructionFnRet {
+    let instr = C::VERSION_TABLES.instruction(op).instr;
+    let r;
+    match pre_step::<T, C>(state.gas_mut(), op) {
+        Ok(()) => {
+            r = instr(&mut pc, stack.as_mut(), state);
+            super::inc_pc(&mut pc, op);
+        }
+        Err(e) => r = Err(e),
+    }
+    if r.is_err() {
+        cold_path();
+        state.set_result(r);
+        return (core::ptr::null(), stack.len);
+    }
+    (pc.as_ptr(), stack.len)
+}
+
+#[inline]
+const fn pre_step<T: EvmTypes, C: EvmConfig<T>>(gas: &mut Gas, op: u8) -> Result {
+    gas.spend(C::VERSION_TABLES.static_gas(op) as _)
+}

--- a/crates/evm2/src/interpreter/instructions/table/normal.rs
+++ b/crates/evm2/src/interpreter/instructions/table/normal.rs
@@ -8,12 +8,12 @@ use core::hint::cold_path;
 pub(crate) type InstructionFnRet = (*const u8, usize);
 
 /// Normal instruction function pointer.
-pub(crate) type NormalInstructionFn<T> = extern_table!(
+pub(super) type RawInstructionFn<T> = extern_table!(
     fn(pc: Pc, stack: Stack<'_>, state: &mut InterpreterState<'_, T>) -> InstructionFnRet
 );
 
 /// Normal instruction dispatch table.
-pub(crate) type NormalInstructionTable<T> = [NormalInstructionFn<T>; 256];
+pub(super) type RawInstructionTable<T> = [RawInstructionFn<T>; 256];
 
 macro_rules! assign_instruction_table_entries {
     ([$table:expr, $evm_types:ty, $config:ty, $dispatch:ident, $instr_fn:ty] $($op:literal,)*) => {
@@ -23,7 +23,7 @@ macro_rules! assign_instruction_table_entries {
     };
 }
 
-pub(crate) const fn make_instruction_table<T, C>() -> NormalInstructionTable<T>
+pub(crate) const fn make_instruction_table<T, C>() -> RawInstructionTable<T>
 where
     T: EvmTypes,
     C: EvmConfig<T>,

--- a/crates/evm2/src/interpreter/instructions/table/normal.rs
+++ b/crates/evm2/src/interpreter/instructions/table/normal.rs
@@ -8,12 +8,12 @@ use core::hint::cold_path;
 pub(crate) type InstructionFnRet = (*const u8, usize);
 
 /// Normal instruction function pointer.
-pub(crate) type InstructionFn<T> = extern_table!(
+pub(crate) type NormalInstructionFn<T> = extern_table!(
     fn(pc: Pc, stack: Stack<'_>, state: &mut InterpreterState<'_, T>) -> InstructionFnRet
 );
 
 /// Normal instruction dispatch table.
-pub(crate) type InstructionTable<T> = [InstructionFn<T>; 256];
+pub(crate) type NormalInstructionTable<T> = [NormalInstructionFn<T>; 256];
 
 macro_rules! assign_instruction_table_entries {
     ([$table:expr, $evm_types:ty, $config:ty, $dispatch:ident, $instr_fn:ty] $($op:literal,)*) => {
@@ -23,13 +23,13 @@ macro_rules! assign_instruction_table_entries {
     };
 }
 
-pub(crate) const fn make_instruction_table<T, C>() -> InstructionTable<T>
+pub(crate) const fn make_instruction_table<T, C>() -> NormalInstructionTable<T>
 where
     T: EvmTypes,
     C: EvmConfig<T>,
 {
-    let mut table = [dispatch::<T, C, 0> as InstructionFn<T>; 256];
-    for_each_opcode_value!([table, T, C, dispatch, InstructionFn<T>] assign_instruction_table_entries);
+    let mut table = [dispatch::<T, C, 0> as super::InstructionFn<T>; 256];
+    for_each_opcode_value!([table, T, C, dispatch, super::InstructionFn<T>] assign_instruction_table_entries);
 
     // Make all unknown entries point to the same dispatch function.
     let mut i = 0;

--- a/crates/evm2/src/interpreter/instructions/table/tco.rs
+++ b/crates/evm2/src/interpreter/instructions/table/tco.rs
@@ -1,0 +1,149 @@
+use crate::{
+    EvmConfig, EvmTypes,
+    interpreter::{InstrStop, InterpreterState, Pc, Result, Stack, gas::RemainingGas},
+};
+use core::hint::cold_path;
+
+/// Normal instruction function pointer.
+pub(crate) type InstructionFn<T> = TailInstructionFn<T>;
+
+/// Normal instruction dispatch table.
+pub(crate) type InstructionTable<T> = TailInstructionTable<T>;
+
+/// Tail instruction function pointer.
+pub(crate) type TailInstructionFn<T> = extern_table!(
+    fn(pc: Pc, stack: Stack<'_>, remaining_gas: RemainingGas, state: &mut InterpreterState<'_, T>)
+);
+
+/// Tail instruction dispatch table.
+pub(crate) type TailInstructionTable<T> = [TailInstructionFn<T>; 256];
+
+macro_rules! assign_instruction_table_entries {
+    ([$table:expr, $evm_types:ty, $config:ty, $dispatch:ident, $instr_fn:ty] $($op:literal,)*) => {
+        $(
+            let instruction = <$config as EvmConfig<$evm_types>>::VERSION_TABLES.instruction($op);
+            $table[$op] = if instruction.dynamic_gas {
+                $dispatch::<$evm_types, $config, $op, true> as $instr_fn
+            } else {
+                $dispatch::<$evm_types, $config, $op, false> as $instr_fn
+            };
+        )*
+    };
+}
+
+pub(crate) const fn make_instruction_table<T, C>() -> InstructionTable<T>
+where
+    T: EvmTypes,
+    C: EvmConfig<T>,
+{
+    use tail_dispatch as dispatch;
+
+    let mut table = [dispatch::<T, C, 0, true> as InstructionFn<T>; 256];
+    for_each_opcode_value!([table, T, C, dispatch, InstructionFn<T>] assign_instruction_table_entries);
+
+    // Make all unknown entries point to the same dispatch function.
+    let mut i = 0;
+    while i < 256 {
+        if C::VERSION_TABLES.is_unknown_opcode(i as u8) {
+            table[i] = tail_unknown_dispatch::<T, C> as InstructionFn<T>;
+        }
+        i += 1;
+    }
+
+    table
+}
+
+extern_table! {
+    fn tail_dispatch<T: EvmTypes, C: EvmConfig<T>, const OP: u8, const DYNAMIC_GAS: bool>(
+        pc: Pc,
+        stack: Stack<'_>,
+        remaining_gas: RemainingGas,
+        state: &mut InterpreterState<'_, T>,
+    ) {
+        assume!(pc.op() == OP);
+        tail_return!(tail_dispatch_mono::<T, C, DYNAMIC_GAS>(pc, stack, remaining_gas, state));
+    }
+}
+
+extern_table! {
+    #[cold]
+    fn tail_unknown_dispatch<T: EvmTypes, C: EvmConfig<T>>(
+        pc: Pc,
+        stack: Stack<'_>,
+        remaining_gas: RemainingGas,
+        state: &mut InterpreterState<'_, T>,
+    ) {
+        assume!(C::VERSION_TABLES.is_unknown_opcode(pc.op()));
+        state.set_result(Err(InstrStop::OpcodeNotFound));
+        tail_return!(tail_call_restore::<T>(pc, stack, remaining_gas, state));
+    }
+}
+
+extern_table! {
+    #[inline(always)]
+    fn tail_dispatch_mono<T: EvmTypes, C: EvmConfig<T>, const DYNAMIC_GAS: bool>(
+        mut pc: Pc,
+        mut stack: Stack<'_>,
+        mut remaining_gas: RemainingGas,
+        state: &mut InterpreterState<'_, T>,
+    ) {
+        let op = pc.op();
+        let instr = C::VERSION_TABLES.instruction(op).instr;
+        if let Err(e) = pre_step::<T, C>(&mut remaining_gas, op) {
+            cold_path();
+            state.set_result(Err(e));
+            tail_return!(tail_call_restore::<T>(pc, stack, remaining_gas, state));
+        }
+        if DYNAMIC_GAS {
+            state.gas_mut().set_remaining(remaining_gas.get());
+        }
+        let r = instr(&mut pc, stack.as_mut(), state);
+        if DYNAMIC_GAS {
+            remaining_gas.set(state.gas_mut().remaining());
+        }
+        if let Err(e) = r {
+            cold_path();
+            state.set_result(Err(e));
+            tail_return!(tail_call_restore::<T>(pc, stack, remaining_gas, state));
+        }
+        super::inc_pc(&mut pc, op);
+        tail_return!(tail_call_next::<T, C>(pc, stack, remaining_gas, state));
+    }
+}
+
+extern_table! {
+    #[inline]
+    fn tail_call_next<T: EvmTypes, C: EvmConfig<T>>(
+        pc: Pc,
+        stack: Stack<'_>,
+        remaining_gas: RemainingGas,
+        state: &mut InterpreterState<'_, T>,
+    ) {
+        let instr = <T as super::InstructionTables<C>>::INSTRUCTIONS[pc.op() as usize];
+        tail_return!(instr(pc, stack, remaining_gas, state));
+    }
+}
+
+extern_table! {
+    #[inline(never)] // TODO
+    #[cold]
+    fn tail_call_restore<T: EvmTypes>(
+        pc: Pc,
+        stack: Stack<'_>,
+        remaining_gas: RemainingGas,
+        state: &mut InterpreterState<'_, T>,
+    ) {
+        state.gas_mut().set_remaining(remaining_gas.get());
+        state.set_pc_stack_len(pc.as_ptr(), stack.len);
+        debug_assert!(state.result().is_err());
+        // Exits by returning normally.
+    }
+}
+
+#[inline]
+const fn pre_step<T: EvmTypes, C: EvmConfig<T>>(
+    remaining_gas: &mut RemainingGas,
+    op: u8,
+) -> Result {
+    remaining_gas.spend(C::VERSION_TABLES.static_gas(op) as _)
+}

--- a/crates/evm2/src/interpreter/instructions/table/tco.rs
+++ b/crates/evm2/src/interpreter/instructions/table/tco.rs
@@ -4,12 +4,6 @@ use crate::{
 };
 use core::hint::cold_path;
 
-/// Normal instruction function pointer.
-pub(crate) type InstructionFn<T> = TailInstructionFn<T>;
-
-/// Normal instruction dispatch table.
-pub(crate) type InstructionTable<T> = TailInstructionTable<T>;
-
 /// Tail instruction function pointer.
 pub(crate) type TailInstructionFn<T> = extern_table!(
     fn(pc: Pc, stack: Stack<'_>, remaining_gas: RemainingGas, state: &mut InterpreterState<'_, T>)
@@ -31,21 +25,21 @@ macro_rules! assign_instruction_table_entries {
     };
 }
 
-pub(crate) const fn make_instruction_table<T, C>() -> InstructionTable<T>
+pub(crate) const fn make_instruction_table<T, C>() -> TailInstructionTable<T>
 where
     T: EvmTypes,
     C: EvmConfig<T>,
 {
     use tail_dispatch as dispatch;
 
-    let mut table = [dispatch::<T, C, 0, true> as InstructionFn<T>; 256];
-    for_each_opcode_value!([table, T, C, dispatch, InstructionFn<T>] assign_instruction_table_entries);
+    let mut table = [dispatch::<T, C, 0, true> as super::InstructionFn<T>; 256];
+    for_each_opcode_value!([table, T, C, dispatch, super::InstructionFn<T>] assign_instruction_table_entries);
 
     // Make all unknown entries point to the same dispatch function.
     let mut i = 0;
     while i < 256 {
         if C::VERSION_TABLES.is_unknown_opcode(i as u8) {
-            table[i] = tail_unknown_dispatch::<T, C> as InstructionFn<T>;
+            table[i] = tail_unknown_dispatch::<T, C> as super::InstructionFn<T>;
         }
         i += 1;
     }

--- a/crates/evm2/src/interpreter/instructions/table/tco.rs
+++ b/crates/evm2/src/interpreter/instructions/table/tco.rs
@@ -5,16 +5,16 @@ use crate::{
 use core::hint::cold_path;
 
 /// Tail instruction function pointer.
-type TailInstructionFn<T> = extern_table!(
+type TailInstrFn<T> = extern_table!(
     fn(pc: Pc, stack: Stack<'_>, remaining_gas: RemainingGas, state: &mut InterpreterState<'_, T>)
 );
 
 /// Tail instruction dispatch table.
-type TailInstructionTable<T> = [TailInstructionFn<T>; 256];
+type TailInstrTable<T> = [TailInstrFn<T>; 256];
 
-pub(super) type RawInstructionFn<T> = TailInstructionFn<T>;
+pub(super) type RawInstrFn<T> = TailInstrFn<T>;
 
-pub(super) type RawInstructionTable<T> = TailInstructionTable<T>;
+pub(super) type RawInstrTable<T> = TailInstrTable<T>;
 
 macro_rules! assign_instruction_table_entries {
     ([$table:expr, $evm_types:ty, $config:ty, $dispatch:ident, $instr_fn:ty] $($op:literal,)*) => {
@@ -29,21 +29,21 @@ macro_rules! assign_instruction_table_entries {
     };
 }
 
-pub(crate) const fn make_instruction_table<T, C>() -> RawInstructionTable<T>
+pub(crate) const fn make_instruction_table<T, C>() -> RawInstrTable<T>
 where
     T: EvmTypes,
     C: EvmConfig<T>,
 {
     use tail_dispatch as dispatch;
 
-    let mut table = [dispatch::<T, C, 0, true> as super::InstructionFn<T>; 256];
-    for_each_opcode_value!([table, T, C, dispatch, super::InstructionFn<T>] assign_instruction_table_entries);
+    let mut table = [dispatch::<T, C, 0, true> as super::InstrFn<T>; 256];
+    for_each_opcode_value!([table, T, C, dispatch, super::InstrFn<T>] assign_instruction_table_entries);
 
     // Make all unknown entries point to the same dispatch function.
     let mut i = 0;
     while i < 256 {
         if C::VERSION_TABLES.is_unknown_opcode(i as u8) {
-            table[i] = tail_unknown_dispatch::<T, C> as super::InstructionFn<T>;
+            table[i] = tail_unknown_dispatch::<T, C> as super::InstrFn<T>;
         }
         i += 1;
     }
@@ -117,7 +117,7 @@ extern_table! {
         remaining_gas: RemainingGas,
         state: &mut InterpreterState<'_, T>,
     ) {
-        let instr = <T as super::InstructionTables<C>>::INSTRUCTIONS[pc.op() as usize];
+        let instr = <T as super::InstrTables<C>>::INSTRUCTIONS[pc.op() as usize];
         tail_return!(instr(pc, stack, remaining_gas, state));
     }
 }

--- a/crates/evm2/src/interpreter/instructions/table/tco.rs
+++ b/crates/evm2/src/interpreter/instructions/table/tco.rs
@@ -5,12 +5,16 @@ use crate::{
 use core::hint::cold_path;
 
 /// Tail instruction function pointer.
-pub(crate) type TailInstructionFn<T> = extern_table!(
+type TailInstructionFn<T> = extern_table!(
     fn(pc: Pc, stack: Stack<'_>, remaining_gas: RemainingGas, state: &mut InterpreterState<'_, T>)
 );
 
 /// Tail instruction dispatch table.
-pub(crate) type TailInstructionTable<T> = [TailInstructionFn<T>; 256];
+type TailInstructionTable<T> = [TailInstructionFn<T>; 256];
+
+pub(super) type RawInstructionFn<T> = TailInstructionFn<T>;
+
+pub(super) type RawInstructionTable<T> = TailInstructionTable<T>;
 
 macro_rules! assign_instruction_table_entries {
     ([$table:expr, $evm_types:ty, $config:ty, $dispatch:ident, $instr_fn:ty] $($op:literal,)*) => {
@@ -25,7 +29,7 @@ macro_rules! assign_instruction_table_entries {
     };
 }
 
-pub(crate) const fn make_instruction_table<T, C>() -> TailInstructionTable<T>
+pub(crate) const fn make_instruction_table<T, C>() -> RawInstructionTable<T>
 where
     T: EvmTypes,
     C: EvmConfig<T>,


### PR DESCRIPTION
Split the interpreter instruction table implementation into separate normal and TCO modules while keeping the shared table surface in table.rs.

This leaves a single TCO cfg at the module selection point and keeps opcode iteration, instruction table access, and instruction length handling shared.