### PR TITLE
feat: add core extension fields

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,6 @@ alloy-primitives = { version = "1.5.7", default-features = false }
 alloy-rlp = { version = "0.3", default-features = false }
 alloy-rpc-types-eth = { version = "2.0.4", default-features = false }
 alloy-trie = { version = "0.9", default-features = false }
-derive_more = { version = "2.0", default-features = false, features = ["debug"] }
 derive-where = { version = "1.6", default-features = false }
 
 cfg-if = { version = "1.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ alloy-rlp = { version = "0.3", default-features = false }
 alloy-rpc-types-eth = { version = "2.0.4", default-features = false }
 alloy-trie = { version = "0.9", default-features = false }
 derive_more = { version = "2.0", default-features = false, features = ["debug"] }
+derive-where = { version = "1.6", default-features = false }
 
 cfg-if = { version = "1.0", default-features = false }
 libtest-mimic = "0.8"

--- a/crates/eest/src/blockchaintest/execute.rs
+++ b/crates/eest/src/blockchaintest/execute.rs
@@ -377,6 +377,7 @@ fn block_env_from_header(header: &BlockHeader, excess_blob_gas: u64, spec: SpecI
         },
         blob_basefee: U256::from(blob_basefee(excess_blob_gas, spec)),
         slot_num: header.slot_number.unwrap_or_default(),
+        ext: (),
     }
 }
 

--- a/crates/eest/src/execute.rs
+++ b/crates/eest/src/execute.rs
@@ -341,6 +341,7 @@ fn parse_block(env: &Env, spec: SpecId) -> BlockEnv {
             .current_excess_blob_gas
             .map_or(U256::ONE, |excess| U256::from(blob_basefee(excess, spec))),
         slot_num: env.slot_number.unwrap_or_default(),
+        ext: (),
     }
 }
 

--- a/crates/evm2/Cargo.toml
+++ b/crates/evm2/Cargo.toml
@@ -22,6 +22,7 @@ alloy-primitives.workspace = true
 alloy-rlp.workspace = true
 alloy-trie = { workspace = true, features = ["ethereum"] }
 derive_more.workspace = true
+derive-where.workspace = true
 thiserror.workspace = true
 cfg-if.workspace = true
 

--- a/crates/evm2/Cargo.toml
+++ b/crates/evm2/Cargo.toml
@@ -21,7 +21,6 @@ alloy-eips = { workspace = true, features = ["k256"] }
 alloy-primitives.workspace = true
 alloy-rlp.workspace = true
 alloy-trie = { workspace = true, features = ["ethereum"] }
-derive_more.workspace = true
 derive-where.workspace = true
 thiserror.workspace = true
 cfg-if.workspace = true
