### PR TITLE
perf: reduce interpreter and dependency overhead

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,3 +89,15 @@ panic = "abort"
 inherits = "release"
 lto = "thin"
 codegen-units = 1
+
+[patch.crates-io]
+# Temporary fork with unrolling removed to avoid excessive generated code size.
+ark-ec = { git = "https://github.com/DaniPopes/algebra", branch = "remove-unrolls" }
+ark-bls12-381 = { git = "https://github.com/DaniPopes/algebra", branch = "remove-unrolls" }
+ark-bn254 = { git = "https://github.com/DaniPopes/algebra", branch = "remove-unrolls" }
+ark-ff = { git = "https://github.com/DaniPopes/algebra", branch = "remove-unrolls" }
+ark-ff-asm = { git = "https://github.com/DaniPopes/algebra", branch = "remove-unrolls" }
+ark-ff-macros = { git = "https://github.com/DaniPopes/algebra", branch = "remove-unrolls" }
+ark-poly = { git = "https://github.com/DaniPopes/algebra", branch = "remove-unrolls" }
+ark-serialize = { git = "https://github.com/DaniPopes/algebra", branch = "remove-unrolls" }
+ark-serialize-derive = { git = "https://github.com/DaniPopes/algebra", branch = "remove-unrolls" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,12 +56,12 @@ thiserror = { version = "2.0", default-features = false }
 walkdir = { version = "2.5", default-features = false }
 
 # Precompiles
-ark-bls12-381 = { version = "0.6", default-features = false }
-ark-bn254 = { version = "0.6", default-features = false }
-ark-ec = { version = "0.6", default-features = false }
-ark-ff = { version = "0.6", default-features = false }
-ark-serialize = { version = "0.6", default-features = false }
-ark-std = { version = "0.6", default-features = false }
+ark-bls12-381 = { version = "0.5", default-features = false }
+ark-bn254 = { version = "0.5", default-features = false }
+ark-ec = { version = "0.5", default-features = false }
+ark-ff = { version = "0.5", default-features = false }
+ark-serialize = { version = "0.5", default-features = false }
+ark-std = { version = "0.5", default-features = false }
 aurora-engine-modexp = { version = "1.2", default-features = false }
 aws-lc-rs = { version = "1.16.2", default-features = false, features = ["aws-lc-sys"] }
 blst = "0.3.15"
@@ -89,3 +89,15 @@ panic = "abort"
 inherits = "release"
 lto = "thin"
 codegen-units = 1
+
+[patch.crates-io]
+# Temporary fork with unrolling removed to avoid excessive generated code size.
+ark-ec = { git = "https://github.com/DaniPopes/algebra", branch = "remove-unrolls" }
+ark-bls12-381 = { git = "https://github.com/DaniPopes/algebra", branch = "remove-unrolls" }
+ark-bn254 = { git = "https://github.com/DaniPopes/algebra", branch = "remove-unrolls" }
+ark-ff = { git = "https://github.com/DaniPopes/algebra", branch = "remove-unrolls" }
+ark-ff-asm = { git = "https://github.com/DaniPopes/algebra", branch = "remove-unrolls" }
+ark-ff-macros = { git = "https://github.com/DaniPopes/algebra", branch = "remove-unrolls" }
+ark-poly = { git = "https://github.com/DaniPopes/algebra", branch = "remove-unrolls" }
+ark-serialize = { git = "https://github.com/DaniPopes/algebra", branch = "remove-unrolls" }
+ark-serialize-derive = { git = "https://github.com/DaniPopes/algebra", branch = "remove-unrolls" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,12 +56,12 @@ thiserror = { version = "2.0", default-features = false }
 walkdir = { version = "2.5", default-features = false }
 
 # Precompiles
-ark-bls12-381 = { version = "0.5", default-features = false }
-ark-bn254 = { version = "0.5", default-features = false }
-ark-ec = { version = "0.5", default-features = false }
-ark-ff = { version = "0.5", default-features = false }
-ark-serialize = { version = "0.5", default-features = false }
-ark-std = { version = "0.5", default-features = false }
+ark-bls12-381 = { version = "0.5.0", default-features = false }
+ark-bn254 = { version = "0.5.0", default-features = false }
+ark-ec = { version = "0.5.0", default-features = false }
+ark-ff = { version = "0.5.0", default-features = false }
+ark-serialize = { version = "0.5.0", default-features = false }
+ark-std = { version = "0.5.0", default-features = false }
 aurora-engine-modexp = { version = "1.2", default-features = false }
 aws-lc-rs = { version = "1.16.2", default-features = false, features = ["aws-lc-sys"] }
 blst = "0.3.15"
@@ -89,15 +89,3 @@ panic = "abort"
 inherits = "release"
 lto = "thin"
 codegen-units = 1
-
-[patch.crates-io]
-# Temporary fork with unrolling removed to avoid excessive generated code size.
-ark-ec = { git = "https://github.com/DaniPopes/algebra", branch = "remove-unrolls" }
-ark-bls12-381 = { git = "https://github.com/DaniPopes/algebra", branch = "remove-unrolls" }
-ark-bn254 = { git = "https://github.com/DaniPopes/algebra", branch = "remove-unrolls" }
-ark-ff = { git = "https://github.com/DaniPopes/algebra", branch = "remove-unrolls" }
-ark-ff-asm = { git = "https://github.com/DaniPopes/algebra", branch = "remove-unrolls" }
-ark-ff-macros = { git = "https://github.com/DaniPopes/algebra", branch = "remove-unrolls" }
-ark-poly = { git = "https://github.com/DaniPopes/algebra", branch = "remove-unrolls" }
-ark-serialize = { git = "https://github.com/DaniPopes/algebra", branch = "remove-unrolls" }
-ark-serialize-derive = { git = "https://github.com/DaniPopes/algebra", branch = "remove-unrolls" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,7 +91,7 @@ lto = "thin"
 codegen-units = 1
 
 [patch.crates-io]
-# Temporary fork with unrolling removed to avoid excessive generated code size.
+# https://github.com/arkworks-rs/algebra/issues/1104
 ark-ec = { git = "https://github.com/DaniPopes/algebra", branch = "remove-unrolls" }
 ark-bls12-381 = { git = "https://github.com/DaniPopes/algebra", branch = "remove-unrolls" }
 ark-bn254 = { git = "https://github.com/DaniPopes/algebra", branch = "remove-unrolls" }

--- a/crates/evm2/Cargo.toml
+++ b/crates/evm2/Cargo.toml
@@ -133,11 +133,12 @@ serde = [
     "alloy-eips/serde",
     "alloy-primitives/serde",
     "alloy-trie/serde",
+    "ark-serialize/serde",
     "k256/serde",
     "p256/serde",
     "blst?/serde",
     "c-kzg?/serde",
-    "secp256k1?/serde"
+    "secp256k1?/serde",
 ]
 arbitrary = [
     "alloy-consensus/arbitrary",

--- a/crates/evm2/Cargo.toml
+++ b/crates/evm2/Cargo.toml
@@ -133,7 +133,6 @@ serde = [
     "alloy-eips/serde",
     "alloy-primitives/serde",
     "alloy-trie/serde",
-    "ark-serialize/serde",
     "k256/serde",
     "p256/serde",
     "blst?/serde",

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -160,6 +160,7 @@ pub struct Evm<T: EvmTypes> {
     spec_id: T::SpecId,
     #[debug(skip)]
     execution_config: ExecutionConfig<T>,
+    features: EvmFeatures,
     pub(crate) block: BlockEnv,
     registry: TxRegistry<T::Tx, TxResult, Self>,
     #[debug(skip)]
@@ -229,6 +230,7 @@ impl<T: EvmTypes> Evm<T> {
         );
         Self {
             spec_id,
+            features: execution_config.version().features,
             execution_config,
             block,
             registry,
@@ -370,7 +372,7 @@ impl<T: EvmTypes> Evm<T> {
     /// Returns `true` if the active EVM feature set contains `feature`.
     #[inline]
     pub const fn feature(&self, feature: EvmFeatures) -> bool {
-        self.version().feature(feature)
+        self.features.contains(feature)
     }
 
     /// Returns the active base specification ID.

--- a/crates/evm2/src/interpreter/instructions/host.rs
+++ b/crates/evm2/src/interpreter/instructions/host.rs
@@ -67,7 +67,7 @@ pub(crate) fn sstore(cx: _) -> Result {
     // EIP-8037 / Amsterdam: creating a new storage slot (original == present == 0,
     // new != 0) also consumes state gas from the reservoir before spilling into
     // regular gas.
-    if cx.state.version().feature(EvmFeatures::EIP8037) {
+    if cx.state.feature(EvmFeatures::EIP8037) {
         cx.gas.spend_state(cx.state.gas_params().sstore_state_gas(&state_load))?;
     }
 

--- a/crates/evm2/src/interpreter/instructions/system.rs
+++ b/crates/evm2/src/interpreter/instructions/system.rs
@@ -274,7 +274,7 @@ fn create_inner<T: EvmTypes>(
     let salt = if is_create2 { Some(stack.pop()?) } else { None };
 
     let len = word_to_usize(len)?;
-    if cx.state.version().feature(EvmFeatures::EIP3860) {
+    if cx.state.feature(EvmFeatures::EIP3860) {
         if len > cx.state.version().max_initcode_size {
             return Err(InstrStop::CreateInitCodeSizeLimit);
         }

--- a/crates/evm2/src/interpreter/instructions/table/tco.rs
+++ b/crates/evm2/src/interpreter/instructions/table/tco.rs
@@ -113,34 +113,6 @@ extern_table! {
         const DYNAMIC_GAS: bool,
         const UNKNOWN: bool,
     >(
-        pc: Pc,
-        stack: Stack<'_>,
-        remaining_gas: RemainingGas,
-        state: &mut InterpreterState<'_, T>,
-        instructions: *const (),
-    ) {
-        if !UNKNOWN {
-            unsafe { core::hint::assert_unchecked(pc.op() == OP) };
-        }
-        tail_return!(tail_dispatch_mono::<T, C, M, DYNAMIC_GAS, UNKNOWN>(
-            pc,
-            stack,
-            remaining_gas,
-            state,
-            instructions
-        ));
-    }
-}
-
-extern_table! {
-    #[inline(always)]
-    fn tail_dispatch_mono<
-        T: EvmTypes,
-        C: EvmConfig<T>,
-        M: InspectMode<T>,
-        const DYNAMIC_GAS: bool,
-        const UNKNOWN: bool,
-    >(
         mut pc: Pc,
         mut stack: Stack<'_>,
         mut remaining_gas: RemainingGas,
@@ -150,8 +122,7 @@ extern_table! {
         let (op, instr) = if UNKNOWN {
             (0xFE, super::unknown_instruction as crate::interpreter::private::InstructionImplFn<T>)
         } else {
-            let op = pc.op();
-            (op, C::VERSION_TABLES.instruction(op).instr)
+            (OP, C::VERSION_TABLES.instruction(OP).instr)
         };
         if M::INSPECT {
             M::step(state, pc, stack.len);

--- a/crates/evm2/src/interpreter/instructions/table/tco.rs
+++ b/crates/evm2/src/interpreter/instructions/table/tco.rs
@@ -37,11 +37,11 @@ macro_rules! assign_instruction_table_entry {
         let changed = super::instruction_changed($vt, $previous_vt, $op);
         if changed {
             $table[$op] = if $vt.is_unknown_opcode($op) {
-                $($dispatch)* 0xFE, false, true> as $instr_fn
+                $($dispatch)* 0xFE, false> as $instr_fn
             } else if $vt.instruction($op).dynamic_gas {
-                $($dispatch)* $op, true, false> as $instr_fn
+                $($dispatch)* $op, true> as $instr_fn
             } else {
-                $($dispatch)* $op, false, false> as $instr_fn
+                $($dispatch)* $op, false> as $instr_fn
             };
         }
     }};
@@ -58,7 +58,7 @@ where
 {
     let mut table = match previous {
         Some(previous) => *previous,
-        None => [tail_dispatch::<T, C, M, 0xFE, false, true> as super::InstrFn<T>; 256],
+        None => [tail_dispatch::<T, C, M, 0xFE, false> as super::InstrFn<T>; 256],
     };
     let vt = C::VERSION_TABLES;
     for_each_opcode_value!([table, vt, previous_version_tables, super::InstrFn<T>, [tail_dispatch::<T, C, M,]] assign_instruction_table_entries);
@@ -111,7 +111,6 @@ extern_table! {
         M: InspectMode<T>,
         const OP: u8,
         const DYNAMIC_GAS: bool,
-        const UNKNOWN: bool,
     >(
         mut pc: Pc,
         mut stack: Stack<'_>,
@@ -119,11 +118,8 @@ extern_table! {
         state: &mut InterpreterState<'_, T>,
         instructions: *const (),
     ) {
-        let (op, instr) = if UNKNOWN {
-            (0xFE, super::unknown_instruction as crate::interpreter::private::InstructionImplFn<T>)
-        } else {
-            (OP, C::VERSION_TABLES.instruction(OP).instr)
-        };
+        let op = OP;
+        let instr = C::VERSION_TABLES.instruction(OP).instr;
         if M::INSPECT {
             M::step(state, pc, stack.len);
         }

--- a/crates/evm2/src/interpreter/instructions/table/tco.rs
+++ b/crates/evm2/src/interpreter/instructions/table/tco.rs
@@ -37,11 +37,11 @@ macro_rules! assign_instruction_table_entry {
         let changed = super::instruction_changed($vt, $previous_vt, $op);
         if changed {
             $table[$op] = if $vt.is_unknown_opcode($op) {
-                $($dispatch)* 0xFE, false> as $instr_fn
+                $($dispatch)* 0xFE, false, true> as $instr_fn
             } else if $vt.instruction($op).dynamic_gas {
-                $($dispatch)* $op, true> as $instr_fn
+                $($dispatch)* $op, true, false> as $instr_fn
             } else {
-                $($dispatch)* $op, false> as $instr_fn
+                $($dispatch)* $op, false, false> as $instr_fn
             };
         }
     }};
@@ -58,7 +58,7 @@ where
 {
     let mut table = match previous {
         Some(previous) => *previous,
-        None => [tail_dispatch::<T, C, M, 0xFE, false> as super::InstrFn<T>; 256],
+        None => [tail_dispatch::<T, C, M, 0xFE, false, true> as super::InstrFn<T>; 256],
     };
     let vt = C::VERSION_TABLES;
     for_each_opcode_value!([table, vt, previous_version_tables, super::InstrFn<T>, [tail_dispatch::<T, C, M,]] assign_instruction_table_entries);
@@ -111,6 +111,35 @@ extern_table! {
         M: InspectMode<T>,
         const OP: u8,
         const DYNAMIC_GAS: bool,
+        const UNKNOWN: bool,
+    >(
+        pc: Pc,
+        stack: Stack<'_>,
+        remaining_gas: RemainingGas,
+        state: &mut InterpreterState<'_, T>,
+        instructions: *const (),
+    ) {
+        if !UNKNOWN {
+            unsafe { core::hint::assert_unchecked(pc.op() == OP) };
+        }
+        tail_return!(tail_dispatch_mono::<T, C, M, DYNAMIC_GAS, UNKNOWN>(
+            pc,
+            stack,
+            remaining_gas,
+            state,
+            instructions
+        ));
+    }
+}
+
+extern_table! {
+    #[inline(always)]
+    fn tail_dispatch_mono<
+        T: EvmTypes,
+        C: EvmConfig<T>,
+        M: InspectMode<T>,
+        const DYNAMIC_GAS: bool,
+        const UNKNOWN: bool,
     >(
         mut pc: Pc,
         mut stack: Stack<'_>,
@@ -118,8 +147,12 @@ extern_table! {
         state: &mut InterpreterState<'_, T>,
         instructions: *const (),
     ) {
-        let op = OP;
-        let instr = C::VERSION_TABLES.instruction(OP).instr;
+        let (op, instr) = if UNKNOWN {
+            (0xFE, super::unknown_instruction as crate::interpreter::private::InstructionImplFn<T>)
+        } else {
+            let op = pc.op();
+            (op, C::VERSION_TABLES.instruction(op).instr)
+        };
         if M::INSPECT {
             M::step(state, pc, stack.len);
         }

--- a/crates/evm2/src/interpreter/runtime.rs
+++ b/crates/evm2/src/interpreter/runtime.rs
@@ -5,9 +5,13 @@ use super::{
     StackBacking, Word,
 };
 use crate::{
-    EvmTypes, ExecutionConfig, SpecId, Version, bytecode::Bytecode, env::TxEnv,
-    evm::inspector::Inspector, interpreter::instructions::table::InstrTable, trustme,
-    version::GasParams,
+    EvmTypes, ExecutionConfig, SpecId, Version,
+    bytecode::Bytecode,
+    env::TxEnv,
+    evm::inspector::Inspector,
+    interpreter::instructions::table::InstrTable,
+    trustme,
+    version::{EvmFeatures, GasParams},
 };
 use alloc::{boxed::Box, vec::Vec};
 use alloy_primitives::{Address, Bytes, Log};
@@ -36,6 +40,7 @@ pub struct Interpreter<'frame, T: EvmTypes> {
     gas: Gas,
     result: Result,
     spec: SpecId,
+    features: EvmFeatures,
     is_static: bool,
 
     #[debug(skip)]
@@ -61,6 +66,7 @@ impl<T: EvmTypes> Default for Interpreter<'_, T> {
             inspector: None,
             version: core::ptr::null(),
             spec: SpecId::DEFAULT,
+            features: EvmFeatures::empty(),
             // SAFETY: `MaybeUninit<Word>` does not need initialization.
             stack: unsafe { Box::new_uninit().assume_init() },
             _marker: PhantomData,
@@ -202,6 +208,7 @@ impl<'frame, T: EvmTypes> Interpreter<'frame, T> {
         self.inspector = inspector;
         self.version = version;
         self.spec = version.spec_id;
+        self.features = version.features;
 
         #[cfg(tco)]
         let r = self.step_tail(instructions);
@@ -351,6 +358,12 @@ impl<'frame, T: EvmTypes> InterpreterState<'frame, T> {
     #[inline]
     pub const fn spec(&self) -> SpecId {
         self.0.spec
+    }
+
+    /// Returns `true` if the active feature set contains `feature`.
+    #[inline]
+    pub const fn feature(&self, feature: EvmFeatures) -> bool {
+        self.0.features.contains(feature)
     }
 
     /// Returns the active dynamic gas parameters.


### PR DESCRIPTION
This reduces hot-path overhead in the interpreter by caching active EVM feature flags directly on the EVM and interpreter state, avoiding an extra indirection when feature checks run in instruction paths.

It also temporarily patches the arkworks 0.5.0 crates to the DaniPopes/algebra remove-unrolls branch while https://github.com/arkworks-rs/algebra/issues/1104 is unresolved, to keep generated unrolling from bloating downstream code size.