### PR TITLE
chore: auto-enable TCO on nightly

### DIFF
--- a/crates/evm2/Cargo.toml
+++ b/crates/evm2/Cargo.toml
@@ -151,3 +151,5 @@ c-kzg = ["dep:c-kzg"]
 blst = ["dep:blst"]
 portable = ["c-kzg?/portable", "blst?/portable"]
 p256-aws-lc-rs = ["dep:aws-lc-rs"]
+
+nightly = []

--- a/crates/evm2/Cargo.toml
+++ b/crates/evm2/Cargo.toml
@@ -151,7 +151,3 @@ c-kzg = ["dep:c-kzg"]
 blst = ["dep:blst"]
 portable = ["c-kzg?/portable", "blst?/portable"]
 p256-aws-lc-rs = ["dep:aws-lc-rs"]
-
-# Automatically enabled by the build script on nightly compilers when the target supports it.
-tco = []
-nightly = ["tco"]

--- a/crates/evm2/Cargo.toml
+++ b/crates/evm2/Cargo.toml
@@ -152,5 +152,6 @@ blst = ["dep:blst"]
 portable = ["c-kzg?/portable", "blst?/portable"]
 p256-aws-lc-rs = ["dep:aws-lc-rs"]
 
+# Automatically enabled by the build script on nightly compilers when the target supports it.
 tco = []
 nightly = ["tco"]