@@ -118,7 +117,6 @@ std = [
     "ark-serialize/std",
     "ark-std/std",
     "aurora-engine-modexp/std",
-    "derive_more/std",
     "k256/std",
     "once_cell/std",
     "p256/std",

--- a/crates/evm2/Cargo.toml
+++ b/crates/evm2/Cargo.toml
@@ -133,6 +133,7 @@ serde = [
     "alloy-primitives/serde",
     "alloy-trie/serde",
     "ark-serialize/serde",
+    "derive-where/serde",
     "k256/serde",
     "p256/serde",
     "blst?/serde",

--- a/crates/evm2/examples/custom_evm/config.rs
+++ b/crates/evm2/examples/custom_evm/config.rs
@@ -59,6 +59,8 @@ impl EvmTypes for CustomTypes {
     type TxEnvExt = CustomTxEnvExt;
     type BlockEnvExt = CustomBlockEnvExt;
     type MessageExt = CustomMessageExt;
+    type MessageResultExt = CustomMessageResultExt;
+    type TxResultExt = CustomTxResultExt;
     type Host = Evm<Self>;
 }
 
@@ -75,6 +77,16 @@ pub struct CustomBlockEnvExt {
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct CustomMessageExt {
     pub is_system: bool,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct CustomMessageResultExt {
+    pub handled_custom_message: bool,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct CustomTxResultExt {
+    pub handled_custom_tx: bool,
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/crates/evm2/examples/custom_evm/config.rs
+++ b/crates/evm2/examples/custom_evm/config.rs
@@ -56,7 +56,25 @@ impl EvmTypes for CustomTypes {
     type ConfigSelector = CustomConfigSelector;
     type SpecId = CustomSpecId;
     type Tx = crate::tx::CustomEnvelope;
+    type TxEnvExt = CustomTxEnvExt;
+    type BlockEnvExt = CustomBlockEnvExt;
+    type MessageExt = CustomMessageExt;
     type Host = Evm<Self>;
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct CustomTxEnvExt {
+    pub label: &'static str,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct CustomBlockEnvExt {
+    pub l1_block_number: u64,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct CustomMessageExt {
+    pub is_system: bool,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -85,6 +103,10 @@ pub const fn custom_version_tables<const BASE_SPEC_ID: u8, const CUSTOM_SPEC_ID:
         version.set_instruction::<opcode::custom<CustomTypes>>(
             opcode::CUSTOM_OPCODE,
             opcode::CUSTOM_OPCODE_GAS,
+        );
+        version.set_instruction::<opcode::l1_blocknumber>(
+            opcode::L1_BLOCKNUMBER_OPCODE,
+            opcode::L1_BLOCKNUMBER_GAS,
         );
     }
     version

--- a/crates/evm2/examples/custom_evm/config.rs
+++ b/crates/evm2/examples/custom_evm/config.rs
@@ -56,22 +56,12 @@ impl EvmTypes for CustomTypes {
     type ConfigSelector = CustomConfigSelector;
     type SpecId = CustomSpecId;
     type Tx = crate::tx::CustomEnvelope;
-    type TxEnvExt = CustomTxEnvExt;
-    type BlockEnvExt = CustomBlockEnvExt;
     type MessageExt = CustomMessageExt;
     type MessageResultExt = CustomMessageResultExt;
+    type TxEnvExt = CustomTxEnvExt;
     type TxResultExt = CustomTxResultExt;
+    type BlockEnvExt = CustomBlockEnvExt;
     type Host = Evm<Self>;
-}
-
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub struct CustomTxEnvExt {
-    pub label: &'static str,
-}
-
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub struct CustomBlockEnvExt {
-    pub l1_block_number: u64,
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -85,8 +75,18 @@ pub struct CustomMessageResultExt {
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct CustomTxEnvExt {
+    pub label: &'static str,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct CustomTxResultExt {
     pub handled_custom_tx: bool,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct CustomBlockEnvExt {
+    pub l1_block_number: u64,
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/crates/evm2/examples/custom_evm/main.rs
+++ b/crates/evm2/examples/custom_evm/main.rs
@@ -57,6 +57,7 @@ fn custom_opcode() -> HandlerResult<()> {
     assert_eq!(result.stop, InstrStop::Stop);
     assert!(result.status);
     assert_eq!(result.gas_used, expected_gas);
+    assert!(result.ext.handled_custom_tx);
     Ok(())
 }
 
@@ -83,6 +84,7 @@ fn l1_blocknumber_opcode() -> HandlerResult<()> {
     assert_eq!(result.stop, InstrStop::Return);
     assert!(result.status);
     assert_eq!(result.output, expected);
+    assert!(result.ext.handled_custom_tx);
     Ok(())
 }
 
@@ -221,7 +223,7 @@ impl Inspector<CustomTypes> for ExampleInspector {
         self.0.borrow_mut().logs += 1;
     }
 
-    fn call(&mut self, _message: &mut Message<CustomTypes>) -> Option<MessageResult> {
+    fn call(&mut self, _message: &mut Message<CustomTypes>) -> Option<MessageResult<CustomTypes>> {
         self.0.borrow_mut().calls += 1;
         None
     }

--- a/crates/evm2/examples/custom_evm/main.rs
+++ b/crates/evm2/examples/custom_evm/main.rs
@@ -4,8 +4,8 @@
 
 use crate::config::CustomConfigSelector;
 use alloy_eips::eip2718::Typed2718;
-use alloy_primitives::{Address, Bytes};
-use config::{CustomSpecId, CustomTypes, custom_version};
+use alloy_primitives::{Address, Bytes, U256};
+use config::{CustomBlockEnvExt, CustomSpecId, CustomTypes, custom_version};
 use evm2::{
     Evm, EvmConfigSelector, ExecutionConfig, SpecId, Version,
     env::BlockEnv,
@@ -23,6 +23,7 @@ pub mod tx;
 
 fn main() -> HandlerResult<()> {
     custom_opcode()?;
+    l1_blocknumber_opcode()?;
     mainnet_fallback()?;
     inspector()?;
     Ok(())
@@ -56,6 +57,32 @@ fn custom_opcode() -> HandlerResult<()> {
     assert_eq!(result.stop, InstrStop::Stop);
     assert!(result.status);
     assert_eq!(result.gas_used, expected_gas);
+    Ok(())
+}
+
+fn l1_blocknumber_opcode() -> HandlerResult<()> {
+    let mut evm = custom_evm();
+    let tx = custom_opcode_tx(Bytes::from_static(&[
+        opcode::L1_BLOCKNUMBER_OPCODE,
+        op::PUSH0,
+        op::MSTORE,
+        op::PUSH1,
+        32,
+        op::PUSH0,
+        op::RETURN,
+    ]));
+
+    let result = evm.transact(&tx)?;
+    let expected = Bytes::copy_from_slice(&U256::from(CUSTOM_L1_BLOCK_NUMBER).to_be_bytes::<32>());
+
+    println!(
+        "l1 blocknumber opcode: expected status=true stop=Return output={expected:?}; got status={} stop={:?} output={:?}",
+        result.status, result.stop, result.output,
+    );
+
+    assert_eq!(result.stop, InstrStop::Return);
+    assert!(result.status);
+    assert_eq!(result.output, expected);
     Ok(())
 }
 
@@ -114,11 +141,17 @@ fn inspector() -> HandlerResult<()> {
     Ok(())
 }
 
+const CUSTOM_L1_BLOCK_NUMBER: u64 = 42;
+const MAINNET_L1_BLOCK_NUMBER: u64 = 1;
+
 fn custom_evm() -> Evm<CustomTypes> {
     Evm::<CustomTypes>::new_with_execution_config(
         custom_execution_config(),
         CustomSpecId::CustomOsaka,
-        BlockEnv::default(),
+        BlockEnv {
+            ext: CustomBlockEnvExt { l1_block_number: CUSTOM_L1_BLOCK_NUMBER },
+            ..BlockEnv::default()
+        },
         custom_registry(),
         InMemoryDB::default(),
         NoPrecompiles::default(),
@@ -128,7 +161,10 @@ fn custom_evm() -> Evm<CustomTypes> {
 fn mainnet_evm() -> Evm<CustomTypes> {
     Evm::<CustomTypes>::new(
         CustomSpecId::MainnetOsaka,
-        BlockEnv::default(),
+        BlockEnv {
+            ext: CustomBlockEnvExt { l1_block_number: MAINNET_L1_BLOCK_NUMBER },
+            ..BlockEnv::default()
+        },
         custom_registry(),
         InMemoryDB::default(),
         NoPrecompiles::default(),
@@ -185,7 +221,7 @@ impl Inspector<CustomTypes> for ExampleInspector {
         self.0.borrow_mut().logs += 1;
     }
 
-    fn call(&mut self, _message: &mut Message) -> Option<MessageResult> {
+    fn call(&mut self, _message: &mut Message<CustomTypes>) -> Option<MessageResult> {
         self.0.borrow_mut().calls += 1;
         None
     }

--- a/crates/evm2/examples/custom_evm/opcode.rs
+++ b/crates/evm2/examples/custom_evm/opcode.rs
@@ -1,7 +1,8 @@
-//! Custom opcode definition.
+//! Custom opcode definitions.
 
+use crate::config::CustomTypes;
 use evm2::{
-    interpreter::Word,
+    interpreter::{Host, InstrStop, InterpreterState, Pc, StackMut, Word, private::Instruction},
     version::{GasId, GasParams},
 };
 use evm2_macros::instruction;
@@ -10,6 +11,8 @@ pub const CUSTOM_OPCODE: u8 = 0x0c;
 pub const CUSTOM_OPCODE_GAS: u16 = 7;
 pub const CUSTOM_OPCODE_DYNAMIC_GAS_ID: GasId = GasId::Custom0;
 pub const CUSTOM_OPCODE_DYNAMIC_GAS: u32 = 3;
+pub const L1_BLOCKNUMBER_OPCODE: u8 = 0x0d;
+pub const L1_BLOCKNUMBER_GAS: u16 = 2;
 
 pub const fn install_gas_params(gas_params: &mut GasParams) {
     gas_params.set(CUSTOM_OPCODE_DYNAMIC_GAS_ID, CUSTOM_OPCODE_DYNAMIC_GAS);
@@ -20,4 +23,21 @@ pub const fn install_gas_params(gas_params: &mut GasParams) {
 pub fn custom(cx: _) -> Result<out> {
     cx.gas.spend(cx.state.gas_params().get(CUSTOM_OPCODE_DYNAMIC_GAS_ID).into())?;
     *out = Word::from(0xdead_u64);
+}
+
+#[allow(non_camel_case_types)]
+#[derive(Clone, Copy, derive_more::Debug)]
+pub struct l1_blocknumber(core::marker::PhantomData<fn() -> CustomTypes>);
+
+impl Instruction<CustomTypes> for l1_blocknumber {
+    const DYNAMIC_GAS: bool = false;
+
+    #[inline]
+    fn execute(
+        _pc: &mut Pc,
+        mut stack: StackMut<'_>,
+        state: &mut InterpreterState<'_, CustomTypes>,
+    ) -> Result<(), InstrStop> {
+        stack.push(Word::from(state.host().block_env().ext.l1_block_number))
+    }
 }

--- a/crates/evm2/examples/custom_evm/opcode.rs
+++ b/crates/evm2/examples/custom_evm/opcode.rs
@@ -2,7 +2,7 @@
 
 use crate::config::CustomTypes;
 use evm2::{
-    interpreter::{Host, InstrStop, InterpreterState, Pc, StackMut, Word, private::Instruction},
+    interpreter::{Host, Word},
     version::{GasId, GasParams},
 };
 use evm2_macros::instruction;
@@ -25,19 +25,7 @@ pub fn custom(cx: _) -> Result<out> {
     *out = Word::from(0xdead_u64);
 }
 
-#[allow(non_camel_case_types)]
-#[derive(Clone, Copy, derive_more::Debug)]
-pub struct l1_blocknumber(core::marker::PhantomData<fn() -> CustomTypes>);
-
-impl Instruction<CustomTypes> for l1_blocknumber {
-    const DYNAMIC_GAS: bool = false;
-
-    #[inline]
-    fn execute(
-        _pc: &mut Pc,
-        mut stack: StackMut<'_>,
-        state: &mut InterpreterState<'_, CustomTypes>,
-    ) -> Result<(), InstrStop> {
-        stack.push(Word::from(state.host().block_env().ext.l1_block_number))
-    }
+#[instruction(EvmTypes = CustomTypes)]
+pub fn l1_blocknumber(cx: _) -> out {
+    *out = Word::from(cx.state.host().block_env().ext.l1_block_number);
 }

--- a/crates/evm2/examples/custom_evm/tx.rs
+++ b/crates/evm2/examples/custom_evm/tx.rs
@@ -1,11 +1,12 @@
 //! Custom transaction envelope and registry handlers.
 
-use crate::config::CustomTypes;
+use crate::config::{CustomMessageExt, CustomTxEnvExt, CustomTypes};
 use alloy_eips::eip2718::Typed2718;
 use alloy_primitives::{Address, Bytes};
 use evm2::{
     Evm,
     bytecode::Bytecode,
+    env::TxEnv,
     interpreter::{Host, Message},
     registry::{HandlerResult, TxRegistry, TxRequest},
 };
@@ -54,10 +55,12 @@ pub fn execute_code(
         gas_limit: req.tx.gas_limit,
         destination: req.tx.target,
         code_address: req.tx.target,
+        ext: CustomMessageExt { is_system: false },
         ..Message::default()
     };
+    let tx_env = TxEnv { ext: CustomTxEnvExt { label: "execute-code" }, ..TxEnv::default() };
     let result = req.host.execute_message(
-        &Default::default(),
+        &tx_env,
         Bytecode::new_legacy(req.tx.code.clone()),
         &message,
         false,

--- a/crates/evm2/examples/custom_evm/tx.rs
+++ b/crates/evm2/examples/custom_evm/tx.rs
@@ -1,6 +1,8 @@
 //! Custom transaction envelope and registry handlers.
 
-use crate::config::{CustomMessageExt, CustomTxEnvExt, CustomTypes};
+use crate::config::{
+    CustomMessageExt, CustomMessageResultExt, CustomTxEnvExt, CustomTxResultExt, CustomTypes,
+};
 use alloy_eips::eip2718::Typed2718;
 use alloy_primitives::{Address, Bytes};
 use evm2::{
@@ -49,7 +51,7 @@ impl ExecuteCodeTx {
 
 pub fn execute_code(
     req: TxRequest<'_, ExecuteCodeTx, Evm<CustomTypes>>,
-) -> HandlerResult<evm2::TxResult> {
+) -> HandlerResult<evm2::TxResult<CustomTypes>> {
     // The transaction handler owns policy; the interpreter still executes a normal message.
     let message = Message {
         gas_limit: req.tx.gas_limit,
@@ -59,22 +61,25 @@ pub fn execute_code(
         ..Message::default()
     };
     let tx_env = TxEnv { ext: CustomTxEnvExt { label: "execute-code" }, ..TxEnv::default() };
-    let result = req.host.execute_message(
+    let mut result = req.host.execute_message(
         &tx_env,
         Bytecode::new_legacy(req.tx.code.clone()),
         &message,
         false,
     );
-    Ok(evm2::TxResult {
+    result.ext = CustomMessageResultExt { handled_custom_message: true };
+    Ok(evm2::TxResult::<CustomTypes> {
         status: result.stop.is_success(),
         gas_used: req.tx.gas_limit - result.gas.remaining(),
         stop: result.stop,
         output: result.output,
+        ext: CustomTxResultExt { handled_custom_tx: result.ext.handled_custom_message },
         ..Default::default()
     })
 }
 
-pub fn custom_registry() -> TxRegistry<CustomEnvelope, evm2::TxResult, Evm<CustomTypes>> {
+pub fn custom_registry() -> TxRegistry<CustomEnvelope, evm2::TxResult<CustomTypes>, Evm<CustomTypes>>
+{
     // The EIP-2718 type byte selects the typed extractor and handler.
     TxRegistry::new().with_handler(
         EXECUTE_CODE_TX_TYPE,

--- a/crates/evm2/src/ethereum/eip1559.rs
+++ b/crates/evm2/src/ethereum/eip1559.rs
@@ -17,7 +17,7 @@ use alloy_primitives::U256;
 
 pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     req: TxRequest<'_, Recovered<TxEip1559>, Evm<T>>,
-) -> HandlerResult<TxResult> {
+) -> HandlerResult<TxResult<T>> {
     let caller = req.tx.signer();
     let tx = req.tx.inner();
     let max_fee_per_gas = U256::from(tx.max_fee_per_gas);

--- a/crates/evm2/src/ethereum/eip2930.rs
+++ b/crates/evm2/src/ethereum/eip2930.rs
@@ -16,7 +16,7 @@ use alloy_primitives::U256;
 
 pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     req: TxRequest<'_, Recovered<TxEip2930>, Evm<T>>,
-) -> HandlerResult<TxResult> {
+) -> HandlerResult<TxResult<T>> {
     let caller = req.tx.signer();
     let tx = req.tx.inner();
     let gas_price = U256::from(tx.gas_price);

--- a/crates/evm2/src/ethereum/eip4844.rs
+++ b/crates/evm2/src/ethereum/eip4844.rs
@@ -76,6 +76,7 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
         gas_price,
         chain_id: U256::from(req.host.version().chain_id),
         blob_hashes: tx.blob_versioned_hashes.iter().copied().map(b256_to_word).collect(),
+        ext: T::TxEnvExt::default(),
     };
     let (bytecode, message) =
         initial_message(req.host, caller, tx.nonce, tx.to.into(), &tx.input, tx.value, gas_limit)?;

--- a/crates/evm2/src/ethereum/eip4844.rs
+++ b/crates/evm2/src/ethereum/eip4844.rs
@@ -19,7 +19,7 @@ use alloy_primitives::U256;
 
 pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     req: TxRequest<'_, Recovered<TxEip4844Variant>, Evm<T>>,
-) -> HandlerResult<TxResult> {
+) -> HandlerResult<TxResult<T>> {
     let caller = req.tx.signer();
     let tx = req.tx.inner().tx();
     let max_fee_per_gas = U256::from(tx.max_fee_per_gas);

--- a/crates/evm2/src/ethereum/eip7702.rs
+++ b/crates/evm2/src/ethereum/eip7702.rs
@@ -20,7 +20,7 @@ use alloy_primitives::{Address, U256};
 
 pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     req: TxRequest<'_, Recovered<TxEip7702>, Evm<T>>,
-) -> HandlerResult<TxResult> {
+) -> HandlerResult<TxResult<T>> {
     let caller = req.tx.signer();
     let tx = req.tx.inner();
     if tx.authorization_list.is_empty() {

--- a/crates/evm2/src/ethereum/legacy.rs
+++ b/crates/evm2/src/ethereum/legacy.rs
@@ -15,7 +15,7 @@ use alloy_primitives::U256;
 
 pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     req: TxRequest<'_, Recovered<TxLegacy>, Evm<T>>,
-) -> HandlerResult<TxResult> {
+) -> HandlerResult<TxResult<T>> {
     let caller = req.tx.signer();
     let tx = req.tx.inner();
     let gas_price = U256::from(tx.gas_price);

--- a/crates/evm2/src/ethereum/mod.rs
+++ b/crates/evm2/src/ethereum/mod.rs
@@ -94,7 +94,7 @@ impl Typed2718 for RecoveredTxEnvelope {
 /// Returns the Ethereum transaction registry for `spec_id`.
 pub fn ethereum_tx_registry<T: EvmTypes<Host = Evm<T>>>(
     spec_id: SpecId,
-) -> TxRegistry<RecoveredTxEnvelope, TxResult, Evm<T>> {
+) -> TxRegistry<RecoveredTxEnvelope, TxResult<T>, Evm<T>> {
     let mut registry =
         TxRegistry::new().with_handler(0, RecoveredTxEnvelope::as_legacy, legacy::handle::<T>);
 
@@ -405,7 +405,7 @@ fn initial_call_code<T: EvmTypes<Host = Evm<T>>>(
 pub(super) fn rollback_failed_execution<T: EvmTypes<Host = Evm<T>>>(
     host: &mut Evm<T>,
     checkpoint: StateCheckpoint,
-    result: &mut MessageResult,
+    result: &mut MessageResult<T>,
 ) {
     if !result.stop.is_success() {
         host.state.rollback(checkpoint, host.spec_id());
@@ -421,8 +421,8 @@ pub(super) fn settle_gas<T: EvmTypes<Host = Evm<T>>>(
     gas_price: U256,
     tx_gas_limit: u64,
     floor_gas: u64,
-    result: MessageResult,
-) -> HandlerResult<TxResult> {
+    result: MessageResult<T>,
+) -> HandlerResult<TxResult<T>> {
     let (gas_remaining, gas_used) =
         final_tx_gas(&result, tx_gas_limit, host.feature(EvmFeatures::EIP3529), floor_gas);
     if host.feature(EvmFeatures::FEE_CHARGE) {
@@ -443,12 +443,13 @@ pub(super) fn settle_gas<T: EvmTypes<Host = Evm<T>>>(
         gas_used,
         stop: result.stop,
         output: result.output,
+        ext: T::TxResultExt::default(),
         ..TxResult::default()
     })
 }
 
-const fn final_tx_gas(
-    result: &MessageResult,
+const fn final_tx_gas<T: EvmTypes>(
+    result: &MessageResult<T>,
     tx_gas_limit: u64,
     is_eip3529: bool,
     floor_gas: u64,
@@ -709,14 +710,14 @@ mod tests {
 
     #[test]
     fn final_tx_gas_charges_calldata_floor_after_refund() {
-        let result = MessageResult {
+        let result = MessageResult::<BaseEvmTypes> {
             stop: crate::interpreter::InstrStop::Return,
             gas: {
                 let mut gas = GasTracker::new(100_000, 50_000, 0);
                 gas.set_refunded(10_000);
                 gas
             },
-            ..MessageResult::default()
+            ..MessageResult::<BaseEvmTypes>::default()
         };
 
         assert_eq!(final_tx_gas(&result, 100_000, true, 60_000), (40_000, 60_000));
@@ -724,10 +725,10 @@ mod tests {
 
     #[test]
     fn final_tx_gas_preserves_higher_actual_usage() {
-        let result = MessageResult {
+        let result = MessageResult::<BaseEvmTypes> {
             stop: crate::interpreter::InstrStop::Return,
             gas: GasTracker::new(100_000, 30_000, 0),
-            ..MessageResult::default()
+            ..MessageResult::<BaseEvmTypes>::default()
         };
 
         assert_eq!(final_tx_gas(&result, 100_000, true, 60_000), (30_000, 70_000));

--- a/crates/evm2/src/ethereum/mod.rs
+++ b/crates/evm2/src/ethereum/mod.rs
@@ -334,7 +334,7 @@ pub(crate) fn initial_message<T: EvmTypes<Host = Evm<T>>>(
     input: &Bytes,
     value: U256,
     gas_limit: u64,
-) -> HandlerResult<(Bytecode, Message)> {
+) -> HandlerResult<(Bytecode, Message<T>)> {
     let r = match to {
         TxKind::Call(to) => {
             let initial_code = initial_call_code(host, to)?;
@@ -349,6 +349,7 @@ pub(crate) fn initial_message<T: EvmTypes<Host = Evm<T>>>(
                 code_address: initial_code.code_address,
                 disable_precompiles: initial_code.disable_precompiles,
                 salt: B256::ZERO,
+                ext: T::MessageExt::default(),
             };
             (initial_code.code, message)
         }
@@ -365,6 +366,7 @@ pub(crate) fn initial_message<T: EvmTypes<Host = Evm<T>>>(
                 code_address: address,
                 disable_precompiles: false,
                 salt: B256::ZERO,
+                ext: T::MessageExt::default(),
             };
             (Bytecode::new_legacy(input.clone()), message)
         }

--- a/crates/evm2/src/evm/config.rs
+++ b/crates/evm2/src/evm/config.rs
@@ -28,19 +28,19 @@ pub trait EvmTypes: Sized + 'static {
     type Tx;
 
     /// Extra data stored in frame messages.
-    type MessageExt: Clone + core::fmt::Debug + PartialEq + Eq + Default;
+    type MessageExt: Clone + core::fmt::Debug + Default;
 
     /// Extra data stored in message execution results.
-    type MessageResultExt: Clone + core::fmt::Debug + PartialEq + Eq + Default;
+    type MessageResultExt: Clone + core::fmt::Debug + Default;
 
     /// Extra data stored in transaction environments.
-    type TxEnvExt: Clone + core::fmt::Debug + PartialEq + Eq + Default;
+    type TxEnvExt: Clone + core::fmt::Debug + Default;
 
     /// Extra data stored in transaction execution results.
-    type TxResultExt: Clone + core::fmt::Debug + PartialEq + Eq + Default;
+    type TxResultExt: Clone + core::fmt::Debug + Default;
 
     /// Extra data stored in block environments.
-    type BlockEnvExt: Copy + core::fmt::Debug + PartialEq + Eq + Default;
+    type BlockEnvExt: Copy + core::fmt::Debug + Default;
 
     /// Host type used by this EVM.
     type Host: Host<Self> + ?Sized;

--- a/crates/evm2/src/evm/config.rs
+++ b/crates/evm2/src/evm/config.rs
@@ -9,6 +9,7 @@ use crate::{
     },
     version::Version,
 };
+use derive_where::derive_where;
 
 /// Runtime EVM type family.
 ///
@@ -114,12 +115,12 @@ where
 ///
 /// Bundles the active runtime `Version` with the finalized instruction dispatch table selected for
 /// an EVM instance. This is the data passed to the interpreter when it runs.
-#[derive(derive_more::Debug)]
+#[derive_where(Debug)]
 pub struct ExecutionConfig<T: EvmTypes> {
     pub(crate) version: Version,
-    #[debug(skip)]
+    #[derive_where(skip)]
     pub(crate) instructions: &'static InstrTable<T>,
-    #[debug(skip)]
+    #[derive_where(skip)]
     pub(crate) inspect_instructions: &'static InstrTable<T>,
 }
 

--- a/crates/evm2/src/evm/config.rs
+++ b/crates/evm2/src/evm/config.rs
@@ -27,20 +27,20 @@ pub trait EvmTypes: Sized + 'static {
     /// Transaction type handled by this EVM.
     type Tx;
 
-    /// Extra data stored in transaction environments.
-    type TxEnvExt: Clone + core::fmt::Debug + PartialEq + Eq + Default;
-
-    /// Extra data stored in block environments.
-    type BlockEnvExt: Copy + core::fmt::Debug + PartialEq + Eq + Default;
-
     /// Extra data stored in frame messages.
     type MessageExt: Clone + core::fmt::Debug + PartialEq + Eq + Default;
 
     /// Extra data stored in message execution results.
     type MessageResultExt: Clone + core::fmt::Debug + PartialEq + Eq + Default;
 
+    /// Extra data stored in transaction environments.
+    type TxEnvExt: Clone + core::fmt::Debug + PartialEq + Eq + Default;
+
     /// Extra data stored in transaction execution results.
     type TxResultExt: Clone + core::fmt::Debug + PartialEq + Eq + Default;
+
+    /// Extra data stored in block environments.
+    type BlockEnvExt: Copy + core::fmt::Debug + PartialEq + Eq + Default;
 
     /// Host type used by this EVM.
     type Host: Host<Self> + ?Sized;
@@ -198,11 +198,11 @@ impl EvmTypes for BaseEvmTypes {
     type ConfigSelector = BaseEvmConfigSelector;
     type SpecId = SpecId;
     type Tx = RecoveredTxEnvelope;
-    type TxEnvExt = ();
-    type BlockEnvExt = ();
     type MessageExt = ();
     type MessageResultExt = ();
+    type TxEnvExt = ();
     type TxResultExt = ();
+    type BlockEnvExt = ();
     type Host = crate::evm::Evm<Self>;
 }
 

--- a/crates/evm2/src/evm/config.rs
+++ b/crates/evm2/src/evm/config.rs
@@ -36,6 +36,12 @@ pub trait EvmTypes: Sized + 'static {
     /// Extra data stored in frame messages.
     type MessageExt: Clone + core::fmt::Debug + PartialEq + Eq + Default;
 
+    /// Extra data stored in message execution results.
+    type MessageResultExt: Clone + core::fmt::Debug + PartialEq + Eq + Default;
+
+    /// Extra data stored in transaction execution results.
+    type TxResultExt: Clone + core::fmt::Debug + PartialEq + Eq + Default;
+
     /// Host type used by this EVM.
     type Host: Host<Self> + ?Sized;
 }
@@ -195,6 +201,8 @@ impl EvmTypes for BaseEvmTypes {
     type TxEnvExt = ();
     type BlockEnvExt = ();
     type MessageExt = ();
+    type MessageResultExt = ();
+    type TxResultExt = ();
     type Host = crate::evm::Evm<Self>;
 }
 

--- a/crates/evm2/src/evm/config.rs
+++ b/crates/evm2/src/evm/config.rs
@@ -27,8 +27,17 @@ pub trait EvmTypes: Sized + 'static {
     /// Transaction type handled by this EVM.
     type Tx;
 
+    /// Extra data stored in transaction environments.
+    type TxEnvExt: Clone + core::fmt::Debug + PartialEq + Eq + Default;
+
+    /// Extra data stored in block environments.
+    type BlockEnvExt: Copy + core::fmt::Debug + PartialEq + Eq + Default;
+
+    /// Extra data stored in frame messages.
+    type MessageExt: Clone + core::fmt::Debug + PartialEq + Eq + Default;
+
     /// Host type used by this EVM.
-    type Host: Host + ?Sized;
+    type Host: Host<Self> + ?Sized;
 }
 
 /// Compile-time EVM table configuration.
@@ -183,6 +192,9 @@ impl EvmTypes for BaseEvmTypes {
     type ConfigSelector = BaseEvmConfigSelector;
     type SpecId = SpecId;
     type Tx = RecoveredTxEnvelope;
+    type TxEnvExt = ();
+    type BlockEnvExt = ();
+    type MessageExt = ();
     type Host = crate::evm::Evm<Self>;
 }
 

--- a/crates/evm2/src/evm/env.rs
+++ b/crates/evm2/src/evm/env.rs
@@ -5,7 +5,7 @@ use alloc::{vec, vec::Vec};
 use alloy_primitives::{Address, U256};
 
 /// Transaction-global environment values visible to opcodes.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug)]
 pub struct TxEnv<T: EvmTypes = BaseEvmTypes> {
     /// Transaction origin.
     pub origin: Address,
@@ -17,6 +17,28 @@ pub struct TxEnv<T: EvmTypes = BaseEvmTypes> {
     pub blob_hashes: Vec<U256>,
     /// EVM type-specific extension data.
     pub ext: T::TxEnvExt,
+}
+
+impl<T> PartialEq for TxEnv<T>
+where
+    T: EvmTypes,
+    T::TxEnvExt: PartialEq,
+{
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        self.origin == other.origin
+            && self.gas_price == other.gas_price
+            && self.chain_id == other.chain_id
+            && self.blob_hashes == other.blob_hashes
+            && self.ext == other.ext
+    }
+}
+
+impl<T> Eq for TxEnv<T>
+where
+    T: EvmTypes,
+    T::TxEnvExt: Eq,
+{
 }
 
 impl<T: EvmTypes> Default for TxEnv<T> {
@@ -33,7 +55,7 @@ impl<T: EvmTypes> Default for TxEnv<T> {
 }
 
 /// Block environment values visible to opcodes.
-#[derive(derive_more::Debug, PartialEq, Eq)]
+#[derive(derive_more::Debug)]
 pub struct BlockEnv<T: EvmTypes = BaseEvmTypes> {
     /// Block number.
     pub number: U256,
@@ -55,6 +77,33 @@ pub struct BlockEnv<T: EvmTypes = BaseEvmTypes> {
     pub slot_num: U256,
     /// EVM type-specific extension data.
     pub ext: T::BlockEnvExt,
+}
+
+impl<T> PartialEq for BlockEnv<T>
+where
+    T: EvmTypes,
+    T::BlockEnvExt: PartialEq,
+{
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        self.number == other.number
+            && self.beneficiary == other.beneficiary
+            && self.timestamp == other.timestamp
+            && self.gas_limit == other.gas_limit
+            && self.basefee == other.basefee
+            && self.difficulty == other.difficulty
+            && self.prevrandao == other.prevrandao
+            && self.blob_basefee == other.blob_basefee
+            && self.slot_num == other.slot_num
+            && self.ext == other.ext
+    }
+}
+
+impl<T> Eq for BlockEnv<T>
+where
+    T: EvmTypes,
+    T::BlockEnvExt: Eq,
+{
 }
 
 impl<T: EvmTypes> Clone for BlockEnv<T> {

--- a/crates/evm2/src/evm/env.rs
+++ b/crates/evm2/src/evm/env.rs
@@ -3,9 +3,10 @@
 use crate::{BaseEvmTypes, EvmTypes};
 use alloc::{vec, vec::Vec};
 use alloy_primitives::{Address, U256};
+use derive_where::derive_where;
 
 /// Transaction-global environment values visible to opcodes.
-#[derive(Clone, Debug)]
+#[derive_where(Clone, Debug, PartialEq, Eq; T::TxEnvExt)]
 pub struct TxEnv<T: EvmTypes = BaseEvmTypes> {
     /// Transaction origin.
     pub origin: Address,
@@ -17,28 +18,6 @@ pub struct TxEnv<T: EvmTypes = BaseEvmTypes> {
     pub blob_hashes: Vec<U256>,
     /// EVM type-specific extension data.
     pub ext: T::TxEnvExt,
-}
-
-impl<T> PartialEq for TxEnv<T>
-where
-    T: EvmTypes,
-    T::TxEnvExt: PartialEq,
-{
-    #[inline]
-    fn eq(&self, other: &Self) -> bool {
-        self.origin == other.origin
-            && self.gas_price == other.gas_price
-            && self.chain_id == other.chain_id
-            && self.blob_hashes == other.blob_hashes
-            && self.ext == other.ext
-    }
-}
-
-impl<T> Eq for TxEnv<T>
-where
-    T: EvmTypes,
-    T::TxEnvExt: Eq,
-{
 }
 
 impl<T: EvmTypes> Default for TxEnv<T> {
@@ -55,7 +34,7 @@ impl<T: EvmTypes> Default for TxEnv<T> {
 }
 
 /// Block environment values visible to opcodes.
-#[derive(derive_more::Debug)]
+#[derive_where(Clone, Copy, Debug, PartialEq, Eq; T::BlockEnvExt)]
 pub struct BlockEnv<T: EvmTypes = BaseEvmTypes> {
     /// Block number.
     pub number: U256,
@@ -78,42 +57,6 @@ pub struct BlockEnv<T: EvmTypes = BaseEvmTypes> {
     /// EVM type-specific extension data.
     pub ext: T::BlockEnvExt,
 }
-
-impl<T> PartialEq for BlockEnv<T>
-where
-    T: EvmTypes,
-    T::BlockEnvExt: PartialEq,
-{
-    #[inline]
-    fn eq(&self, other: &Self) -> bool {
-        self.number == other.number
-            && self.beneficiary == other.beneficiary
-            && self.timestamp == other.timestamp
-            && self.gas_limit == other.gas_limit
-            && self.basefee == other.basefee
-            && self.difficulty == other.difficulty
-            && self.prevrandao == other.prevrandao
-            && self.blob_basefee == other.blob_basefee
-            && self.slot_num == other.slot_num
-            && self.ext == other.ext
-    }
-}
-
-impl<T> Eq for BlockEnv<T>
-where
-    T: EvmTypes,
-    T::BlockEnvExt: Eq,
-{
-}
-
-impl<T: EvmTypes> Clone for BlockEnv<T> {
-    #[inline]
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-
-impl<T: EvmTypes> Copy for BlockEnv<T> {}
 
 impl<T: EvmTypes> Default for BlockEnv<T> {
     #[inline]

--- a/crates/evm2/src/evm/env.rs
+++ b/crates/evm2/src/evm/env.rs
@@ -1,11 +1,12 @@
 //! EVM environment types.
 
+use crate::{BaseEvmTypes, EvmTypes};
 use alloc::{vec, vec::Vec};
 use alloy_primitives::{Address, U256};
 
 /// Transaction-global environment values visible to opcodes.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct TxEnv {
+pub struct TxEnv<T: EvmTypes = BaseEvmTypes> {
     /// Transaction origin.
     pub origin: Address,
     /// Effective gas price.
@@ -14,9 +15,11 @@ pub struct TxEnv {
     pub chain_id: U256,
     /// Transaction blob versioned hashes.
     pub blob_hashes: Vec<U256>,
+    /// EVM type-specific extension data.
+    pub ext: T::TxEnvExt,
 }
 
-impl Default for TxEnv {
+impl<T: EvmTypes> Default for TxEnv<T> {
     #[inline]
     fn default() -> Self {
         Self {
@@ -24,13 +27,14 @@ impl Default for TxEnv {
             gas_price: U256::ZERO,
             chain_id: U256::ONE,
             blob_hashes: vec![],
+            ext: T::TxEnvExt::default(),
         }
     }
 }
 
 /// Block environment values visible to opcodes.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct BlockEnv {
+#[derive(derive_more::Debug, PartialEq, Eq)]
+pub struct BlockEnv<T: EvmTypes = BaseEvmTypes> {
     /// Block number.
     pub number: U256,
     /// Block beneficiary.
@@ -49,9 +53,20 @@ pub struct BlockEnv {
     pub blob_basefee: U256,
     /// Beacon slot number.
     pub slot_num: U256,
+    /// EVM type-specific extension data.
+    pub ext: T::BlockEnvExt,
 }
 
-impl Default for BlockEnv {
+impl<T: EvmTypes> Clone for BlockEnv<T> {
+    #[inline]
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<T: EvmTypes> Copy for BlockEnv<T> {}
+
+impl<T: EvmTypes> Default for BlockEnv<T> {
     #[inline]
     fn default() -> Self {
         Self {
@@ -64,6 +79,7 @@ impl Default for BlockEnv {
             prevrandao: U256::ZERO,
             blob_basefee: U256::ONE,
             slot_num: U256::ZERO,
+            ext: T::BlockEnvExt::default(),
         }
     }
 }

--- a/crates/evm2/src/evm/inspector.rs
+++ b/crates/evm2/src/evm/inspector.rs
@@ -35,28 +35,28 @@ pub trait Inspector<T: EvmTypes>: Any {
 
     /// Called before a call message executes.
     #[inline]
-    fn call(&mut self, message: &mut Message) -> Option<MessageResult> {
+    fn call(&mut self, message: &mut Message<T>) -> Option<MessageResult> {
         let _ = message;
         None
     }
 
     /// Called after a call message executes.
     #[inline]
-    fn call_end(&mut self, message: &Message, result: &mut MessageResult) {
+    fn call_end(&mut self, message: &Message<T>, result: &mut MessageResult) {
         let _ = message;
         let _ = result;
     }
 
     /// Called before a create message executes.
     #[inline]
-    fn create(&mut self, message: &mut Message) -> Option<MessageResult> {
+    fn create(&mut self, message: &mut Message<T>) -> Option<MessageResult> {
         let _ = message;
         None
     }
 
     /// Called after a create message executes.
     #[inline]
-    fn create_end(&mut self, message: &Message, result: &mut MessageResult) {
+    fn create_end(&mut self, message: &Message<T>, result: &mut MessageResult) {
         let _ = message;
         let _ = result;
     }
@@ -119,21 +119,21 @@ mod tests {
     }
 
     impl Inspector<TestTypes> for MessageInspector {
-        fn call(&mut self, message: &mut Message) -> Option<MessageResult> {
+        fn call(&mut self, message: &mut Message<TestTypes>) -> Option<MessageResult> {
             self.call_depth = Some(message.depth);
             None
         }
 
-        fn call_end(&mut self, _message: &Message, result: &mut MessageResult) {
+        fn call_end(&mut self, _message: &Message<TestTypes>, result: &mut MessageResult) {
             self.call_end_stop = Some(result.stop);
         }
 
-        fn create(&mut self, message: &mut Message) -> Option<MessageResult> {
+        fn create(&mut self, message: &mut Message<TestTypes>) -> Option<MessageResult> {
             self.create_depth = Some(message.depth);
             None
         }
 
-        fn create_end(&mut self, _message: &Message, result: &mut MessageResult) {
+        fn create_end(&mut self, _message: &Message<TestTypes>, result: &mut MessageResult) {
             self.create_end_stop = Some(result.stop);
         }
 
@@ -149,14 +149,14 @@ mod tests {
     }
 
     impl Inspector<TestTypes> for OverrideCallInspector {
-        fn call(&mut self, message: &mut Message) -> Option<MessageResult> {
+        fn call(&mut self, message: &mut Message<TestTypes>) -> Option<MessageResult> {
             self.call_depth = Some(message.depth);
             let mut result = self.result.clone();
             result.gas.set_remaining(message.gas_limit);
             Some(result)
         }
 
-        fn call_end(&mut self, _message: &Message, result: &mut MessageResult) {
+        fn call_end(&mut self, _message: &Message<TestTypes>, result: &mut MessageResult) {
             self.call_end_stop = Some(result.stop);
         }
     }
@@ -166,7 +166,7 @@ mod tests {
     }
 
     impl Inspector<TestTypes> for MutateCallInspector {
-        fn call(&mut self, message: &mut Message) -> Option<MessageResult> {
+        fn call(&mut self, message: &mut Message<TestTypes>) -> Option<MessageResult> {
             message.destination = self.destination;
             None
         }
@@ -175,7 +175,7 @@ mod tests {
     struct CallEndInspector;
 
     impl Inspector<TestTypes> for CallEndInspector {
-        fn call(&mut self, message: &mut Message) -> Option<MessageResult> {
+        fn call(&mut self, message: &mut Message<TestTypes>) -> Option<MessageResult> {
             Some(MessageResult {
                 stop: InstrStop::Revert,
                 gas: GasTracker::new(message.gas_limit, message.gas_limit, 0),
@@ -183,7 +183,7 @@ mod tests {
             })
         }
 
-        fn call_end(&mut self, _message: &Message, result: &mut MessageResult) {
+        fn call_end(&mut self, _message: &Message<TestTypes>, result: &mut MessageResult) {
             result.stop = InstrStop::Return;
             result.output = Bytes::from_static(&[0xaa, 0xbb]);
         }
@@ -196,7 +196,7 @@ mod tests {
     }
 
     impl Inspector<TestTypes> for OverrideCreateInspector {
-        fn create(&mut self, message: &mut Message) -> Option<MessageResult> {
+        fn create(&mut self, message: &mut Message<TestTypes>) -> Option<MessageResult> {
             self.create_depth = Some(message.depth);
             Some(MessageResult {
                 stop: InstrStop::Return,
@@ -206,7 +206,7 @@ mod tests {
             })
         }
 
-        fn create_end(&mut self, _message: &Message, result: &mut MessageResult) {
+        fn create_end(&mut self, _message: &Message<TestTypes>, result: &mut MessageResult) {
             self.create_end_stop = Some(result.stop);
         }
     }
@@ -216,7 +216,7 @@ mod tests {
     }
 
     impl Inspector<TestTypes> for CreateEndInspector {
-        fn create(&mut self, message: &mut Message) -> Option<MessageResult> {
+        fn create(&mut self, message: &mut Message<TestTypes>) -> Option<MessageResult> {
             Some(MessageResult {
                 stop: InstrStop::Revert,
                 gas: GasTracker::new(message.gas_limit, message.gas_limit, 0),
@@ -224,7 +224,7 @@ mod tests {
             })
         }
 
-        fn create_end(&mut self, _message: &Message, result: &mut MessageResult) {
+        fn create_end(&mut self, _message: &Message<TestTypes>, result: &mut MessageResult) {
             result.stop = InstrStop::Return;
             result.created_address = Some(self.created);
         }
@@ -287,12 +287,12 @@ mod tests {
             self.0.borrow_mut().logs.push(log.clone());
         }
 
-        fn call(&mut self, _message: &mut Message) -> Option<MessageResult> {
+        fn call(&mut self, _message: &mut Message<BaseEvmTypes>) -> Option<MessageResult> {
             self.0.borrow_mut().calls += 1;
             None
         }
 
-        fn create(&mut self, _message: &mut Message) -> Option<MessageResult> {
+        fn create(&mut self, _message: &mut Message<BaseEvmTypes>) -> Option<MessageResult> {
             self.0.borrow_mut().creates += 1;
             None
         }
@@ -307,7 +307,7 @@ mod tests {
     fn run_with_inspector<I: Inspector<TestTypes>>(
         code: Vec<u8>,
         host: &mut TestHost,
-        message: &Message,
+        message: &Message<TestTypes>,
         gas_limit: u64,
         inspector: &mut I,
     ) -> (InstrStop, Vec<Word>) {

--- a/crates/evm2/src/evm/inspector.rs
+++ b/crates/evm2/src/evm/inspector.rs
@@ -35,28 +35,28 @@ pub trait Inspector<T: EvmTypes>: Any {
 
     /// Called before a call message executes.
     #[inline]
-    fn call(&mut self, message: &mut Message<T>) -> Option<MessageResult> {
+    fn call(&mut self, message: &mut Message<T>) -> Option<MessageResult<T>> {
         let _ = message;
         None
     }
 
     /// Called after a call message executes.
     #[inline]
-    fn call_end(&mut self, message: &Message<T>, result: &mut MessageResult) {
+    fn call_end(&mut self, message: &Message<T>, result: &mut MessageResult<T>) {
         let _ = message;
         let _ = result;
     }
 
     /// Called before a create message executes.
     #[inline]
-    fn create(&mut self, message: &mut Message<T>) -> Option<MessageResult> {
+    fn create(&mut self, message: &mut Message<T>) -> Option<MessageResult<T>> {
         let _ = message;
         None
     }
 
     /// Called after a create message executes.
     #[inline]
-    fn create_end(&mut self, message: &Message<T>, result: &mut MessageResult) {
+    fn create_end(&mut self, message: &Message<T>, result: &mut MessageResult<T>) {
         let _ = message;
         let _ = result;
     }
@@ -119,21 +119,29 @@ mod tests {
     }
 
     impl Inspector<TestTypes> for MessageInspector {
-        fn call(&mut self, message: &mut Message<TestTypes>) -> Option<MessageResult> {
+        fn call(&mut self, message: &mut Message<TestTypes>) -> Option<MessageResult<TestTypes>> {
             self.call_depth = Some(message.depth);
             None
         }
 
-        fn call_end(&mut self, _message: &Message<TestTypes>, result: &mut MessageResult) {
+        fn call_end(
+            &mut self,
+            _message: &Message<TestTypes>,
+            result: &mut MessageResult<TestTypes>,
+        ) {
             self.call_end_stop = Some(result.stop);
         }
 
-        fn create(&mut self, message: &mut Message<TestTypes>) -> Option<MessageResult> {
+        fn create(&mut self, message: &mut Message<TestTypes>) -> Option<MessageResult<TestTypes>> {
             self.create_depth = Some(message.depth);
             None
         }
 
-        fn create_end(&mut self, _message: &Message<TestTypes>, result: &mut MessageResult) {
+        fn create_end(
+            &mut self,
+            _message: &Message<TestTypes>,
+            result: &mut MessageResult<TestTypes>,
+        ) {
             self.create_end_stop = Some(result.stop);
         }
 
@@ -143,20 +151,24 @@ mod tests {
     }
 
     struct OverrideCallInspector {
-        result: MessageResult,
+        result: MessageResult<TestTypes>,
         call_depth: Option<u16>,
         call_end_stop: Option<InstrStop>,
     }
 
     impl Inspector<TestTypes> for OverrideCallInspector {
-        fn call(&mut self, message: &mut Message<TestTypes>) -> Option<MessageResult> {
+        fn call(&mut self, message: &mut Message<TestTypes>) -> Option<MessageResult<TestTypes>> {
             self.call_depth = Some(message.depth);
             let mut result = self.result.clone();
             result.gas.set_remaining(message.gas_limit);
             Some(result)
         }
 
-        fn call_end(&mut self, _message: &Message<TestTypes>, result: &mut MessageResult) {
+        fn call_end(
+            &mut self,
+            _message: &Message<TestTypes>,
+            result: &mut MessageResult<TestTypes>,
+        ) {
             self.call_end_stop = Some(result.stop);
         }
     }
@@ -166,7 +178,7 @@ mod tests {
     }
 
     impl Inspector<TestTypes> for MutateCallInspector {
-        fn call(&mut self, message: &mut Message<TestTypes>) -> Option<MessageResult> {
+        fn call(&mut self, message: &mut Message<TestTypes>) -> Option<MessageResult<TestTypes>> {
             message.destination = self.destination;
             None
         }
@@ -175,7 +187,7 @@ mod tests {
     struct CallEndInspector;
 
     impl Inspector<TestTypes> for CallEndInspector {
-        fn call(&mut self, message: &mut Message<TestTypes>) -> Option<MessageResult> {
+        fn call(&mut self, message: &mut Message<TestTypes>) -> Option<MessageResult<TestTypes>> {
             Some(MessageResult {
                 stop: InstrStop::Revert,
                 gas: GasTracker::new(message.gas_limit, message.gas_limit, 0),
@@ -183,7 +195,11 @@ mod tests {
             })
         }
 
-        fn call_end(&mut self, _message: &Message<TestTypes>, result: &mut MessageResult) {
+        fn call_end(
+            &mut self,
+            _message: &Message<TestTypes>,
+            result: &mut MessageResult<TestTypes>,
+        ) {
             result.stop = InstrStop::Return;
             result.output = Bytes::from_static(&[0xaa, 0xbb]);
         }
@@ -196,7 +212,7 @@ mod tests {
     }
 
     impl Inspector<TestTypes> for OverrideCreateInspector {
-        fn create(&mut self, message: &mut Message<TestTypes>) -> Option<MessageResult> {
+        fn create(&mut self, message: &mut Message<TestTypes>) -> Option<MessageResult<TestTypes>> {
             self.create_depth = Some(message.depth);
             Some(MessageResult {
                 stop: InstrStop::Return,
@@ -206,7 +222,11 @@ mod tests {
             })
         }
 
-        fn create_end(&mut self, _message: &Message<TestTypes>, result: &mut MessageResult) {
+        fn create_end(
+            &mut self,
+            _message: &Message<TestTypes>,
+            result: &mut MessageResult<TestTypes>,
+        ) {
             self.create_end_stop = Some(result.stop);
         }
     }
@@ -216,7 +236,7 @@ mod tests {
     }
 
     impl Inspector<TestTypes> for CreateEndInspector {
-        fn create(&mut self, message: &mut Message<TestTypes>) -> Option<MessageResult> {
+        fn create(&mut self, message: &mut Message<TestTypes>) -> Option<MessageResult<TestTypes>> {
             Some(MessageResult {
                 stop: InstrStop::Revert,
                 gas: GasTracker::new(message.gas_limit, message.gas_limit, 0),
@@ -224,7 +244,11 @@ mod tests {
             })
         }
 
-        fn create_end(&mut self, _message: &Message<TestTypes>, result: &mut MessageResult) {
+        fn create_end(
+            &mut self,
+            _message: &Message<TestTypes>,
+            result: &mut MessageResult<TestTypes>,
+        ) {
             result.stop = InstrStop::Return;
             result.created_address = Some(self.created);
         }
@@ -287,12 +311,18 @@ mod tests {
             self.0.borrow_mut().logs.push(log.clone());
         }
 
-        fn call(&mut self, _message: &mut Message<BaseEvmTypes>) -> Option<MessageResult> {
+        fn call(
+            &mut self,
+            _message: &mut Message<BaseEvmTypes>,
+        ) -> Option<MessageResult<BaseEvmTypes>> {
             self.0.borrow_mut().calls += 1;
             None
         }
 
-        fn create(&mut self, _message: &mut Message<BaseEvmTypes>) -> Option<MessageResult> {
+        fn create(
+            &mut self,
+            _message: &mut Message<BaseEvmTypes>,
+        ) -> Option<MessageResult<BaseEvmTypes>> {
             self.0.borrow_mut().creates += 1;
             None
         }

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -46,22 +46,22 @@ pub use state::{
 };
 
 /// EVM host and transaction dispatcher.
-#[derive(derive_more::Debug)]
+#[derive_where(Debug)]
 pub struct Evm<T: EvmTypes> {
-    #[debug(skip)]
+    #[derive_where(skip)]
     spec_id: T::SpecId,
-    #[debug(skip)]
+    #[derive_where(skip)]
     execution_config: ExecutionConfig<T>,
     features: EvmFeatures,
     pub(crate) block: BlockEnv<T>,
     registry: TxRegistry<T::Tx, TxResult<T>, Self>,
-    #[debug(skip)]
+    #[derive_where(skip)]
     pub(crate) state: State,
-    #[debug(skip)]
+    #[derive_where(skip)]
     precompiles: Box<dyn PrecompileProvider>,
-    #[debug(skip)]
+    #[derive_where(skip)]
     interpreter_pool: InterpreterPool<T>,
-    #[debug(skip)]
+    #[derive_where(skip)]
     inspector: Option<Box<dyn Inspector<T>>>,
     db_error_code: Option<DbErrorCode>,
 }

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -20,6 +20,7 @@ use crate::{
 use alloc::{boxed::Box, vec};
 use alloy_eips::eip2718::Typed2718;
 use alloy_primitives::{Address, B256, Bytes, Log, LogData};
+use derive_where::derive_where;
 
 pub mod config;
 pub mod env;
@@ -946,7 +947,7 @@ pub struct SelfDestructResult {
 }
 
 /// Result of executing a transaction.
-#[derive(Clone, derive_more::Debug)]
+#[derive_where(Clone, Debug, PartialEq, Eq; T::TxResultExt)]
 pub struct TxResult<T: EvmTypes = crate::BaseEvmTypes> {
     /// Whether execution succeeded.
     pub status: bool,
@@ -962,30 +963,6 @@ pub struct TxResult<T: EvmTypes = crate::BaseEvmTypes> {
     pub db_error_code: Option<DbErrorCode>,
     /// EVM type-specific extension data.
     pub ext: T::TxResultExt,
-}
-
-impl<T> PartialEq for TxResult<T>
-where
-    T: EvmTypes,
-    T::TxResultExt: PartialEq,
-{
-    #[inline]
-    fn eq(&self, other: &Self) -> bool {
-        self.status == other.status
-            && self.gas_used == other.gas_used
-            && self.stop == other.stop
-            && self.output == other.output
-            && self.state_changes == other.state_changes
-            && self.db_error_code == other.db_error_code
-            && self.ext == other.ext
-    }
-}
-
-impl<T> Eq for TxResult<T>
-where
-    T: EvmTypes,
-    T::TxResultExt: Eq,
-{
 }
 
 impl<T: EvmTypes> Default for TxResult<T> {

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -947,7 +947,7 @@ pub struct SelfDestructResult {
 }
 
 /// Result of executing a transaction.
-#[derive_where(Clone, Debug, PartialEq, Eq; T::TxResultExt)]
+#[derive_where(Clone, Debug, Default, PartialEq, Eq; T::TxResultExt)]
 pub struct TxResult<T: EvmTypes = crate::BaseEvmTypes> {
     /// Whether execution succeeded.
     pub status: bool,
@@ -963,21 +963,6 @@ pub struct TxResult<T: EvmTypes = crate::BaseEvmTypes> {
     pub db_error_code: Option<DbErrorCode>,
     /// EVM type-specific extension data.
     pub ext: T::TxResultExt,
-}
-
-impl<T: EvmTypes> Default for TxResult<T> {
-    #[inline]
-    fn default() -> Self {
-        Self {
-            status: false,
-            gas_used: 0,
-            stop: InstrStop::default(),
-            output: Bytes::new(),
-            state_changes: StateChanges::default(),
-            db_error_code: None,
-            ext: T::TxResultExt::default(),
-        }
-    }
 }
 
 fn eip7708_transfer_log(from: Address, to: Address, value: Word) -> Option<Log> {

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -53,7 +53,7 @@ pub struct Evm<T: EvmTypes> {
     execution_config: ExecutionConfig<T>,
     features: EvmFeatures,
     pub(crate) block: BlockEnv<T>,
-    registry: TxRegistry<T::Tx, TxResult, Self>,
+    registry: TxRegistry<T::Tx, TxResult<T>, Self>,
     #[debug(skip)]
     pub(crate) state: State,
     #[debug(skip)]
@@ -72,7 +72,7 @@ impl<T: EvmTypes> Evm<T> {
     pub fn new(
         spec_id: T::SpecId,
         block: BlockEnv<T>,
-        registry: TxRegistry<T::Tx, TxResult, Self>,
+        registry: TxRegistry<T::Tx, TxResult<T>, Self>,
         database: impl DynDatabase,
         precompiles: impl PrecompileProvider,
     ) -> Self {
@@ -92,7 +92,7 @@ impl<T: EvmTypes> Evm<T> {
         execution_config: ExecutionConfig<T>,
         spec_id: T::SpecId,
         block: BlockEnv<T>,
-        registry: TxRegistry<T::Tx, TxResult, Self>,
+        registry: TxRegistry<T::Tx, TxResult<T>, Self>,
         database: impl DynDatabase,
         precompiles: impl PrecompileProvider,
     ) -> Self {
@@ -111,7 +111,7 @@ impl<T: EvmTypes> Evm<T> {
         execution_config: ExecutionConfig<T>,
         spec_id: T::SpecId,
         block: BlockEnv<T>,
-        registry: TxRegistry<T::Tx, TxResult, Self>,
+        registry: TxRegistry<T::Tx, TxResult<T>, Self>,
         database: Box<dyn DynDatabase>,
         precompiles: Box<dyn PrecompileProvider>,
     ) -> Self {
@@ -150,7 +150,7 @@ impl<T: EvmTypes> Evm<T> {
 impl<T: EvmTypes> Evm<T> {
     /// Returns the transaction handler registry.
     #[inline]
-    pub const fn registry(&self) -> &TxRegistry<T::Tx, TxResult, Self> {
+    pub const fn registry(&self) -> &TxRegistry<T::Tx, TxResult<T>, Self> {
         &self.registry
     }
 
@@ -333,7 +333,7 @@ impl<T: EvmTypes> Evm<T> {
 
 impl<T: EvmTypes<Tx: Typed2718>> Evm<T> {
     /// Dispatches the transaction to the handler registered for its EIP-2718 type byte.
-    pub fn transact(&mut self, tx: &T::Tx) -> HandlerResult<TxResult> {
+    pub fn transact(&mut self, tx: &T::Tx) -> HandlerResult<TxResult<T>> {
         self.db_error_code = None;
         let handler = self.registry.try_get_by_type(tx.ty())?;
         let mut result = handler.call(tx, self);
@@ -356,7 +356,7 @@ impl<T: EvmTypes<Tx: Typed2718>> Evm<T> {
     pub fn transact_iter<'a, I>(
         &'a mut self,
         txs: I,
-    ) -> impl Iterator<Item = HandlerResult<TxResult>> + 'a
+    ) -> impl Iterator<Item = HandlerResult<TxResult<T>>> + 'a
     where
         I: IntoIterator<Item = &'a T::Tx>,
         I::IntoIter: 'a,
@@ -375,7 +375,7 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
         bytecode: Bytecode,
         message: &Message<T>,
         caller_is_static: bool,
-    ) -> MessageResult {
+    ) -> MessageResult<T> {
         self.execute_create_message_inner(tx_env, bytecode, message, caller_is_static)
             .unwrap_or_else(|stop| Self::error_message_result(stop, message.gas_limit))
     }
@@ -386,7 +386,7 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
         bytecode: Bytecode,
         message: &Message<T>,
         caller_is_static: bool,
-    ) -> Result<MessageResult, InstrStop> {
+    ) -> Result<MessageResult<T>, InstrStop> {
         self.check_create_funds(message)?;
         if message.depth > 0 {
             // EIP-2681 caps account nonces at u64::MAX; CREATE/CREATE2 return zero
@@ -449,6 +449,7 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
                     gas: Self::message_gas(*gas.tracker(), stop),
                     output,
                     created_address: None,
+                    ext: T::MessageResultExt::default(),
                 });
             }
 
@@ -464,6 +465,7 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
             gas: Self::message_gas(*gas.tracker(), stop),
             output,
             created_address: stop.is_success().then_some(address),
+            ext: T::MessageResultExt::default(),
         })
     }
 
@@ -533,7 +535,7 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
         bytecode: Bytecode,
         message: &Message<T>,
         caller_is_static: bool,
-    ) -> MessageResult {
+    ) -> MessageResult<T> {
         self.execute_call_message_inner(tx_env, bytecode, message, caller_is_static)
             .unwrap_or_else(|stop| Self::error_message_result(stop, message.gas_limit))
     }
@@ -544,7 +546,7 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
         bytecode: Bytecode,
         message: &Message<T>,
         caller_is_static: bool,
-    ) -> Result<MessageResult, InstrStop> {
+    ) -> Result<MessageResult<T>, InstrStop> {
         let checkpoint = self.state.checkpoint();
         // EIP-161 state clearing depends on zero-value direct call targets being touched.
         // CALLCODE also needs the value-transfer balance check.
@@ -584,6 +586,7 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
                 gas: Self::message_gas(*gas.tracker(), stop),
                 output,
                 created_address: None,
+                ext: T::MessageResultExt::default(),
             });
         }
 
@@ -602,11 +605,12 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
             gas: Self::message_gas(*child_gas.tracker(), stop),
             output,
             created_address: None,
+            ext: T::MessageResultExt::default(),
         })
     }
 
     #[inline]
-    fn error_message_result(stop: InstrStop, gas_remaining: u64) -> MessageResult {
+    fn error_message_result(stop: InstrStop, gas_remaining: u64) -> MessageResult<T> {
         MessageResult {
             stop,
             gas: GasTracker::new(gas_remaining, gas_remaining, 0),
@@ -772,7 +776,7 @@ impl<T: EvmTypes<Host = Self>> Host<T> for Evm<T> {
         bytecode: Bytecode,
         message: &Message<T>,
         caller_is_static: bool,
-    ) -> MessageResult {
+    ) -> MessageResult<T> {
         match message.kind {
             MessageKind::Create | MessageKind::Create2 => {
                 self.execute_create_message(tx_env, bytecode, message, caller_is_static)
@@ -942,8 +946,8 @@ pub struct SelfDestructResult {
 }
 
 /// Result of executing a transaction.
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub struct TxResult {
+#[derive(Clone, derive_more::Debug)]
+pub struct TxResult<T: EvmTypes = crate::BaseEvmTypes> {
     /// Whether execution succeeded.
     pub status: bool,
     /// Gas used by execution.
@@ -956,6 +960,38 @@ pub struct TxResult {
     pub state_changes: StateChanges,
     /// Database error handle, if execution stopped on a database error.
     pub db_error_code: Option<DbErrorCode>,
+    /// EVM type-specific extension data.
+    pub ext: T::TxResultExt,
+}
+
+impl<T: EvmTypes> PartialEq for TxResult<T> {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        self.status == other.status
+            && self.gas_used == other.gas_used
+            && self.stop == other.stop
+            && self.output == other.output
+            && self.state_changes == other.state_changes
+            && self.db_error_code == other.db_error_code
+            && self.ext == other.ext
+    }
+}
+
+impl<T: EvmTypes> Eq for TxResult<T> {}
+
+impl<T: EvmTypes> Default for TxResult<T> {
+    #[inline]
+    fn default() -> Self {
+        Self {
+            status: false,
+            gas_used: 0,
+            stop: InstrStop::default(),
+            output: Bytes::new(),
+            state_changes: StateChanges::default(),
+            db_error_code: None,
+            ext: T::TxResultExt::default(),
+        }
+    }
 }
 
 fn eip7708_transfer_log(from: Address, to: Address, value: Word) -> Option<Log> {

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -964,7 +964,11 @@ pub struct TxResult<T: EvmTypes = crate::BaseEvmTypes> {
     pub ext: T::TxResultExt,
 }
 
-impl<T: EvmTypes> PartialEq for TxResult<T> {
+impl<T> PartialEq for TxResult<T>
+where
+    T: EvmTypes,
+    T::TxResultExt: PartialEq,
+{
     #[inline]
     fn eq(&self, other: &Self) -> bool {
         self.status == other.status
@@ -977,7 +981,12 @@ impl<T: EvmTypes> PartialEq for TxResult<T> {
     }
 }
 
-impl<T: EvmTypes> Eq for TxResult<T> {}
+impl<T> Eq for TxResult<T>
+where
+    T: EvmTypes,
+    T::TxResultExt: Eq,
+{
+}
 
 impl<T: EvmTypes> Default for TxResult<T> {
     #[inline]

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -52,7 +52,7 @@ pub struct Evm<T: EvmTypes> {
     #[debug(skip)]
     execution_config: ExecutionConfig<T>,
     features: EvmFeatures,
-    pub(crate) block: BlockEnv,
+    pub(crate) block: BlockEnv<T>,
     registry: TxRegistry<T::Tx, TxResult, Self>,
     #[debug(skip)]
     pub(crate) state: State,
@@ -71,7 +71,7 @@ impl<T: EvmTypes> Evm<T> {
     #[inline]
     pub fn new(
         spec_id: T::SpecId,
-        block: BlockEnv,
+        block: BlockEnv<T>,
         registry: TxRegistry<T::Tx, TxResult, Self>,
         database: impl DynDatabase,
         precompiles: impl PrecompileProvider,
@@ -91,7 +91,7 @@ impl<T: EvmTypes> Evm<T> {
     pub fn new_with_execution_config(
         execution_config: ExecutionConfig<T>,
         spec_id: T::SpecId,
-        block: BlockEnv,
+        block: BlockEnv<T>,
         registry: TxRegistry<T::Tx, TxResult, Self>,
         database: impl DynDatabase,
         precompiles: impl PrecompileProvider,
@@ -110,7 +110,7 @@ impl<T: EvmTypes> Evm<T> {
     fn new_mono(
         execution_config: ExecutionConfig<T>,
         spec_id: T::SpecId,
-        block: BlockEnv,
+        block: BlockEnv<T>,
         registry: TxRegistry<T::Tx, TxResult, Self>,
         database: Box<dyn DynDatabase>,
         precompiles: Box<dyn PrecompileProvider>,
@@ -137,7 +137,7 @@ impl<T: EvmTypes> Evm<T> {
     #[inline]
     fn execute_precompile(
         &mut self,
-        message: &Message,
+        message: &Message<T>,
         gas: &mut Gas,
     ) -> Option<Result<PrecompileOutput, PrecompileError>> {
         if message.disable_precompiles {
@@ -371,9 +371,9 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
     #[inline(never)]
     fn execute_create_message(
         &mut self,
-        tx_env: &TxEnv,
+        tx_env: &TxEnv<T>,
         bytecode: Bytecode,
-        message: &Message,
+        message: &Message<T>,
         caller_is_static: bool,
     ) -> MessageResult {
         self.execute_create_message_inner(tx_env, bytecode, message, caller_is_static)
@@ -382,9 +382,9 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
 
     fn execute_create_message_inner(
         &mut self,
-        tx_env: &TxEnv,
+        tx_env: &TxEnv<T>,
         bytecode: Bytecode,
-        message: &Message,
+        message: &Message<T>,
         caller_is_static: bool,
     ) -> Result<MessageResult, InstrStop> {
         self.check_create_funds(message)?;
@@ -433,6 +433,7 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
             caller: message.caller,
             value: message.value,
             salt: message.salt,
+            ext: message.ext.clone(),
         };
         let (stop, mut gas, mut output) = {
             let (stop, interpreter) =
@@ -467,7 +468,7 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
     }
 
     #[inline(never)]
-    fn check_create_funds(&mut self, message: &Message) -> Result<(), InstrStop> {
+    fn check_create_funds(&mut self, message: &Message<T>) -> Result<(), InstrStop> {
         if message.value > 0
             && self
                 .state
@@ -510,7 +511,7 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
     fn create_address(
         &mut self,
         bytecode: &Bytecode,
-        message: &Message,
+        message: &Message<T>,
     ) -> Result<Address, InstrStop> {
         match message.kind {
             MessageKind::Create if message.depth == 0 => Ok(message.destination),
@@ -528,9 +529,9 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
     #[inline(never)]
     fn execute_call_message(
         &mut self,
-        tx_env: &TxEnv,
+        tx_env: &TxEnv<T>,
         bytecode: Bytecode,
-        message: &Message,
+        message: &Message<T>,
         caller_is_static: bool,
     ) -> MessageResult {
         self.execute_call_message_inner(tx_env, bytecode, message, caller_is_static)
@@ -539,9 +540,9 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
 
     fn execute_call_message_inner(
         &mut self,
-        tx_env: &TxEnv,
+        tx_env: &TxEnv<T>,
         bytecode: Bytecode,
-        message: &Message,
+        message: &Message<T>,
         caller_is_static: bool,
     ) -> Result<MessageResult, InstrStop> {
         let checkpoint = self.state.checkpoint();
@@ -628,8 +629,8 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
     fn run_interpreter<'frame>(
         &mut self,
         bytecode: Bytecode,
-        tx_env: &'frame TxEnv,
-        message: &'frame Message,
+        tx_env: &'frame TxEnv<T>,
+        message: &'frame Message<T>,
         caller_is_static: bool,
     ) -> (InstrStop, &mut Interpreter<'frame, T>) {
         let mut interpreter = self.interpreter_pool.pop();
@@ -660,12 +661,12 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
     }
 }
 
-impl<T: EvmTypes<Host = Self>> Host for Evm<T> {
+impl<T: EvmTypes<Host = Self>> Host<T> for Evm<T> {
     fn spec_id(&self) -> SpecId {
         self.spec_id()
     }
 
-    fn block_env(&mut self) -> &BlockEnv {
+    fn block_env(&mut self) -> &BlockEnv<T> {
         &self.block
     }
 
@@ -767,9 +768,9 @@ impl<T: EvmTypes<Host = Self>> Host for Evm<T> {
 
     fn execute_message(
         &mut self,
-        tx_env: &TxEnv,
+        tx_env: &TxEnv<T>,
         bytecode: Bytecode,
-        message: &Message,
+        message: &Message<T>,
         caller_is_static: bool,
     ) -> MessageResult {
         match message.kind {

--- a/crates/evm2/src/evm/state.rs
+++ b/crates/evm2/src/evm/state.rs
@@ -17,6 +17,7 @@ use alloy_primitives::{
     map::{AddressMap, AddressSet, U256Map, hash_map},
 };
 use core::mem;
+use derive_where::derive_where;
 
 /// A value tracked together with the value it had at the start of the current
 /// transaction.
@@ -328,11 +329,11 @@ pub enum JournalEntry {
 }
 
 /// Mutable EVM state with an overlay and reversible journal.
-#[derive(derive_more::Debug)]
+#[derive_where(Debug)]
 #[non_exhaustive]
 pub struct State {
     /// Read-only initial database.
-    #[debug(skip)]
+    #[derive_where(skip)]
     initial: Box<dyn DynDatabase>,
     /// Account data overlay keyed by address.
     ///

--- a/crates/evm2/src/evm/system.rs
+++ b/crates/evm2/src/evm/system.rs
@@ -39,7 +39,7 @@ pub const CONSOLIDATION_REQUEST_ADDRESS: Address =
 impl<T: EvmTypes<Host = Self>> Evm<T> {
     /// Executes a system call from [`SYSTEM_ADDRESS`] to `system_contract_address`.
     #[inline]
-    pub fn system_call(&mut self, system_contract_address: Address, data: Bytes) -> TxResult {
+    pub fn system_call(&mut self, system_contract_address: Address, data: Bytes) -> TxResult<T> {
         self.system_call_with_caller(SYSTEM_ADDRESS, system_contract_address, data)
     }
 
@@ -56,7 +56,7 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
         caller: Address,
         system_contract_address: Address,
         data: Bytes,
-    ) -> TxResult {
+    ) -> TxResult<T> {
         self.state.warm_account_non_revertible(system_contract_address);
         let tx_env = TxEnv {
             origin: caller,

--- a/crates/evm2/src/evm/system.rs
+++ b/crates/evm2/src/evm/system.rs
@@ -63,6 +63,7 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
             gas_price: U256::ZERO,
             chain_id: U256::from(self.version().chain_id),
             blob_hashes: Vec::new(),
+            ext: T::TxEnvExt::default(),
         };
         let Ok((bytecode, message)) = initial_message(
             self,

--- a/crates/evm2/src/interpreter/host.rs
+++ b/crates/evm2/src/interpreter/host.rs
@@ -28,7 +28,11 @@ pub struct MessageResult<T: EvmTypes = BaseEvmTypes> {
     pub ext: T::MessageResultExt,
 }
 
-impl<T: EvmTypes> PartialEq for MessageResult<T> {
+impl<T> PartialEq for MessageResult<T>
+where
+    T: EvmTypes,
+    T::MessageResultExt: PartialEq,
+{
     #[inline]
     fn eq(&self, other: &Self) -> bool {
         self.stop == other.stop
@@ -39,7 +43,12 @@ impl<T: EvmTypes> PartialEq for MessageResult<T> {
     }
 }
 
-impl<T: EvmTypes> Eq for MessageResult<T> {}
+impl<T> Eq for MessageResult<T>
+where
+    T: EvmTypes,
+    T::MessageResultExt: Eq,
+{
+}
 
 impl<T: EvmTypes> Default for MessageResult<T> {
     #[inline]

--- a/crates/evm2/src/interpreter/host.rs
+++ b/crates/evm2/src/interpreter/host.rs
@@ -15,7 +15,7 @@ use derive_where::derive_where;
 /// [`Self::gas_returned_to_parent`] and [`Self::refund_propagated_to_parent`] when applying a child
 /// result to a caller frame. Use [`Self::gas_remaining_after_final_refund`] or
 /// [`Self::gas_used_after_final_refund`] for top-level transaction accounting.
-#[derive_where(Clone, Debug, PartialEq, Eq; T::MessageResultExt)]
+#[derive_where(Clone, Debug, Default, PartialEq, Eq; T::MessageResultExt)]
 pub struct MessageResult<T: EvmTypes = BaseEvmTypes> {
     /// Interpreter stop reason.
     pub stop: InstrStop,
@@ -27,19 +27,6 @@ pub struct MessageResult<T: EvmTypes = BaseEvmTypes> {
     pub created_address: Option<Address>,
     /// EVM type-specific extension data.
     pub ext: T::MessageResultExt,
-}
-
-impl<T: EvmTypes> Default for MessageResult<T> {
-    #[inline]
-    fn default() -> Self {
-        Self {
-            stop: InstrStop::default(),
-            gas: GasTracker::default(),
-            output: Bytes::new(),
-            created_address: None,
-            ext: T::MessageResultExt::default(),
-        }
-    }
 }
 
 impl<T: EvmTypes> MessageResult<T> {

--- a/crates/evm2/src/interpreter/host.rs
+++ b/crates/evm2/src/interpreter/host.rs
@@ -1,6 +1,6 @@
 use super::{GasTracker, InstrStop, Message, Result, Word};
 use crate::{
-    EvmTypes, SpecId,
+    BaseEvmTypes, EvmTypes, SpecId,
     bytecode::Bytecode,
     env::{BlockEnv, TxEnv},
     evm::{AccountLoad, SLoad, SStore, SelfDestructResult},
@@ -14,8 +14,8 @@ use alloy_primitives::{Address, B256, Bytes, Log};
 /// [`Self::gas_returned_to_parent`] and [`Self::refund_propagated_to_parent`] when applying a child
 /// result to a caller frame. Use [`Self::gas_remaining_after_final_refund`] or
 /// [`Self::gas_used_after_final_refund`] for top-level transaction accounting.
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub struct MessageResult {
+#[derive(Clone, derive_more::Debug)]
+pub struct MessageResult<T: EvmTypes = BaseEvmTypes> {
     /// Interpreter stop reason.
     pub stop: InstrStop,
     /// Gas accounting for the child frame.
@@ -24,9 +24,37 @@ pub struct MessageResult {
     pub output: Bytes,
     /// Created address for successful create messages.
     pub created_address: Option<Address>,
+    /// EVM type-specific extension data.
+    pub ext: T::MessageResultExt,
 }
 
-impl MessageResult {
+impl<T: EvmTypes> PartialEq for MessageResult<T> {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        self.stop == other.stop
+            && self.gas == other.gas
+            && self.output == other.output
+            && self.created_address == other.created_address
+            && self.ext == other.ext
+    }
+}
+
+impl<T: EvmTypes> Eq for MessageResult<T> {}
+
+impl<T: EvmTypes> Default for MessageResult<T> {
+    #[inline]
+    fn default() -> Self {
+        Self {
+            stop: InstrStop::default(),
+            gas: GasTracker::default(),
+            output: Bytes::new(),
+            created_address: None,
+            ext: T::MessageResultExt::default(),
+        }
+    }
+}
+
+impl<T: EvmTypes> MessageResult<T> {
     /// Returns whether the message committed state changes.
     #[inline]
     pub const fn is_success(&self) -> bool {
@@ -138,7 +166,7 @@ pub trait Host<T: EvmTypes> {
         bytecode: Bytecode,
         message: &Message<T>,
         caller_is_static: bool,
-    ) -> MessageResult;
+    ) -> MessageResult<T>;
 
     /// Registers the current contract for self-destruction.
     fn selfdestruct(

--- a/crates/evm2/src/interpreter/host.rs
+++ b/crates/evm2/src/interpreter/host.rs
@@ -6,6 +6,7 @@ use crate::{
     evm::{AccountLoad, SLoad, SStore, SelfDestructResult},
 };
 use alloy_primitives::{Address, B256, Bytes, Log};
+use derive_where::derive_where;
 
 /// Result of executing a call/create message.
 ///
@@ -14,7 +15,7 @@ use alloy_primitives::{Address, B256, Bytes, Log};
 /// [`Self::gas_returned_to_parent`] and [`Self::refund_propagated_to_parent`] when applying a child
 /// result to a caller frame. Use [`Self::gas_remaining_after_final_refund`] or
 /// [`Self::gas_used_after_final_refund`] for top-level transaction accounting.
-#[derive(Clone, derive_more::Debug)]
+#[derive_where(Clone, Debug, PartialEq, Eq; T::MessageResultExt)]
 pub struct MessageResult<T: EvmTypes = BaseEvmTypes> {
     /// Interpreter stop reason.
     pub stop: InstrStop,
@@ -26,28 +27,6 @@ pub struct MessageResult<T: EvmTypes = BaseEvmTypes> {
     pub created_address: Option<Address>,
     /// EVM type-specific extension data.
     pub ext: T::MessageResultExt,
-}
-
-impl<T> PartialEq for MessageResult<T>
-where
-    T: EvmTypes,
-    T::MessageResultExt: PartialEq,
-{
-    #[inline]
-    fn eq(&self, other: &Self) -> bool {
-        self.stop == other.stop
-            && self.gas == other.gas
-            && self.output == other.output
-            && self.created_address == other.created_address
-            && self.ext == other.ext
-    }
-}
-
-impl<T> Eq for MessageResult<T>
-where
-    T: EvmTypes,
-    T::MessageResultExt: Eq,
-{
 }
 
 impl<T: EvmTypes> Default for MessageResult<T> {

--- a/crates/evm2/src/interpreter/host.rs
+++ b/crates/evm2/src/interpreter/host.rs
@@ -1,6 +1,6 @@
 use super::{GasTracker, InstrStop, Message, Result, Word};
 use crate::{
-    SpecId,
+    EvmTypes, SpecId,
     bytecode::Bytecode,
     env::{BlockEnv, TxEnv},
     evm::{AccountLoad, SLoad, SStore, SelfDestructResult},
@@ -80,12 +80,12 @@ impl MessageResult {
 }
 
 /// External host operations.
-pub trait Host {
+pub trait Host<T: EvmTypes> {
     /// Returns the active base specification ID.
     fn spec_id(&self) -> SpecId;
 
     /// Returns the block environment.
-    fn block_env(&mut self) -> &BlockEnv;
+    fn block_env(&mut self) -> &BlockEnv<T>;
 
     /// Loads account information.
     fn load_account(
@@ -134,9 +134,9 @@ pub trait Host {
     /// Executes a message inside this host.
     fn execute_message(
         &mut self,
-        tx_env: &TxEnv,
+        tx_env: &TxEnv<T>,
         bytecode: Bytecode,
-        message: &Message,
+        message: &Message<T>,
         caller_is_static: bool,
     ) -> MessageResult;
 

--- a/crates/evm2/src/interpreter/instructions/block.rs
+++ b/crates/evm2/src/interpreter/instructions/block.rs
@@ -91,7 +91,7 @@ mod tests {
         env::{BlockEnv, TxEnv},
         interpreter::{
             InstrStop, Message, Word,
-            instructions::tests::{RunConfig, TestHost, push, run},
+            instructions::tests::{RunConfig, TestHost, TestTypes, push, run},
             op,
         },
         utils::{address_to_word, b256_to_word},
@@ -99,7 +99,7 @@ mod tests {
     use alloc::vec::Vec;
     use alloy_primitives::{Address, B256};
 
-    fn test_host(block: BlockEnv) -> TestHost {
+    fn test_host(block: BlockEnv<TestTypes>) -> TestHost {
         TestHost { block, ..TestHost::default() }
     }
 

--- a/crates/evm2/src/interpreter/instructions/env.rs
+++ b/crates/evm2/src/interpreter/instructions/env.rs
@@ -186,7 +186,9 @@ mod tests {
         env::TxEnv,
         interpreter::{
             InstrStop, Message, Word,
-            instructions::tests::{RunConfig, TestHost, assert_stack, push, run, run_stack},
+            instructions::tests::{
+                RunConfig, TestHost, TestTypes, assert_stack, push, run, run_stack,
+            },
             op,
         },
         utils::{address_to_word, b256_to_word},
@@ -198,7 +200,7 @@ mod tests {
         Word::from(0).wrapping_sub(Word::from(value))
     }
 
-    fn test_message() -> Message {
+    fn test_message() -> Message<TestTypes> {
         Message { gas_limit: 10_000, ..Message::default() }
     }
 

--- a/crates/evm2/src/interpreter/instructions/macro_tests.rs
+++ b/crates/evm2/src/interpreter/instructions/macro_tests.rs
@@ -6,6 +6,7 @@ use crate::{
     interpreter::{Host, InstrStop, Interpreter, Word, op},
     version::VersionTables,
 };
+use alloc::vec::Vec;
 use alloy_primitives::Bytes;
 use evm2_macros::instruction;
 

--- a/crates/evm2/src/interpreter/instructions/macro_tests.rs
+++ b/crates/evm2/src/interpreter/instructions/macro_tests.rs
@@ -1,9 +1,9 @@
 use super::tests::{RunConfig, TestHost, TestInterpreter, TestTypes, push};
 use crate::{
-    BaseEvmConfig, EvmConfig, ExecutionConfig, SpecId,
+    BaseEvmConfig, EvmConfig, EvmTypes, ExecutionConfig, SpecId,
     bytecode::Bytecode,
     env::BlockEnv,
-    interpreter::{Host, InstrStop, Interpreter, Word, op},
+    interpreter::{Host, InstrStop, Interpreter, InterpreterState, Word, op},
     version::VersionTables,
 };
 use alloc::vec::Vec;
@@ -38,18 +38,20 @@ fn macro_concrete_eq(cx: _) -> out {
     *out = cx.state.host().block_env().number;
 }
 
-trait MacroTypesExt {
-    const MACRO_TYPE_BOUND_VALUE: u64;
-}
+trait MacroTypesExt {}
 
-impl MacroTypesExt for TestTypes {
-    const MACRO_TYPE_BOUND_VALUE: u64 = 31337;
+impl MacroTypesExt for TestTypes {}
+
+fn macro_type_bound_value<T>(state: &mut InterpreterState<'_, T>) -> Word
+where
+    T: EvmTypes<Host = TestHost> + MacroTypesExt,
+{
+    state.host().macro_bound_value()
 }
 
 #[instruction(EvmTypes: MacroTypesExt, EvmTypes<Host = TestHost>)]
 fn macro_type_bound(cx: _) -> out {
-    let _ = cx.state.host();
-    *out = Word::from(<TestTypes as MacroTypesExt>::MACRO_TYPE_BOUND_VALUE);
+    *out = macro_type_bound_value(cx.state);
 }
 
 trait MacroHostExt {

--- a/crates/evm2/src/interpreter/instructions/macro_tests.rs
+++ b/crates/evm2/src/interpreter/instructions/macro_tests.rs
@@ -1,9 +1,9 @@
 use super::tests::{RunConfig, TestHost, TestInterpreter, TestTypes, push};
 use crate::{
-    BaseEvmConfig, EvmConfig, EvmTypes, ExecutionConfig, SpecId,
+    BaseEvmConfig, EvmConfig, ExecutionConfig, SpecId,
     bytecode::Bytecode,
     env::BlockEnv,
-    interpreter::{Host, InstrStop, Interpreter, InterpreterState, Word, op},
+    interpreter::{Host, InstrStop, Interpreter, Word, op},
     version::VersionTables,
 };
 use alloc::vec::Vec;
@@ -42,17 +42,8 @@ trait MacroTypesExt {}
 
 impl MacroTypesExt for TestTypes {}
 
-fn macro_type_bound_value<T>(state: &mut InterpreterState<'_, T>) -> Word
-where
-    T: EvmTypes<Host = TestHost> + MacroTypesExt,
-{
-    state.host().macro_bound_value()
-}
-
-#[instruction(EvmTypes: MacroTypesExt, EvmTypes<Host = TestHost>)]
-fn macro_type_bound(cx: _) -> out {
-    *out = macro_type_bound_value(cx.state);
-}
+#[instruction(EvmTypes: MacroTypesExt)]
+fn macro_type_bound(cx: _) {}
 
 trait MacroHostExt {
     fn macro_bound_value(&self) -> Word;
@@ -153,7 +144,7 @@ fn instruction_macro_evm_types_colon_bound_attribute() {
     let interpreter = run(RunConfig::new([TYPE_BOUND_OPCODE, op::STOP]).host(&mut host));
 
     assert_eq!(interpreter.err, InstrStop::Stop);
-    assert_eq!(interpreter.stack(), [Word::from(31337)]);
+    assert!(interpreter.stack().is_empty());
 }
 
 #[test]

--- a/crates/evm2/src/interpreter/instructions/macro_tests.rs
+++ b/crates/evm2/src/interpreter/instructions/macro_tests.rs
@@ -1,8 +1,8 @@
 use super::tests::{RunConfig, TestHost, TestInterpreter, TestTypes, push};
 use crate::{
-    BaseEvmConfig, EvmConfig, ExecutionConfig, SpecId,
+    BaseEvmConfig, EvmConfig, EvmTypes, ExecutionConfig, SpecId,
     bytecode::Bytecode,
-    env::{BlockEnv, TxEnv},
+    env::BlockEnv,
     interpreter::{Host, InstrStop, Interpreter, Word, op},
     version::VersionTables,
 };
@@ -14,7 +14,8 @@ const ADD_OPCODE: u8 = 0x0c;
 const DYNAMIC_GAS_OPCODE: u8 = 0x0d;
 const NO_STACK_PREAMBLE_OPCODE: u8 = 0x0e;
 const CONCRETE_EQ_OPCODE: u8 = 0x0f;
-const CONCRETE_COLON_OPCODE: u8 = 0x1e;
+const TYPE_BOUND_OPCODE: u8 = 0x1d;
+const ASSOC_BOUND_OPCODE: u8 = 0x1e;
 
 #[instruction]
 fn macro_add([a, b]: [Word]) -> out {
@@ -37,9 +38,47 @@ fn macro_concrete_eq(cx: _) -> out {
     *out = cx.state.host().block_env().number;
 }
 
-#[instruction(EvmTypes: TestTypes)]
-fn macro_concrete_colon(cx: _) -> out {
-    *out = cx.state.tx().chain_id;
+trait MacroTypesExt {
+    fn macro_type_bound_value(host: &TestHost) -> Word;
+}
+
+impl MacroTypesExt for TestTypes {
+    fn macro_type_bound_value(host: &TestHost) -> Word {
+        host.block.number
+    }
+}
+
+trait MacroCxExt {
+    fn macro_type_bound_value(&mut self) -> Word;
+}
+
+impl<T> MacroCxExt for crate::interpreter::private::InstructionCx<'_, '_, T>
+where
+    T: EvmTypes<Host = TestHost> + MacroTypesExt,
+{
+    fn macro_type_bound_value(&mut self) -> Word {
+        T::macro_type_bound_value(self.state.host())
+    }
+}
+
+#[instruction(EvmTypes: MacroTypesExt, EvmTypes<Host = TestHost>)]
+fn macro_type_bound(cx: _) -> out {
+    *out = cx.macro_type_bound_value();
+}
+
+trait MacroHostExt {
+    fn macro_bound_value(&self) -> Word;
+}
+
+impl MacroHostExt for TestHost {
+    fn macro_bound_value(&self) -> Word {
+        self.block.number
+    }
+}
+
+#[instruction(EvmTypes<Host: MacroHostExt>)]
+fn macro_assoc_bound(cx: _) -> out {
+    *out = cx.state.host().macro_bound_value();
 }
 
 struct MacroConfig;
@@ -55,7 +94,8 @@ const fn macro_version_tables() -> VersionTables<TestTypes> {
     version.set_instruction::<macro_dynamic_gas<TestTypes>>(DYNAMIC_GAS_OPCODE, 2);
     version.set_instruction::<macro_no_stack_preamble<TestTypes>>(NO_STACK_PREAMBLE_OPCODE, 0);
     version.set_instruction::<macro_concrete_eq>(CONCRETE_EQ_OPCODE, 0);
-    version.set_instruction::<macro_concrete_colon>(CONCRETE_COLON_OPCODE, 0);
+    version.set_instruction::<macro_type_bound<TestTypes>>(TYPE_BOUND_OPCODE, 0);
+    version.set_instruction::<macro_assoc_bound<TestTypes>>(ASSOC_BOUND_OPCODE, 0);
     version
 }
 
@@ -117,9 +157,24 @@ fn instruction_macro_concrete_evm_types_equals_attribute() {
 }
 
 #[test]
-fn instruction_macro_concrete_evm_types_colon_attribute() {
-    let tx_env = TxEnv { chain_id: Word::from(31337), ..TxEnv::default() };
-    let interpreter = run(RunConfig::new([CONCRETE_COLON_OPCODE, op::STOP]).tx_env(tx_env));
+fn instruction_macro_evm_types_colon_bound_attribute() {
+    let mut host = TestHost {
+        block: BlockEnv { number: Word::from(31337), ..BlockEnv::default() },
+        ..TestHost::default()
+    };
+    let interpreter = run(RunConfig::new([TYPE_BOUND_OPCODE, op::STOP]).host(&mut host));
+
+    assert_eq!(interpreter.err, InstrStop::Stop);
+    assert_eq!(interpreter.stack(), [Word::from(31337)]);
+}
+
+#[test]
+fn instruction_macro_evm_types_assoc_colon_bound_attribute() {
+    let mut host = TestHost {
+        block: BlockEnv { number: Word::from(31337), ..BlockEnv::default() },
+        ..TestHost::default()
+    };
+    let interpreter = run(RunConfig::new([ASSOC_BOUND_OPCODE, op::STOP]).host(&mut host));
 
     assert_eq!(interpreter.err, InstrStop::Stop);
     assert_eq!(interpreter.stack(), [Word::from(31337)]);

--- a/crates/evm2/src/interpreter/instructions/macro_tests.rs
+++ b/crates/evm2/src/interpreter/instructions/macro_tests.rs
@@ -1,0 +1,125 @@
+use super::tests::{RunConfig, TestHost, TestInterpreter, TestTypes, push};
+use crate::{
+    BaseEvmConfig, EvmConfig, ExecutionConfig, SpecId,
+    bytecode::Bytecode,
+    env::{BlockEnv, TxEnv},
+    interpreter::{Host, InstrStop, Interpreter, Word, op},
+    version::VersionTables,
+};
+use alloy_primitives::Bytes;
+use evm2_macros::instruction;
+
+const ADD_OPCODE: u8 = 0x0c;
+const DYNAMIC_GAS_OPCODE: u8 = 0x0d;
+const NO_STACK_PREAMBLE_OPCODE: u8 = 0x0e;
+const CONCRETE_EQ_OPCODE: u8 = 0x0f;
+const CONCRETE_COLON_OPCODE: u8 = 0x1e;
+
+#[instruction]
+fn macro_add([a, b]: [Word]) -> out {
+    *out = a + b;
+}
+
+#[instruction(dynamic_gas)]
+fn macro_dynamic_gas(cx: _) -> Result<out> {
+    cx.gas.spend(3)?;
+    *out = Word::from(0xda_u64);
+}
+
+#[instruction(no_stack_preamble)]
+fn macro_no_stack_preamble() -> Result {
+    stack.push(Word::from(0xbeef_u64))
+}
+
+#[instruction(EvmTypes = TestTypes)]
+fn macro_concrete_eq(cx: _) -> out {
+    *out = cx.state.host().block_env().number;
+}
+
+#[instruction(EvmTypes: TestTypes)]
+fn macro_concrete_colon(cx: _) -> out {
+    *out = cx.state.tx().chain_id;
+}
+
+struct MacroConfig;
+
+impl EvmConfig<TestTypes> for MacroConfig {
+    const BASE_SPEC_ID: SpecId = SpecId::OSAKA;
+    const VERSION_TABLES: &'static VersionTables<TestTypes> = &macro_version_tables();
+}
+
+const fn macro_version_tables() -> VersionTables<TestTypes> {
+    let mut version = VersionTables::<TestTypes>::base::<BaseEvmConfig<{ SpecId::OSAKA as u8 }>>();
+    version.set_instruction::<macro_add<TestTypes>>(ADD_OPCODE, 0);
+    version.set_instruction::<macro_dynamic_gas<TestTypes>>(DYNAMIC_GAS_OPCODE, 2);
+    version.set_instruction::<macro_no_stack_preamble<TestTypes>>(NO_STACK_PREAMBLE_OPCODE, 0);
+    version.set_instruction::<macro_concrete_eq>(CONCRETE_EQ_OPCODE, 0);
+    version.set_instruction::<macro_concrete_colon>(CONCRETE_COLON_OPCODE, 0);
+    version
+}
+
+fn run(config: RunConfig<'_>) -> TestInterpreter {
+    let execution_config = ExecutionConfig::<TestTypes>::for_config::<MacroConfig>();
+    let RunConfig { code, host, spec_id, tx_env, mut message, gas_limit, return_data } = config;
+    let bytecode = Bytecode::new_legacy(Bytes::from(code));
+    message.gas_limit = gas_limit;
+    let mut inner = Interpreter::<TestTypes>::new(bytecode, &tx_env, &message, false);
+    inner.set_return_data(return_data);
+    let mut default_host = TestHost::default();
+    let host = host.unwrap_or(&mut default_host);
+    host.spec_id = spec_id;
+    let err = inner.run(&execution_config, host);
+    let (stack, stack_len, gas, memory, output) = inner.into_parts();
+    TestInterpreter { stack, stack_len, gas, memory, output, err }
+}
+
+#[test]
+fn instruction_macro_stack_inputs_and_output() {
+    let mut code = Vec::new();
+    push(&mut code, 2);
+    push(&mut code, 3);
+    code.extend([ADD_OPCODE, op::STOP]);
+
+    let interpreter = run(RunConfig::new(code));
+
+    assert_eq!(interpreter.err, InstrStop::Stop);
+    assert_eq!(interpreter.stack(), [Word::from(5)]);
+}
+
+#[test]
+fn instruction_macro_dynamic_gas_attribute() {
+    let interpreter = run(RunConfig::new([DYNAMIC_GAS_OPCODE, op::STOP]));
+
+    assert_eq!(interpreter.err, InstrStop::Stop);
+    assert_eq!(interpreter.stack(), [Word::from(0xda_u64)]);
+    assert_eq!(interpreter.gas_remaining(), 9_995);
+}
+
+#[test]
+fn instruction_macro_no_stack_preamble_attribute() {
+    let interpreter = run(RunConfig::new([NO_STACK_PREAMBLE_OPCODE, op::STOP]));
+
+    assert_eq!(interpreter.err, InstrStop::Stop);
+    assert_eq!(interpreter.stack(), [Word::from(0xbeef_u64)]);
+}
+
+#[test]
+fn instruction_macro_concrete_evm_types_equals_attribute() {
+    let mut host = TestHost {
+        block: BlockEnv { number: Word::from(42), ..BlockEnv::default() },
+        ..TestHost::default()
+    };
+    let interpreter = run(RunConfig::new([CONCRETE_EQ_OPCODE, op::STOP]).host(&mut host));
+
+    assert_eq!(interpreter.err, InstrStop::Stop);
+    assert_eq!(interpreter.stack(), [Word::from(42)]);
+}
+
+#[test]
+fn instruction_macro_concrete_evm_types_colon_attribute() {
+    let tx_env = TxEnv { chain_id: Word::from(31337), ..TxEnv::default() };
+    let interpreter = run(RunConfig::new([CONCRETE_COLON_OPCODE, op::STOP]).tx_env(tx_env));
+
+    assert_eq!(interpreter.err, InstrStop::Stop);
+    assert_eq!(interpreter.stack(), [Word::from(31337)]);
+}

--- a/crates/evm2/src/interpreter/instructions/macro_tests.rs
+++ b/crates/evm2/src/interpreter/instructions/macro_tests.rs
@@ -1,6 +1,6 @@
 use super::tests::{RunConfig, TestHost, TestInterpreter, TestTypes, push};
 use crate::{
-    BaseEvmConfig, EvmConfig, EvmTypes, ExecutionConfig, SpecId,
+    BaseEvmConfig, EvmConfig, ExecutionConfig, SpecId,
     bytecode::Bytecode,
     env::BlockEnv,
     interpreter::{Host, InstrStop, Interpreter, Word, op},
@@ -39,31 +39,17 @@ fn macro_concrete_eq(cx: _) -> out {
 }
 
 trait MacroTypesExt {
-    fn macro_type_bound_value(host: &TestHost) -> Word;
+    const MACRO_TYPE_BOUND_VALUE: u64;
 }
 
 impl MacroTypesExt for TestTypes {
-    fn macro_type_bound_value(host: &TestHost) -> Word {
-        host.block.number
-    }
-}
-
-trait MacroCxExt {
-    fn macro_type_bound_value(&mut self) -> Word;
-}
-
-impl<T> MacroCxExt for crate::interpreter::private::InstructionCx<'_, '_, T>
-where
-    T: EvmTypes<Host = TestHost> + MacroTypesExt,
-{
-    fn macro_type_bound_value(&mut self) -> Word {
-        T::macro_type_bound_value(self.state.host())
-    }
+    const MACRO_TYPE_BOUND_VALUE: u64 = 31337;
 }
 
 #[instruction(EvmTypes: MacroTypesExt, EvmTypes<Host = TestHost>)]
 fn macro_type_bound(cx: _) -> out {
-    *out = cx.macro_type_bound_value();
+    let _ = cx.state.host();
+    *out = Word::from(<TestTypes as MacroTypesExt>::MACRO_TYPE_BOUND_VALUE);
 }
 
 trait MacroHostExt {

--- a/crates/evm2/src/interpreter/instructions/mod.rs
+++ b/crates/evm2/src/interpreter/instructions/mod.rs
@@ -32,4 +32,7 @@ mod i256;
 pub(crate) mod table;
 
 #[cfg(test)]
+mod macro_tests;
+
+#[cfg(test)]
 pub(crate) mod tests;

--- a/crates/evm2/src/interpreter/instructions/system.rs
+++ b/crates/evm2/src/interpreter/instructions/system.rs
@@ -39,7 +39,7 @@ const fn should_charge_new_account_gas(
 }
 
 #[inline]
-fn call_too_deep_result(gas_limit: u64) -> MessageResult {
+fn call_too_deep_result<T: EvmTypes>(gas_limit: u64) -> MessageResult<T> {
     MessageResult {
         stop: InstrStop::CallTooDeep,
         gas: GasTracker::new(gas_limit, gas_limit, 0),
@@ -226,7 +226,7 @@ fn call_inner<T: EvmTypes>(
     let mut result = if let Some(result) = cx.state.inspect_call(&mut message) {
         result
     } else if message.depth > CALL_DEPTH_LIMIT {
-        call_too_deep_result(message.gas_limit)
+        call_too_deep_result::<T>(message.gas_limit)
     } else {
         let bytecode = crate::bytecode::Bytecode::new_legacy(code);
         let tx_env = unsafe { trustme::decouple_lt(cx.state.tx()) };
@@ -317,7 +317,7 @@ fn create_inner<T: EvmTypes>(
     let mut result = if let Some(result) = cx.state.inspect_create(&mut message) {
         result
     } else if message.depth > CALL_DEPTH_LIMIT {
-        call_too_deep_result(message.gas_limit)
+        call_too_deep_result::<T>(message.gas_limit)
     } else {
         let bytecode = crate::bytecode::Bytecode::new_legacy(input);
         let tx_env = unsafe { trustme::decouple_lt(cx.state.tx()) };

--- a/crates/evm2/src/interpreter/instructions/system.rs
+++ b/crates/evm2/src/interpreter/instructions/system.rs
@@ -220,6 +220,7 @@ fn call_inner<T: EvmTypes>(
         code_address,
         disable_precompiles,
         salt: B256::ZERO,
+        ext: T::MessageExt::default(),
     };
     let caller_is_static = cx.state.is_static();
     let mut result = if let Some(result) = cx.state.inspect_call(&mut message) {
@@ -311,6 +312,7 @@ fn create_inner<T: EvmTypes>(
         code_address: current.destination,
         disable_precompiles: false,
         salt: salt.map(|salt| B256::from(salt.to_be_bytes())).unwrap_or_default(),
+        ext: T::MessageExt::default(),
     };
     let mut result = if let Some(result) = cx.state.inspect_create(&mut message) {
         result

--- a/crates/evm2/src/interpreter/instructions/tests.rs
+++ b/crates/evm2/src/interpreter/instructions/tests.rs
@@ -19,11 +19,11 @@ impl EvmTypes for TestTypes {
     type ConfigSelector = crate::BaseEvmConfigSelector;
     type SpecId = crate::SpecId;
     type Tx = ();
-    type TxEnvExt = ();
-    type BlockEnvExt = ();
     type MessageExt = ();
     type MessageResultExt = ();
+    type TxEnvExt = ();
     type TxResultExt = ();
+    type BlockEnvExt = ();
     type Host = TestHost;
 }
 

--- a/crates/evm2/src/interpreter/instructions/tests.rs
+++ b/crates/evm2/src/interpreter/instructions/tests.rs
@@ -19,13 +19,16 @@ impl EvmTypes for TestTypes {
     type ConfigSelector = crate::BaseEvmConfigSelector;
     type SpecId = crate::SpecId;
     type Tx = ();
+    type TxEnvExt = ();
+    type BlockEnvExt = ();
+    type MessageExt = ();
     type Host = TestHost;
 }
 
 #[derive(Debug)]
 pub(crate) struct TestHost {
     pub(super) spec_id: SpecId,
-    pub(super) block: BlockEnv,
+    pub(super) block: BlockEnv<TestTypes>,
     pub(super) code_hash: B256,
     pub(super) code: Bytes,
     pub(super) exists: bool,
@@ -39,7 +42,7 @@ pub(crate) struct TestHost {
     pub(super) execute_result: MessageResult,
     pub(crate) selfdestruct_result: SelfDestructResult,
     pub(crate) selfdestruct_error: Option<InstrStop>,
-    pub(crate) calls: Vec<Message>,
+    pub(crate) calls: Vec<Message<TestTypes>>,
     pub(super) call_static_flags: Vec<bool>,
     pub(super) selfdestructs: Vec<(Address, Address, bool)>,
 }
@@ -69,12 +72,12 @@ impl Default for TestHost {
     }
 }
 
-impl Host for TestHost {
+impl Host<TestTypes> for TestHost {
     fn spec_id(&self) -> SpecId {
         self.spec_id
     }
 
-    fn block_env(&mut self) -> &BlockEnv {
+    fn block_env(&mut self) -> &BlockEnv<TestTypes> {
         &self.block
     }
 
@@ -162,9 +165,9 @@ impl Host for TestHost {
 
     fn execute_message(
         &mut self,
-        _tx_env: &TxEnv,
+        _tx_env: &TxEnv<TestTypes>,
         _bytecode: Bytecode,
-        message: &Message,
+        message: &Message<TestTypes>,
         caller_is_static: bool,
     ) -> MessageResult {
         self.call_static_flags.push(caller_is_static || message.kind == MessageKind::StaticCall);
@@ -227,8 +230,8 @@ pub(super) struct RunConfig<'a> {
     pub(super) code: Vec<u8>,
     pub(super) host: Option<&'a mut TestHost>,
     pub(super) spec_id: SpecId,
-    pub(super) tx_env: TxEnv,
-    pub(super) message: Message,
+    pub(super) tx_env: TxEnv<TestTypes>,
+    pub(super) message: Message<TestTypes>,
     pub(super) gas_limit: u64,
     pub(super) return_data: Bytes,
 }
@@ -248,12 +251,12 @@ impl<'a> RunConfig<'a> {
         self
     }
 
-    pub(super) fn tx_env(mut self, tx_env: TxEnv) -> Self {
+    pub(super) fn tx_env(mut self, tx_env: TxEnv<TestTypes>) -> Self {
         self.tx_env = tx_env;
         self
     }
 
-    pub(super) fn message(mut self, message: Message) -> Self {
+    pub(super) fn message(mut self, message: Message<TestTypes>) -> Self {
         self.message = message;
         self
     }

--- a/crates/evm2/src/interpreter/instructions/tests.rs
+++ b/crates/evm2/src/interpreter/instructions/tests.rs
@@ -22,6 +22,8 @@ impl EvmTypes for TestTypes {
     type TxEnvExt = ();
     type BlockEnvExt = ();
     type MessageExt = ();
+    type MessageResultExt = ();
+    type TxResultExt = ();
     type Host = TestHost;
 }
 
@@ -39,7 +41,7 @@ pub(crate) struct TestHost {
     pub(super) original_storage: StorageKeyMap<Word>,
     pub(super) transient_storage: StorageKeyMap<Word>,
     pub(crate) logs: Vec<Log>,
-    pub(super) execute_result: MessageResult,
+    pub(super) execute_result: MessageResult<TestTypes>,
     pub(crate) selfdestruct_result: SelfDestructResult,
     pub(crate) selfdestruct_error: Option<InstrStop>,
     pub(crate) calls: Vec<Message<TestTypes>>,
@@ -169,7 +171,7 @@ impl Host<TestTypes> for TestHost {
         _bytecode: Bytecode,
         message: &Message<TestTypes>,
         caller_is_static: bool,
-    ) -> MessageResult {
+    ) -> MessageResult<TestTypes> {
         self.call_static_flags.push(caller_is_static || message.kind == MessageKind::StaticCall);
         self.calls.push(message.clone());
         self.execute_result.clone()

--- a/crates/evm2/src/interpreter/message.rs
+++ b/crates/evm2/src/interpreter/message.rs
@@ -1,5 +1,7 @@
 use alloy_primitives::{Address, B256, Bytes, U256};
 
+use crate::{BaseEvmTypes, EvmTypes};
+
 /// EVM message kind.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
 #[non_exhaustive]
@@ -29,7 +31,7 @@ impl MessageKind {
 
 /// Frame-local EVM call/create message executed by the interpreter.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct Message {
+pub struct Message<T: EvmTypes = BaseEvmTypes> {
     /// Message kind.
     pub kind: MessageKind,
     /// Current call depth.
@@ -52,9 +54,11 @@ pub struct Message {
     pub disable_precompiles: bool,
     /// CREATE2 salt. Ignored for other message kinds.
     pub salt: B256,
+    /// EVM type-specific extension data.
+    pub ext: T::MessageExt,
 }
 
-impl Default for Message {
+impl<T: EvmTypes> Default for Message<T> {
     #[inline]
     fn default() -> Self {
         Self {
@@ -68,6 +72,7 @@ impl Default for Message {
             code_address: Address::ZERO,
             disable_precompiles: false,
             salt: B256::ZERO,
+            ext: T::MessageExt::default(),
         }
     }
 }

--- a/crates/evm2/src/interpreter/message.rs
+++ b/crates/evm2/src/interpreter/message.rs
@@ -30,7 +30,7 @@ impl MessageKind {
 }
 
 /// Frame-local EVM call/create message executed by the interpreter.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug)]
 pub struct Message<T: EvmTypes = BaseEvmTypes> {
     /// Message kind.
     pub kind: MessageKind,
@@ -56,6 +56,34 @@ pub struct Message<T: EvmTypes = BaseEvmTypes> {
     pub salt: B256,
     /// EVM type-specific extension data.
     pub ext: T::MessageExt,
+}
+
+impl<T> PartialEq for Message<T>
+where
+    T: EvmTypes,
+    T::MessageExt: PartialEq,
+{
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        self.kind == other.kind
+            && self.depth == other.depth
+            && self.gas_limit == other.gas_limit
+            && self.destination == other.destination
+            && self.caller == other.caller
+            && self.input == other.input
+            && self.value == other.value
+            && self.code_address == other.code_address
+            && self.disable_precompiles == other.disable_precompiles
+            && self.salt == other.salt
+            && self.ext == other.ext
+    }
+}
+
+impl<T> Eq for Message<T>
+where
+    T: EvmTypes,
+    T::MessageExt: Eq,
+{
 }
 
 impl<T: EvmTypes> Default for Message<T> {

--- a/crates/evm2/src/interpreter/message.rs
+++ b/crates/evm2/src/interpreter/message.rs
@@ -31,7 +31,7 @@ impl MessageKind {
 }
 
 /// Frame-local EVM call/create message executed by the interpreter.
-#[derive_where(Clone, Debug, PartialEq, Eq; T::MessageExt)]
+#[derive_where(Clone, Debug, Default, PartialEq, Eq; T::MessageExt)]
 pub struct Message<T: EvmTypes = BaseEvmTypes> {
     /// Message kind.
     pub kind: MessageKind,
@@ -57,23 +57,4 @@ pub struct Message<T: EvmTypes = BaseEvmTypes> {
     pub salt: B256,
     /// EVM type-specific extension data.
     pub ext: T::MessageExt,
-}
-
-impl<T: EvmTypes> Default for Message<T> {
-    #[inline]
-    fn default() -> Self {
-        Self {
-            kind: MessageKind::Call,
-            depth: 0,
-            gas_limit: 0,
-            destination: Address::ZERO,
-            caller: Address::ZERO,
-            input: Bytes::new(),
-            value: U256::ZERO,
-            code_address: Address::ZERO,
-            disable_precompiles: false,
-            salt: B256::ZERO,
-            ext: T::MessageExt::default(),
-        }
-    }
 }

--- a/crates/evm2/src/interpreter/message.rs
+++ b/crates/evm2/src/interpreter/message.rs
@@ -1,4 +1,5 @@
 use alloy_primitives::{Address, B256, Bytes, U256};
+use derive_where::derive_where;
 
 use crate::{BaseEvmTypes, EvmTypes};
 
@@ -30,7 +31,7 @@ impl MessageKind {
 }
 
 /// Frame-local EVM call/create message executed by the interpreter.
-#[derive(Clone, Debug)]
+#[derive_where(Clone, Debug, PartialEq, Eq; T::MessageExt)]
 pub struct Message<T: EvmTypes = BaseEvmTypes> {
     /// Message kind.
     pub kind: MessageKind,
@@ -56,34 +57,6 @@ pub struct Message<T: EvmTypes = BaseEvmTypes> {
     pub salt: B256,
     /// EVM type-specific extension data.
     pub ext: T::MessageExt,
-}
-
-impl<T> PartialEq for Message<T>
-where
-    T: EvmTypes,
-    T::MessageExt: PartialEq,
-{
-    #[inline]
-    fn eq(&self, other: &Self) -> bool {
-        self.kind == other.kind
-            && self.depth == other.depth
-            && self.gas_limit == other.gas_limit
-            && self.destination == other.destination
-            && self.caller == other.caller
-            && self.input == other.input
-            && self.value == other.value
-            && self.code_address == other.code_address
-            && self.disable_precompiles == other.disable_precompiles
-            && self.salt == other.salt
-            && self.ext == other.ext
-    }
-}
-
-impl<T> Eq for Message<T>
-where
-    T: EvmTypes,
-    T::MessageExt: Eq,
-{
 }
 
 impl<T: EvmTypes> Default for Message<T> {

--- a/crates/evm2/src/interpreter/runtime.rs
+++ b/crates/evm2/src/interpreter/runtime.rs
@@ -420,24 +420,28 @@ impl<'frame, T: EvmTypes> InterpreterState<'frame, T> {
     }
 
     #[inline]
-    pub(crate) fn inspect_call(&mut self, message: &mut Message<T>) -> Option<MessageResult> {
+    pub(crate) fn inspect_call(&mut self, message: &mut Message<T>) -> Option<MessageResult<T>> {
         self.inspector().and_then(|inspector| inspector.call(message))
     }
 
     #[inline]
-    pub(crate) fn inspect_call_end(&mut self, message: &Message<T>, result: &mut MessageResult) {
+    pub(crate) fn inspect_call_end(&mut self, message: &Message<T>, result: &mut MessageResult<T>) {
         if let Some(inspector) = self.inspector() {
             inspector.call_end(message, result);
         }
     }
 
     #[inline]
-    pub(crate) fn inspect_create(&mut self, message: &mut Message<T>) -> Option<MessageResult> {
+    pub(crate) fn inspect_create(&mut self, message: &mut Message<T>) -> Option<MessageResult<T>> {
         self.inspector().and_then(|inspector| inspector.create(message))
     }
 
     #[inline]
-    pub(crate) fn inspect_create_end(&mut self, message: &Message<T>, result: &mut MessageResult) {
+    pub(crate) fn inspect_create_end(
+        &mut self,
+        message: &Message<T>,
+        result: &mut MessageResult<T>,
+    ) {
         if let Some(inspector) = self.inspector() {
             inspector.create_end(message, result);
         }

--- a/crates/evm2/src/interpreter/runtime.rs
+++ b/crates/evm2/src/interpreter/runtime.rs
@@ -28,8 +28,10 @@ pub struct Interpreter<'frame, T: EvmTypes> {
 
     pc: *const u8,
     output: *const [u8],
-    tx_env: Option<&'frame TxEnv>,
-    message: Option<&'frame Message>,
+    #[debug(skip)]
+    tx_env: Option<&'frame TxEnv<T>>,
+    #[debug(skip)]
+    message: Option<&'frame Message<T>>,
     host: Option<NonNull<T::Host>>,
     inspector: Option<NonNull<dyn Inspector<T>>>,
     version: *const Version,
@@ -79,8 +81,8 @@ impl<'frame, T: EvmTypes> Interpreter<'frame, T> {
     /// frame-local message.
     pub fn new(
         bytecode: Bytecode,
-        tx_env: &'frame TxEnv,
-        message: &'frame Message,
+        tx_env: &'frame TxEnv<T>,
+        message: &'frame Message<T>,
         caller_is_static: bool,
     ) -> Self {
         let mut interpreter = Self::default();
@@ -92,8 +94,8 @@ impl<'frame, T: EvmTypes> Interpreter<'frame, T> {
     pub(crate) fn init(
         &mut self,
         bytecode: Bytecode,
-        tx_env: &'frame TxEnv,
-        message: &'frame Message,
+        tx_env: &'frame TxEnv<T>,
+        message: &'frame Message<T>,
         caller_is_static: bool,
     ) {
         let gas_limit = message.gas_limit;
@@ -311,7 +313,7 @@ impl<'frame, T: EvmTypes> InterpreterState<'frame, T> {
 
     /// Returns the cached transaction-global environment.
     #[inline]
-    pub const fn tx(&self) -> &TxEnv {
+    pub const fn tx(&self) -> &TxEnv<T> {
         // SAFETY: `tx_env` is initialized at the beginning of `run` and remains set for
         // instruction execution.
         unsafe { self.0.tx_env.unwrap_unchecked() }
@@ -342,7 +344,7 @@ impl<'frame, T: EvmTypes> InterpreterState<'frame, T> {
 
     /// Returns the active frame-local call/create message.
     #[inline]
-    pub const fn message(&self) -> &Message {
+    pub const fn message(&self) -> &Message<T> {
         // SAFETY: `message` is initialized at the beginning of `run` and remains set for
         // instruction execution.
         unsafe { self.0.message.unwrap_unchecked() }
@@ -418,24 +420,24 @@ impl<'frame, T: EvmTypes> InterpreterState<'frame, T> {
     }
 
     #[inline]
-    pub(crate) fn inspect_call(&mut self, message: &mut Message) -> Option<MessageResult> {
+    pub(crate) fn inspect_call(&mut self, message: &mut Message<T>) -> Option<MessageResult> {
         self.inspector().and_then(|inspector| inspector.call(message))
     }
 
     #[inline]
-    pub(crate) fn inspect_call_end(&mut self, message: &Message, result: &mut MessageResult) {
+    pub(crate) fn inspect_call_end(&mut self, message: &Message<T>, result: &mut MessageResult) {
         if let Some(inspector) = self.inspector() {
             inspector.call_end(message, result);
         }
     }
 
     #[inline]
-    pub(crate) fn inspect_create(&mut self, message: &mut Message) -> Option<MessageResult> {
+    pub(crate) fn inspect_create(&mut self, message: &mut Message<T>) -> Option<MessageResult> {
         self.inspector().and_then(|inspector| inspector.create(message))
     }
 
     #[inline]
-    pub(crate) fn inspect_create_end(&mut self, message: &Message, result: &mut MessageResult) {
+    pub(crate) fn inspect_create_end(&mut self, message: &Message<T>, result: &mut MessageResult) {
         if let Some(inspector) = self.inspector() {
             inspector.create_end(message, result);
         }

--- a/crates/evm2/src/interpreter/runtime.rs
+++ b/crates/evm2/src/interpreter/runtime.rs
@@ -17,10 +17,11 @@ use alloc::{boxed::Box, vec::Vec};
 use alloy_primitives::{Address, Bytes, Log};
 #[cfg(not(tco))]
 use core::hint::cold_path;
-use core::{fmt, marker::PhantomData, ptr::NonNull};
+use core::{fmt, ptr::NonNull};
+use derive_where::derive_where;
 
 /// EVM interpreter.
-#[derive(derive_more::Debug)]
+#[derive_where(Debug)]
 pub struct Interpreter<'frame, T: EvmTypes> {
     bytecode: Bytecode,
     memory: Memory,
@@ -28,15 +29,15 @@ pub struct Interpreter<'frame, T: EvmTypes> {
 
     pc: *const u8,
     output: *const [u8],
-    #[debug(skip)]
+    #[derive_where(skip)]
     tx_env: Option<&'frame TxEnv<T>>,
-    #[debug(skip)]
+    #[derive_where(skip)]
     message: Option<&'frame Message<T>>,
     host: Option<NonNull<T::Host>>,
     inspector: Option<NonNull<dyn Inspector<T>>>,
     version: *const Version,
     stack_len: usize,
-    #[debug(skip)]
+    #[derive_where(skip)]
     stack: Box<StackBacking>,
 
     gas: Gas,
@@ -44,9 +45,6 @@ pub struct Interpreter<'frame, T: EvmTypes> {
     spec: SpecId,
     features: EvmFeatures,
     is_static: bool,
-
-    #[debug(skip)]
-    _marker: PhantomData<fn() -> T>,
 }
 
 impl<T: EvmTypes> Default for Interpreter<'_, T> {
@@ -71,7 +69,6 @@ impl<T: EvmTypes> Default for Interpreter<'_, T> {
             features: EvmFeatures::empty(),
             // SAFETY: `MaybeUninit<Word>` does not need initialization.
             stack: unsafe { Box::new_uninit().assume_init() },
-            _marker: PhantomData,
         }
     }
 }

--- a/crates/evm2/src/once_lock.rs
+++ b/crates/evm2/src/once_lock.rs
@@ -1,5 +1,7 @@
 //! `OnceLock` abstraction that uses [`std::sync::OnceLock`] when available, once_cell otherwise.
 
+#![allow(dead_code)]
+
 #[cfg(not(feature = "std"))]
 use alloc::boxed::Box;
 #[cfg(feature = "std")]

--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -5,8 +5,8 @@ use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
 use syn::{
     AngleBracketedGenericArguments, FnArg, GenericArgument, GenericParam, Ident, ItemFn, LitStr,
-    Pat, PatIdent, PatSlice, PathArguments, ReturnType, Stmt, Token, Type, TypeInfer, TypePath,
-    TypeSlice,
+    Pat, PatIdent, PatSlice, PathArguments, ReturnType, Stmt, Token, Type, TypeInfer,
+    TypeParamBound, TypePath, TypeSlice,
     parse::{Parse, ParseStream},
     parse_macro_input,
     punctuated::Punctuated,
@@ -36,8 +36,11 @@ use syn::{
 /// - `#[instruction(dynamic_gas)]`: Exposes `cx.gas` and marks the instruction as needing access to
 ///   mutable gas state.
 /// - `#[instruction(EvmTypes = CustomTypes)]`: Implements the instruction for a concrete `EvmTypes`
-///   implementor instead of generating a generic implementation. `:` is also accepted as the
-///   separator.
+///   implementor instead of generating a generic implementation.
+/// - `#[instruction(EvmTypes: CustomTypesTrait)]`: Adds a trait bound to the generated generic
+///   `EvmTypes` type parameter.
+/// - `#[instruction(EvmTypes<Host: CustomHostTrait>)]`: Adds associated-type constraints to the
+///   generated generic `EvmTypes` implementation.
 ///
 /// ## Examples
 ///
@@ -94,7 +97,9 @@ pub fn instruction(attr: TokenStream, item: TokenStream) -> TokenStream {
 
 enum InstructionAttr {
     Flag(Ident),
-    EvmTypes(Type),
+    EvmTypesConcrete(Type),
+    EvmTypesBounds(Punctuated<TypeParamBound, Token![+]>),
+    EvmTypesArgs(AngleBracketedGenericArguments),
 }
 
 impl Parse for InstructionAttr {
@@ -103,12 +108,20 @@ impl Parse for InstructionAttr {
         if ident == "EvmTypes" || ident == "evm_types" {
             if input.peek(Token![=]) {
                 input.parse::<Token![=]>()?;
+                Ok(Self::EvmTypesConcrete(input.parse()?))
             } else if input.peek(Token![:]) {
                 input.parse::<Token![:]>()?;
+                Ok(Self::EvmTypesBounds(
+                    Punctuated::<TypeParamBound, Token![+]>::parse_separated_nonempty(input)?,
+                ))
+            } else if input.peek(Token![<]) {
+                Ok(Self::EvmTypesArgs(input.parse()?))
             } else {
-                return Err(syn::Error::new_spanned(ident, "expected `=` or `:` after `EvmTypes`"));
+                Err(syn::Error::new_spanned(
+                    ident,
+                    "expected `=`, `:`, or `<...>` after `EvmTypes`",
+                ))
             }
-            Ok(Self::EvmTypes(input.parse()?))
         } else {
             Ok(Self::Flag(ident))
         }
@@ -120,6 +133,8 @@ struct InstructionAttrs {
     no_stack_preamble: bool,
     dynamic_gas: bool,
     evm_types: Option<Type>,
+    evm_types_bounds: Vec<Punctuated<TypeParamBound, Token![+]>>,
+    evm_types_args: Option<AngleBracketedGenericArguments>,
 }
 
 impl InstructionAttrs {
@@ -139,7 +154,7 @@ impl InstructionAttrs {
                         "unsupported #[instruction] argument",
                     ));
                 }
-                InstructionAttr::EvmTypes(evm_types) => {
+                InstructionAttr::EvmTypesConcrete(evm_types) => {
                     if attrs.evm_types.replace(evm_types).is_some() {
                         return Err(syn::Error::new(
                             proc_macro2::Span::call_site(),
@@ -147,7 +162,26 @@ impl InstructionAttrs {
                         ));
                     }
                 }
+                InstructionAttr::EvmTypesBounds(bounds) => {
+                    attrs.evm_types_bounds.push(bounds);
+                }
+                InstructionAttr::EvmTypesArgs(args) => {
+                    if attrs.evm_types_args.replace(args).is_some() {
+                        return Err(syn::Error::new(
+                            proc_macro2::Span::call_site(),
+                            "duplicate `EvmTypes<...>` argument",
+                        ));
+                    }
+                }
             }
+        }
+        if attrs.evm_types.is_some()
+            && (!attrs.evm_types_bounds.is_empty() || attrs.evm_types_args.is_some())
+        {
+            return Err(syn::Error::new(
+                proc_macro2::Span::call_site(),
+                "`EvmTypes = ...` cannot be combined with generic `EvmTypes` bounds",
+            ));
         }
         Ok(attrs)
     }
@@ -183,12 +217,18 @@ fn expand_instruction(instruction_attrs: InstructionAttrs, input: ItemFn) -> Tok
     } else {
         quote! { <#evm_types_ident #(, #type_params)*> }
     };
+    let evm_types_bound = if let Some(args) = instruction_attrs.evm_types_args {
+        quote! { evm2::EvmTypes #args }
+    } else {
+        quote! { evm2::EvmTypes }
+    };
+    let evm_types_bounds = instruction_attrs.evm_types_bounds;
     let where_predicates =
         generics.where_clause.as_ref().map(|where_clause| &where_clause.predicates);
     let where_clause = if let Some(predicates) = where_predicates {
-        quote! { where #evm_types: evm2::EvmTypes, #predicates }
+        quote! { where #evm_types: #evm_types_bound #( + #evm_types_bounds)*, #predicates }
     } else {
-        quote! { where #evm_types: evm2::EvmTypes }
+        quote! { where #evm_types: #evm_types_bound #( + #evm_types_bounds)* }
     };
     let (_, outputs) = parse_return(sig.output);
     let body = body(input.block.stmts, outputs.is_empty());

--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -6,7 +6,10 @@ use quote::quote;
 use syn::{
     AngleBracketedGenericArguments, FnArg, GenericArgument, GenericParam, Ident, ItemFn, LitStr,
     Pat, PatIdent, PatSlice, PathArguments, ReturnType, Stmt, Token, Type, TypeInfer, TypePath,
-    TypeSlice, parse_macro_input, punctuated::Punctuated,
+    TypeSlice,
+    parse::{Parse, ParseStream},
+    parse_macro_input,
+    punctuated::Punctuated,
 };
 
 /// Generates an `Instruction` impl for an instruction function definition.
@@ -32,6 +35,9 @@ use syn::{
 ///   checks.
 /// - `#[instruction(dynamic_gas)]`: Exposes `cx.gas` and marks the instruction as needing access to
 ///   mutable gas state.
+/// - `#[instruction(EvmTypes = CustomTypes)]`: Implements the instruction for a concrete `EvmTypes`
+///   implementor instead of generating a generic implementation. `:` is also accepted as the
+///   separator.
 ///
 /// ## Examples
 ///
@@ -76,7 +82,8 @@ use syn::{
 /// ```
 #[proc_macro_attribute]
 pub fn instruction(attr: TokenStream, item: TokenStream) -> TokenStream {
-    let args = parse_macro_input!(attr with Punctuated::<Ident, Token![,]>::parse_terminated);
+    let args =
+        parse_macro_input!(attr with Punctuated::<InstructionAttr, Token![,]>::parse_terminated);
     let attrs = match InstructionAttrs::parse(args) {
         Ok(attrs) => attrs,
         Err(err) => return err.to_compile_error().into(),
@@ -85,22 +92,61 @@ pub fn instruction(attr: TokenStream, item: TokenStream) -> TokenStream {
     expand_instruction(attrs, input).into()
 }
 
-#[derive(Clone, Copy, Debug, Default)]
+enum InstructionAttr {
+    Flag(Ident),
+    EvmTypes(Type),
+}
+
+impl Parse for InstructionAttr {
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
+        let ident = input.parse::<Ident>()?;
+        if ident == "EvmTypes" || ident == "evm_types" {
+            if input.peek(Token![=]) {
+                input.parse::<Token![=]>()?;
+            } else if input.peek(Token![:]) {
+                input.parse::<Token![:]>()?;
+            } else {
+                return Err(syn::Error::new_spanned(ident, "expected `=` or `:` after `EvmTypes`"));
+            }
+            Ok(Self::EvmTypes(input.parse()?))
+        } else {
+            Ok(Self::Flag(ident))
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default)]
 struct InstructionAttrs {
     no_stack_preamble: bool,
     dynamic_gas: bool,
+    evm_types: Option<Type>,
 }
 
 impl InstructionAttrs {
-    fn parse(args: Punctuated<Ident, Token![,]>) -> syn::Result<Self> {
+    fn parse(args: Punctuated<InstructionAttr, Token![,]>) -> syn::Result<Self> {
         let mut attrs = Self::default();
         for arg in args {
-            if arg == "no_stack_preamble" {
-                attrs.no_stack_preamble = true;
-            } else if arg == "dynamic_gas" {
-                attrs.dynamic_gas = true;
-            } else {
-                return Err(syn::Error::new_spanned(arg, "unsupported #[instruction] argument"));
+            match arg {
+                InstructionAttr::Flag(arg) if arg == "no_stack_preamble" => {
+                    attrs.no_stack_preamble = true;
+                }
+                InstructionAttr::Flag(arg) if arg == "dynamic_gas" => {
+                    attrs.dynamic_gas = true;
+                }
+                InstructionAttr::Flag(arg) => {
+                    return Err(syn::Error::new_spanned(
+                        arg,
+                        "unsupported #[instruction] argument",
+                    ));
+                }
+                InstructionAttr::EvmTypes(evm_types) => {
+                    if attrs.evm_types.replace(evm_types).is_some() {
+                        return Err(syn::Error::new(
+                            proc_macro2::Span::call_site(),
+                            "duplicate `EvmTypes` argument",
+                        ));
+                    }
+                }
             }
         }
         Ok(attrs)
@@ -116,14 +162,28 @@ fn expand_instruction(instruction_attrs: InstructionAttrs, input: ItemFn) -> Tok
     let generics = sig.generics;
     let struct_where_clause = generics.where_clause.clone();
     let impl_params = generics.params.clone();
-    let evm_types = Ident::new("__Evm2T", ident.span());
-    let struct_generics = if impl_params.is_empty() {
-        quote! { <#evm_types: evm2::EvmTypes> }
-    } else {
-        quote! { <#evm_types: evm2::EvmTypes, #impl_params> }
+    let evm_types_ident = Ident::new("__Evm2T", ident.span());
+    let evm_types = instruction_attrs
+        .evm_types
+        .as_ref()
+        .map(|ty| quote! { #ty })
+        .unwrap_or_else(|| quote! { #evm_types_ident });
+    let struct_generics = match (&instruction_attrs.evm_types, impl_params.is_empty()) {
+        (Some(_), true) => quote! {},
+        (Some(_), false) => quote! { <#impl_params> },
+        (None, true) => quote! { <#evm_types_ident: evm2::EvmTypes> },
+        (None, false) => quote! { <#evm_types_ident: evm2::EvmTypes, #impl_params> },
     };
     let type_params = generics.params.iter().map(generic_param_ident);
-    let type_generics = quote! { <#evm_types #(, #type_params)*> };
+    let type_generics = if instruction_attrs.evm_types.is_some() {
+        if generics.params.is_empty() {
+            quote! {}
+        } else {
+            quote! { <#(#type_params),*> }
+        }
+    } else {
+        quote! { <#evm_types_ident #(, #type_params)*> }
+    };
     let where_predicates =
         struct_where_clause.as_ref().map(|where_clause| &where_clause.predicates);
     let impl_where_clause = where_predicates.map(|predicates| quote! { where #predicates });

--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -97,25 +97,29 @@ pub fn instruction(attr: TokenStream, item: TokenStream) -> TokenStream {
 
 enum InstructionAttr {
     Flag(Ident),
-    EvmTypesConcrete(Type),
-    EvmTypesBounds(Punctuated<TypeParamBound, Token![+]>),
-    EvmTypesArgs(AngleBracketedGenericArguments),
+    EvmTypesConcrete { span: proc_macro2::Span, evm_types: Type },
+    EvmTypesBounds { span: proc_macro2::Span, bounds: Punctuated<TypeParamBound, Token![+]> },
+    EvmTypesArgs { span: proc_macro2::Span, args: AngleBracketedGenericArguments },
 }
 
 impl Parse for InstructionAttr {
     fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
         let ident = input.parse::<Ident>()?;
         if ident == "EvmTypes" || ident == "evm_types" {
+            let span = ident.span();
             if input.peek(Token![=]) {
                 input.parse::<Token![=]>()?;
-                Ok(Self::EvmTypesConcrete(input.parse()?))
+                Ok(Self::EvmTypesConcrete { span, evm_types: input.parse()? })
             } else if input.peek(Token![:]) {
                 input.parse::<Token![:]>()?;
-                Ok(Self::EvmTypesBounds(
-                    Punctuated::<TypeParamBound, Token![+]>::parse_separated_nonempty(input)?,
-                ))
+                Ok(Self::EvmTypesBounds {
+                    span,
+                    bounds: Punctuated::<TypeParamBound, Token![+]>::parse_separated_nonempty(
+                        input,
+                    )?,
+                })
             } else if input.peek(Token![<]) {
-                Ok(Self::EvmTypesArgs(input.parse()?))
+                Ok(Self::EvmTypesArgs { span, args: input.parse()? })
             } else {
                 Err(syn::Error::new_spanned(
                     ident,
@@ -133,6 +137,7 @@ struct InstructionAttrs {
     no_stack_preamble: bool,
     dynamic_gas: bool,
     evm_types: Option<Type>,
+    evm_types_span: Option<proc_macro2::Span>,
     evm_types_bounds: Vec<Punctuated<TypeParamBound, Token![+]>>,
     evm_types_args: Option<AngleBracketedGenericArguments>,
 }
@@ -154,24 +159,21 @@ impl InstructionAttrs {
                         "unsupported #[instruction] argument",
                     ));
                 }
-                InstructionAttr::EvmTypesConcrete(evm_types) => {
+                InstructionAttr::EvmTypesConcrete { span, evm_types } => {
                     if attrs.evm_types.replace(evm_types).is_some() {
-                        return Err(syn::Error::new(
-                            proc_macro2::Span::call_site(),
-                            "duplicate `EvmTypes` argument",
-                        ));
+                        return Err(syn::Error::new(span, "duplicate `EvmTypes` argument"));
                     }
+                    attrs.evm_types_span = Some(span);
                 }
-                InstructionAttr::EvmTypesBounds(bounds) => {
+                InstructionAttr::EvmTypesBounds { span, bounds } => {
+                    attrs.evm_types_span.get_or_insert(span);
                     attrs.evm_types_bounds.push(bounds);
                 }
-                InstructionAttr::EvmTypesArgs(args) => {
+                InstructionAttr::EvmTypesArgs { span, args } => {
                     if attrs.evm_types_args.replace(args).is_some() {
-                        return Err(syn::Error::new(
-                            proc_macro2::Span::call_site(),
-                            "duplicate `EvmTypes<...>` argument",
-                        ));
+                        return Err(syn::Error::new(span, "duplicate `EvmTypes<...>` argument"));
                     }
+                    attrs.evm_types_span.get_or_insert(span);
                 }
             }
         }
@@ -179,7 +181,7 @@ impl InstructionAttrs {
             && (!attrs.evm_types_bounds.is_empty() || attrs.evm_types_args.is_some())
         {
             return Err(syn::Error::new(
-                proc_macro2::Span::call_site(),
+                attrs.evm_types_span.unwrap_or_else(proc_macro2::Span::call_site),
                 "`EvmTypes = ...` cannot be combined with generic `EvmTypes` bounds",
             ));
         }
@@ -195,7 +197,8 @@ fn expand_instruction(instruction_attrs: InstructionAttrs, input: ItemFn) -> Tok
     let asm_comment = LitStr::new(&ident.to_string(), ident.span());
     let generics = sig.generics;
     let impl_params = generics.params.clone();
-    let evm_types_ident = Ident::new("__Evm2T", ident.span());
+    let evm_types_span = instruction_attrs.evm_types_span.unwrap_or_else(|| ident.span());
+    let evm_types_ident = Ident::new("__Evm2T", evm_types_span);
     let evm_types = instruction_attrs
         .evm_types
         .as_ref()

--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -115,7 +115,7 @@ impl Parse for InstructionAttr {
     }
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Default)]
 struct InstructionAttrs {
     no_stack_preamble: bool,
     dynamic_gas: bool,
@@ -160,7 +160,6 @@ fn expand_instruction(instruction_attrs: InstructionAttrs, input: ItemFn) -> Tok
     let ident = sig.ident;
     let asm_comment = LitStr::new(&ident.to_string(), ident.span());
     let generics = sig.generics;
-    let struct_where_clause = generics.where_clause.clone();
     let impl_params = generics.params.clone();
     let evm_types_ident = Ident::new("__Evm2T", ident.span());
     let evm_types = instruction_attrs
@@ -171,8 +170,8 @@ fn expand_instruction(instruction_attrs: InstructionAttrs, input: ItemFn) -> Tok
     let struct_generics = match (&instruction_attrs.evm_types, impl_params.is_empty()) {
         (Some(_), true) => quote! {},
         (Some(_), false) => quote! { <#impl_params> },
-        (None, true) => quote! { <#evm_types_ident: evm2::EvmTypes> },
-        (None, false) => quote! { <#evm_types_ident: evm2::EvmTypes, #impl_params> },
+        (None, true) => quote! { <#evm_types_ident> },
+        (None, false) => quote! { <#evm_types_ident, #impl_params> },
     };
     let type_params = generics.params.iter().map(generic_param_ident);
     let type_generics = if instruction_attrs.evm_types.is_some() {
@@ -185,8 +184,12 @@ fn expand_instruction(instruction_attrs: InstructionAttrs, input: ItemFn) -> Tok
         quote! { <#evm_types_ident #(, #type_params)*> }
     };
     let where_predicates =
-        struct_where_clause.as_ref().map(|where_clause| &where_clause.predicates);
-    let impl_where_clause = where_predicates.map(|predicates| quote! { where #predicates });
+        generics.where_clause.as_ref().map(|where_clause| &where_clause.predicates);
+    let where_clause = if let Some(predicates) = where_predicates {
+        quote! { where #evm_types: evm2::EvmTypes, #predicates }
+    } else {
+        quote! { where #evm_types: evm2::EvmTypes }
+    };
     let (_, outputs) = parse_return(sig.output);
     let body = body(input.block.stmts, outputs.is_empty());
 
@@ -246,10 +249,10 @@ fn expand_instruction(instruction_attrs: InstructionAttrs, input: ItemFn) -> Tok
         #[allow(non_camel_case_types)]
         #vis struct #ident #struct_generics(
             core::marker::PhantomData<fn() -> #evm_types>
-        ) #struct_where_clause;
+        ) #where_clause;
 
         impl #struct_generics evm2::interpreter::private::Instruction<#evm_types> for #ident #type_generics
-        #impl_where_clause
+        #where_clause
         {
             const DYNAMIC_GAS: bool = #dynamic_gas;
 


### PR DESCRIPTION
Adds extension associated types to the EVM type family and threads them through transaction environments, block environments, and frame messages. The base EVM uses unit extensions, while custom EVMs can attach concrete payloads without changing core fields.

The custom EVM example now defines transaction, block, and message extension types, and includes a custom L1_BLOCKNUMBER opcode that reads from the block extension field.
