### PR TITLE
perf(interpreter): pack dispatch return

### DIFF
--- a/crates/evm2/src/interpreter/gas/mod.rs
+++ b/crates/evm2/src/interpreter/gas/mod.rs
@@ -200,13 +200,11 @@ impl GasTracker {
     }
 }
 
-/// Remaining regular gas threaded through tail calls.
-#[cfg(tco)]
+/// Remaining regular gas threaded through dispatch calls.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
 #[repr(transparent)]
 pub(crate) struct RemainingGas(u64);
 
-#[cfg(tco)]
 impl RemainingGas {
     /// Creates a remaining gas counter.
     #[inline]

--- a/crates/evm2/src/interpreter/instructions/table.rs
+++ b/crates/evm2/src/interpreter/instructions/table.rs
@@ -70,8 +70,6 @@ pub(crate) type InstrFn<T> = imp::RawInstrFn<T>;
 pub(crate) type InstrTable<T> = imp::RawInstrTable<T>;
 
 pub(crate) use imp::make_instruction_table;
-#[cfg(not(tco))]
-pub(crate) use imp::unpack_pc_stack_len;
 
 pub(crate) trait InstrTables<C>: EvmTypes
 where

--- a/crates/evm2/src/interpreter/instructions/table.rs
+++ b/crates/evm2/src/interpreter/instructions/table.rs
@@ -70,6 +70,8 @@ pub(crate) type InstrFn<T> = imp::RawInstrFn<T>;
 pub(crate) type InstrTable<T> = imp::RawInstrTable<T>;
 
 pub(crate) use imp::make_instruction_table;
+#[cfg(not(tco))]
+pub(crate) use imp::unpack_pc_stack_len;
 
 pub(crate) trait InstrTables<C>: EvmTypes
 where

--- a/crates/evm2/src/interpreter/instructions/table/normal.rs
+++ b/crates/evm2/src/interpreter/instructions/table/normal.rs
@@ -95,8 +95,7 @@ fn dispatch_mono<T: EvmTypes, C: EvmConfig<T>, const DYNAMIC_GAS: bool>(
     if r.is_err() {
         cold_path();
         state.set_result(r);
-        let stack_len = if stack.len <= STACK_LIMIT { stack.len } else { 0 };
-        return (PackedPcStackLen::pack(core::ptr::null(), stack_len), remaining_gas);
+        return (PackedPcStackLen::pack(core::ptr::null(), stack.len), remaining_gas);
     }
     (PackedPcStackLen::pack(pc.as_ptr(), stack.len), remaining_gas)
 }
@@ -123,7 +122,6 @@ pub(crate) struct PackedPcStackLen(usize);
 impl PackedPcStackLen {
     #[inline(always)]
     pub(crate) fn pack(pc: *const u8, stack_len: usize) -> Self {
-        debug_assert!(stack_len <= STACK_LIMIT);
         Self((stack_len << PC_BITS) | (pc as usize & PC_MASK))
     }
 

--- a/crates/evm2/src/interpreter/instructions/table/normal.rs
+++ b/crates/evm2/src/interpreter/instructions/table/normal.rs
@@ -1,15 +1,22 @@
 use crate::{
     EvmConfig, EvmTypes,
-    interpreter::{InterpreterState, Pc, Result, Stack, gas::Gas},
+    constants::STACK_LIMIT,
+    interpreter::{InterpreterState, Pc, Result, Stack, gas::RemainingGas},
 };
 use core::hint::cold_path;
 
 /// Normal instruction return value.
-pub(crate) type InstrFnRet = (*const u8, usize);
+pub(crate) type InstrFnRet = (usize, RemainingGas);
 
 /// Normal instruction function pointer.
-pub(super) type RawInstrFn<T> =
-    extern_table!(fn(pc: Pc, stack: Stack<'_>, state: &mut InterpreterState<'_, T>) -> InstrFnRet);
+pub(super) type RawInstrFn<T> = extern_table!(
+    fn(
+        pc: Pc,
+        stack: Stack<'_>,
+        remaining_gas: RemainingGas,
+        state: &mut InterpreterState<'_, T>,
+    ) -> InstrFnRet
+);
 
 /// Normal instruction dispatch table.
 pub(super) type RawInstrTable<T> = [RawInstrFn<T>; 256];
@@ -17,7 +24,12 @@ pub(super) type RawInstrTable<T> = [RawInstrFn<T>; 256];
 macro_rules! assign_instruction_table_entries {
     ([$table:expr, $evm_types:ty, $config:ty, $dispatch:ident, $instr_fn:ty] $($op:literal,)*) => {
         $(
-            $table[$op] = $dispatch::<$evm_types, $config, $op> as $instr_fn;
+            let instruction = <$config as EvmConfig<$evm_types>>::VERSION_TABLES.instruction($op);
+            $table[$op] = if instruction.dynamic_gas {
+                $dispatch::<$evm_types, $config, $op, true> as $instr_fn
+            } else {
+                $dispatch::<$evm_types, $config, $op, false> as $instr_fn
+            };
         )*
     };
 }
@@ -27,7 +39,7 @@ where
     T: EvmTypes,
     C: EvmConfig<T>,
 {
-    let mut table = [dispatch::<T, C, 0> as super::InstrFn<T>; 256];
+    let mut table = [dispatch::<T, C, 0, true> as super::InstrFn<T>; 256];
     for_each_opcode_value!([table, T, C, dispatch, super::InstrFn<T>] assign_instruction_table_entries);
 
     // Make all unknown entries point to the same dispatch function.
@@ -47,27 +59,35 @@ where
 }
 
 extern_table! {
-    fn dispatch<T: EvmTypes, C: EvmConfig<T>, const OP: u8>(
+    fn dispatch<T: EvmTypes, C: EvmConfig<T>, const OP: u8, const DYNAMIC_GAS: bool>(
         pc: Pc,
         stack: Stack<'_>,
+        remaining_gas: RemainingGas,
         state: &mut InterpreterState<'_, T>,
     ) -> InstrFnRet {
-        dispatch_mono::<T, C>(OP, pc, stack, state)
+        dispatch_mono::<T, C, DYNAMIC_GAS>(OP, pc, stack, remaining_gas, state)
     }
 }
 
 #[inline(always)]
-fn dispatch_mono<T: EvmTypes, C: EvmConfig<T>>(
+fn dispatch_mono<T: EvmTypes, C: EvmConfig<T>, const DYNAMIC_GAS: bool>(
     op: u8,
     mut pc: Pc,
     mut stack: Stack<'_>,
+    mut remaining_gas: RemainingGas,
     state: &mut InterpreterState<'_, T>,
 ) -> InstrFnRet {
     let instr = C::VERSION_TABLES.instruction(op).instr;
     let r;
-    match pre_step::<T, C>(state.gas_mut(), op) {
+    match pre_step::<T, C>(&mut remaining_gas, op) {
         Ok(()) => {
+            if DYNAMIC_GAS {
+                state.gas_mut().set_remaining(remaining_gas.get());
+            }
             r = instr(&mut pc, stack.as_mut(), state);
+            if DYNAMIC_GAS {
+                remaining_gas.set(state.gas_mut().remaining());
+            }
             super::inc_pc(&mut pc, op);
         }
         Err(e) => r = Err(e),
@@ -75,12 +95,33 @@ fn dispatch_mono<T: EvmTypes, C: EvmConfig<T>>(
     if r.is_err() {
         cold_path();
         state.set_result(r);
-        return (core::ptr::null(), stack.len);
+        let stack_len = if stack.len <= STACK_LIMIT { stack.len } else { 0 };
+        return (pack_pc_stack_len(core::ptr::null(), stack_len), remaining_gas);
     }
-    (pc.as_ptr(), stack.len)
+    (pack_pc_stack_len(pc.as_ptr(), stack.len), remaining_gas)
 }
 
 #[inline]
-const fn pre_step<T: EvmTypes, C: EvmConfig<T>>(gas: &mut Gas, op: u8) -> Result {
-    gas.spend(C::VERSION_TABLES.static_gas(op) as _)
+const fn pre_step<T: EvmTypes, C: EvmConfig<T>>(
+    remaining_gas: &mut RemainingGas,
+    op: u8,
+) -> Result {
+    remaining_gas.spend(C::VERSION_TABLES.static_gas(op) as _)
+}
+
+const STACK_LEN_BITS: u32 = 11;
+const PC_BITS: u32 = usize::BITS - STACK_LEN_BITS;
+const PC_MASK: usize = usize::MAX >> STACK_LEN_BITS;
+
+const _: () = assert!(STACK_LIMIT <= (1 << STACK_LEN_BITS));
+
+#[inline(always)]
+pub(crate) fn pack_pc_stack_len(pc: *const u8, stack_len: usize) -> usize {
+    debug_assert!(stack_len <= STACK_LIMIT);
+    (stack_len << PC_BITS) | (pc as usize & PC_MASK)
+}
+
+#[inline(always)]
+pub(crate) const fn unpack_pc_stack_len(packed: usize) -> (*const u8, usize) {
+    ((packed & PC_MASK) as *const u8, packed >> PC_BITS)
 }

--- a/crates/evm2/src/interpreter/instructions/table/normal.rs
+++ b/crates/evm2/src/interpreter/instructions/table/normal.rs
@@ -6,7 +6,7 @@ use crate::{
 use core::hint::cold_path;
 
 /// Normal instruction return value.
-pub(crate) type InstrFnRet = (usize, RemainingGas);
+pub(crate) type InstrFnRet = (PackedPcStackLen, RemainingGas);
 
 /// Normal instruction function pointer.
 pub(super) type RawInstrFn<T> = extern_table!(
@@ -96,9 +96,9 @@ fn dispatch_mono<T: EvmTypes, C: EvmConfig<T>, const DYNAMIC_GAS: bool>(
         cold_path();
         state.set_result(r);
         let stack_len = if stack.len <= STACK_LIMIT { stack.len } else { 0 };
-        return (pack_pc_stack_len(core::ptr::null(), stack_len), remaining_gas);
+        return (PackedPcStackLen::pack(core::ptr::null(), stack_len), remaining_gas);
     }
-    (pack_pc_stack_len(pc.as_ptr(), stack.len), remaining_gas)
+    (PackedPcStackLen::pack(pc.as_ptr(), stack.len), remaining_gas)
 }
 
 #[inline]
@@ -115,13 +115,20 @@ const PC_MASK: usize = usize::MAX >> STACK_LEN_BITS;
 
 const _: () = assert!(STACK_LIMIT <= (1 << STACK_LEN_BITS));
 
-#[inline(always)]
-pub(crate) fn pack_pc_stack_len(pc: *const u8, stack_len: usize) -> usize {
-    debug_assert!(stack_len <= STACK_LIMIT);
-    (stack_len << PC_BITS) | (pc as usize & PC_MASK)
-}
+/// Packed normal dispatch pc and stack length.
+#[derive(Clone, Copy)]
+#[repr(transparent)]
+pub(crate) struct PackedPcStackLen(usize);
 
-#[inline(always)]
-pub(crate) const fn unpack_pc_stack_len(packed: usize) -> (*const u8, usize) {
-    ((packed & PC_MASK) as *const u8, packed >> PC_BITS)
+impl PackedPcStackLen {
+    #[inline(always)]
+    pub(crate) fn pack(pc: *const u8, stack_len: usize) -> Self {
+        debug_assert!(stack_len <= STACK_LIMIT);
+        Self((stack_len << PC_BITS) | (pc as usize & PC_MASK))
+    }
+
+    #[inline(always)]
+    pub(crate) const fn unpack(self) -> (*const u8, usize) {
+        ((self.0 & PC_MASK) as *const u8, self.0 >> PC_BITS)
+    }
 }

--- a/crates/evm2/src/interpreter/instructions/table/normal.rs
+++ b/crates/evm2/src/interpreter/instructions/table/normal.rs
@@ -122,7 +122,7 @@ pub(crate) struct PackedPcStackLen(usize);
 impl PackedPcStackLen {
     #[inline(always)]
     pub(crate) fn pack(pc: *const u8, stack_len: usize) -> Self {
-        Self((stack_len << PC_BITS) | (pc as usize & PC_MASK))
+        Self((stack_len << PC_BITS) | pc as usize)
     }
 
     #[inline(always)]

--- a/crates/evm2/src/interpreter/runtime.rs
+++ b/crates/evm2/src/interpreter/runtime.rs
@@ -1,7 +1,6 @@
-#[cfg(tco)]
-use super::gas::RemainingGas;
 use super::{
     BytecodeRef, Gas, InstrStop, Memory, Message, MessageKind, Pc, Result, Stack, StackBacking,
+    gas::RemainingGas,
 };
 use crate::{
     EvmConfig, EvmTypes, ExecutionConfig, SpecId, Version, bytecode::Bytecode, env::TxEnv,
@@ -171,16 +170,20 @@ impl<'frame, T: EvmTypes> Interpreter<'frame, T> {
         let state = InterpreterState::wrap_mut(unsafe { &mut *raw });
         let mut pc = Pc::new(self.pc);
         let mut stack = Stack::new(&mut self.stack, self.stack_len);
+        let mut remaining_gas = RemainingGas::new(self.gas.remaining());
         loop {
             let op = pc.op();
             let instr = config.instructions[op as usize];
-            let (next_pc, next_stack_len) = instr(pc, stack.reborrow(), state);
+            let (packed, next_remaining_gas) = instr(pc, stack.reborrow(), remaining_gas, state);
+            let (next_pc, next_stack_len) = super::instructions::table::unpack_pc_stack_len(packed);
             pc = Pc::new(next_pc);
             stack.len = next_stack_len;
+            remaining_gas = next_remaining_gas;
             if next_pc.is_null() {
                 cold_path();
                 self.pc = next_pc;
                 self.stack_len = stack.len;
+                self.gas.set_remaining(remaining_gas.get());
                 return self.result.unwrap_err();
             }
         }

--- a/crates/evm2/src/interpreter/runtime.rs
+++ b/crates/evm2/src/interpreter/runtime.rs
@@ -175,7 +175,7 @@ impl<'frame, T: EvmTypes> Interpreter<'frame, T> {
             let op = pc.op();
             let instr = config.instructions[op as usize];
             let (packed, next_remaining_gas) = instr(pc, stack.reborrow(), remaining_gas, state);
-            let (next_pc, next_stack_len) = super::instructions::table::unpack_pc_stack_len(packed);
+            let (next_pc, next_stack_len) = packed.unpack();
             pc = Pc::new(next_pc);
             stack.len = next_stack_len;
             remaining_gas = next_remaining_gas;


### PR DESCRIPTION
This changes the non-TCO interpreter dispatch return shape to carry the stack length in the upper bits of the returned pc word, while threading remaining gas as the second return value. That lets the normal dispatch path mirror the TCO path's local remaining-gas handling and avoid syncing static-gas-only instructions through the interpreter gas tracker.

The packed pc keeps the stack length unmasked on the hot path and masks only the pc bits needed for unpacking. Cold error exits preserve valid stack lengths and fall back to zero for transient invalid lengths produced by failed stack setup.