--- a/crates/evm2/build.rs
+++ b/crates/evm2/build.rs
@@ -1,0 +1,95 @@
+//! Configures the optional tail-call interpreter backend.
+
+use std::{
+    env,
+    ffi::OsString,
+    fs,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+fn main() {
+    println!("cargo:rustc-check-cfg=cfg(evm2_tco)");
+    println!("cargo:rerun-if-env-changed=RUSTC");
+    println!("cargo:rerun-if-env-changed=TARGET");
+
+    let tco_requested = env::var_os("CARGO_FEATURE_TCO").is_some();
+    let nightly_requested = env::var_os("CARGO_FEATURE_NIGHTLY").is_some();
+    let is_nightly = rustc_is_nightly();
+
+    if !(is_nightly || tco_requested || nightly_requested) {
+        return;
+    }
+
+    if probe_tco_support() {
+        println!("cargo:rustc-cfg=evm2_tco");
+    } else if tco_requested || nightly_requested {
+        panic!("requested tco backend is not supported by this rustc/target");
+    }
+}
+
+fn rustc_is_nightly() -> bool {
+    let output = Command::new(rustc()).arg("-Vv").output();
+    let Ok(output) = output else { return false };
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    output.status.success()
+        && stdout.lines().any(|line| {
+            line.strip_prefix("release: ").is_some_and(|release| release.contains("nightly"))
+        })
+}
+
+fn probe_tco_support() -> bool {
+    let Some(target) = env::var_os("TARGET") else { return false };
+    let out_dir = PathBuf::from(env::var_os("OUT_DIR").expect("OUT_DIR is set by Cargo"));
+    let source = out_dir.join("evm2_tco_probe.rs");
+    let metadata = out_dir.join("evm2_tco_probe.rmeta");
+
+    if fs::write(&source, TCO_PROBE).is_err() {
+        return false;
+    }
+
+    let output = Command::new(rustc())
+        .arg("--crate-name")
+        .arg("evm2_tco_probe")
+        .arg("--crate-type")
+        .arg("lib")
+        .arg("--edition")
+        .arg("2024")
+        .arg("--target")
+        .arg(target)
+        .arg("--emit")
+        .arg("metadata")
+        .arg("-o")
+        .arg(&metadata)
+        .arg(&source)
+        .output();
+
+    remove_file(&source);
+    remove_file(&metadata);
+
+    output.is_ok_and(|output| output.status.success())
+}
+
+fn rustc() -> OsString {
+    env::var_os("RUSTC").unwrap_or_else(|| OsString::from("rustc"))
+}
+
+fn remove_file(path: &Path) {
+    if path.exists() {
+        let _ = fs::remove_file(path);
+    }
+}
+
+const TCO_PROBE: &str = r#"
+#![no_std]
+#![feature(explicit_tail_calls, rust_preserve_none_cc)]
+#![allow(incomplete_features)]
+
+pub extern "rust-preserve-none" fn caller(x: usize) -> usize {
+    become callee(x)
+}
+
+extern "rust-preserve-none" fn callee(x: usize) -> usize {
+    x
+}
+"#;

--- a/crates/evm2/build.rs
+++ b/crates/evm2/build.rs
@@ -9,18 +9,21 @@ use std::{
 };
 
 fn main() {
-    println!("cargo:rustc-check-cfg=cfg(evm2_tco)");
+    println!("cargo:rustc-check-cfg=cfg(tco)");
     println!("cargo:rerun-if-env-changed=RUSTC");
     println!("cargo:rerun-if-env-changed=TARGET");
 
+    let nightly_requested = env::var_os("CARGO_FEATURE_NIGHTLY").is_some();
     let is_nightly = rustc_is_nightly();
 
-    if !is_nightly {
+    if !(is_nightly || nightly_requested) {
         return;
     }
 
     if probe_tco_support() {
-        println!("cargo:rustc-cfg=evm2_tco");
+        println!("cargo:rustc-cfg=tco");
+    } else if nightly_requested {
+        panic!("requested nightly backend is not supported by this rustc/target");
     }
 }
 
@@ -37,8 +40,8 @@ fn rustc_is_nightly() -> bool {
 fn probe_tco_support() -> bool {
     let Some(target) = env::var_os("TARGET") else { return false };
     let out_dir = PathBuf::from(env::var_os("OUT_DIR").expect("OUT_DIR is set by Cargo"));
-    let source = out_dir.join("evm2_tco_probe.rs");
-    let metadata = out_dir.join("evm2_tco_probe.rmeta");
+    let source = out_dir.join("tco_probe.rs");
+    let metadata = out_dir.join("tco_probe.rmeta");
 
     if fs::write(&source, TCO_PROBE).is_err() {
         return false;
@@ -46,7 +49,7 @@ fn probe_tco_support() -> bool {
 
     let output = Command::new(rustc())
         .arg("--crate-name")
-        .arg("evm2_tco_probe")
+        .arg("tco_probe")
         .arg("--crate-type")
         .arg("lib")
         .arg("--edition")

--- a/crates/evm2/build.rs
+++ b/crates/evm2/build.rs
@@ -13,18 +13,14 @@ fn main() {
     println!("cargo:rerun-if-env-changed=RUSTC");
     println!("cargo:rerun-if-env-changed=TARGET");
 
-    let tco_requested = env::var_os("CARGO_FEATURE_TCO").is_some();
-    let nightly_requested = env::var_os("CARGO_FEATURE_NIGHTLY").is_some();
     let is_nightly = rustc_is_nightly();
 
-    if !(is_nightly || tco_requested || nightly_requested) {
+    if !is_nightly {
         return;
     }
 
     if probe_tco_support() {
         println!("cargo:rustc-cfg=evm2_tco");
-    } else if tco_requested || nightly_requested {
-        panic!("requested tco backend is not supported by this rustc/target");
     }
 }
 

--- a/crates/evm2/build.rs
+++ b/crates/evm2/build.rs
@@ -1,12 +1,6 @@
 //! Configures the optional tail-call interpreter backend.
 
-use std::{
-    env,
-    ffi::OsString,
-    fs,
-    path::{Path, PathBuf},
-    process::Command,
-};
+use std::{env, ffi::OsString, process::Command};
 
 fn main() {
     println!("cargo:rustc-check-cfg=cfg(tco)");
@@ -16,14 +10,10 @@ fn main() {
     let nightly_requested = env::var_os("CARGO_FEATURE_NIGHTLY").is_some();
     let is_nightly = rustc_is_nightly();
 
-    if !(is_nightly || nightly_requested) {
-        return;
-    }
-
-    if probe_tco_support() {
+    if is_nightly {
         println!("cargo:rustc-cfg=tco");
     } else if nightly_requested {
-        panic!("requested nightly backend is not supported by this rustc/target");
+        panic!("requested nightly backend requires a nightly compiler");
     }
 }
 
@@ -37,58 +27,6 @@ fn rustc_is_nightly() -> bool {
         })
 }
 
-fn probe_tco_support() -> bool {
-    let Some(target) = env::var_os("TARGET") else { return false };
-    let out_dir = PathBuf::from(env::var_os("OUT_DIR").expect("OUT_DIR is set by Cargo"));
-    let source = out_dir.join("tco_probe.rs");
-    let metadata = out_dir.join("tco_probe.rmeta");
-
-    if fs::write(&source, TCO_PROBE).is_err() {
-        return false;
-    }
-
-    let output = Command::new(rustc())
-        .arg("--crate-name")
-        .arg("tco_probe")
-        .arg("--crate-type")
-        .arg("lib")
-        .arg("--edition")
-        .arg("2024")
-        .arg("--target")
-        .arg(target)
-        .arg("--emit")
-        .arg("metadata")
-        .arg("-o")
-        .arg(&metadata)
-        .arg(&source)
-        .output();
-
-    remove_file(&source);
-    remove_file(&metadata);
-
-    output.is_ok_and(|output| output.status.success())
-}
-
 fn rustc() -> OsString {
     env::var_os("RUSTC").unwrap_or_else(|| OsString::from("rustc"))
 }
-
-fn remove_file(path: &Path) {
-    if path.exists() {
-        let _ = fs::remove_file(path);
-    }
-}
-
-const TCO_PROBE: &str = r#"
-#![no_std]
-#![feature(explicit_tail_calls, rust_preserve_none_cc)]
-#![allow(incomplete_features)]
-
-pub extern "rust-preserve-none" fn caller(x: usize) -> usize {
-    become callee(x)
-}
-
-extern "rust-preserve-none" fn callee(x: usize) -> usize {
-    x
-}
-"#;

--- a/crates/evm2/build.rs
+++ b/crates/evm2/build.rs
@@ -4,6 +4,7 @@ use std::{env, ffi::OsString, process::Command};
 
 fn main() {
     println!("cargo:rustc-check-cfg=cfg(tco)");
+    println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-env-changed=RUSTC");
     println!("cargo:rerun-if-env-changed=TARGET");
 

--- a/crates/evm2/src/interpreter/gas/mod.rs
+++ b/crates/evm2/src/interpreter/gas/mod.rs
@@ -201,12 +201,12 @@ impl GasTracker {
 }
 
 /// Remaining regular gas threaded through tail calls.
-#[cfg(evm2_tco)]
+#[cfg(tco)]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
 #[repr(transparent)]
 pub(crate) struct RemainingGas(u64);
 
-#[cfg(evm2_tco)]
+#[cfg(tco)]
 impl RemainingGas {
     /// Creates a remaining gas counter.
     #[inline]

--- a/crates/evm2/src/interpreter/gas/mod.rs
+++ b/crates/evm2/src/interpreter/gas/mod.rs
@@ -201,12 +201,12 @@ impl GasTracker {
 }
 
 /// Remaining regular gas threaded through tail calls.
-#[cfg(feature = "tco")]
+#[cfg(evm2_tco)]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
 #[repr(transparent)]
 pub(crate) struct RemainingGas(u64);
 
-#[cfg(feature = "tco")]
+#[cfg(evm2_tco)]
 impl RemainingGas {
     /// Creates a remaining gas counter.
     #[inline]

--- a/crates/evm2/src/interpreter/instructions/table.rs
+++ b/crates/evm2/src/interpreter/instructions/table.rs
@@ -54,7 +54,7 @@ macro_rules! for_each_opcode_value {
 }
 
 cfg_if::cfg_if! {
-    if #[cfg(feature = "tco")] {
+    if #[cfg(evm2_tco)] {
         mod tco;
         use tco as imp;
     } else {

--- a/crates/evm2/src/interpreter/instructions/table.rs
+++ b/crates/evm2/src/interpreter/instructions/table.rs
@@ -54,7 +54,7 @@ macro_rules! for_each_opcode_value {
 }
 
 cfg_if::cfg_if! {
-    if #[cfg(evm2_tco)] {
+    if #[cfg(tco)] {
         mod tco;
         use tco as imp;
     } else {

--- a/crates/evm2/src/interpreter/runtime.rs
+++ b/crates/evm2/src/interpreter/runtime.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "tco")]
+#[cfg(evm2_tco)]
 use super::gas::RemainingGas;
 use super::{
     BytecodeRef, Gas, InstrStop, Memory, Message, MessageKind, Pc, Result, Stack, StackBacking,
@@ -9,7 +9,7 @@ use crate::{
 };
 use alloc::{boxed::Box, vec::Vec};
 use alloy_primitives::Bytes;
-#[cfg(not(feature = "tco"))]
+#[cfg(not(evm2_tco))]
 use core::hint::cold_path;
 use core::{fmt, marker::PhantomData, ptr::NonNull};
 
@@ -152,9 +152,9 @@ impl<'frame, T: EvmTypes> Interpreter<'frame, T> {
         self.version = &config.version;
         self.spec = config.version.spec_id;
 
-        #[cfg(feature = "tco")]
+        #[cfg(evm2_tco)]
         let r = self.step_tail(config);
-        #[cfg(not(feature = "tco"))]
+        #[cfg(not(evm2_tco))]
         let r = self.run_table_loop(config);
 
         self.host = None;
@@ -162,7 +162,7 @@ impl<'frame, T: EvmTypes> Interpreter<'frame, T> {
         r
     }
 
-    #[cfg(not(feature = "tco"))]
+    #[cfg(not(evm2_tco))]
     fn run_table_loop(&mut self, config: &ExecutionConfig<T>) -> InstrStop {
         #[expect(clippy::unnecessary_cast, reason = "cast erases the active interpreter lifetime")]
         let raw = self as *mut Self as *mut Interpreter<'_, T>;
@@ -187,7 +187,7 @@ impl<'frame, T: EvmTypes> Interpreter<'frame, T> {
     }
 
     #[inline(always)]
-    #[cfg(feature = "tco")]
+    #[cfg(evm2_tco)]
     fn step_tail(&mut self, config: &ExecutionConfig<T>) -> InstrStop {
         #[expect(clippy::unnecessary_cast, reason = "cast erases the active interpreter lifetime")]
         let raw = self as *mut Self as *mut Interpreter<'_, T>;
@@ -239,13 +239,13 @@ impl<'frame, T: EvmTypes> InterpreterState<'frame, T> {
     }
 
     #[inline]
-    #[cfg(feature = "nightly")]
+    #[cfg(evm2_tco)]
     pub(crate) const fn result(&self) -> Result {
         self.0.result
     }
 
     #[inline]
-    #[cfg(feature = "nightly")]
+    #[cfg(evm2_tco)]
     pub(crate) const fn set_pc_stack_len(&mut self, pc: *const u8, stack_len: usize) {
         self.0.pc = pc;
         self.0.stack_len = stack_len;

--- a/crates/evm2/src/interpreter/runtime.rs
+++ b/crates/evm2/src/interpreter/runtime.rs
@@ -1,4 +1,4 @@
-#[cfg(evm2_tco)]
+#[cfg(tco)]
 use super::gas::RemainingGas;
 use super::{
     BytecodeRef, Gas, InstrStop, Memory, Message, MessageKind, Pc, Result, Stack, StackBacking,
@@ -9,7 +9,7 @@ use crate::{
 };
 use alloc::{boxed::Box, vec::Vec};
 use alloy_primitives::Bytes;
-#[cfg(not(evm2_tco))]
+#[cfg(not(tco))]
 use core::hint::cold_path;
 use core::{fmt, marker::PhantomData, ptr::NonNull};
 
@@ -152,9 +152,9 @@ impl<'frame, T: EvmTypes> Interpreter<'frame, T> {
         self.version = &config.version;
         self.spec = config.version.spec_id;
 
-        #[cfg(evm2_tco)]
+        #[cfg(tco)]
         let r = self.step_tail(config);
-        #[cfg(not(evm2_tco))]
+        #[cfg(not(tco))]
         let r = self.run_table_loop(config);
 
         self.host = None;
@@ -162,7 +162,7 @@ impl<'frame, T: EvmTypes> Interpreter<'frame, T> {
         r
     }
 
-    #[cfg(not(evm2_tco))]
+    #[cfg(not(tco))]
     fn run_table_loop(&mut self, config: &ExecutionConfig<T>) -> InstrStop {
         #[expect(clippy::unnecessary_cast, reason = "cast erases the active interpreter lifetime")]
         let raw = self as *mut Self as *mut Interpreter<'_, T>;
@@ -187,7 +187,7 @@ impl<'frame, T: EvmTypes> Interpreter<'frame, T> {
     }
 
     #[inline(always)]
-    #[cfg(evm2_tco)]
+    #[cfg(tco)]
     fn step_tail(&mut self, config: &ExecutionConfig<T>) -> InstrStop {
         #[expect(clippy::unnecessary_cast, reason = "cast erases the active interpreter lifetime")]
         let raw = self as *mut Self as *mut Interpreter<'_, T>;
@@ -239,13 +239,13 @@ impl<'frame, T: EvmTypes> InterpreterState<'frame, T> {
     }
 
     #[inline]
-    #[cfg(evm2_tco)]
+    #[cfg(tco)]
     pub(crate) const fn result(&self) -> Result {
         self.0.result
     }
 
     #[inline]
-    #[cfg(evm2_tco)]
+    #[cfg(tco)]
     pub(crate) const fn set_pc_stack_len(&mut self, pc: *const u8, stack_len: usize) {
         self.0.pc = pc;
         self.0.stack_len = stack_len;

--- a/crates/evm2/src/interpreter/stack.rs
+++ b/crates/evm2/src/interpreter/stack.rs
@@ -42,7 +42,7 @@ impl<'a> Stack<'a> {
     }
 
     #[inline]
-    #[cfg(not(evm2_tco))]
+    #[cfg(not(tco))]
     pub(crate) fn reborrow(&mut self) -> Stack<'_> {
         Stack { stack: self.stack, len: self.len }
     }

--- a/crates/evm2/src/interpreter/stack.rs
+++ b/crates/evm2/src/interpreter/stack.rs
@@ -42,7 +42,7 @@ impl<'a> Stack<'a> {
     }
 
     #[inline]
-    #[cfg(not(feature = "tco"))]
+    #[cfg(not(evm2_tco))]
     pub(crate) fn reborrow(&mut self) -> Stack<'_> {
         Stack { stack: self.stack, len: self.len }
     }

--- a/crates/evm2/src/interpreter/utils.rs
+++ b/crates/evm2/src/interpreter/utils.rs
@@ -43,7 +43,7 @@ macro_rules! asm_comment {
     };
 }
 
-#[cfg(evm2_tco)]
+#[cfg(tco)]
 #[collapse_debuginfo(yes)]
 macro_rules! tail_return {
     ($e:expr) => {
@@ -51,7 +51,7 @@ macro_rules! tail_return {
     };
 }
 
-#[cfg(evm2_tco)]
+#[cfg(tco)]
 #[collapse_debuginfo(yes)]
 macro_rules! extern_table {
     ($(#[$attr:meta])* fn $($f:tt)*) => {
@@ -62,7 +62,7 @@ macro_rules! extern_table {
     };
 }
 
-#[cfg(not(evm2_tco))]
+#[cfg(not(tco))]
 #[collapse_debuginfo(yes)]
 macro_rules! extern_table {
     ($(#[$attr:meta])* fn $($f:tt)*) => {

--- a/crates/evm2/src/interpreter/utils.rs
+++ b/crates/evm2/src/interpreter/utils.rs
@@ -43,7 +43,7 @@ macro_rules! asm_comment {
     };
 }
 
-#[cfg(feature = "tco")]
+#[cfg(evm2_tco)]
 #[collapse_debuginfo(yes)]
 macro_rules! tail_return {
     ($e:expr) => {
@@ -51,7 +51,7 @@ macro_rules! tail_return {
     };
 }
 
-#[cfg(feature = "tco")]
+#[cfg(evm2_tco)]
 #[collapse_debuginfo(yes)]
 macro_rules! extern_table {
     ($(#[$attr:meta])* fn $($f:tt)*) => {
@@ -62,7 +62,7 @@ macro_rules! extern_table {
     };
 }
 
-#[cfg(not(feature = "tco"))]
+#[cfg(not(evm2_tco))]
 #[collapse_debuginfo(yes)]
 macro_rules! extern_table {
     ($(#[$attr:meta])* fn $($f:tt)*) => {

--- a/crates/evm2/src/lib.rs
+++ b/crates/evm2/src/lib.rs
@@ -1,9 +1,5 @@
 #![doc = include_str!("../README.md")]
-#![cfg_attr(
-    evm2_tco,
-    feature(explicit_tail_calls, rust_preserve_none_cc),
-    allow(incomplete_features)
-)]
+#![cfg_attr(tco, feature(explicit_tail_calls, rust_preserve_none_cc), allow(incomplete_features))]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 extern crate self as evm2;

--- a/crates/evm2/src/lib.rs
+++ b/crates/evm2/src/lib.rs
@@ -1,6 +1,6 @@
 #![doc = include_str!("../README.md")]
 #![cfg_attr(
-    feature = "tco",
+    evm2_tco,
     feature(explicit_tail_calls, rust_preserve_none_cc),
     allow(incomplete_features)
 )]

--- a/crates/evm2/src/precompiles/modexp.rs
+++ b/crates/evm2/src/precompiles/modexp.rs
@@ -6,6 +6,8 @@ use crate::{
     precompiles::{PrecompileHalt, PrecompileOutput, PrecompileResult, eip7823},
     utils::{left_pad, left_pad_vec_be, right_pad_vec, right_pad_with_offset},
 };
+#[cfg(feature = "gmp")]
+use alloc::vec;
 use alloc::vec::Vec;
 use alloy_primitives::{Bytes, U256};
 use core::cmp::{max, min};

--- a/scripts/dump_opcode_asm.py
+++ b/scripts/dump_opcode_asm.py
@@ -8,6 +8,7 @@
 Examples:
     ./scripts/dump_opcode_asm.py
     ./scripts/dump_opcode_asm.py ADD PUSH1 SSTORE -o tmp/mydump
+    ./scripts/dump_opcode_asm.py --features evm2/nightly ADD
 """
 
 import argparse

--- a/scripts/dump_opcode_asm.py
+++ b/scripts/dump_opcode_asm.py
@@ -8,7 +8,6 @@
 Examples:
     ./scripts/dump_opcode_asm.py
     ./scripts/dump_opcode_asm.py ADD PUSH1 SSTORE -o tmp/mydump
-    ./scripts/dump_opcode_asm.py --features evm2/nightly ADD
 """
 
 import argparse


### PR DESCRIPTION
This moves the tail-call interpreter switch from the public Cargo feature gate to an internal cfg emitted by the evm2 build script. The build script enables `evm2_tco` automatically when the active rustc is nightly and a small target-specific probe for `become` plus `extern "rust-preserve-none"` succeeds.

The existing `tco` and `nightly` features now act as explicit requests for the same backend, failing early from the build script when the active compiler or target cannot support it. Stable builds keep using the normal table-loop backend without touching unstable language features.
