### PR TITLE
fix(evm): respect configured EVM features

### DIFF
--- a/crates/evm2/src/ethereum/eip1559.rs
+++ b/crates/evm2/src/ethereum/eip1559.rs
@@ -18,7 +18,6 @@ use alloy_primitives::U256;
 pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     req: TxRequest<'_, Recovered<TxEip1559>, Evm<T>>,
 ) -> HandlerResult<TxResult> {
-    let spec_id = req.host.spec_id();
     let caller = req.tx.signer();
     let tx = req.tx.inner();
     let max_fee_per_gas = U256::from(tx.max_fee_per_gas);
@@ -69,5 +68,5 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     let mut result = req.host.execute_message(&tx_env, bytecode, &message, false);
     rollback_failed_execution(req.host, execution_checkpoint, &mut result);
 
-    Ok(settle_gas(req.host, spec_id, caller, gas_price, tx.gas_limit, floor_gas, result))
+    Ok(settle_gas(req.host, caller, gas_price, tx.gas_limit, floor_gas, result))
 }

--- a/crates/evm2/src/ethereum/eip2930.rs
+++ b/crates/evm2/src/ethereum/eip2930.rs
@@ -17,7 +17,6 @@ use alloy_primitives::U256;
 pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     req: TxRequest<'_, Recovered<TxEip2930>, Evm<T>>,
 ) -> HandlerResult<TxResult> {
-    let spec_id = req.host.spec_id();
     let caller = req.tx.signer();
     let tx = req.tx.inner();
     let gas_price = U256::from(tx.gas_price);
@@ -63,5 +62,5 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     let mut result = req.host.execute_message(&tx_env, bytecode, &message, false);
     rollback_failed_execution(req.host, execution_checkpoint, &mut result);
 
-    Ok(settle_gas(req.host, spec_id, caller, gas_price, tx.gas_limit, floor_gas, result))
+    Ok(settle_gas(req.host, caller, gas_price, tx.gas_limit, floor_gas, result))
 }

