### PR TITLE
feat(evm): implement EIP-7981 access list costs

### DIFF
--- a/crates/evm2/src/ethereum/eip1559.rs
+++ b/crates/evm2/src/ethereum/eip1559.rs
@@ -41,7 +41,8 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
         access_list_storage_keys,
     );
     validate_intrinsic_gas(tx.gas_limit, intrinsic)?;
-    let floor_gas = floor_gas(req.host.version(), &tx.input);
+    let floor_gas =
+        floor_gas(req.host.version(), &tx.input, access_list_accounts, access_list_storage_keys);
     validate_floor_gas(tx.gas_limit, floor_gas)?;
     validate_regular_gas_limit_cap(req.host.version(), tx.gas_limit, intrinsic, floor_gas)?;
 

--- a/crates/evm2/src/ethereum/eip2930.rs
+++ b/crates/evm2/src/ethereum/eip2930.rs
@@ -36,7 +36,8 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
         access_list_storage_keys,
     );
     validate_intrinsic_gas(tx.gas_limit, intrinsic)?;
-    let floor_gas = floor_gas(req.host.version(), &tx.input);
+    let floor_gas =
+        floor_gas(req.host.version(), &tx.input, access_list_accounts, access_list_storage_keys);
     validate_floor_gas(tx.gas_limit, floor_gas)?;
     validate_regular_gas_limit_cap(req.host.version(), tx.gas_limit, intrinsic, floor_gas)?;
 

--- a/crates/evm2/src/ethereum/eip4844.rs
+++ b/crates/evm2/src/ethereum/eip4844.rs
@@ -46,7 +46,8 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
         access_list_storage_keys,
     );
     validate_intrinsic_gas(tx.gas_limit, intrinsic)?;
-    let floor_gas = floor_gas(req.host.version(), &tx.input);
+    let floor_gas =
+        floor_gas(req.host.version(), &tx.input, access_list_accounts, access_list_storage_keys);
     validate_floor_gas(tx.gas_limit, floor_gas)?;
     validate_regular_gas_limit_cap(req.host.version(), tx.gas_limit, intrinsic, floor_gas)?;
 

--- a/crates/evm2/src/ethereum/eip7702.rs
+++ b/crates/evm2/src/ethereum/eip7702.rs
@@ -47,7 +47,8 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
         access_list_storage_keys,
     ) + eip7702_authorization_gas(req.host, tx.authorization_list.len());
     validate_intrinsic_gas(tx.gas_limit, intrinsic)?;
-    let floor_gas = floor_gas(req.host.version(), &tx.input);
+    let floor_gas =
+        floor_gas(req.host.version(), &tx.input, access_list_accounts, access_list_storage_keys);
     validate_floor_gas(tx.gas_limit, floor_gas)?;
     validate_regular_gas_limit_cap(req.host.version(), tx.gas_limit, intrinsic, floor_gas)?;
 

--- a/crates/evm2/src/ethereum/legacy.rs
+++ b/crates/evm2/src/ethereum/legacy.rs
@@ -28,7 +28,7 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     validate_nonce_not_overflow(tx.nonce)?;
     let intrinsic = intrinsic_gas(req.host.version(), tx.to, &tx.input, 0, 0);
     validate_intrinsic_gas(tx.gas_limit, intrinsic)?;
-    let floor_gas = floor_gas(req.host.version(), &tx.input);
+    let floor_gas = floor_gas(req.host.version(), &tx.input, 0, 0);
     validate_floor_gas(tx.gas_limit, floor_gas)?;
     validate_regular_gas_limit_cap(req.host.version(), tx.gas_limit, intrinsic, floor_gas)?;
 

--- a/crates/evm2/src/ethereum/mod.rs
+++ b/crates/evm2/src/ethereum/mod.rs
@@ -449,8 +449,28 @@ pub(super) fn access_list_counts(access_list: &AccessList) -> (u64, u64) {
     (access_list.len() as u64, access_list.storage_keys_count() as u64)
 }
 
+const ACCESS_LIST_ADDRESS_FLOOR_TOKENS: u64 = 80;
+const ACCESS_LIST_STORAGE_KEY_FLOOR_TOKENS: u64 = 128;
+
+const fn access_list_floor_tokens(
+    version: &Version,
+    access_list_accounts: u64,
+    access_list_storage_keys: u64,
+) -> u64 {
+    if !version.feature(EvmFeatures::EIP7981) {
+        return 0;
+    }
+    access_list_accounts * ACCESS_LIST_ADDRESS_FLOOR_TOKENS
+        + access_list_storage_keys * ACCESS_LIST_STORAGE_KEY_FLOOR_TOKENS
+}
+
 /// Calculates transaction calldata floor gas.
