### PR TITLE
fix(evm): use configured create tx gas

### DIFF
--- a/crates/evm2/src/ethereum/mod.rs
+++ b/crates/evm2/src/ethereum/mod.rs
@@ -509,7 +509,7 @@ pub(super) fn intrinsic_gas(
     gas += access_list_floor_tokens(version, access_list_accounts, access_list_storage_keys)
         * u64::from(params.get(GasId::TxFloorCostPerToken));
     if to.is_create() && version.feature(EvmFeatures::EIP2) {
-        gas += 32_000;
+        gas += u64::from(params.get(GasId::TxCreateCost));
     }
     if to.is_create() && version.feature(EvmFeatures::EIP3860) {
         gas += u64::from(params.get(GasId::TxInitcodeCost)) * num_words(input.len()) as u64;


### PR DESCRIPTION
Use `GasId::TxCreateCost` when calculating intrinsic gas for create transactions instead of hard-coding the legacy 32,000 gas value. This lets fork-specific gas tables, including Amsterdam, control the create transaction cost.