### PR TITLE
feat(db): add database state commits

### DIFF
--- a/crates/eest/src/state.rs
+++ b/crates/eest/src/state.rs
@@ -1,8 +1,7 @@
 use alloy_primitives::{Address, B256};
 use evm2::{
-    StorageKey,
     bytecode::Bytecode,
-    evm::{AccountInfo, InMemoryDB, StateChanges},
+    evm::{AccountInfo, DatabaseCommit, InMemoryDB, StateChanges},
 };
 
 /// Parses fixture bytecode into evm2 bytecode.
@@ -32,30 +31,7 @@ pub(crate) fn apply_state_changes(pre: &InMemoryDB, changes: &StateChanges) -> I
 
 /// Applies state changes to an in-memory database.
 pub(crate) fn apply_state_changes_in_place(database: &mut InMemoryDB, changes: &StateChanges) {
-    for (&code_hash, code) in &changes.code {
-        database.cache.contracts.insert(code_hash, code.clone());
-    }
-    for (&address, storage) in &changes.storage {
-        if storage.wipe {
-            database.cache.storage.retain(|key, _| key.address() != address);
-        }
-        for (&key, change) in &storage.slots {
-            if change.current.is_zero() {
-                database.cache.storage.remove(&StorageKey::new(address, key));
-            } else {
-                database.cache.storage.insert(StorageKey::new(address, key), change.current);
-            }
-        }
-    }
-    for (&address, change) in &changes.accounts {
-        match &change.current {
-            Some(info) => database.insert_account_info(address, info.clone()),
-            None => {
-                database.cache.accounts.remove(&address);
-                database.cache.storage.retain(|key, _| key.address() != address);
-            }
-        }
-    }
+    database.commit(changes);
 }
 
 /// Returns whether the given system contract exists with non-empty code.

--- a/crates/evm2/src/evm/db.rs
+++ b/crates/evm2/src/evm/db.rs
@@ -1,6 +1,6 @@
 //! Database helpers for the EVM state overlay.
 
-use super::state::AccountInfo;
+use super::state::{AccountInfo, StateChanges};
 use crate::{bytecode::Bytecode, interpreter::Word};
 use alloc::{boxed::Box, string::ToString};
 use alloy_primitives::{Address, B256, keccak256};
@@ -8,6 +8,12 @@ use core::any::Any;
 
 mod cache;
 pub use cache::{Cache, CacheDB, InMemoryDB};
+
+/// Commits accepted state changes to a database.
+pub trait DatabaseCommit {
+    /// Commits state changes to the database.
+    fn commit(&mut self, changes: &StateChanges);
+}
 
 /// Backing database view used to initialize mutable [`super::State`].
 pub trait Database: Any {

--- a/crates/evm2/src/evm/db/cache.rs
+++ b/crates/evm2/src/evm/db/cache.rs
@@ -1,9 +1,9 @@
 //! In-memory cache database.
 
-use super::{Database, EmptyDB};
+use super::{Database, DatabaseCommit, EmptyDB};
 use crate::{
     bytecode::Bytecode,
-    evm::state::AccountInfo,
+    evm::state::{AccountInfo, StateChanges},
     interpreter::Word,
     storage_key::{StorageKey, StorageKeyMap},
 };
@@ -117,6 +117,35 @@ impl<ExtDB> CacheDB<ExtDB> {
     #[inline]
     pub fn insert_block_hash(&mut self, number: Word, hash: B256) {
         self.cache.block_hashes.insert(number, hash);
+    }
+}
+
+impl<ExtDB> DatabaseCommit for CacheDB<ExtDB> {
+    fn commit(&mut self, changes: &StateChanges) {
+        for (&code_hash, code) in &changes.code {
+            self.cache.contracts.insert(code_hash, code.clone());
+        }
+        for (&address, storage) in &changes.storage {
+            if storage.wipe {
+                self.cache.storage.retain(|key, _| key.address() != address);
+            }
+            for (&key, change) in &storage.slots {
+                if change.current.is_zero() {
+                    self.cache.storage.remove(&StorageKey::new(address, key));
+                } else {
+                    self.cache.storage.insert(StorageKey::new(address, key), change.current);
+                }
+            }
+        }
+        for (&address, change) in &changes.accounts {
+            match &change.current {
+                Some(info) => self.insert_account_info(address, info.clone()),
+                None => {
+                    self.cache.accounts.remove(&address);
+                    self.cache.storage.retain(|key, _| key.address() != address);
+                }
+            }
+        }
     }
 }
 

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -32,7 +32,7 @@ pub use system::{
 };
 
 mod db;
-pub use db::{Cache, CacheDB, Database, EmptyDB, InMemoryDB};
+pub use db::{Cache, CacheDB, Database, DatabaseCommit, EmptyDB, InMemoryDB};
 
 mod state;
 pub use state::{

--- a/crates/evm2/src/evm/state.rs
+++ b/crates/evm2/src/evm/state.rs
@@ -1150,7 +1150,7 @@ impl State {
     /// writes as pending changes. This rolls the current account and storage
     /// values forward into their `original` slots and applies local deletion/wipe
     /// bookkeeping. It only advances the in-memory overlay; callers are still
-    /// responsible for applying the emitted write-set to their backing database
+    /// responsible for committing the emitted write-set to their backing database
     /// and clearing transaction-local state.
     pub(super) fn commit_transaction_overlay(&mut self) {
         for account in self.accounts.values_mut() {


### PR DESCRIPTION
Adds a DatabaseCommit trait for applying StateChanges to a database and implements it for CacheDB. Updates the EEST helper to use the shared commit implementation instead of duplicating state-change application logic.