--- a/crates/evm2/src/ethereum/eip4844.rs
+++ b/crates/evm2/src/ethereum/eip4844.rs
@@ -20,7 +20,6 @@ use alloy_primitives::U256;
 pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     req: TxRequest<'_, Recovered<TxEip4844Variant>, Evm<T>>,
 ) -> HandlerResult<TxResult> {
-    let spec_id = req.host.spec_id();
     let caller = req.tx.signer();
     let tx = req.tx.inner().tx();
     let max_fee_per_gas = U256::from(tx.max_fee_per_gas);
@@ -82,7 +81,7 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     let mut result = req.host.execute_message(&tx_env, bytecode, &message, false);
     rollback_failed_execution(req.host, execution_checkpoint, &mut result);
 
-    Ok(settle_gas(req.host, spec_id, caller, gas_price, tx.gas_limit, floor_gas, result))
+    Ok(settle_gas(req.host, caller, gas_price, tx.gas_limit, floor_gas, result))
 }
 
 fn validate_blob_fee(max_fee_per_blob_gas: U256, blob_basefee: U256) -> HandlerResult<()> {

--- a/crates/evm2/src/ethereum/eip7702.rs
+++ b/crates/evm2/src/ethereum/eip7702.rs
@@ -21,7 +21,6 @@ use alloy_primitives::{Address, U256};
 pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     req: TxRequest<'_, Recovered<TxEip7702>, Evm<T>>,
 ) -> HandlerResult<TxResult> {
-    let spec_id = req.host.spec_id();
     let caller = req.tx.signer();
     let tx = req.tx.inner();
     if tx.authorization_list.is_empty() {
@@ -79,7 +78,7 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     result.gas_refunded =
         result.gas_refunded.saturating_add(i64::try_from(eip7702_refund).unwrap_or(i64::MAX));
 
-    Ok(settle_gas(req.host, spec_id, caller, gas_price, tx.gas_limit, floor_gas, result))
+    Ok(settle_gas(req.host, caller, gas_price, tx.gas_limit, floor_gas, result))
 }
 
 fn eip7702_authorization_gas<T: EvmTypes<Host = Evm<T>>>(

--- a/crates/evm2/src/ethereum/legacy.rs
+++ b/crates/evm2/src/ethereum/legacy.rs
@@ -18,7 +18,6 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
 ) -> HandlerResult<TxResult> {
     let caller = req.tx.signer();
     let tx = req.tx.inner();
-    let spec_id = req.host.spec_id();
     let gas_price = U256::from(tx.gas_price);
 
     validate_gas_price(req.host.version(), gas_price, req.host.block.basefee)?;
@@ -54,5 +53,5 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     let mut result = req.host.execute_message(&tx_env, bytecode, &message, false);
     rollback_failed_execution(req.host, execution_checkpoint, &mut result);
 
-    Ok(settle_gas(req.host, spec_id, caller, gas_price, tx.gas_limit, floor_gas, result))
+    Ok(settle_gas(req.host, caller, gas_price, tx.gas_limit, floor_gas, result))
 }

--- a/crates/evm2/src/ethereum/mod.rs
+++ b/crates/evm2/src/ethereum/mod.rs
@@ -401,7 +401,6 @@ pub(super) fn rollback_failed_execution<T: EvmTypes<Host = Evm<T>>>(
 
 pub(super) fn settle_gas<T: EvmTypes<Host = Evm<T>>>(
     host: &mut Evm<T>,
-    spec_id: SpecId,
     caller: Address,
     gas_price: U256,
     tx_gas_limit: u64,
@@ -412,7 +411,7 @@ pub(super) fn settle_gas<T: EvmTypes<Host = Evm<T>>>(
         final_tx_gas(&result, tx_gas_limit, host.feature(EvmFeatures::EIP3529), floor_gas);
     if host.feature(EvmFeatures::FEE_CHARGE) {
         host.state.add_balance(caller, U256::from(gas_remaining) * gas_price);
-        let beneficiary_gas_price = if spec_id.enables(SpecId::LONDON) {
+        let beneficiary_gas_price = if host.feature(EvmFeatures::BASE_FEE_CHECK) {
             gas_price.saturating_sub(host.block.basefee)
         } else {
             gas_price

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -458,7 +458,7 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
                 let code_deposit_gas = u64::try_from(code_deposit_gas).unwrap_or(u64::MAX);
                 if gas.remaining() >= code_deposit_gas {
                     gas.spend(code_deposit_gas).err()
-                } else if self.spec_id().enables(SpecId::HOMESTEAD) {
+                } else if self.feature(EvmFeatures::EIP2) {
                     // EIP-2 makes code-deposit OOG fail contract creation; Frontier instead
                     // creates the account with empty code.
                     Some(InstrStop::OutOfGas)

--- a/crates/evm2/src/interpreter/instructions/system.rs
+++ b/crates/evm2/src/interpreter/instructions/system.rs
@@ -1,7 +1,7 @@
 //! System opcode implementations.
 
 use crate::{
-    EvmTypes, SpecId,
+    EvmFeatures, EvmTypes, SpecId,
     constants::{CALL_DEPTH_LIMIT, EIP7702_BYTECODE_LEN, EIP7702_MAGIC_BYTES, EIP7702_VERSION},
     interpreter::{
         Host, InstrStop, InterpreterState, Message, MessageKind, MessageResult, Result, StackMut,
@@ -272,7 +272,7 @@ fn create_inner<T: EvmTypes>(
     let salt = if is_create2 { Some(stack.pop()?) } else { None };
 
     let len = word_to_usize(len)?;
-    if cx.state.spec().enables(SpecId::SHANGHAI) {
+    if cx.state.version().feature(EvmFeatures::EIP3860) {
         if len > cx.state.version().max_initcode_size {
             return Err(InstrStop::CreateInitCodeSizeLimit);
         }


### PR DESCRIPTION
Use configured `EvmFeatures` for EIP-2 code-deposit OOG handling, EIP-3860 initcode checks, and base-fee settlement instead of hard-coding fork checks.