### PR TITLE
feat(db): make database fallible

### DIFF
--- a/crates/evm2/src/ethereum/eip1559.rs
+++ b/crates/evm2/src/ethereum/eip1559.rs
@@ -53,8 +53,8 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     warm_access_list(req.host, &tx.access_list);
 
     let effective_gas_cost = U256::from(tx.gas_limit) * gas_price;
-    charge_upfront(req.host, caller, effective_gas_cost);
-    req.host.state.increment_nonce(caller);
+    charge_upfront(req.host, caller, effective_gas_cost)?;
+    req.host.state.increment_nonce(caller).map_err(|code| req.host.db_error_handler(code))?;
     let execution_checkpoint = req.host.state.checkpoint();
 
     let gas_limit = tx.gas_limit - intrinsic;
@@ -65,9 +65,9 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
         ..TxEnv::default()
     };
     let (bytecode, message) =
-        initial_message(req.host, caller, tx.nonce, tx.to, &tx.input, tx.value, gas_limit);
+        initial_message(req.host, caller, tx.nonce, tx.to, &tx.input, tx.value, gas_limit)?;
     let mut result = req.host.execute_message(&tx_env, bytecode, &message, false);
     rollback_failed_execution(req.host, execution_checkpoint, &mut result);
 
-    Ok(settle_gas(req.host, caller, gas_price, tx.gas_limit, floor_gas, result))
+    settle_gas(req.host, caller, gas_price, tx.gas_limit, floor_gas, result)
 }

--- a/crates/evm2/src/ethereum/eip2930.rs
+++ b/crates/evm2/src/ethereum/eip2930.rs
@@ -47,8 +47,8 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     warm_base_accounts(req.host, caller, tx.to);
     warm_access_list(req.host, &tx.access_list);
 
-    charge_upfront(req.host, caller, max_gas_cost);
-    req.host.state.increment_nonce(caller);
+    charge_upfront(req.host, caller, max_gas_cost)?;
+    req.host.state.increment_nonce(caller).map_err(|code| req.host.db_error_handler(code))?;
     let execution_checkpoint = req.host.state.checkpoint();
 
     let gas_limit = tx.gas_limit - intrinsic;
@@ -59,9 +59,9 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
         ..TxEnv::default()
     };
     let (bytecode, message) =
-        initial_message(req.host, caller, tx.nonce, tx.to, &tx.input, tx.value, gas_limit);
+        initial_message(req.host, caller, tx.nonce, tx.to, &tx.input, tx.value, gas_limit)?;
     let mut result = req.host.execute_message(&tx_env, bytecode, &message, false);
     rollback_failed_execution(req.host, execution_checkpoint, &mut result);
 
-    Ok(settle_gas(req.host, caller, gas_price, tx.gas_limit, floor_gas, result))
+    settle_gas(req.host, caller, gas_price, tx.gas_limit, floor_gas, result)
 }

--- a/crates/evm2/src/ethereum/eip4844.rs
+++ b/crates/evm2/src/ethereum/eip4844.rs
@@ -66,8 +66,8 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
 
     let effective_gas_cost = U256::from(tx.gas_limit) * gas_price;
     let blob_basefee_cost = blob_gas_cost * req.host.block.blob_basefee;
-    charge_upfront(req.host, caller, effective_gas_cost + blob_basefee_cost);
-    req.host.state.increment_nonce(caller);
+    charge_upfront(req.host, caller, effective_gas_cost + blob_basefee_cost)?;
+    req.host.state.increment_nonce(caller).map_err(|code| req.host.db_error_handler(code))?;
     let execution_checkpoint = req.host.state.checkpoint();
 
     let gas_limit = tx.gas_limit - intrinsic;
@@ -78,11 +78,11 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
         blob_hashes: tx.blob_versioned_hashes.iter().copied().map(b256_to_word).collect(),
     };
     let (bytecode, message) =
-        initial_message(req.host, caller, tx.nonce, tx.to.into(), &tx.input, tx.value, gas_limit);
+        initial_message(req.host, caller, tx.nonce, tx.to.into(), &tx.input, tx.value, gas_limit)?;
     let mut result = req.host.execute_message(&tx_env, bytecode, &message, false);
     rollback_failed_execution(req.host, execution_checkpoint, &mut result);
 
-    Ok(settle_gas(req.host, caller, gas_price, tx.gas_limit, floor_gas, result))
+    settle_gas(req.host, caller, gas_price, tx.gas_limit, floor_gas, result)
 }
 
 fn validate_blob_fee(max_fee_per_blob_gas: U256, blob_basefee: U256) -> HandlerResult<()> {

--- a/crates/evm2/src/ethereum/eip7702.rs
+++ b/crates/evm2/src/ethereum/eip7702.rs
@@ -59,10 +59,10 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     warm_access_list(req.host, &tx.access_list);
 
     let effective_gas_cost = U256::from(tx.gas_limit) * gas_price;
-    charge_upfront(req.host, caller, effective_gas_cost);
-    req.host.state.increment_nonce(caller);
+    charge_upfront(req.host, caller, effective_gas_cost)?;
+    req.host.state.increment_nonce(caller).map_err(|code| req.host.db_error_handler(code))?;
     let chain_id = req.host.version().chain_id;
-    let eip7702_refund = apply_auth_list(req.host, chain_id, &tx.authorization_list);
+    let eip7702_refund = apply_auth_list(req.host, chain_id, &tx.authorization_list)?;
     let execution_checkpoint = req.host.state.checkpoint();
 
     let gas_limit = tx.gas_limit - intrinsic;
@@ -73,14 +73,14 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
         ..TxEnv::default()
     };
     let (bytecode, message) =
-        initial_message(req.host, caller, tx.nonce, tx.to.into(), &tx.input, tx.value, gas_limit);
+        initial_message(req.host, caller, tx.nonce, tx.to.into(), &tx.input, tx.value, gas_limit)?;
     let mut result = req.host.execute_message(&tx_env, bytecode, &message, false);
     rollback_failed_execution(req.host, execution_checkpoint, &mut result);
     result.gas.set_refunded(
         result.gas.refunded().saturating_add(i64::try_from(eip7702_refund).unwrap_or(i64::MAX)),
     );
 
-    Ok(settle_gas(req.host, caller, gas_price, tx.gas_limit, floor_gas, result))
+    settle_gas(req.host, caller, gas_price, tx.gas_limit, floor_gas, result)
 }
 
 fn eip7702_authorization_gas<T: EvmTypes<Host = Evm<T>>>(
@@ -95,7 +95,7 @@ fn apply_auth_list<T: EvmTypes<Host = Evm<T>>>(
     host: &mut Evm<T>,
     chain_id: u64,
     authorizations: &[SignedAuthorization],
-) -> u64 {
+) -> HandlerResult<u64> {
     let mut refunded_accounts = 0u64;
     for authorization in authorizations {
         if !authorization.chain_id().is_zero() && authorization.chain_id() != &U256::from(chain_id)
@@ -110,10 +110,11 @@ fn apply_auth_list<T: EvmTypes<Host = Evm<T>>>(
             continue;
         };
         host.state.warm_account_non_revertible(authority);
-        let authority_info = host.state.account_info(authority);
+        let authority_info =
+            host.state.account_info(authority).map_err(|code| host.db_error_handler(code))?;
         let existed = authority_info.is_some();
         let authority_info = authority_info.unwrap_or_default();
-        let code = host.state.get_code(authority);
+        let code = host.state.get_code(authority).map_err(|code| host.db_error_handler(code))?;
         if !code.is_empty() && !code.is_eip7702() {
             continue;
         }
@@ -124,23 +125,24 @@ fn apply_auth_list<T: EvmTypes<Host = Evm<T>>>(
         if existed {
             refunded_accounts = refunded_accounts.saturating_add(1);
         }
-        set_delegation(host, authority, *authorization.address());
+        set_delegation(host, authority, *authorization.address())?;
     }
 
     let refund_per_auth = u64::from(host.version().gas_params.get(GasId::TxEip7702AuthRefund));
-    refunded_accounts.saturating_mul(refund_per_auth)
+    Ok(refunded_accounts.saturating_mul(refund_per_auth))
 }
 
 fn set_delegation<T: EvmTypes<Host = Evm<T>>>(
     host: &mut Evm<T>,
     authority: Address,
     delegated_address: Address,
-) {
+) -> HandlerResult<()> {
     let code = if delegated_address.is_zero() {
         Bytecode::default()
     } else {
         Bytecode::new_eip7702(delegated_address)
     };
-    host.state.set_code(authority, code);
-    host.state.increment_nonce(authority);
+    host.state.set_code(authority, code).map_err(|code| host.db_error_handler(code))?;
+    host.state.increment_nonce(authority).map_err(|code| host.db_error_handler(code))?;
+    Ok(())
 }

--- a/crates/evm2/src/ethereum/legacy.rs
+++ b/crates/evm2/src/ethereum/legacy.rs
@@ -37,8 +37,8 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
 
     warm_base_accounts(req.host, caller, tx.to);
 
-    charge_upfront(req.host, caller, max_gas_cost);
-    req.host.state.increment_nonce(caller);
+    charge_upfront(req.host, caller, max_gas_cost)?;
+    req.host.state.increment_nonce(caller).map_err(|code| req.host.db_error_handler(code))?;
     let execution_checkpoint = req.host.state.checkpoint();
 
     let gas_limit = tx.gas_limit - intrinsic;
@@ -49,9 +49,9 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
         ..TxEnv::default()
     };
     let (bytecode, message) =
-        initial_message(req.host, caller, tx.nonce, tx.to, &tx.input, tx.value, gas_limit);
+        initial_message(req.host, caller, tx.nonce, tx.to, &tx.input, tx.value, gas_limit)?;
     let mut result = req.host.execute_message(&tx_env, bytecode, &message, false);
     rollback_failed_execution(req.host, execution_checkpoint, &mut result);
 
-    Ok(settle_gas(req.host, caller, gas_price, tx.gas_limit, floor_gas, result))
+    settle_gas(req.host, caller, gas_price, tx.gas_limit, floor_gas, result)
 }

