### PR TITLE
refactor: track message result gas together

### DIFF
--- a/crates/evm2/examples/custom_evm/tx.rs
+++ b/crates/evm2/examples/custom_evm/tx.rs
@@ -64,7 +64,7 @@ pub fn execute_code(
     );
     Ok(evm2::TxResult {
         status: result.stop.is_success(),
-        gas_used: req.tx.gas_limit - result.gas_remaining,
+        gas_used: req.tx.gas_limit - result.gas.remaining(),
         stop: result.stop,
         output: result.output,
         ..Default::default()

--- a/crates/evm2/src/ethereum/eip7702.rs
+++ b/crates/evm2/src/ethereum/eip7702.rs
@@ -75,8 +75,9 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
         initial_message(req.host, caller, tx.nonce, tx.to.into(), &tx.input, tx.value, gas_limit);
     let mut result = req.host.execute_message(&tx_env, bytecode, &message, false);
     rollback_failed_execution(req.host, execution_checkpoint, &mut result);
-    result.gas_refunded =
-        result.gas_refunded.saturating_add(i64::try_from(eip7702_refund).unwrap_or(i64::MAX));
+    result.gas.set_refunded(
+        result.gas.refunded().saturating_add(i64::try_from(eip7702_refund).unwrap_or(i64::MAX)),
+    );
 
     Ok(settle_gas(req.host, caller, gas_price, tx.gas_limit, floor_gas, result))
 }

--- a/crates/evm2/src/ethereum/mod.rs
+++ b/crates/evm2/src/ethereum/mod.rs
@@ -396,7 +396,7 @@ pub(super) fn rollback_failed_execution<T: EvmTypes<Host = Evm<T>>>(
     if !result.stop.is_success() {
         host.state.rollback(checkpoint, host.spec_id());
         if result.stop.is_halt() {
-            result.gas_remaining = 0;
+            result.gas.set_remaining(0);
         }
     }
 }
@@ -501,7 +501,7 @@ mod tests {
         BaseEvmTypes, ExecutionConfig, Precompiles,
         env::{BlockEnv, TxEnv},
         evm::InMemoryDB,
-        interpreter::{Host, InstrStop, op},
+        interpreter::{GasTracker, Host, InstrStop, op},
         registry::TxRegistry,
     };
     use alloc::vec;
@@ -614,8 +614,11 @@ mod tests {
     fn final_tx_gas_charges_calldata_floor_after_refund() {
         let result = MessageResult {
             stop: crate::interpreter::InstrStop::Return,
-            gas_remaining: 50_000,
-            gas_refunded: 10_000,
+            gas: {
+                let mut gas = GasTracker::new(100_000, 50_000, 0);
+                gas.set_refunded(10_000);
+                gas
+            },
             ..MessageResult::default()
         };
 
@@ -626,8 +629,7 @@ mod tests {
     fn final_tx_gas_preserves_higher_actual_usage() {
         let result = MessageResult {
             stop: crate::interpreter::InstrStop::Return,
-            gas_remaining: 30_000,
-            gas_refunded: 0,
+            gas: GasTracker::new(100_000, 30_000, 0),
             ..MessageResult::default()
         };
 

--- a/crates/evm2/src/evm/inspector.rs
+++ b/crates/evm2/src/evm/inspector.rs
@@ -81,7 +81,7 @@ mod tests {
         ethereum::{RecoveredTxEnvelope, ethereum_tx_registry},
         evm::{AccountInfo, InMemoryDB, SelfDestructResult},
         interpreter::{
-            InstrStop, Interpreter, Message, MessageResult, Word,
+            GasTracker, InstrStop, Interpreter, Message, MessageResult, Word,
             instructions::tests::{TestHost, TestTypes, push},
             op,
         },
@@ -151,7 +151,7 @@ mod tests {
         fn call(&mut self, message: &mut Message) -> Option<MessageResult> {
             self.call_depth = Some(message.depth);
             let mut result = self.result.clone();
-            result.gas_remaining = message.gas_limit;
+            result.gas.set_remaining(message.gas_limit);
             Some(result)
         }
 
@@ -177,7 +177,7 @@ mod tests {
         fn call(&mut self, message: &mut Message) -> Option<MessageResult> {
             Some(MessageResult {
                 stop: InstrStop::Revert,
-                gas_remaining: message.gas_limit,
+                gas: GasTracker::new(message.gas_limit, message.gas_limit, 0),
                 ..Default::default()
             })
         }
@@ -199,7 +199,7 @@ mod tests {
             self.create_depth = Some(message.depth);
             Some(MessageResult {
                 stop: InstrStop::Return,
-                gas_remaining: message.gas_limit,
+                gas: GasTracker::new(message.gas_limit, message.gas_limit, 0),
                 created_address: Some(self.created),
                 ..Default::default()
             })
@@ -218,7 +218,7 @@ mod tests {
         fn create(&mut self, message: &mut Message) -> Option<MessageResult> {
             Some(MessageResult {
                 stop: InstrStop::Revert,
-                gas_remaining: message.gas_limit,
+                gas: GasTracker::new(message.gas_limit, message.gas_limit, 0),
                 ..Default::default()
             })
         }

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -9,8 +9,8 @@ use crate::{
     bytecode::Bytecode,
     env::{BlockEnv, TxEnv},
     interpreter::{
-        Gas, Host, InstrStop, Interpreter, InterpreterPool, Message, MessageKind, MessageResult,
-        Word,
+        Gas, GasTracker, Host, InstrStop, Interpreter, InterpreterPool, Message, MessageKind,
+        MessageResult, Word,
     },
     registry::{HandlerResult, TxRegistry},
     trustme,
@@ -426,24 +426,24 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
         message: &Message,
         caller_is_static: bool,
     ) -> MessageResult {
-        if let Err(stop) = self.check_create_funds(message) {
-            return MessageResult {
-                stop,
-                gas_remaining: message.gas_limit,
-                ..MessageResult::default()
-            };
-        }
+        self.execute_create_message_inner(tx_env, bytecode, message, caller_is_static)
+            .unwrap_or_else(|stop| Self::error_message_result(stop, message.gas_limit))
+    }
 
+    fn execute_create_message_inner(
+        &mut self,
+        tx_env: &TxEnv,
+        bytecode: Bytecode,
+        message: &Message,
+        caller_is_static: bool,
+    ) -> Result<MessageResult, InstrStop> {
+        self.check_create_funds(message)?;
         if message.depth > 0 {
             // EIP-2681 caps account nonces at u64::MAX; CREATE/CREATE2 return zero
             // instead of wrapping or saturating the creator nonce.
             // TODO: Fold this into nonce bumping so account info is not loaded repeatedly.
             if self.state.account_info(message.caller).is_some_and(|info| info.nonce == u64::MAX) {
-                return MessageResult {
-                    stop: InstrStop::Return,
-                    gas_remaining: message.gas_limit,
-                    ..MessageResult::default()
-                };
+                return Err(InstrStop::Return);
             }
         }
 
@@ -460,11 +460,7 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
             self.state.create_account(message.caller, address, message.value, self.spec_id())
         {
             self.state.rollback(checkpoint, self.spec_id());
-            return MessageResult {
-                stop,
-                gas_remaining: message.gas_limit,
-                ..MessageResult::default()
-            };
+            return Err(stop);
         }
 
         let create_message = Message {
@@ -485,64 +481,29 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
                 self.run_interpreter(bytecode, tx_env, &create_message, caller_is_static);
             (stop, interpreter.gas(), Bytes::copy_from_slice(interpreter.output()))
         };
-        let mut gas_remaining = gas.remaining();
-        let mut gas_refunded = if stop.is_success() { gas.refunded() } else { 0 };
 
         if stop.is_success() {
-            let stop = if self.spec_id().enables(SpecId::SPURIOUS_DRAGON)
-                && output.len() > self.version().max_code_size
-            {
-                Some(InstrStop::CreateContractSizeLimit)
-            } else if self.feature(EvmFeatures::EIP3541)
-                && output.first().is_some_and(|byte| *byte == 0xef)
-            {
-                Some(InstrStop::CreateContractStartingWithEF)
-            } else {
-                let code_deposit_gas = output
-                    .len()
-                    .saturating_mul(self.version().gas_params.get(GasId::CodeDepositCost) as usize);
-                let code_deposit_gas = u64::try_from(code_deposit_gas).unwrap_or(u64::MAX);
-                if gas.remaining() >= code_deposit_gas {
-                    gas.spend(code_deposit_gas).err()
-                } else if self.feature(EvmFeatures::EIP2) {
-                    // EIP-2 makes code-deposit OOG fail contract creation; Frontier instead
-                    // creates the account with empty code.
-                    Some(InstrStop::OutOfGas)
-                } else {
-                    output = Bytes::new();
-                    None
-                }
-            };
-
-            if let Some(stop) = stop {
+            if let Err(stop) = self.validate_create_output(&mut gas, &mut output) {
                 self.state.rollback(checkpoint, self.spec_id());
-                gas_remaining = if stop.is_halt() { 0 } else { gas.remaining() };
-                return MessageResult {
+                return Ok(MessageResult {
                     stop,
-                    gas_remaining,
-                    gas_refunded: 0,
+                    gas: Self::message_gas(*gas.tracker(), stop),
                     output,
                     created_address: None,
-                };
+                });
             }
 
-            gas_remaining = gas.remaining();
-            gas_refunded = gas.refunded();
             self.state.set_code(address, Bytecode::new_legacy(output.clone()));
         } else {
             self.state.rollback(checkpoint, self.spec_id());
-            if stop.is_halt() {
-                gas_remaining = 0;
-            }
         }
 
-        MessageResult {
+        Ok(MessageResult {
             stop,
-            gas_remaining,
-            gas_refunded: if stop.is_success() { gas_refunded } else { 0 },
+            gas: Self::message_gas(*gas.tracker(), stop),
             output,
             created_address: stop.is_success().then_some(address),
-        }
+        })
     }
 
     #[inline(never)]
@@ -555,6 +516,32 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
         {
             return Err(InstrStop::OutOfFunds);
         }
+        Ok(())
+    }
+
+    fn validate_create_output(&self, gas: &mut Gas, output: &mut Bytes) -> Result<(), InstrStop> {
+        if self.spec_id().enables(SpecId::SPURIOUS_DRAGON)
+            && output.len() > self.version().max_code_size
+        {
+            return Err(InstrStop::CreateContractSizeLimit);
+        }
+        if self.feature(EvmFeatures::EIP3541) && output.first().is_some_and(|byte| *byte == 0xef) {
+            return Err(InstrStop::CreateContractStartingWithEF);
+        }
+
+        let code_deposit_gas = output
+            .len()
+            .saturating_mul(self.version().gas_params.get(GasId::CodeDepositCost) as usize);
+        let code_deposit_gas = u64::try_from(code_deposit_gas).unwrap_or(u64::MAX);
+        if gas.remaining() >= code_deposit_gas {
+            return gas.spend(code_deposit_gas);
+        }
+        if self.feature(EvmFeatures::EIP2) {
+            // EIP-2 makes code-deposit OOG fail contract creation; Frontier instead creates the
+            // account with empty code.
+            return Err(InstrStop::OutOfGas);
+        }
+        *output = Bytes::new();
         Ok(())
     }
 
@@ -578,6 +565,17 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
         message: &Message,
         caller_is_static: bool,
     ) -> MessageResult {
+        self.execute_call_message_inner(tx_env, bytecode, message, caller_is_static)
+            .unwrap_or_else(|stop| Self::error_message_result(stop, message.gas_limit))
+    }
+
+    fn execute_call_message_inner(
+        &mut self,
+        tx_env: &TxEnv,
+        bytecode: Bytecode,
+        message: &Message,
+        caller_is_static: bool,
+    ) -> Result<MessageResult, InstrStop> {
         let checkpoint = self.state.checkpoint();
         // EIP-161 state clearing depends on zero-value direct call targets being touched.
         // CALLCODE also needs the value-transfer balance check.
@@ -586,39 +584,30 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
             MessageKind::Call | MessageKind::CallCode | MessageKind::StaticCall
         ) && !self.state.transfer(message.caller, message.destination, message.value)
         {
-            return MessageResult {
-                stop: InstrStop::OutOfFunds,
-                gas_remaining: message.gas_limit,
-                ..MessageResult::default()
-            };
+            return Err(InstrStop::OutOfFunds);
         }
 
         let mut gas = Gas::new(message.gas_limit);
         if let Some(result) = self.execute_precompile(message, &mut gas) {
-            let (stop, gas_remaining, output) = match result {
-                Ok(output) => (InstrStop::Return, gas.remaining(), output.into_bytes()),
-                Err(PrecompileError::Revert(output)) => {
-                    (InstrStop::Revert, gas.remaining(), output)
-                }
+            let (stop, output) = match result {
+                Ok(output) => (InstrStop::Return, output.into_bytes()),
+                Err(PrecompileError::Revert(output)) => (InstrStop::Revert, output),
                 Err(PrecompileError::Halt(PrecompileHalt::OutOfGas)) => {
-                    (InstrStop::PrecompileOOG, 0, Bytes::new())
+                    (InstrStop::PrecompileOOG, Bytes::new())
                 }
                 Err(PrecompileError::Halt(_) | PrecompileError::Fatal(_)) => {
-                    let stop = InstrStop::PrecompileError;
-                    let gas_remaining = if stop.is_halt() { 0 } else { gas.remaining() };
-                    (stop, gas_remaining, Bytes::new())
+                    (InstrStop::PrecompileError, Bytes::new())
                 }
             };
             if !stop.is_success() {
                 self.state.rollback(checkpoint, self.spec_id());
             }
-            return MessageResult {
+            return Ok(MessageResult {
                 stop,
-                gas_remaining,
-                gas_refunded: 0,
+                gas: Self::message_gas(*gas.tracker(), stop),
                 output,
                 created_address: None,
-            };
+            });
         }
 
         let (stop, child_gas, output) = {
@@ -626,22 +615,37 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
                 self.run_interpreter(bytecode, tx_env, message, caller_is_static);
             (stop, interpreter.gas(), Bytes::copy_from_slice(interpreter.output()))
         };
-        let mut gas_remaining = child_gas.remaining();
 
         if !stop.is_success() {
             self.state.rollback(checkpoint, self.spec_id());
-            if stop.is_halt() {
-                gas_remaining = 0;
-            }
         }
 
-        MessageResult {
+        Ok(MessageResult {
             stop,
-            gas_remaining,
-            gas_refunded: if stop.is_success() { child_gas.refunded() } else { 0 },
+            gas: Self::message_gas(*child_gas.tracker(), stop),
             output,
             created_address: None,
+        })
+    }
+
+    #[inline]
+    fn error_message_result(stop: InstrStop, gas_remaining: u64) -> MessageResult {
+        MessageResult {
+            stop,
+            gas: GasTracker::new(gas_remaining, gas_remaining, 0),
+            ..MessageResult::default()
         }
+    }
+
+    #[inline]
+    const fn message_gas(mut gas: GasTracker, stop: InstrStop) -> GasTracker {
+        if stop.is_halt() {
+            gas.set_remaining(0);
+        }
+        if !stop.is_success() {
+            gas.set_refunded(0);
+        }
+        gas
     }
 
     #[inline(never)]

--- a/crates/evm2/src/evm/system.rs
+++ b/crates/evm2/src/evm/system.rs
@@ -69,9 +69,9 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
             SYSTEM_CALL_GAS_LIMIT,
         );
         let result = Host::execute_message(self, &tx_env, bytecode, &message, false);
-        let gas_spent = SYSTEM_CALL_GAS_LIMIT.saturating_sub(result.gas_remaining);
-        let gas_refunded = if result.stop.is_success() && result.gas_refunded > 0 {
-            result.gas_refunded as u64
+        let gas_spent = SYSTEM_CALL_GAS_LIMIT.saturating_sub(result.gas.remaining());
+        let gas_refunded = if result.stop.is_success() && result.gas.refunded() > 0 {
+            result.gas.refunded() as u64
         } else {
             0
         };

--- a/crates/evm2/src/interpreter/host.rs
+++ b/crates/evm2/src/interpreter/host.rs
@@ -1,4 +1,4 @@
-use super::{InstrStop, Message, Result, Word};
+use super::{GasTracker, InstrStop, Message, Result, Word};
 use crate::{
     SpecId,
     bytecode::Bytecode,
@@ -18,16 +18,8 @@ use alloy_primitives::{Address, B256, Bytes, Log};
 pub struct MessageResult {
     /// Interpreter stop reason.
     pub stop: InstrStop,
-    /// Gas left in the child frame before refund accounting.
-    ///
-    /// Do not use this field directly for parent-frame or transaction-level refund handling; see
-    /// the [`MessageResult`] docs and helper methods.
-    pub gas_remaining: u64,
-    /// Raw refund counter produced by this frame.
-    ///
-    /// This value may be negative locally. Do not use this field directly for propagation or final
-    /// transaction refunds; see the [`MessageResult`] docs and helper methods.
-    pub gas_refunded: i64,
+    /// Gas accounting for the child frame.
+    pub gas: GasTracker,
     /// Return or revert output.
     pub output: Bytes,
     /// Created address for successful create messages.
@@ -50,24 +42,24 @@ impl MessageResult {
     /// Returns unused gas that should be returned to the parent frame.
     #[inline]
     pub const fn gas_returned_to_parent(&self) -> u64 {
-        if self.returns_unused_gas() { self.gas_remaining } else { 0 }
+        if self.returns_unused_gas() { self.gas.remaining() } else { 0 }
     }
 
     /// Returns the refund counter delta that should be propagated to the parent frame.
     #[inline]
     pub const fn refund_propagated_to_parent(&self) -> i64 {
-        if self.stop.is_success() { self.gas_refunded } else { 0 }
+        if self.stop.is_success() { self.gas.refunded() } else { 0 }
     }
 
     /// Calculates the final refund amount for a top-level transaction.
     #[inline]
     pub const fn final_refund(&self, gas_limit: u64, is_london: bool) -> u64 {
-        if self.gas_refunded <= 0 {
+        if self.gas.refunded() <= 0 {
             return 0;
         }
         let max_refund_quotient = if is_london { 5 } else { 2 };
-        let spent = gas_limit.saturating_sub(self.gas_remaining);
-        let refund = self.gas_refunded as u64;
+        let spent = gas_limit.saturating_sub(self.gas.remaining());
+        let refund = self.gas.refunded() as u64;
         let cap = spent / max_refund_quotient;
         if refund < cap { refund } else { cap }
     }
@@ -76,7 +68,7 @@ impl MessageResult {
     #[inline]
     pub const fn gas_remaining_after_final_refund(&self, gas_limit: u64, is_london: bool) -> u64 {
         let refunded = self.final_refund(gas_limit, is_london);
-        let remaining = self.gas_remaining.saturating_add(refunded);
+        let remaining = self.gas.remaining().saturating_add(refunded);
         if remaining < gas_limit { remaining } else { gas_limit }
     }
 

--- a/crates/evm2/src/interpreter/instructions/system.rs
+++ b/crates/evm2/src/interpreter/instructions/system.rs
@@ -4,8 +4,8 @@ use crate::{
     EvmFeatures, EvmTypes, SpecId,
     constants::{CALL_DEPTH_LIMIT, EIP7702_BYTECODE_LEN, EIP7702_MAGIC_BYTES, EIP7702_VERSION},
     interpreter::{
-        Host, InstrStop, InterpreterState, Message, MessageKind, MessageResult, Result, StackMut,
-        Word, memory::resize_memory, private::GasInstructionCx,
+        GasTracker, Host, InstrStop, InterpreterState, Message, MessageKind, MessageResult, Result,
+        StackMut, Word, memory::resize_memory, private::GasInstructionCx,
     },
     trustme,
     utils::{word_to_address, word_to_usize},
@@ -40,7 +40,11 @@ const fn should_charge_new_account_gas(
 
 #[inline]
 fn call_too_deep_result(gas_limit: u64) -> MessageResult {
-    MessageResult { stop: InstrStop::CallTooDeep, gas_remaining: gas_limit, ..Default::default() }
+    MessageResult {
+        stop: InstrStop::CallTooDeep,
+        gas: GasTracker::new(gas_limit, gas_limit, 0),
+        ..Default::default()
+    }
 }
 
 fn resize_memory_range<T: EvmTypes>(

--- a/crates/evm2/src/tests.rs
+++ b/crates/evm2/src/tests.rs
@@ -151,7 +151,7 @@ fn evm_propagates_child_sstore_negative_refund() {
     );
 
     assert!(result.stop.is_success());
-    assert_eq!(result.gas_refunded, 0);
+    assert_eq!(result.gas.refunded(), 0);
 }
 
 #[test]


### PR DESCRIPTION
This changes message execution results to carry a `GasTracker` instead of separate remaining-gas and refund counters. That keeps the gas state bundled through call/create execution and lets `MessageResult` helpers derive parent gas return, propagated refunds, and final transaction gas from the tracker.

The execute paths now use inner `Result<MessageResult, InstrStop>` helpers for early error exits, and create output validation returns `Result` directly instead of building optional errors.