-pub(super) fn floor_gas(version: &Version, input: &Bytes) -> u64 {
+pub(super) fn floor_gas(
+    version: &Version,
+    input: &Bytes,
+    access_list_accounts: u64,
+    access_list_storage_keys: u64,
+) -> u64 {
     if !version.feature(EvmFeatures::EIP7623) {
         return 0;
     }
@@ -461,7 +481,8 @@ pub(super) fn floor_gas(version: &Version, input: &Bytes) -> u64 {
     }
 
     let non_zero_multiplier = u64::from(params.get(GasId::TxTokenNonZeroByteMultiplier));
-    let mut tokens = 0;
+    let mut tokens =
+        access_list_floor_tokens(version, access_list_accounts, access_list_storage_keys);
     for byte in input {
         tokens += if *byte == 0 { 1 } else { non_zero_multiplier };
     }
@@ -485,6 +506,8 @@ pub(super) fn intrinsic_gas(
     }
     gas += access_list_accounts * u64::from(params.get(GasId::TxAccessListAddressCost));
     gas += access_list_storage_keys * u64::from(params.get(GasId::TxAccessListStorageKeyCost));
+    gas += access_list_floor_tokens(version, access_list_accounts, access_list_storage_keys)
+        * u64::from(params.get(GasId::TxFloorCostPerToken));
     if to.is_create() && version.feature(EvmFeatures::EIP2) {
         gas += 32_000;
     }
@@ -530,6 +553,16 @@ mod tests {
             intrinsic_gas(Version::base(SpecId::BERLIN), TxKind::Call(Address::ZERO), &input, 2, 3),
             21_000 + 2 * 2400 + 3 * 1900
         );
+        assert_eq!(
+            intrinsic_gas(
+                Version::base(SpecId::AMSTERDAM),
+                TxKind::Call(Address::ZERO),
+                &input,
+                1,
+                1
+            ),
+            21_000 + 2400 + 1900 + (80 + 128) * 16
+        );
     }
 
     #[test]
@@ -573,9 +606,19 @@ mod tests {
         let mut prague_without_eip7623 = Version::new(SpecId::PRAGUE);
         prague_without_eip7623.features.remove(EvmFeatures::EIP7623);
 
-        assert_eq!(floor_gas(Version::base(SpecId::SHANGHAI), &input), 0);
-        assert_eq!(floor_gas(Version::base(SpecId::PRAGUE), &input), 21_000 + 9 * 10);
-        assert_eq!(floor_gas(&prague_without_eip7623, &input), 0);
+        assert_eq!(floor_gas(Version::base(SpecId::SHANGHAI), &input, 0, 0), 0);
+        assert_eq!(floor_gas(Version::base(SpecId::PRAGUE), &input, 0, 0), 21_000 + 9 * 10);
+        assert_eq!(floor_gas(&prague_without_eip7623, &input, 0, 0), 0);
+    }
+
+    #[test]
+    fn floor_gas_charges_amsterdam_access_list_tokens() {
+        let input = Bytes::from(vec![1; 1000]);
+
+        assert_eq!(
+            floor_gas(Version::base(SpecId::AMSTERDAM), &input, 1, 1),
+            21_000 + (1000 * 4 + 80 + 128) * 16
+        );
     }
 
     #[test]

--- a/crates/evm2/src/interpreter/gas/mod.rs
+++ b/crates/evm2/src/interpreter/gas/mod.rs
@@ -31,6 +31,7 @@ pub(crate) const STANDARD_TOKEN_COST: u32 = 4;
 pub(crate) const NON_ZERO_BYTE_MULTIPLIER: u32 = 17;
 pub(crate) const NON_ZERO_BYTE_MULTIPLIER_ISTANBUL: u32 = 4;
 pub(crate) const TOTAL_COST_FLOOR_PER_TOKEN: u32 = 10;
+pub(crate) const TOTAL_COST_FLOOR_PER_TOKEN_AMSTERDAM: u32 = 16;
 pub(crate) const INITCODE_WORD_COST: u32 = 2;
 pub(crate) const CALL_STIPEND: u32 = 2300;
 pub(crate) const ISTANBUL_SLOAD_GAS: u32 = 800;

--- a/crates/evm2/src/version/features.rs
+++ b/crates/evm2/src/version/features.rs
@@ -172,6 +172,10 @@ evm_features! {
     ///
     /// Default: on
     FEE_CHARGE,
+    /// Applies [EIP-7981](https://eips.ethereum.org/EIPS/eip-7981) access-list data gas costs.
+    ///
+    /// Default: on since Amsterdam
+    EIP7981,
     /// Applies [EIP-8037](https://eips.ethereum.org/EIPS/eip-8037) state creation gas accounting.
     ///
     /// Default: on since Amsterdam

--- a/crates/evm2/src/version/mod.rs
+++ b/crates/evm2/src/version/mod.rs
@@ -639,6 +639,7 @@ evm_versions! {
 
     AMSTERDAM {
         features: [
+            EIP7981,
             EIP8037,
             EIP7708,
             EIP7708_DELAYED_BURN,
@@ -671,6 +672,7 @@ evm_versions! {
             CodeDepositState: AMSTERDAM_CPSB,
             CreateState: 112 * AMSTERDAM_CPSB,
             SstoreSetRefund: 32 * AMSTERDAM_CPSB + 2800,
+            TxFloorCostPerToken: TOTAL_COST_FLOOR_PER_TOKEN_AMSTERDAM,
             TxEip7702PerEmptyAccountCost: 7500 + (112 + 23) * AMSTERDAM_CPSB,
             TxEip7702AuthRefund: 112 * AMSTERDAM_CPSB,
             TxEip7702PerAuthState: (112 + 23) * AMSTERDAM_CPSB,


### PR DESCRIPTION
Implements [EIP-7981](https://eips.ethereum.org/EIPS/eip-7981) access-list byte footprint costs for Amsterdam intrinsic and floor gas validation. Access-list addresses and storage keys now contribute the added data cost to both paths.