--- a/crates/evm2/src/ethereum/mod.rs
+++ b/crates/evm2/src/ethereum/mod.rs
@@ -259,9 +259,13 @@ pub(super) fn validate_sender<T: EvmTypes<Host = Evm<T>>>(
     nonce: u64,
     max_upfront: U256,
 ) -> HandlerResult<AccountInfo> {
-    let sender_info = host.state.account_info(caller).unwrap_or_default();
+    let sender_info = host
+        .state
+        .account_info(caller)
+        .map_err(|code| host.db_error_handler(code))?
+        .unwrap_or_default();
     if host.feature(EvmFeatures::EIP3607) && sender_info.code_hash != KECCAK256_EMPTY {
-        let code = host.state.get_code(caller);
+        let code = host.state.get_code(caller).map_err(|code| host.db_error_handler(code))?;
         if !code.is_empty() && !code.is_eip7702() {
             return Err(HandlerError::RejectCallerWithCode);
         }
@@ -273,7 +277,9 @@ pub(super) fn validate_sender<T: EvmTypes<Host = Evm<T>>>(
         return Err(HandlerError::InsufficientFunds);
     }
     if !host.feature(EvmFeatures::BALANCE_CHECK) && sender_info.balance < max_upfront {
-        host.state.add_balance(caller, max_upfront - sender_info.balance);
+        host.state
+            .add_balance(caller, max_upfront - sender_info.balance)
+            .map_err(|code| host.db_error_handler(code))?;
     }
     Ok(sender_info)
 }
@@ -310,11 +316,14 @@ pub(super) fn charge_upfront<T: EvmTypes<Host = Evm<T>>>(
     host: &mut Evm<T>,
     caller: Address,
     max_gas_cost: U256,
-) {
+) -> HandlerResult<()> {
     if !host.feature(EvmFeatures::FEE_CHARGE) {
-        return;
+        return Ok(());
     }
-    host.state.add_balance(caller, Word::ZERO.wrapping_sub(max_gas_cost));
+    host.state
+        .add_balance(caller, Word::ZERO.wrapping_sub(max_gas_cost))
+        .map_err(|code| host.db_error_handler(code))?;
+    Ok(())
 }
 
 pub(crate) fn initial_message<T: EvmTypes<Host = Evm<T>>>(
@@ -325,10 +334,10 @@ pub(crate) fn initial_message<T: EvmTypes<Host = Evm<T>>>(
     input: &Bytes,
     value: U256,
     gas_limit: u64,
-) -> (Bytecode, Message) {
+) -> HandlerResult<(Bytecode, Message)> {
     let r = match to {
         TxKind::Call(to) => {
-            let initial_code = initial_call_code(host, to);
+            let initial_code = initial_call_code(host, to)?;
             let message = Message {
                 kind: MessageKind::Call,
                 depth: 0,
@@ -361,7 +370,7 @@ pub(crate) fn initial_message<T: EvmTypes<Host = Evm<T>>>(
         }
     };
     debug_assert_eq!(r.1.depth, 0);
-    r
+    Ok(r)
 }
 
 struct InitialCallCode {
@@ -373,19 +382,22 @@ struct InitialCallCode {
 fn initial_call_code<T: EvmTypes<Host = Evm<T>>>(
     host: &mut Evm<T>,
     to: Address,
-) -> InitialCallCode {
-    let code = host.state.get_code(to);
+) -> HandlerResult<InitialCallCode> {
+    let code = host.state.get_code(to).map_err(|code| host.db_error_handler(code))?;
     if host.spec_id().enables(SpecId::PRAGUE)
         && let Some(delegated_address) = code.eip7702_address()
     {
         let _ = host.state.warm_account(delegated_address);
-        return InitialCallCode {
-            code: host.state.get_code(delegated_address),
+        return Ok(InitialCallCode {
+            code: host
+                .state
+                .get_code(delegated_address)
+                .map_err(|code| host.db_error_handler(code))?,
             code_address: delegated_address,
             disable_precompiles: true,
-        };
+        });
     }
-    InitialCallCode { code, code_address: to, disable_precompiles: false }
+    Ok(InitialCallCode { code, code_address: to, disable_precompiles: false })
 }
 
 pub(super) fn rollback_failed_execution<T: EvmTypes<Host = Evm<T>>>(
@@ -408,26 +420,29 @@ pub(super) fn settle_gas<T: EvmTypes<Host = Evm<T>>>(
     tx_gas_limit: u64,
     floor_gas: u64,
     result: MessageResult,
-) -> TxResult {
+) -> HandlerResult<TxResult> {
     let (gas_remaining, gas_used) =
         final_tx_gas(&result, tx_gas_limit, host.feature(EvmFeatures::EIP3529), floor_gas);
     if host.feature(EvmFeatures::FEE_CHARGE) {
-        host.state.add_balance(caller, U256::from(gas_remaining) * gas_price);
+        host.state
+            .add_balance(caller, U256::from(gas_remaining) * gas_price)
+            .map_err(|code| host.db_error_handler(code))?;
         let beneficiary_gas_price = if host.feature(EvmFeatures::BASE_FEE_CHECK) {
             gas_price.saturating_sub(host.block.basefee)
         } else {
             gas_price
         };
         host.state
-            .add_balance(host.block.beneficiary, U256::from(gas_used) * beneficiary_gas_price);
+            .add_balance(host.block.beneficiary, U256::from(gas_used) * beneficiary_gas_price)
+            .map_err(|code| host.db_error_handler(code))?;
     }
-    TxResult {
+    Ok(TxResult {
         status: result.stop.is_success(),
         gas_used,
         stop: result.stop,
         output: result.output,
         ..TxResult::default()
-    }
+    })
 }
 
 const fn final_tx_gas(
@@ -687,7 +702,7 @@ mod tests {
         );
 
         assert!(validate_sender(&mut evm, caller, 0, U256::from(100)).is_ok());
-        assert_eq!(evm.state.account_info(caller).unwrap().balance, U256::from(100));
+        assert_eq!(evm.state.account_info(caller).unwrap().unwrap().balance, U256::from(100));
     }
 
     #[test]
@@ -753,7 +768,8 @@ mod tests {
             &Bytes::new(),
             U256::ZERO,
             100_000,
-        );
+        )
+        .unwrap();
         assert_eq!(message.destination, target);
         assert_eq!(message.code_address, delegated);
         assert!(message.disable_precompiles);

--- a/crates/evm2/src/evm/db.rs
+++ b/crates/evm2/src/evm/db.rs
@@ -4,7 +4,7 @@ use super::state::{AccountInfo, StateChanges};
 use crate::{bytecode::Bytecode, interpreter::Word};
 use alloc::{boxed::Box, string::ToString};
 use alloy_primitives::{Address, B256, keccak256};
-use core::{any::Any, error::Error, fmt};
+use core::{any::Any, error::Error, fmt, num::NonZeroUsize};
 
 mod cache;
 pub use cache::{Cache, CacheDB, InMemoryDB};
@@ -16,8 +16,25 @@ pub trait DatabaseCommit {
 }
 
 /// Lightweight handle for a database error.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
-pub struct DbErrorCode(pub usize);
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct DbErrorCode(NonZeroUsize);
+
+impl DbErrorCode {
+    /// Creates a database error code.
+    #[inline]
+    pub const fn new(code: usize) -> Option<Self> {
+        let Some(code) = NonZeroUsize::new(code) else {
+            return None;
+        };
+        Some(Self(code))
+    }
+
+    /// Returns the raw database error code.
+    #[inline]
+    pub const fn get(self) -> usize {
+        self.0.get()
+    }
+}
 
 /// Result of a database operation.
 pub type DbResult<T> = Result<T, DbErrorCode>;

--- a/crates/evm2/src/evm/db.rs
+++ b/crates/evm2/src/evm/db.rs
@@ -4,7 +4,7 @@ use super::state::{AccountInfo, StateChanges};
 use crate::{bytecode::Bytecode, interpreter::Word};
 use alloc::{boxed::Box, string::ToString};
 use alloy_primitives::{Address, B256, keccak256};
-use core::any::Any;
+use core::{any::Any, error::Error, fmt};
 
 mod cache;
 pub use cache::{Cache, CacheDB, InMemoryDB};
@@ -15,40 +15,68 @@ pub trait DatabaseCommit {
     fn commit(&mut self, changes: &StateChanges);
 }
 
+/// Lightweight handle for a database error.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub struct DbErrorCode(pub usize);
+
+/// Result of a database operation.
+pub type DbResult<T> = Result<T, DbErrorCode>;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct DbErrorUnavailable(DbErrorCode);
+
+impl fmt::Display for DbErrorUnavailable {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "database error {:?} is unavailable", self.0)
+    }
+}
+
+impl Error for DbErrorUnavailable {}
+
 /// Backing database view used to initialize mutable [`super::State`].
 pub trait Database: Any {
     /// Loads account information.
-    fn get_account(&mut self, address: Address) -> Option<AccountInfo>;
+    fn get_account(&mut self, address: Address) -> DbResult<Option<AccountInfo>>;
 
     /// Loads bytecode by code hash.
-    fn get_code_by_hash(&mut self, code_hash: B256) -> Bytecode;
+    fn get_code_by_hash(&mut self, code_hash: B256) -> DbResult<Bytecode>;
 
     /// Loads a persistent storage slot.
-    fn get_storage(&mut self, address: Address, key: Word) -> Word;
+    fn get_storage(&mut self, address: Address, key: Word) -> DbResult<Word>;
 
     /// Loads a historical block hash.
-    fn get_block_hash(&mut self, number: Word) -> Option<B256>;
+    fn get_block_hash(&mut self, number: Word) -> DbResult<Option<B256>>;
+
+    /// Retrieves the full error for a previously returned error code.
+    fn error(&mut self, code: DbErrorCode) -> Box<dyn Error> {
+        Box::new(DbErrorUnavailable(code))
+    }
 }
 
 impl Database for Box<dyn Database> {
     #[inline]
-    fn get_account(&mut self, address: Address) -> Option<AccountInfo> {
+    fn get_account(&mut self, address: Address) -> DbResult<Option<AccountInfo>> {
         self.as_mut().get_account(address)
     }
 
     #[inline]
-    fn get_code_by_hash(&mut self, code_hash: B256) -> Bytecode {
+    fn get_code_by_hash(&mut self, code_hash: B256) -> DbResult<Bytecode> {
         self.as_mut().get_code_by_hash(code_hash)
     }
 
     #[inline]
-    fn get_storage(&mut self, address: Address, key: Word) -> Word {
+    fn get_storage(&mut self, address: Address, key: Word) -> DbResult<Word> {
         self.as_mut().get_storage(address, key)
     }
 
     #[inline]
-    fn get_block_hash(&mut self, number: Word) -> Option<B256> {
+    fn get_block_hash(&mut self, number: Word) -> DbResult<Option<B256>> {
         self.as_mut().get_block_hash(number)
+    }
+
+    #[inline]
+    fn error(&mut self, code: DbErrorCode) -> Box<dyn Error> {
+        self.as_mut().error(code)
     }
 }
 
@@ -58,22 +86,22 @@ pub struct EmptyDB(());
 
 impl Database for EmptyDB {
     #[inline]
-    fn get_account(&mut self, _address: Address) -> Option<AccountInfo> {
-        None
+    fn get_account(&mut self, _address: Address) -> DbResult<Option<AccountInfo>> {
+        Ok(None)
     }
 
     #[inline]
-    fn get_code_by_hash(&mut self, _code_hash: B256) -> Bytecode {
-        Bytecode::default()
+    fn get_code_by_hash(&mut self, _code_hash: B256) -> DbResult<Bytecode> {
+        Ok(Bytecode::default())
     }
 
     #[inline]
-    fn get_storage(&mut self, _address: Address, _key: Word) -> Word {
-        Word::ZERO
+    fn get_storage(&mut self, _address: Address, _key: Word) -> DbResult<Word> {
+        Ok(Word::ZERO)
     }
 
     #[inline]
-    fn get_block_hash(&mut self, number: Word) -> Option<B256> {
-        Some(keccak256(number.to_string().as_bytes()))
+    fn get_block_hash(&mut self, number: Word) -> DbResult<Option<B256>> {
+        Ok(Some(keccak256(number.to_string().as_bytes())))
     }
 }

--- a/crates/evm2/src/evm/db.rs
+++ b/crates/evm2/src/evm/db.rs
@@ -48,7 +48,7 @@ impl DbErrorCode {
 pub type DbResult<T> = Result<T, DbErrorCode>;
 
 /// Backing database implementation with a concrete error type.
-pub trait DbTyped: Any {
+pub trait Database: Any {
     /// Database error type.
     type Error: Error + 'static;
 
@@ -67,12 +67,12 @@ pub trait DbTyped: Any {
 
 /// Object-safe database adapter for typed database implementations.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub struct Db<T: DbTyped> {
+pub struct Db<T: Database> {
     db: T,
     result: Option<T::Error>,
 }
 
-impl<T: DbTyped> Db<T> {
+impl<T: Database> Db<T> {
     /// Creates a new database adapter.
     #[inline]
     pub const fn new(db: T) -> Self {
@@ -116,7 +116,7 @@ impl<T: DbTyped> Db<T> {
     }
 }
 
-impl<T: DbTyped + DatabaseCommit> DatabaseCommit for Db<T> {
+impl<T: Database + DatabaseCommit> DatabaseCommit for Db<T> {
     #[inline]
     fn commit(&mut self, changes: &StateChanges) {
         self.db.commit(changes);
@@ -142,7 +142,7 @@ impl fmt::Display for DbErrorUnavailable {
 
 impl Error for DbErrorUnavailable {}
 
-impl<T: DbTyped> Database for Db<T> {
+impl<T: Database> DynDatabase for Db<T> {
     #[inline]
     fn get_account(&mut self, address: Address) -> DbResult<Option<AccountInfo>> {
         self.db.get_account(address).map_err(|err| self.store_error(err))
@@ -175,7 +175,7 @@ impl<T: DbTyped> Database for Db<T> {
 }
 
 /// Backing database view used to initialize mutable [`super::State`].
-pub trait Database: Any {
+pub trait DynDatabase: Any {
     /// Loads account information.
     fn get_account(&mut self, address: Address) -> DbResult<Option<AccountInfo>>;
 
@@ -194,7 +194,7 @@ pub trait Database: Any {
     }
 }
 
-impl Database for Box<dyn Database> {
+impl DynDatabase for Box<dyn DynDatabase> {
     #[inline]
     fn get_account(&mut self, address: Address) -> DbResult<Option<AccountInfo>> {
         self.as_mut().get_account(address)
@@ -225,7 +225,7 @@ impl Database for Box<dyn Database> {
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct EmptyDB(());
 
-impl DbTyped for EmptyDB {
+impl Database for EmptyDB {
     type Error = core::convert::Infallible;
 
     #[inline]
@@ -249,7 +249,7 @@ impl DbTyped for EmptyDB {
     }
 }
 
-impl Database for EmptyDB {
+impl DynDatabase for EmptyDB {
     #[inline]
     fn get_account(&mut self, address: Address) -> DbResult<Option<AccountInfo>> {
         Db::new(*self).get_account(address)

--- a/crates/evm2/src/evm/db.rs
+++ b/crates/evm2/src/evm/db.rs
@@ -34,10 +34,102 @@ impl DbErrorCode {
     pub const fn get(self) -> usize {
         self.0.get()
     }
+
+    /// Updates the raw database error code.
+    #[inline]
+    pub fn set(&mut self, code: usize) -> Option<()> {
+        let code = NonZeroUsize::new(code)?;
+        self.0 = code;
+        Some(())
+    }
 }
 
 /// Result of a database operation.
 pub type DbResult<T> = Result<T, DbErrorCode>;
+
+/// Backing database implementation with a concrete error type.
+pub trait DbTyped: Any {
+    /// Database error type.
+    type Error: Error + 'static;
+
+    /// Loads account information.
+    fn get_account(&mut self, address: Address) -> Result<Option<AccountInfo>, Self::Error>;
+
+    /// Loads bytecode by code hash.
+    fn get_code_by_hash(&mut self, code_hash: B256) -> Result<Bytecode, Self::Error>;
+
+    /// Loads a persistent storage slot.
+    fn get_storage(&mut self, address: Address, key: Word) -> Result<Word, Self::Error>;
+
+    /// Loads a historical block hash.
+    fn get_block_hash(&mut self, number: Word) -> Result<Option<B256>, Self::Error>;
+}
+
+/// Object-safe database adapter for typed database implementations.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct Db<T: DbTyped> {
+    db: T,
+    result: Option<T::Error>,
+}
+
+impl<T: DbTyped> Db<T> {
+    /// Creates a new database adapter.
+    #[inline]
+    pub const fn new(db: T) -> Self {
+        Self { db, result: None }
+    }
+
+    /// Returns the wrapped database.
+    #[inline]
+    pub const fn inner(&self) -> &T {
+        &self.db
+    }
+
+    /// Returns the wrapped database mutably.
+    #[inline]
+    pub const fn inner_mut(&mut self) -> &mut T {
+        &mut self.db
+    }
+
+    /// Consumes the adapter and returns the wrapped database.
+    #[inline]
+    pub fn into_inner(self) -> T {
+        self.db
+    }
+
+    /// Returns the stored database error.
+    #[inline]
+    pub const fn result(&self) -> Option<&T::Error> {
+        self.result.as_ref()
+    }
+
+    /// Takes the stored database error.
+    #[inline]
+    pub const fn take_result(&mut self) -> Option<T::Error> {
+        self.result.take()
+    }
+
+    #[inline]
+    fn store_error(&mut self, err: T::Error) -> DbErrorCode {
+        self.result = Some(err);
+        stored_error_code()
+    }
+}
+
+impl<T: DbTyped + DatabaseCommit> DatabaseCommit for Db<T> {
+    #[inline]
+    fn commit(&mut self, changes: &StateChanges) {
+        self.db.commit(changes);
+    }
+}
+
+#[inline]
+fn stored_error_code() -> DbErrorCode {
+    match DbErrorCode::new(1) {
+        Some(code) => code,
+        None => unreachable!("stored database error code is non-zero"),
+    }
+}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct DbErrorUnavailable(DbErrorCode);
@@ -49,6 +141,38 @@ impl fmt::Display for DbErrorUnavailable {
 }
 
 impl Error for DbErrorUnavailable {}
+
+impl<T: DbTyped> Database for Db<T> {
+    #[inline]
+    fn get_account(&mut self, address: Address) -> DbResult<Option<AccountInfo>> {
+        self.db.get_account(address).map_err(|err| self.store_error(err))
+    }
+
+    #[inline]
+    fn get_code_by_hash(&mut self, code_hash: B256) -> DbResult<Bytecode> {
+        self.db.get_code_by_hash(code_hash).map_err(|err| self.store_error(err))
+    }
+
+    #[inline]
+    fn get_storage(&mut self, address: Address, key: Word) -> DbResult<Word> {
+        self.db.get_storage(address, key).map_err(|err| self.store_error(err))
+    }
+
+    #[inline]
+    fn get_block_hash(&mut self, number: Word) -> DbResult<Option<B256>> {
+        self.db.get_block_hash(number).map_err(|err| self.store_error(err))
+    }
+
+    #[inline]
+    fn error(&mut self, code: DbErrorCode) -> Box<dyn Error> {
+        if code == stored_error_code()
+            && let Some(err) = self.result.take()
+        {
+            return Box::new(err);
+        }
+        Box::new(DbErrorUnavailable(code))
+    }
+}
 
 /// Backing database view used to initialize mutable [`super::State`].
 pub trait Database: Any {
@@ -101,24 +225,48 @@ impl Database for Box<dyn Database> {
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct EmptyDB(());
 
-impl Database for EmptyDB {
+impl DbTyped for EmptyDB {
+    type Error = core::convert::Infallible;
+
     #[inline]
-    fn get_account(&mut self, _address: Address) -> DbResult<Option<AccountInfo>> {
+    fn get_account(&mut self, _address: Address) -> Result<Option<AccountInfo>, Self::Error> {
         Ok(None)
     }
 
     #[inline]
-    fn get_code_by_hash(&mut self, _code_hash: B256) -> DbResult<Bytecode> {
+    fn get_code_by_hash(&mut self, _code_hash: B256) -> Result<Bytecode, Self::Error> {
         Ok(Bytecode::default())
     }
 
     #[inline]
-    fn get_storage(&mut self, _address: Address, _key: Word) -> DbResult<Word> {
+    fn get_storage(&mut self, _address: Address, _key: Word) -> Result<Word, Self::Error> {
         Ok(Word::ZERO)
     }
 
     #[inline]
-    fn get_block_hash(&mut self, number: Word) -> DbResult<Option<B256>> {
+    fn get_block_hash(&mut self, number: Word) -> Result<Option<B256>, Self::Error> {
         Ok(Some(keccak256(number.to_string().as_bytes())))
+    }
+}
+
+impl Database for EmptyDB {
+    #[inline]
+    fn get_account(&mut self, address: Address) -> DbResult<Option<AccountInfo>> {
+        Db::new(*self).get_account(address)
+    }
+
+    #[inline]
+    fn get_code_by_hash(&mut self, code_hash: B256) -> DbResult<Bytecode> {
+        Db::new(*self).get_code_by_hash(code_hash)
+    }
+
+    #[inline]
+    fn get_storage(&mut self, address: Address, key: Word) -> DbResult<Word> {
+        Db::new(*self).get_storage(address, key)
+    }
+
+    #[inline]
+    fn get_block_hash(&mut self, number: Word) -> DbResult<Option<B256>> {
+        Db::new(*self).get_block_hash(number)
     }
 }

--- a/crates/evm2/src/evm/db/cache.rs
+++ b/crates/evm2/src/evm/db/cache.rs
@@ -1,6 +1,6 @@
 //! In-memory cache database.
 
-use super::{Database, DatabaseCommit, DbErrorCode, DbResult, EmptyDB};
+use super::{DatabaseCommit, DbErrorCode, DbResult, DynDatabase, EmptyDB};
 use crate::{
     bytecode::Bytecode,
     evm::state::{AccountInfo, StateChanges},
@@ -149,7 +149,7 @@ impl<ExtDB> DatabaseCommit for CacheDB<ExtDB> {
     }
 }
 
-impl<ExtDB: Database> Database for CacheDB<ExtDB> {
+impl<ExtDB: DynDatabase> DynDatabase for CacheDB<ExtDB> {
     #[inline]
     fn get_account(&mut self, address: Address) -> DbResult<Option<AccountInfo>> {
         let Cache { accounts, contracts, .. } = &mut self.cache;
@@ -221,7 +221,7 @@ mod tests {
         block_hash_loads: usize,
     }
 
-    impl crate::evm::DbTyped for CountingDB {
+    impl crate::evm::Database for CountingDB {
         type Error = core::convert::Infallible;
 
         fn get_account(&mut self, _address: Address) -> Result<Option<AccountInfo>, Self::Error> {

--- a/crates/evm2/src/evm/db/cache.rs
+++ b/crates/evm2/src/evm/db/cache.rs
@@ -1,6 +1,6 @@
 //! In-memory cache database.
 
-use super::{Database, DatabaseCommit, EmptyDB};
+use super::{Database, DatabaseCommit, DbErrorCode, DbResult, EmptyDB};
 use crate::{
     bytecode::Bytecode,
     evm::state::{AccountInfo, StateChanges},
@@ -151,47 +151,56 @@ impl<ExtDB> DatabaseCommit for CacheDB<ExtDB> {
 
 impl<ExtDB: Database> Database for CacheDB<ExtDB> {
     #[inline]
-    fn get_account(&mut self, address: Address) -> Option<AccountInfo> {
+    fn get_account(&mut self, address: Address) -> DbResult<Option<AccountInfo>> {
         let Cache { accounts, contracts, .. } = &mut self.cache;
         match accounts.entry(address) {
-            Entry::Occupied(entry) => Some(entry.get().clone()),
+            Entry::Occupied(entry) => Ok(Some(entry.get().clone())),
             Entry::Vacant(entry) => {
-                let mut info = self.db.get_account(address)?;
+                let Some(mut info) = self.db.get_account(address)? else {
+                    return Ok(None);
+                };
                 Self::insert_contract_inner(contracts, &mut info);
                 info.code = None;
-                Some(entry.insert(info).clone())
+                Ok(Some(entry.insert(info).clone()))
             }
         }
     }
 
     #[inline]
-    fn get_code_by_hash(&mut self, code_hash: B256) -> Bytecode {
+    fn get_code_by_hash(&mut self, code_hash: B256) -> DbResult<Bytecode> {
         match self.cache.contracts.entry(code_hash) {
-            Entry::Occupied(entry) => entry.get().clone(),
-            Entry::Vacant(entry) => entry.insert(self.db.get_code_by_hash(code_hash)).clone(),
+            Entry::Occupied(entry) => Ok(entry.get().clone()),
+            Entry::Vacant(entry) => Ok(entry.insert(self.db.get_code_by_hash(code_hash)?).clone()),
         }
     }
 
     #[inline]
-    fn get_storage(&mut self, address: Address, key: Word) -> Word {
+    fn get_storage(&mut self, address: Address, key: Word) -> DbResult<Word> {
         match self.cache.storage.entry(StorageKey::new(address, key)) {
-            Entry::Occupied(entry) => *entry.get(),
+            Entry::Occupied(entry) => Ok(*entry.get()),
             Entry::Vacant(entry) => {
-                let value = self.db.get_storage(address, key);
-                *entry.insert(value)
+                let value = self.db.get_storage(address, key)?;
+                Ok(*entry.insert(value))
             }
         }
     }
 
     #[inline]
-    fn get_block_hash(&mut self, number: Word) -> Option<B256> {
+    fn get_block_hash(&mut self, number: Word) -> DbResult<Option<B256>> {
         match self.cache.block_hashes.entry(number) {
-            Entry::Occupied(entry) => Some(*entry.get()),
+            Entry::Occupied(entry) => Ok(Some(*entry.get())),
             Entry::Vacant(entry) => {
-                let hash = self.db.get_block_hash(number)?;
-                Some(*entry.insert(hash))
+                let Some(hash) = self.db.get_block_hash(number)? else {
+                    return Ok(None);
+                };
+                Ok(Some(*entry.insert(hash)))
             }
         }
+    }
+
+    #[inline]
+    fn error(&mut self, code: DbErrorCode) -> alloc::boxed::Box<dyn core::error::Error> {
+        self.db.error(code)
     }
 }
 
@@ -213,28 +222,29 @@ mod tests {
     }
 
     impl Database for CountingDB {
-        fn get_account(&mut self, _address: Address) -> Option<AccountInfo> {
+        fn get_account(&mut self, _address: Address) -> DbResult<Option<AccountInfo>> {
             self.account_loads += 1;
-            self.account.clone()
+            Ok(self.account.clone())
         }
 
-        fn get_code_by_hash(&mut self, code_hash: B256) -> Bytecode {
+        fn get_code_by_hash(&mut self, code_hash: B256) -> DbResult<Bytecode> {
             self.code_loads += 1;
-            self.account
+            Ok(self
+                .account
                 .as_ref()
                 .filter(|info| info.code_hash == code_hash)
                 .and_then(|info| info.code.clone())
-                .unwrap_or_default()
+                .unwrap_or_default())
         }
 
-        fn get_storage(&mut self, _address: Address, _key: Word) -> Word {
+        fn get_storage(&mut self, _address: Address, _key: Word) -> DbResult<Word> {
             self.storage_loads += 1;
-            self.storage
+            Ok(self.storage)
         }
 
-        fn get_block_hash(&mut self, _number: Word) -> Option<B256> {
+        fn get_block_hash(&mut self, _number: Word) -> DbResult<Option<B256>> {
             self.block_hash_loads += 1;
-            self.block_hash
+            Ok(self.block_hash)
         }
     }
 
@@ -253,18 +263,18 @@ mod tests {
         let mut cache = CacheDB::new(db);
 
         let code_hash = code.hash_slow();
-        assert_eq!(cache.get_account(address).map(|info| info.code_hash), Some(code_hash));
-        assert_eq!(cache.get_code_by_hash(code_hash), code);
-        assert_eq!(cache.get_code_by_hash(code_hash), code);
+        assert_eq!(cache.get_account(address).unwrap().map(|info| info.code_hash), Some(code_hash));
+        assert_eq!(cache.get_code_by_hash(code_hash).unwrap(), code);
+        assert_eq!(cache.get_code_by_hash(code_hash).unwrap(), code);
         assert_eq!(cache.db.account_loads, 1);
         assert_eq!(cache.db.code_loads, 0);
 
-        assert_eq!(cache.get_storage(address, key), Word::from(4));
-        assert_eq!(cache.get_storage(address, key), Word::from(4));
+        assert_eq!(cache.get_storage(address, key).unwrap(), Word::from(4));
+        assert_eq!(cache.get_storage(address, key).unwrap(), Word::from(4));
         assert_eq!(cache.db.storage_loads, 1);
 
-        assert_eq!(cache.get_block_hash(Word::from(5)), Some(block_hash));
-        assert_eq!(cache.get_block_hash(Word::from(5)), Some(block_hash));
+        assert_eq!(cache.get_block_hash(Word::from(5)).unwrap(), Some(block_hash));
+        assert_eq!(cache.get_block_hash(Word::from(5)).unwrap(), Some(block_hash));
         assert_eq!(cache.db.block_hash_loads, 1);
     }
 }

--- a/crates/evm2/src/evm/db/cache.rs
+++ b/crates/evm2/src/evm/db/cache.rs
@@ -221,13 +221,15 @@ mod tests {
         block_hash_loads: usize,
     }
 
-    impl Database for CountingDB {
-        fn get_account(&mut self, _address: Address) -> DbResult<Option<AccountInfo>> {
+    impl crate::evm::DbTyped for CountingDB {
+        type Error = core::convert::Infallible;
+
+        fn get_account(&mut self, _address: Address) -> Result<Option<AccountInfo>, Self::Error> {
             self.account_loads += 1;
             Ok(self.account.clone())
         }
 
-        fn get_code_by_hash(&mut self, code_hash: B256) -> DbResult<Bytecode> {
+        fn get_code_by_hash(&mut self, code_hash: B256) -> Result<Bytecode, Self::Error> {
             self.code_loads += 1;
             Ok(self
                 .account
@@ -237,12 +239,12 @@ mod tests {
                 .unwrap_or_default())
         }
 
-        fn get_storage(&mut self, _address: Address, _key: Word) -> DbResult<Word> {
+        fn get_storage(&mut self, _address: Address, _key: Word) -> Result<Word, Self::Error> {
             self.storage_loads += 1;
             Ok(self.storage)
         }
 
-        fn get_block_hash(&mut self, _number: Word) -> DbResult<Option<B256>> {
+        fn get_block_hash(&mut self, _number: Word) -> Result<Option<B256>, Self::Error> {
             self.block_hash_loads += 1;
             Ok(self.block_hash)
         }
@@ -260,21 +262,21 @@ mod tests {
             block_hash: Some(block_hash),
             ..CountingDB::default()
         };
-        let mut cache = CacheDB::new(db);
+        let mut cache = CacheDB::new(crate::evm::Db::new(db));
 
         let code_hash = code.hash_slow();
         assert_eq!(cache.get_account(address).unwrap().map(|info| info.code_hash), Some(code_hash));
         assert_eq!(cache.get_code_by_hash(code_hash).unwrap(), code);
         assert_eq!(cache.get_code_by_hash(code_hash).unwrap(), code);
-        assert_eq!(cache.db.account_loads, 1);
-        assert_eq!(cache.db.code_loads, 0);
+        assert_eq!(cache.db.inner().account_loads, 1);
+        assert_eq!(cache.db.inner().code_loads, 0);
 
         assert_eq!(cache.get_storage(address, key).unwrap(), Word::from(4));
         assert_eq!(cache.get_storage(address, key).unwrap(), Word::from(4));
-        assert_eq!(cache.db.storage_loads, 1);
+        assert_eq!(cache.db.inner().storage_loads, 1);
 
         assert_eq!(cache.get_block_hash(Word::from(5)).unwrap(), Some(block_hash));
         assert_eq!(cache.get_block_hash(Word::from(5)).unwrap(), Some(block_hash));
-        assert_eq!(cache.db.block_hash_loads, 1);
+        assert_eq!(cache.db.inner().block_hash_loads, 1);
     }
 }

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -992,7 +992,7 @@ mod tests {
         interpreter::{MessageKind, op},
         registry::TxRequest,
     };
-    use alloc::{boxed::Box, vec, vec::Vec};
+    use alloc::{boxed::Box, string::ToString, vec, vec::Vec};
     use alloy_consensus::{TxLegacy, transaction::Recovered};
     use alloy_primitives::{Address, Bytes, KECCAK256_EMPTY, U256};
     use core::{error::Error, fmt};

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -34,7 +34,7 @@ pub use system::{
 
 mod db;
 pub use db::{
-    Cache, CacheDB, Database, DatabaseCommit, Db, DbErrorCode, DbResult, DbTyped, EmptyDB,
+    Cache, CacheDB, Database, DatabaseCommit, Db, DbErrorCode, DbResult, DynDatabase, EmptyDB,
     InMemoryDB,
 };
 
@@ -73,7 +73,7 @@ impl<T: EvmTypes> Evm<T> {
         spec_id: T::SpecId,
         block: BlockEnv,
         registry: TxRegistry<T::Tx, TxResult, Self>,
-        database: impl Database,
+        database: impl DynDatabase,
         precompiles: impl PrecompileProvider,
     ) -> Self {
         Self::new_with_execution_config(
@@ -93,7 +93,7 @@ impl<T: EvmTypes> Evm<T> {
         spec_id: T::SpecId,
         block: BlockEnv,
         registry: TxRegistry<T::Tx, TxResult, Self>,
-        database: impl Database,
+        database: impl DynDatabase,
         precompiles: impl PrecompileProvider,
     ) -> Self {
         Self::new_mono(
@@ -112,7 +112,7 @@ impl<T: EvmTypes> Evm<T> {
         spec_id: T::SpecId,
         block: BlockEnv,
         registry: TxRegistry<T::Tx, TxResult, Self>,
-        database: Box<dyn Database>,
+        database: Box<dyn DynDatabase>,
         precompiles: Box<dyn PrecompileProvider>,
     ) -> Self {
         assert_eq!(
@@ -156,13 +156,13 @@ impl<T: EvmTypes> Evm<T> {
 
     /// Returns the backing database.
     #[inline]
-    pub fn database(&self) -> &dyn Database {
+    pub fn database(&self) -> &dyn DynDatabase {
         self.state.initial()
     }
 
     /// Returns the backing database mutably.
     #[inline]
-    pub fn database_mut(&mut self) -> &mut dyn Database {
+    pub fn database_mut(&mut self) -> &mut dyn DynDatabase {
         self.state.initial_mut()
     }
 
@@ -174,19 +174,19 @@ impl<T: EvmTypes> Evm<T> {
 
     /// Replaces the backing database.
     #[inline]
-    pub fn set_database(&mut self, database: impl Database) {
+    pub fn set_database(&mut self, database: impl DynDatabase) {
         self.state.set_initial(database);
     }
 
     /// Returns the backing database as `D` if it has that concrete type.
     #[inline]
-    pub fn database_as<D: Database>(&self) -> Option<&D> {
+    pub fn database_as<D: DynDatabase>(&self) -> Option<&D> {
         <dyn core::any::Any>::downcast_ref(self.database())
     }
 
     /// Returns the backing database mutably as `D` if it has that concrete type.
     #[inline]
-    pub fn database_as_mut<D: Database>(&mut self) -> Option<&mut D> {
+    pub fn database_as_mut<D: DynDatabase>(&mut self) -> Option<&mut D> {
         <dyn core::any::Any>::downcast_mut(self.database_mut())
     }
 
@@ -1145,7 +1145,7 @@ mod tests {
     #[derive(Debug, Default)]
     struct FailingStorageDb;
 
-    impl DbTyped for FailingStorageDb {
+    impl Database for FailingStorageDb {
         type Error = FailingDbError;
 
         fn get_account(&mut self, _address: Address) -> Result<Option<AccountInfo>, Self::Error> {

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -34,7 +34,8 @@ pub use system::{
 
 mod db;
 pub use db::{
-    Cache, CacheDB, Database, DatabaseCommit, DbErrorCode, DbResult, EmptyDB, InMemoryDB,
+    Cache, CacheDB, Database, DatabaseCommit, Db, DbErrorCode, DbResult, DbTyped, EmptyDB,
+    InMemoryDB,
 };
 
 mod state;
@@ -992,7 +993,7 @@ mod tests {
         interpreter::{MessageKind, op},
         registry::TxRequest,
     };
-    use alloc::{boxed::Box, string::ToString, vec, vec::Vec};
+    use alloc::{string::ToString, vec, vec::Vec};
     use alloy_consensus::{TxLegacy, transaction::Recovered};
     use alloy_primitives::{Address, Bytes, KECCAK256_EMPTY, U256};
     use core::{error::Error, fmt};
@@ -1144,26 +1145,23 @@ mod tests {
     #[derive(Debug, Default)]
     struct FailingStorageDb;
 
-    impl Database for FailingStorageDb {
-        fn get_account(&mut self, _address: Address) -> DbResult<Option<AccountInfo>> {
+    impl DbTyped for FailingStorageDb {
+        type Error = FailingDbError;
+
+        fn get_account(&mut self, _address: Address) -> Result<Option<AccountInfo>, Self::Error> {
             Ok(Some(AccountInfo::default()))
         }
 
-        fn get_code_by_hash(&mut self, _code_hash: B256) -> DbResult<Bytecode> {
+        fn get_code_by_hash(&mut self, _code_hash: B256) -> Result<Bytecode, Self::Error> {
             Ok(Bytecode::default())
         }
 
-        fn get_storage(&mut self, _address: Address, _key: Word) -> DbResult<Word> {
-            Err(DbErrorCode::new(7).unwrap())
+        fn get_storage(&mut self, _address: Address, _key: Word) -> Result<Word, Self::Error> {
+            Err(FailingDbError)
         }
 
-        fn get_block_hash(&mut self, _number: Word) -> DbResult<Option<B256>> {
+        fn get_block_hash(&mut self, _number: Word) -> Result<Option<B256>, Self::Error> {
             Ok(None)
-        }
-
-        fn error(&mut self, code: DbErrorCode) -> Box<dyn Error> {
-            assert_eq!(code.get(), 7);
-            Box::new(FailingDbError)
         }
     }
 
@@ -1173,7 +1171,7 @@ mod tests {
             SpecId::OSAKA,
             BlockEnv::default(),
             TxRegistry::new(),
-            FailingStorageDb,
+            Db::new(FailingStorageDb),
             Precompiles::base(SpecId::OSAKA),
         );
         let contract = Address::from([0x11; 20]);
@@ -1189,11 +1187,8 @@ mod tests {
         let result = Host::execute_message(&mut evm, &TxEnv::default(), bytecode, &message, false);
 
         assert_eq!(result.stop, InstrStop::FatalExternalError);
-        assert_eq!(evm.db_error_code().map(DbErrorCode::get), Some(7));
-        assert_eq!(
-            evm.database_mut().error(DbErrorCode::new(7).unwrap()).to_string(),
-            "storage read failed"
-        );
+        let error_code = evm.db_error_code().unwrap();
+        assert_eq!(evm.database_mut().error(error_code).to_string(), "storage read failed");
     }
 
     #[test]

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -1154,7 +1154,7 @@ mod tests {
         }
 
         fn get_storage(&mut self, _address: Address, _key: Word) -> DbResult<Word> {
-            Err(DbErrorCode(7))
+            Err(DbErrorCode::new(7).unwrap())
         }
 
         fn get_block_hash(&mut self, _number: Word) -> DbResult<Option<B256>> {
@@ -1162,7 +1162,7 @@ mod tests {
         }
 
         fn error(&mut self, code: DbErrorCode) -> Box<dyn Error> {
-            assert_eq!(code, DbErrorCode(7));
+            assert_eq!(code.get(), 7);
             Box::new(FailingDbError)
         }
     }
@@ -1189,8 +1189,11 @@ mod tests {
         let result = Host::execute_message(&mut evm, &TxEnv::default(), bytecode, &message, false);
 
         assert_eq!(result.stop, InstrStop::FatalExternalError);
-        assert_eq!(evm.db_error_code(), Some(DbErrorCode(7)));
-        assert_eq!(evm.database_mut().error(DbErrorCode(7)).to_string(), "storage read failed");
+        assert_eq!(evm.db_error_code().map(DbErrorCode::get), Some(7));
+        assert_eq!(
+            evm.database_mut().error(DbErrorCode::new(7).unwrap()).to_string(),
+            "storage read failed"
+        );
     }
 
     #[test]

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -33,7 +33,9 @@ pub use system::{
 };
 
 mod db;
-pub use db::{Cache, CacheDB, Database, DatabaseCommit, EmptyDB, InMemoryDB};
+pub use db::{
+    Cache, CacheDB, Database, DatabaseCommit, DbErrorCode, DbResult, EmptyDB, InMemoryDB,
+};
 
 mod state;
 pub use state::{
@@ -59,6 +61,7 @@ pub struct Evm<T: EvmTypes> {
     interpreter_pool: InterpreterPool<T>,
     #[debug(skip)]
     inspector: Option<Box<dyn Inspector<T>>>,
+    db_error_code: Option<DbErrorCode>,
 }
 
 impl<T: EvmTypes> Evm<T> {
@@ -126,6 +129,7 @@ impl<T: EvmTypes> Evm<T> {
             precompiles,
             interpreter_pool: InterpreterPool::new(),
             inspector: None,
+            db_error_code: None,
         }
     }
 
@@ -159,6 +163,12 @@ impl<T: EvmTypes> Evm<T> {
     #[inline]
     pub fn database_mut(&mut self) -> &mut dyn Database {
         self.state.initial_mut()
+    }
+
+    /// Returns the latest database error code raised during execution.
+    #[inline]
+    pub const fn db_error_code(&self) -> Option<DbErrorCode> {
+        self.db_error_code
     }
 
     /// Replaces the backing database.
@@ -247,12 +257,14 @@ impl<T: EvmTypes> Evm<T> {
     }
 
     #[inline]
-    fn finalize_transaction(&mut self) {
-        self.state.finalize_transaction(self.execution_config.version(), |log| {
-            if let Some(inspector) = &mut self.inspector {
-                inspector.log(log);
-            }
-        });
+    fn finalize_transaction(&mut self) -> Result<(), InstrStop> {
+        self.state
+            .finalize_transaction(self.execution_config.version(), |log| {
+                if let Some(inspector) = &mut self.inspector {
+                    inspector.log(log);
+                }
+            })
+            .map_err(|code| self.db_error_stop(code))
     }
 
     fn log_eip7708_transfer(&mut self, from: Address, to: Address, value: Word) {
@@ -293,6 +305,18 @@ impl<T: EvmTypes> Evm<T> {
         self.features.contains(feature)
     }
 
+    #[inline]
+    const fn db_error_stop(&mut self, code: DbErrorCode) -> InstrStop {
+        self.db_error_code = Some(code);
+        InstrStop::FatalExternalError
+    }
+
+    #[inline]
+    pub(crate) const fn db_error_handler(&mut self, code: DbErrorCode) -> registry::HandlerError {
+        self.db_error_code = Some(code);
+        registry::HandlerError::Database(code)
+    }
+
     /// Returns the active base specification ID.
     #[inline]
     pub const fn spec_id(&self) -> SpecId {
@@ -309,12 +333,19 @@ impl<T: EvmTypes> Evm<T> {
 impl<T: EvmTypes<Tx: Typed2718>> Evm<T> {
     /// Dispatches the transaction to the handler registered for its EIP-2718 type byte.
     pub fn transact(&mut self, tx: &T::Tx) -> HandlerResult<TxResult> {
+        self.db_error_code = None;
         let handler = self.registry.try_get_by_type(tx.ty())?;
         let mut result = handler.call(tx, self);
         if let Ok(result) = &mut result {
-            self.finalize_transaction();
-            result.state_changes = self.state.build_state_changes();
-            self.state.commit_transaction_overlay();
+            if let Err(stop) = self.finalize_transaction() {
+                result.status = false;
+                result.stop = stop;
+                result.output = Bytes::new();
+            } else {
+                result.state_changes = self.state.build_state_changes();
+                self.state.commit_transaction_overlay();
+            }
+            result.db_error_code = self.db_error_code;
         };
         self.state.clear_transaction_state();
         result
@@ -360,22 +391,29 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
             // EIP-2681 caps account nonces at u64::MAX; CREATE/CREATE2 return zero
             // instead of wrapping or saturating the creator nonce.
             // TODO: Fold this into nonce bumping so account info is not loaded repeatedly.
-            if self.state.account_info(message.caller).is_some_and(|info| info.nonce == u64::MAX) {
+            if self
+                .state
+                .account_info(message.caller)
+                .map_err(|code| self.db_error_stop(code))?
+                .is_some_and(|info| info.nonce == u64::MAX)
+            {
                 return Err(InstrStop::Return);
             }
         }
 
-        let address = self.create_address(&bytecode, message);
+        let address = self.create_address(&bytecode, message)?;
 
         let _ = self.state.warm_account(address);
 
         if message.depth > 0 {
-            self.state.increment_nonce(message.caller);
+            self.state.increment_nonce(message.caller).map_err(|code| self.db_error_stop(code))?;
         }
 
         let checkpoint = self.state.checkpoint();
-        if let Err(stop) =
-            self.state.create_account(message.caller, address, message.value, self.spec_id())
+        if let Err(stop) = self
+            .state
+            .create_account(message.caller, address, message.value, self.spec_id())
+            .map_err(|code| self.db_error_stop(code))?
         {
             self.state.rollback(checkpoint, self.spec_id());
             return Err(stop);
@@ -412,7 +450,9 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
                 });
             }
 
-            self.state.set_code(address, Bytecode::new_legacy(output.clone()));
+            self.state
+                .set_code(address, Bytecode::new_legacy(output.clone()))
+                .map_err(|code| self.db_error_stop(code))?;
         } else {
             self.state.rollback(checkpoint, self.spec_id());
         }
@@ -431,6 +471,7 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
             && self
                 .state
                 .account_info(message.caller)
+                .map_err(|code| self.db_error_stop(code))?
                 .is_none_or(|info| info.balance < message.value)
         {
             return Err(InstrStop::OutOfFunds);
@@ -465,13 +506,20 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
     }
 
     #[inline(never)]
-    fn create_address(&mut self, bytecode: &Bytecode, message: &Message) -> Address {
+    fn create_address(
+        &mut self,
+        bytecode: &Bytecode,
+        message: &Message,
+    ) -> Result<Address, InstrStop> {
         match message.kind {
-            MessageKind::Create if message.depth == 0 => message.destination,
-            MessageKind::Create => message
-                .caller
-                .create(self.state.account_info(message.caller).map_or(0, |info| info.nonce)),
-            MessageKind::Create2 => message.caller.create2(message.salt, bytecode.hash_slow()),
+            MessageKind::Create if message.depth == 0 => Ok(message.destination),
+            MessageKind::Create => Ok(message.caller.create(
+                self.state
+                    .account_info(message.caller)
+                    .map_err(|code| self.db_error_stop(code))?
+                    .map_or(0, |info| info.nonce),
+            )),
+            MessageKind::Create2 => Ok(message.caller.create2(message.salt, bytecode.hash_slow())),
             _ => unreachable!("invalid create message kind"),
         }
     }
@@ -503,7 +551,10 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
             MessageKind::Call | MessageKind::CallCode | MessageKind::StaticCall
         );
         let transfer_succeeded = !transfers_balance
-            || self.state.transfer(message.caller, message.destination, message.value);
+            || self
+                .state
+                .transfer(message.caller, message.destination, message.value)
+                .map_err(|code| self.db_error_stop(code))?;
         if transfers_balance && !transfer_succeeded {
             return Err(InstrStop::OutOfFunds);
         }
@@ -632,14 +683,17 @@ impl<T: EvmTypes<Host = Self>> Host for Evm<T> {
         if skip_cold_load && is_cold {
             return Err(InstrStop::OutOfGas);
         }
-        let info = self.state.account_info(address);
+        let info = self.state.account_info(address).map_err(|code| self.db_error_stop(code))?;
         let exists = info.is_some();
         let info = info.unwrap_or_default();
         Ok(AccountLoad {
             balance: info.balance,
             code_hash: if exists { info.code_hash } else { B256::ZERO },
             code: if load_code {
-                self.state.get_code(address).original_bytes()
+                self.state
+                    .get_code(address)
+                    .map_err(|code| self.db_error_stop(code))?
+                    .original_bytes()
             } else {
                 Bytes::new()
             },
@@ -649,12 +703,18 @@ impl<T: EvmTypes<Host = Self>> Host for Evm<T> {
         })
     }
 
-    fn target_is_empty_for_new_account_gas(&mut self, address: Address, spec: SpecId) -> bool {
-        self.state.target_is_empty_for_new_account_gas(address, spec)
+    fn target_is_empty_for_new_account_gas(
+        &mut self,
+        address: Address,
+        spec: SpecId,
+    ) -> Result<bool, InstrStop> {
+        self.state
+            .target_is_empty_for_new_account_gas(address, spec)
+            .map_err(|code| self.db_error_stop(code))
     }
 
-    fn block_hash(&mut self, number: Word) -> Option<B256> {
-        self.state.initial_mut().get_block_hash(number)
+    fn block_hash(&mut self, number: Word) -> Result<Option<B256>, InstrStop> {
+        self.state.initial_mut().get_block_hash(number).map_err(|code| self.db_error_stop(code))
     }
 
     fn sload(
@@ -668,7 +728,10 @@ impl<T: EvmTypes<Host = Self>> Host for Evm<T> {
         if skip_cold_load && is_cold {
             return Err(InstrStop::OutOfGas);
         }
-        Ok(SLoad { value: self.state.storage(address, key), is_cold })
+        Ok(SLoad {
+            value: self.state.storage(address, key).map_err(|code| self.db_error_stop(code))?,
+            is_cold,
+        })
     }
 
     fn sstore(
@@ -683,7 +746,8 @@ impl<T: EvmTypes<Host = Self>> Host for Evm<T> {
         if skip_cold_load && is_cold {
             return Err(InstrStop::OutOfGas);
         }
-        let mut result = self.state.set_storage(address, key, value);
+        let mut result =
+            self.state.set_storage(address, key, value).map_err(|code| self.db_error_stop(code))?;
         result.is_cold = is_cold;
         Ok(result)
     }
@@ -736,14 +800,21 @@ impl<T: EvmTypes<Host = Self>> Host for Evm<T> {
             return Err(InstrStop::OutOfGas);
         }
         let target_is_empty_for_new_account_gas =
-            self.state.target_is_empty_for_new_account_gas(target, self.spec_id());
+            self.target_is_empty_for_new_account_gas(target, self.spec_id())?;
         let previously_destroyed = self.state.is_selfdestructed(contract);
-        let balance = self.state.account_info(contract).map_or(Word::ZERO, |info| info.balance);
+        let balance = self
+            .state
+            .account_info(contract)
+            .map_err(|code| self.db_error_stop(code))?
+            .map_or(Word::ZERO, |info| info.balance);
         let should_destroy = !self.spec_id().enables(SpecId::CANCUN)
             || self.state.is_created_in_transaction(contract);
 
         if contract != target {
-            let transferred = self.state.transfer(contract, target, balance);
+            let transferred = self
+                .state
+                .transfer(contract, target, balance)
+                .map_err(|code| self.db_error_stop(code))?;
             if transferred {
                 self.log_eip7708_transfer(contract, target, balance);
             }
@@ -753,7 +824,9 @@ impl<T: EvmTypes<Host = Self>> Host for Evm<T> {
             {
                 self.emit_log(log);
             }
-            self.state.add_balance(contract, Word::ZERO.wrapping_sub(balance));
+            self.state
+                .add_balance(contract, Word::ZERO.wrapping_sub(balance))
+                .map_err(|code| self.db_error_stop(code))?;
         }
         if should_destroy {
             self.state.mark_destructed(contract);
@@ -879,6 +952,8 @@ pub struct TxResult {
     pub output: Bytes,
     /// State transition and logs produced by this transaction.
     pub state_changes: StateChanges,
+    /// Database error handle, if execution stopped on a database error.
+    pub db_error_code: Option<DbErrorCode>,
 }
 
 fn eip7708_transfer_log(from: Address, to: Address, value: Word) -> Option<Log> {
@@ -917,9 +992,10 @@ mod tests {
         interpreter::{MessageKind, op},
         registry::TxRequest,
     };
-    use alloc::{vec, vec::Vec};
+    use alloc::{boxed::Box, vec, vec::Vec};
     use alloy_consensus::{TxLegacy, transaction::Recovered};
     use alloy_primitives::{Address, Bytes, KECCAK256_EMPTY, U256};
+    use core::{error::Error, fmt};
 
     const TEST_TX_TYPE: u8 = 0x00;
 
@@ -1052,6 +1128,69 @@ mod tests {
 
         let result = Host::execute_message(&mut evm, &TxEnv::default(), bytecode, &message, false);
         assert!(result.stop.is_success());
+    }
+
+    #[derive(Debug)]
+    struct FailingDbError;
+
+    impl fmt::Display for FailingDbError {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.write_str("storage read failed")
+        }
+    }
+
+    impl Error for FailingDbError {}
+
+    #[derive(Debug, Default)]
+    struct FailingStorageDb;
+
+    impl Database for FailingStorageDb {
+        fn get_account(&mut self, _address: Address) -> DbResult<Option<AccountInfo>> {
+            Ok(Some(AccountInfo::default()))
+        }
+
+        fn get_code_by_hash(&mut self, _code_hash: B256) -> DbResult<Bytecode> {
+            Ok(Bytecode::default())
+        }
+
+        fn get_storage(&mut self, _address: Address, _key: Word) -> DbResult<Word> {
+            Err(DbErrorCode(7))
+        }
+
+        fn get_block_hash(&mut self, _number: Word) -> DbResult<Option<B256>> {
+            Ok(None)
+        }
+
+        fn error(&mut self, code: DbErrorCode) -> Box<dyn Error> {
+            assert_eq!(code, DbErrorCode(7));
+            Box::new(FailingDbError)
+        }
+    }
+
+    #[test]
+    fn host_records_database_error_code() {
+        let mut evm = Evm::<BaseEvmTypes>::new(
+            SpecId::OSAKA,
+            BlockEnv::default(),
+            TxRegistry::new(),
+            FailingStorageDb,
+            Precompiles::base(SpecId::OSAKA),
+        );
+        let contract = Address::from([0x11; 20]);
+        let bytecode = Bytecode::new_legacy(Bytes::from_static(&[op::PUSH0, op::SLOAD]));
+        let message = Message {
+            kind: MessageKind::Call,
+            destination: contract,
+            code_address: contract,
+            gas_limit: 50_000,
+            ..Message::default()
+        };
+
+        let result = Host::execute_message(&mut evm, &TxEnv::default(), bytecode, &message, false);
+
+        assert_eq!(result.stop, InstrStop::FatalExternalError);
+        assert_eq!(evm.db_error_code(), Some(DbErrorCode(7)));
+        assert_eq!(evm.database_mut().error(DbErrorCode(7)).to_string(), "storage read failed");
     }
 
     #[test]
@@ -1235,15 +1374,15 @@ mod tests {
         let from = Address::from([0x01; 20]);
         let to = Address::from([0x02; 20]);
         let mut state = State::new(InMemoryDB::default());
-        state.add_balance(from, U256::from(10));
+        state.add_balance(from, U256::from(10)).unwrap();
 
-        assert!(state.transfer(from, to, U256::from(7)));
+        assert!(state.transfer(from, to, U256::from(7)).unwrap());
         assert_eq!(
-            state.account_info(from).expect("sender account should exist").balance,
+            state.account_info(from).expect("sender account should exist").unwrap().balance,
             U256::from(3)
         );
         assert_eq!(
-            state.account_info(to).expect("recipient account should exist").balance,
+            state.account_info(to).expect("recipient account should exist").unwrap().balance,
             U256::from(7)
         );
     }

--- a/crates/evm2/src/evm/registry.rs
+++ b/crates/evm2/src/evm/registry.rs
@@ -63,6 +63,9 @@ pub type HandlerResult<T> = core::result::Result<T, HandlerError>;
 /// Registry, transaction validation, and transaction handler errors.
 #[derive(Clone, Copy, Debug, Error, PartialEq, Eq)]
 pub enum HandlerError {
+    /// Database operation failed.
+    #[error("database error {0:?}")]
+    Database(super::DbErrorCode),
     /// No handler is registered for the transaction type byte.
     #[error("unsupported transaction type 0x{0:02x}")]
     UnsupportedTransactionType(u8),

--- a/crates/evm2/src/evm/state.rs
+++ b/crates/evm2/src/evm/state.rs
@@ -1,6 +1,10 @@
 //! Basic in-memory EVM host state.
 
-use super::{SStore, db::Database, eip7708_burn_log};
+use super::{
+    SStore,
+    db::{Database, DbResult},
+    eip7708_burn_log,
+};
 use crate::{
     EvmFeatures, SpecId, Version,
     bytecode::Bytecode,
@@ -559,162 +563,157 @@ impl State {
         self.logs.clear();
     }
 
-    #[must_use]
-    fn load_account(&mut self, address: Address) -> Option<&mut Tracked<Option<Account>>> {
+    fn load_account(
+        &mut self,
+        address: Address,
+    ) -> DbResult<Option<&mut Tracked<Option<Account>>>> {
         match self.accounts.entry(address) {
-            hash_map::Entry::Occupied(entry) => Some(entry.into_mut()),
+            hash_map::Entry::Occupied(entry) => Ok(Some(entry.into_mut())),
             hash_map::Entry::Vacant(entry) => {
-                let info = self.initial.get_account(address)?;
-                Some(entry.insert(Tracked::new(Some(Account::from_info(info)))))
+                let Some(info) = self.initial.get_account(address)? else {
+                    return Ok(None);
+                };
+                Ok(Some(entry.insert(Tracked::new(Some(Account::from_info(info))))))
             }
         }
     }
 
-    #[must_use]
     fn ensure_account_overlay<'a>(
         initial: &mut dyn Database,
         accounts: &'a mut AddressMap<Tracked<Option<Account>>>,
         journal: &mut Vec<JournalEntry>,
         address: Address,
-    ) -> &'a mut Tracked<Option<Account>> {
+    ) -> DbResult<&'a mut Tracked<Option<Account>>> {
         match accounts.entry(address) {
-            hash_map::Entry::Occupied(entry) => entry.into_mut(),
+            hash_map::Entry::Occupied(entry) => Ok(entry.into_mut()),
             hash_map::Entry::Vacant(entry) => {
-                let original = initial.get_account(address).map(Account::from_info);
+                let original = initial.get_account(address)?.map(Account::from_info);
                 journal.push(JournalEntry::AccountInserted { address });
-                entry.insert(Tracked { original: original.clone(), current: original })
+                Ok(entry.insert(Tracked { original: original.clone(), current: original }))
             }
         }
     }
 
-    #[must_use]
-    fn account_mut(&mut self, address: Address) -> &mut Account {
+    fn account_mut(&mut self, address: Address) -> DbResult<&mut Account> {
         let tracked = Self::ensure_account_overlay(
             &mut self.initial,
             &mut self.accounts,
             &mut self.journal,
             address,
-        );
+        )?;
         if tracked.current.is_none() {
             self.journal.push(JournalEntry::AccountChange { address, previous: None });
         }
-        tracked.current.get_or_insert_with(|| Account {
+        Ok(tracked.current.get_or_insert_with(|| Account {
             code_hash: KECCAK256_EMPTY,
             code: Bytecode::default(),
             ..Account::default()
-        })
+        }))
     }
 
-    #[must_use]
-    fn journal_account_change(&mut self, address: Address) -> &mut Account {
+    fn journal_account_change(&mut self, address: Address) -> DbResult<&mut Account> {
         let tracked = Self::ensure_account_overlay(
             &mut self.initial,
             &mut self.accounts,
             &mut self.journal,
             address,
-        );
+        )?;
         let previous = tracked.current.clone();
         self.journal.push(JournalEntry::AccountChange { address, previous });
-        tracked.current.get_or_insert_with(|| Account {
+        Ok(tracked.current.get_or_insert_with(|| Account {
             code_hash: KECCAK256_EMPTY,
             code: Bytecode::default(),
             ..Account::default()
-        })
+        }))
     }
 
     /// Returns account info.
     #[inline]
-    #[must_use]
-    pub fn account_info(&mut self, address: Address) -> Option<AccountInfo> {
+    pub fn account_info(&mut self, address: Address) -> DbResult<Option<AccountInfo>> {
         if let Some(account) = self.accounts.get(&address) {
-            return account.current.as_ref().map(Account::info);
+            return Ok(account.current.as_ref().map(Account::info));
         }
         self.initial.get_account(address)
     }
 
     /// Returns whether an account is empty/non-existent for EIP-150 new-account gas checks.
     #[inline]
-    #[must_use]
     pub(super) fn target_is_empty_for_new_account_gas(
         &mut self,
         address: Address,
         spec: SpecId,
-    ) -> bool {
+    ) -> DbResult<bool> {
         if spec.enables(SpecId::SPURIOUS_DRAGON) {
-            return self.account_info(address).is_none_or(|info| info.is_empty());
+            return Ok(self.account_info(address)?.is_none_or(|info| info.is_empty()));
         }
-        self.account_info(address).is_none() && !self.touched.contains(&address)
+        Ok(self.account_info(address)?.is_none() && !self.touched.contains(&address))
     }
 
     /// Returns an account if it exists.
     #[inline]
-    #[must_use]
-    pub fn find(&mut self, address: Address) -> Option<&Account> {
-        self.load_account(address)?.current.as_ref()
+    pub fn find(&mut self, address: Address) -> DbResult<Option<&Account>> {
+        Ok(self.load_account(address)?.and_then(|account| account.current.as_ref()))
     }
 
     /// Gets an existing account or inserts a new empty account.
     #[inline]
-    pub fn get_or_insert(&mut self, address: Address) -> &mut Account {
+    pub fn get_or_insert(&mut self, address: Address) -> DbResult<&mut Account> {
         self.account_mut(address)
     }
 
     /// Gets account code.
     #[inline]
-    #[must_use]
-    pub fn get_code(&mut self, address: Address) -> Bytecode {
-        let Some((code_hash, code)) = self.find(address).map(|account| {
+    pub fn get_code(&mut self, address: Address) -> DbResult<Bytecode> {
+        let Some((code_hash, code)) = self.find(address)?.map(|account| {
             let code_hash = account.code_hash;
             let code = account.code.clone();
             (code_hash, code)
         }) else {
-            return Bytecode::default();
+            return Ok(Bytecode::default());
         };
         if code_hash == KECCAK256_EMPTY {
-            return Bytecode::default();
+            return Ok(Bytecode::default());
         }
         if !code.is_empty() {
-            return code;
+            return Ok(code);
         }
         self.initial.get_code_by_hash(code_hash)
     }
 
-    #[must_use]
     fn storage_slot_mut(
         &mut self,
         address: Address,
         key: Word,
         journal_insert: bool,
-    ) -> &mut Tracked<Word> {
+    ) -> DbResult<&mut Tracked<Word>> {
         let Self { initial, accounts, storage, journal, .. } = self;
         let account_created =
             accounts.get(&address).is_some_and(|account| account.original.is_none());
         let storage = storage.entry(address).or_default();
         let storage_wiped = storage.wiped;
         match storage.slots.entry(key) {
-            hash_map::Entry::Occupied(entry) => entry.into_mut(),
+            hash_map::Entry::Occupied(entry) => Ok(entry.into_mut()),
             hash_map::Entry::Vacant(entry) => {
                 let initial = if storage_wiped || account_created {
                     Word::ZERO
                 } else {
-                    initial.get_storage(address, key)
+                    initial.get_storage(address, key)?
                 };
                 if journal_insert {
                     journal.push(JournalEntry::StorageInserted { address, key });
                 }
-                entry.insert(Tracked::new(initial))
+                Ok(entry.insert(Tracked::new(initial)))
             }
         }
     }
 
     /// Loads persistent storage.
     #[inline]
-    #[must_use]
-    pub fn storage(&mut self, address: Address, key: Word) -> Word {
-        let Some(_) = self.account_info(address) else {
-            return Word::ZERO;
+    pub fn storage(&mut self, address: Address, key: Word) -> DbResult<Word> {
+        let Some(_) = self.account_info(address)? else {
+            return Ok(Word::ZERO);
         };
-        self.storage_slot_mut(address, key, false).current
+        Ok(self.storage_slot_mut(address, key, false)?.current)
     }
 
     /// Stores persistent storage and returns values needed for `SSTORE` gas metering.
@@ -725,10 +724,10 @@ impl State {
     /// host `sstore` operation instead, and only use this lower-level helper when those concerns
     /// are handled elsewhere.
     #[inline]
-    pub fn set_storage(&mut self, address: Address, key: Word, value: Word) -> SStore {
-        let _ = self.account_mut(address);
+    pub fn set_storage(&mut self, address: Address, key: Word, value: Word) -> DbResult<SStore> {
+        let _ = self.account_mut(address)?;
         self.touch(address);
-        let slot = self.storage_slot_mut(address, key, true);
+        let slot = self.storage_slot_mut(address, key, true)?;
         let result = SStore {
             original_value: slot.original,
             present_value: slot.current,
@@ -740,7 +739,7 @@ impl State {
             slot.current = value;
             self.journal.push(JournalEntry::StorageChange { address, key, previous });
         }
-        result
+        Ok(result)
     }
 
     /// Marks an account as touched by the current transaction.
@@ -753,51 +752,52 @@ impl State {
 
     /// Adds a signed balance delta by wrapping two's-complement values.
     #[inline]
-    pub fn add_balance(&mut self, address: Address, delta: Word) {
+    pub fn add_balance(&mut self, address: Address, delta: Word) -> DbResult<()> {
         if delta.is_zero() {
             self.touch(address);
-            return;
+            return Ok(());
         }
-        let account = self.journal_account_change(address);
+        let account = self.journal_account_change(address)?;
         account.balance = account.balance.wrapping_add(delta);
         self.touch(address);
+        Ok(())
     }
 
     /// Transfers value between accounts.
-    #[must_use]
-    pub fn transfer(&mut self, from: Address, to: Address, value: Word) -> bool {
+    pub fn transfer(&mut self, from: Address, to: Address, value: Word) -> DbResult<bool> {
         if value.is_zero() {
             self.touch(to);
-            return true;
+            return Ok(true);
         }
 
-        let from_balance = self.account_info(from).map_or(Word::ZERO, |info| info.balance);
+        let from_balance = self.account_info(from)?.map_or(Word::ZERO, |info| info.balance);
         if from == to {
             if from_balance < value {
-                return false;
+                return Ok(false);
             }
             self.touch(to);
-            return true;
+            return Ok(true);
         }
         let Some(new_from_balance) = from_balance.checked_sub(value) else {
-            return false;
+            return Ok(false);
         };
 
-        self.journal_account_change(from).balance = new_from_balance;
+        self.journal_account_change(from)?.balance = new_from_balance;
         self.touch(from);
 
-        let account = self.journal_account_change(to);
+        let account = self.journal_account_change(to)?;
         account.balance = account.balance.saturating_add(value);
         self.touch(to);
-        true
+        Ok(true)
     }
 
     /// Increments account nonce.
     #[inline]
-    pub fn increment_nonce(&mut self, address: Address) {
-        let account = self.journal_account_change(address);
+    pub fn increment_nonce(&mut self, address: Address) -> DbResult<()> {
+        let account = self.journal_account_change(address)?;
         account.nonce = account.nonce.saturating_add(1);
         self.touch(address);
+        Ok(())
     }
 
     /// Creates a contract account and transfers endowment from the caller.
@@ -808,20 +808,20 @@ impl State {
         address: Address,
         value: Word,
         spec: SpecId,
-    ) -> Result<(), InstrStop> {
-        if let Some(info) = self.account_info(address)
+    ) -> DbResult<Result<(), InstrStop>> {
+        if let Some(info) = self.account_info(address)?
             && (info.nonce != 0 || info.code_hash != KECCAK256_EMPTY)
         {
-            return Err(InstrStop::CreateCollision);
+            return Ok(Err(InstrStop::CreateCollision));
         }
 
-        if !self.transfer(caller, address, value) {
-            return Err(InstrStop::OutOfFunds);
+        if !self.transfer(caller, address, value)? {
+            return Ok(Err(InstrStop::OutOfFunds));
         }
 
-        let balance = self.account_mut(address).balance;
+        let balance = self.account_mut(address)?.balance;
         self.wipe_storage(address);
-        let account = self.journal_account_change(address);
+        let account = self.journal_account_change(address)?;
         *account = Account {
             nonce: u64::from(spec.enables(SpecId::SPURIOUS_DRAGON)),
             balance,
@@ -831,16 +831,17 @@ impl State {
             code_changed: true,
         };
         self.touch(address);
-        Ok(())
+        Ok(Ok(()))
     }
 
     /// Sets account bytecode.
     #[inline]
-    pub fn set_code(&mut self, address: Address, code: Bytecode) {
-        let account = self.journal_account_change(address);
+    pub fn set_code(&mut self, address: Address, code: Bytecode) -> DbResult<()> {
+        let account = self.journal_account_change(address)?;
         account.code_hash = code.hash_slow();
         account.code = code;
         account.code_changed = true;
+        Ok(())
     }
 
     /// Marks all prior persistent storage for `address` as deleted.
@@ -996,40 +997,40 @@ impl State {
     /// in Spurious Dragon, touched dead accounts that exist in the pre/final
     /// overlay state are deleted during transaction finalization. Non-existent
     /// touched accounts stay non-existent.
-    #[must_use]
-    fn is_existing_dead(&mut self, address: Address) -> bool {
+    fn is_existing_dead(&mut self, address: Address) -> DbResult<bool> {
         if let Some(account) = self.accounts.get(&address) {
-            return account.current.as_ref().is_some_and(Account::is_empty)
-                || (account.current.is_none() && account.original.is_some());
+            return Ok(account.current.as_ref().is_some_and(Account::is_empty)
+                || (account.current.is_none() && account.original.is_some()));
         }
-        self.initial.get_account(address).is_some_and(|account| account.is_empty())
+        Ok(self.initial.get_account(address)?.is_some_and(|account| account.is_empty()))
     }
 
-    fn account_exists(&mut self, address: Address) -> bool {
+    fn account_exists(&mut self, address: Address) -> DbResult<bool> {
         if let Some(account) = self.accounts.get(&address) {
-            return account.current.is_some();
+            return Ok(account.current.is_some());
         }
-        self.initial.get_account(address).is_some()
+        Ok(self.initial.get_account(address)?.is_some())
     }
 
-    fn delete_account_for_finalization(&mut self, address: Address) {
+    fn delete_account_for_finalization(&mut self, address: Address) -> DbResult<()> {
         let account = Self::ensure_account_overlay(
             &mut self.initial,
             &mut self.accounts,
             &mut self.journal,
             address,
-        );
+        )?;
         account.current = None;
         self.storage.insert(address, StorageOverlay { wiped: true, slots: U256Map::default() });
+        Ok(())
     }
 
-    fn materialize_empty_account_for_finalization(&mut self, address: Address) {
+    fn materialize_empty_account_for_finalization(&mut self, address: Address) -> DbResult<()> {
         let account = Self::ensure_account_overlay(
             &mut self.initial,
             &mut self.accounts,
             &mut self.journal,
             address,
-        );
+        )?;
         if account.original.is_none() {
             account.current.get_or_insert_with(|| Account {
                 code_hash: KECCAK256_EMPTY,
@@ -1037,11 +1038,12 @@ impl State {
                 ..Account::default()
             });
         }
+        Ok(())
     }
 
     #[cfg(test)]
     pub(super) fn finalize_transaction_(&mut self, version: &Version) {
-        self.finalize_transaction(version, |_| {});
+        self.finalize_transaction(version, |_| {}).unwrap();
     }
 
     /// Applies transaction-finalization account-lifetime rules to the overlay.
@@ -1058,7 +1060,7 @@ impl State {
         &mut self,
         version: &Version,
         mut inspect_log: impl FnMut(&Log),
-    ) {
+    ) -> DbResult<()> {
         let selfdestructs = mem::take(&mut self.selfdestructs);
         let touched = mem::take(&mut self.touched);
 
@@ -1088,21 +1090,21 @@ impl State {
         }
 
         for &address in &selfdestructs {
-            self.delete_account_for_finalization(address);
+            self.delete_account_for_finalization(address)?;
         }
 
         if spec.enables(SpecId::SPURIOUS_DRAGON) {
             for &address in &touched {
                 // EIP-161 deletes touched dead accounts at transaction finalization.
-                if self.is_existing_dead(address) {
-                    self.delete_account_for_finalization(address);
+                if self.is_existing_dead(address)? {
+                    self.delete_account_for_finalization(address)?;
                 }
             }
         } else {
             for &address in &touched {
                 // Before EIP-161, touching a non-existent account materializes it as empty.
-                if !selfdestructs.contains(&address) && !self.account_exists(address) {
-                    self.materialize_empty_account_for_finalization(address);
+                if !selfdestructs.contains(&address) && !self.account_exists(address)? {
+                    self.materialize_empty_account_for_finalization(address)?;
                 }
             }
         }
@@ -1112,6 +1114,7 @@ impl State {
 
         self.touched = touched;
         self.touched.clear();
+        Ok(())
     }
 
     /// Builds the state transition and takes emitted logs for the current transaction.
@@ -1204,12 +1207,12 @@ mod tests {
         let mut state = State::new(database);
 
         let checkpoint = state.checkpoint();
-        state.set_storage(address, Word::from(1), Word::from(20));
-        state.set_storage(address, Word::from(1), Word::from(30));
+        state.set_storage(address, Word::from(1), Word::from(20)).unwrap();
+        state.set_storage(address, Word::from(1), Word::from(30)).unwrap();
 
-        assert_eq!(state.storage(address, Word::from(1)), Word::from(30));
+        assert_eq!(state.storage(address, Word::from(1)).unwrap(), Word::from(30));
         state.rollback(checkpoint, SpecId::FRONTIER);
-        assert_eq!(state.storage(address, Word::from(1)), Word::from(10));
+        assert_eq!(state.storage(address, Word::from(1)).unwrap(), Word::from(10));
     }
 
     #[test]
@@ -1342,8 +1345,8 @@ mod tests {
         database.insert_account_info(address, AccountInfo::default().with_balance(Word::from(3)));
         let mut state = State::new(database);
 
-        assert!(!state.transfer(address, address, Word::from(4)));
-        assert!(state.transfer(address, address, Word::from(3)));
+        assert!(!state.transfer(address, address, Word::from(4)).unwrap());
+        assert!(state.transfer(address, address, Word::from(3)).unwrap());
     }
 
     #[test]
@@ -1458,9 +1461,11 @@ mod tests {
         state.mark_destructed(high);
         state.mark_destructed(low);
         let mut inspected = Vec::new();
-        state.finalize_transaction(Version::base(SpecId::AMSTERDAM), |log| {
-            inspected.push(log.clone())
-        });
+        state
+            .finalize_transaction(Version::base(SpecId::AMSTERDAM), |log| {
+                inspected.push(log.clone())
+            })
+            .unwrap();
 
         let changes = state.build_state_changes();
         assert_eq!(inspected, changes.logs);

--- a/crates/evm2/src/evm/state.rs
+++ b/crates/evm2/src/evm/state.rs
@@ -2,7 +2,7 @@
 
 use super::{
     SStore,
-    db::{Database, DbResult},
+    db::{DbResult, DynDatabase},
     eip7708_burn_log,
 };
 use crate::{
@@ -333,7 +333,7 @@ pub enum JournalEntry {
 pub struct State {
     /// Read-only initial database.
     #[debug(skip)]
-    initial: Box<dyn Database>,
+    initial: Box<dyn DynDatabase>,
     /// Account data overlay keyed by address.
     ///
     /// Entries are created when account state is loaded or mutated. The tracked
@@ -369,12 +369,12 @@ pub struct State {
 impl State {
     /// Creates a new state over an initial database.
     #[inline]
-    pub fn new(initial: impl Database) -> Self {
+    pub fn new(initial: impl DynDatabase) -> Self {
         Self::new_mono(Box::new(initial))
     }
 
     #[inline]
-    pub(crate) fn new_mono(initial: Box<dyn Database>) -> Self {
+    pub(crate) fn new_mono(initial: Box<dyn DynDatabase>) -> Self {
         Self {
             initial,
             accounts: AddressMap::default(),
@@ -397,19 +397,19 @@ impl State {
 
     /// Returns the initial database.
     #[inline]
-    pub fn initial(&self) -> &dyn Database {
+    pub fn initial(&self) -> &dyn DynDatabase {
         self.initial.as_ref()
     }
 
     /// Returns the initial database mutably.
     #[inline]
-    pub fn initial_mut(&mut self) -> &mut dyn Database {
+    pub fn initial_mut(&mut self) -> &mut dyn DynDatabase {
         self.initial.as_mut()
     }
 
     /// Replaces the initial database.
     #[inline]
-    pub fn set_initial(&mut self, initial: impl Database) {
+    pub fn set_initial(&mut self, initial: impl DynDatabase) {
         self.initial = Box::new(initial);
     }
 
@@ -579,7 +579,7 @@ impl State {
     }
 
     fn ensure_account_overlay<'a>(
-        initial: &mut dyn Database,
+        initial: &mut dyn DynDatabase,
         accounts: &'a mut AddressMap<Tracked<Option<Account>>>,
         journal: &mut Vec<JournalEntry>,
         address: Address,

--- a/crates/evm2/src/evm/system.rs
+++ b/crates/evm2/src/evm/system.rs
@@ -7,7 +7,12 @@
 //! and produces no state changes.
 
 use super::{Evm, TxResult};
-use crate::{EvmTypes, env::TxEnv, ethereum::initial_message, interpreter::Host};
+use crate::{
+    EvmTypes,
+    env::TxEnv,
+    ethereum::initial_message,
+    interpreter::{Host, InstrStop},
+};
 use alloc::vec::Vec;
 use alloy_primitives::{Address, Bytes, TxKind, U256, address};
 
@@ -59,7 +64,7 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
             chain_id: U256::from(self.version().chain_id),
             blob_hashes: Vec::new(),
         };
-        let (bytecode, message) = initial_message(
+        let Ok((bytecode, message)) = initial_message(
             self,
             caller,
             0,
@@ -67,7 +72,10 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
             &data,
             U256::ZERO,
             SYSTEM_CALL_GAS_LIMIT,
-        );
+        ) else {
+            let stop = InstrStop::FatalExternalError;
+            return TxResult { stop, db_error_code: self.db_error_code(), ..TxResult::default() };
+        };
         let result = Host::execute_message(self, &tx_env, bytecode, &message, false);
         let gas_spent = SYSTEM_CALL_GAS_LIMIT.saturating_sub(result.gas.remaining());
         let gas_refunded = if result.stop.is_success() && result.gas.refunded() > 0 {
@@ -84,9 +92,15 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
             ..TxResult::default()
         };
 
-        self.finalize_transaction();
-        result.state_changes = self.state.build_state_changes();
-        self.state.commit_transaction_overlay();
+        if let Err(stop) = self.finalize_transaction() {
+            result.status = false;
+            result.stop = stop;
+            result.output = Bytes::new();
+        } else {
+            result.state_changes = self.state.build_state_changes();
+            self.state.commit_transaction_overlay();
+        }
+        result.db_error_code = self.db_error_code();
         self.state.clear_transaction_state();
         result
     }

--- a/crates/evm2/src/interpreter/host.rs
+++ b/crates/evm2/src/interpreter/host.rs
@@ -96,10 +96,14 @@ pub trait Host {
     ) -> Result<AccountLoad, InstrStop>;
 
     /// Returns whether an account is empty/non-existent for new-account gas checks.
-    fn target_is_empty_for_new_account_gas(&mut self, address: Address, spec: SpecId) -> bool;
+    fn target_is_empty_for_new_account_gas(
+        &mut self,
+        address: Address,
+        spec: SpecId,
+    ) -> Result<bool, InstrStop>;
 
     /// Returns a historical block hash.
-    fn block_hash(&mut self, number: Word) -> Option<B256>;
+    fn block_hash(&mut self, number: Word) -> Result<Option<B256>, InstrStop>;
 
     /// Loads a persistent storage slot.
     fn sload(

--- a/crates/evm2/src/interpreter/instructions/block.rs
+++ b/crates/evm2/src/interpreter/instructions/block.rs
@@ -14,7 +14,7 @@ pub(crate) fn blockhash(cx: _, [number]: [Word]) -> Result<out> {
         } else {
             cx.state
                 .host()
-                .block_hash(number)
+                .block_hash(number)?
                 .map(b256_to_word)
                 .ok_or(InstrStop::FatalExternalError)?
         }

--- a/crates/evm2/src/interpreter/instructions/system.rs
+++ b/crates/evm2/src/interpreter/instructions/system.rs
@@ -138,7 +138,7 @@ fn load_acc_and_calc_gas<T: EvmTypes>(
         && should_charge_new_account_gas(
             spec,
             transfers_value,
-            cx.state.host().target_is_empty_for_new_account_gas(to, spec),
+            cx.state.host().target_is_empty_for_new_account_gas(to, spec)?,
         )
     {
         cost += u64::from(cx.state.gas_params().get(GasId::NewAccountCost));

--- a/crates/evm2/src/interpreter/instructions/tests.rs
+++ b/crates/evm2/src/interpreter/instructions/tests.rs
@@ -97,15 +97,19 @@ impl Host for TestHost {
         })
     }
 
-    fn target_is_empty_for_new_account_gas(&mut self, _address: Address, spec: SpecId) -> bool {
+    fn target_is_empty_for_new_account_gas(
+        &mut self,
+        _address: Address,
+        spec: SpecId,
+    ) -> Result<bool, InstrStop> {
         if spec.enables(SpecId::SPURIOUS_DRAGON) {
-            return !self.exists || self.is_empty;
+            return Ok(!self.exists || self.is_empty);
         }
-        !self.exists && !self.is_touched
+        Ok(!self.exists && !self.is_touched)
     }
 
-    fn block_hash(&mut self, number: Word) -> Option<B256> {
-        Some(B256::with_last_byte(number.wrapping_to::<u8>()))
+    fn block_hash(&mut self, number: Word) -> Result<Option<B256>, InstrStop> {
+        Ok(Some(B256::with_last_byte(number.wrapping_to::<u8>())))
     }
 
     fn sload(


### PR DESCRIPTION
This makes the EVM backing database fallible without forcing every execution result to carry boxed error data. Database reads now return DbResult<T> with a DbErrorCode handle, and Database::error(code) can be used to lazily retrieve the boxed error if the caller needs it.

The state, host, transaction validation, system-call, and execution paths now propagate database failures to either HandlerError::Database or FatalExternalError while preserving the cheap error code on Evm and TxResult.
