### PR TITLE
feat(precompile): add bn254 mcl backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,9 +83,9 @@ jobs:
           cache-on-failure: true
       - uses: taiki-e/install-action@nextest
       - uses: astral-sh/setup-uv@v7
-        if: ${{ matrix.kind == 'eest' }}
+        if: ${{ matrix.kind == 'eest' || matrix.flags == '--all-features' }}
       - name: Download EEST fixtures
-        if: ${{ matrix.kind == 'eest' }}
+        if: ${{ matrix.kind == 'eest' || matrix.flags == '--all-features' }}
         shell: bash
         run: |
             if [[ "${{ matrix.fixture }}" == "devnet" ]]; then
@@ -100,6 +100,8 @@ jobs:
             extra_flags=()
             if [[ "${{ matrix.kind }}" == "eest" ]]; then
               extra_flags+=(-p evm2-eest --ignore-default-filter)
+            elif [[ "${{ matrix.flags }}" == "--all-features" ]]; then
+              extra_flags+=(--ignore-default-filter)
             fi
             if [[ "${{ matrix.fixture }}" == "devnet" ]]; then
               export EVM2_STATETEST_ROOT="test-fixtures/devnet/state_tests"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ bn = { package = "substrate-bn", version = "0.6", default-features = false }
 c-kzg = { version = "2.1.7", default-features = false }
 gmp-mpfr-sys = { version = "1.6", default-features = false }
 k256 = { version = "0.13", default-features = false }
+mcl_rust = { version = "1", default-features = false }
 p256 = { version = "0.13.2", default-features = false }
 ripemd = { version = "0.2.0", default-features = false }
 secp256k1 = { version = "0.31.1", default-features = false }
@@ -102,3 +103,6 @@ ark-ff-macros = { git = "https://github.com/DaniPopes/algebra", branch = "remove
 ark-poly = { git = "https://github.com/DaniPopes/algebra", branch = "remove-unrolls" }
 ark-serialize = { git = "https://github.com/DaniPopes/algebra", branch = "remove-unrolls" }
 ark-serialize-derive = { git = "https://github.com/DaniPopes/algebra", branch = "remove-unrolls" }
+
+# https://github.com/herumi/mcl-rust/issues/8
+mcl_rust = { git = "https://github.com/herumi/mcl-rust", rev = "f8c96482a6831a64e4cdd5b201e0d874abc84415" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,15 +94,15 @@ codegen-units = 1
 
 [patch.crates-io]
 # https://github.com/arkworks-rs/algebra/issues/1104
-ark-ec = { git = "https://github.com/DaniPopes/algebra", branch = "remove-unrolls" }
-ark-bls12-381 = { git = "https://github.com/DaniPopes/algebra", branch = "remove-unrolls" }
-ark-bn254 = { git = "https://github.com/DaniPopes/algebra", branch = "remove-unrolls" }
-ark-ff = { git = "https://github.com/DaniPopes/algebra", branch = "remove-unrolls" }
-ark-ff-asm = { git = "https://github.com/DaniPopes/algebra", branch = "remove-unrolls" }
-ark-ff-macros = { git = "https://github.com/DaniPopes/algebra", branch = "remove-unrolls" }
-ark-poly = { git = "https://github.com/DaniPopes/algebra", branch = "remove-unrolls" }
-ark-serialize = { git = "https://github.com/DaniPopes/algebra", branch = "remove-unrolls" }
-ark-serialize-derive = { git = "https://github.com/DaniPopes/algebra", branch = "remove-unrolls" }
+ark-ec = { git = "https://github.com/DaniPopes/algebra", rev = "b76fa0a14b6f707b34388d672f3007c5daf7ce3c" }
+ark-bls12-381 = { git = "https://github.com/DaniPopes/algebra", rev = "b76fa0a14b6f707b34388d672f3007c5daf7ce3c" }
+ark-bn254 = { git = "https://github.com/DaniPopes/algebra", rev = "b76fa0a14b6f707b34388d672f3007c5daf7ce3c" }
+ark-ff = { git = "https://github.com/DaniPopes/algebra", rev = "b76fa0a14b6f707b34388d672f3007c5daf7ce3c" }
+ark-ff-asm = { git = "https://github.com/DaniPopes/algebra", rev = "b76fa0a14b6f707b34388d672f3007c5daf7ce3c" }
+ark-ff-macros = { git = "https://github.com/DaniPopes/algebra", rev = "b76fa0a14b6f707b34388d672f3007c5daf7ce3c" }
+ark-poly = { git = "https://github.com/DaniPopes/algebra", rev = "b76fa0a14b6f707b34388d672f3007c5daf7ce3c" }
+ark-serialize = { git = "https://github.com/DaniPopes/algebra", rev = "b76fa0a14b6f707b34388d672f3007c5daf7ce3c" }
+ark-serialize-derive = { git = "https://github.com/DaniPopes/algebra", rev = "b76fa0a14b6f707b34388d672f3007c5daf7ce3c" }
 
 # https://github.com/herumi/mcl-rust/issues/8
 mcl_rust = { git = "https://github.com/herumi/mcl-rust", rev = "f8c96482a6831a64e4cdd5b201e0d874abc84415" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,20 +94,6 @@ codegen-units = 1
 
 [patch.crates-io]
 # https://github.com/arkworks-rs/algebra/issues/1104
-ark-ec = { git = "https://github.com/DaniPopes/algebra", rev = "b76fa0a14b6f707b34388d672f3007c5daf7ce3c" }
-ark-bls12-381 = { git = "https://github.com/DaniPopes/algebra", rev = "b76fa0a14b6f707b34388d672f3007c5daf7ce3c" }
-ark-bn254 = { git = "https://github.com/DaniPopes/algebra", rev = "b76fa0a14b6f707b34388d672f3007c5daf7ce3c" }
-ark-ff = { git = "https://github.com/DaniPopes/algebra", rev = "b76fa0a14b6f707b34388d672f3007c5daf7ce3c" }
-ark-ff-asm = { git = "https://github.com/DaniPopes/algebra", rev = "b76fa0a14b6f707b34388d672f3007c5daf7ce3c" }
-ark-ff-macros = { git = "https://github.com/DaniPopes/algebra", rev = "b76fa0a14b6f707b34388d672f3007c5daf7ce3c" }
-ark-poly = { git = "https://github.com/DaniPopes/algebra", rev = "b76fa0a14b6f707b34388d672f3007c5daf7ce3c" }
-ark-serialize = { git = "https://github.com/DaniPopes/algebra", rev = "b76fa0a14b6f707b34388d672f3007c5daf7ce3c" }
-ark-serialize-derive = { git = "https://github.com/DaniPopes/algebra", rev = "b76fa0a14b6f707b34388d672f3007c5daf7ce3c" }
-
-# https://github.com/herumi/mcl-rust/issues/8
-mcl_rust = { git = "https://github.com/herumi/mcl-rust", rev = "f8c96482a6831a64e4cdd5b201e0d874abc84415" }
-[patch.crates-io]
-# https://github.com/arkworks-rs/algebra/issues/1104
 ark-ec = { git = "https://github.com/DaniPopes/algebra", rev = "a71d9795e2e527cd0c80e6831bd957134de30d22" }
 ark-bls12-381 = { git = "https://github.com/DaniPopes/algebra", rev = "a71d9795e2e527cd0c80e6831bd957134de30d22" }
 ark-bn254 = { git = "https://github.com/DaniPopes/algebra", rev = "a71d9795e2e527cd0c80e6831bd957134de30d22" }
@@ -117,3 +103,6 @@ ark-ff-macros = { git = "https://github.com/DaniPopes/algebra", rev = "a71d9795e
 ark-poly = { git = "https://github.com/DaniPopes/algebra", rev = "a71d9795e2e527cd0c80e6831bd957134de30d22" }
 ark-serialize = { git = "https://github.com/DaniPopes/algebra", rev = "a71d9795e2e527cd0c80e6831bd957134de30d22" }
 ark-serialize-derive = { git = "https://github.com/DaniPopes/algebra", rev = "a71d9795e2e527cd0c80e6831bd957134de30d22" }
+
+# https://github.com/herumi/mcl-rust/issues/8
+mcl_rust = { git = "https://github.com/herumi/mcl-rust", rev = "f8c96482a6831a64e4cdd5b201e0d874abc84415" }

--- a/crates/evm2/Cargo.toml
+++ b/crates/evm2/Cargo.toml
@@ -135,7 +135,6 @@ serde = [
     "alloy-eips/serde",
     "alloy-primitives/serde",
     "alloy-trie/serde",
-    "ark-serialize/serde",
     "k256/serde",
     "p256/serde",
     "blst?/serde",

--- a/crates/evm2/Cargo.toml
+++ b/crates/evm2/Cargo.toml
@@ -53,6 +53,7 @@ gmp-mpfr-sys = { workspace = true, default-features = false, optional = true }
 
 # bn254
 bn = { workspace = true, optional = true }
+mcl_rust = { workspace = true, optional = true }
 ark-bn254 = { workspace = true, features = ["curve"] }
 ark-ec = { workspace = true }
 ark-ff = { workspace = true, features = ["asm"] }
@@ -100,6 +101,7 @@ default = [
     "blst",
     "c-kzg",
     "portable",
+    "bn254-mcl",
     # TODO: probably shouldn't enable these library-wide.
     "asm-keccak",
     "map-foldhash",
@@ -157,6 +159,7 @@ gmp = ["dep:gmp-mpfr-sys"]
 bn = ["dep:bn"]
 c-kzg = ["dep:c-kzg"]
 blst = ["dep:blst"]
+bn254-mcl = ["std", "dep:mcl_rust"]
 portable = ["c-kzg?/portable", "blst?/portable"]
 p256-aws-lc-rs = ["dep:aws-lc-rs"]
 

--- a/crates/evm2/src/precompiles/bn254/arkworks.rs
+++ b/crates/evm2/src/precompiles/bn254/arkworks.rs
@@ -1,13 +1,65 @@
 //! BN128 precompile using Arkworks BLS12-381 implementation.
 
-use super::{FQ_LEN, FQ2_LEN, G1_LEN, SCALAR_LEN};
+use super::{Bn254Ops, FQ_LEN, FQ2_LEN, G1_LEN, SCALAR_LEN};
 use crate::precompiles::PrecompileHalt;
-use alloc::vec::Vec;
 
 use ark_bn254::{Bn254, Fq, Fq2, Fr, G1Affine, G1Projective, G2Affine};
 use ark_ec::{AffineRepr, CurveGroup, pairing::Pairing};
 use ark_ff::{One, PrimeField, Zero};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+
+pub(crate) struct ArkworksOps;
+
+impl Bn254Ops for ArkworksOps {
+    type G1 = G1Affine;
+    type G2 = G2Affine;
+    type Scalar = Fr;
+
+    #[inline]
+    fn read_g1(input: &[u8]) -> Result<Self::G1, PrecompileHalt> {
+        read_g1_point(input)
+    }
+
+    #[inline]
+    fn encode_g1(point: Self::G1) -> [u8; G1_LEN] {
+        encode_g1_point(point)
+    }
+
+    #[inline]
+    fn read_g2(input: &[u8]) -> Result<Self::G2, PrecompileHalt> {
+        read_g2_point(input)
+    }
+
+    #[inline]
+    fn read_scalar(input: &[u8]) -> Self::Scalar {
+        read_scalar(input)
+    }
+
+    #[inline]
+    fn g1_is_zero(p: &Self::G1) -> bool {
+        p.is_zero()
+    }
+
+    #[inline]
+    fn g2_is_zero(p: &Self::G2) -> bool {
+        p.is_zero()
+    }
+
+    #[inline]
+    fn g1_add(p1: Self::G1, p2: Self::G1) -> Self::G1 {
+        (G1Projective::from(p1) + p2).into_affine()
+    }
+
+    #[inline]
+    fn g1_mul(p: Self::G1, s: Self::Scalar) -> Self::G1 {
+        p.mul_bigint(s.into_bigint()).into_affine()
+    }
+
+    #[inline]
+    fn pairing_check(g1: &[Self::G1], g2: &[Self::G2]) -> bool {
+        Bn254::multi_pairing(g1, g2).0.is_one()
+    }
+}
 
 /// Reads a single `Fq` field element from the input slice.
 ///
@@ -179,64 +231,4 @@ pub(super) fn read_scalar(input: &[u8]) -> Fr {
         input.len()
     );
     Fr::from_be_bytes_mod_order(input)
-}
-
-/// Performs point addition on two G1 points.
-#[inline]
-pub(crate) fn g1_point_add(p1_bytes: &[u8], p2_bytes: &[u8]) -> Result<[u8; 64], PrecompileHalt> {
-    let p1 = read_g1_point(p1_bytes)?;
-    let p2 = read_g1_point(p2_bytes)?;
-
-    let p1_jacobian: G1Projective = p1.into();
-
-    let p3 = p1_jacobian + p2;
-    let output = encode_g1_point(p3.into_affine());
-
-    Ok(output)
-}
-
-/// Performs a G1 scalar multiplication.
-#[inline]
-pub(crate) fn g1_point_mul(
-    point_bytes: &[u8],
-    fr_bytes: &[u8],
-) -> Result<[u8; 64], PrecompileHalt> {
-    let p = read_g1_point(point_bytes)?;
-    let fr = read_scalar(fr_bytes);
-
-    let big_int = fr.into_bigint();
-    let result = p.mul_bigint(big_int);
-
-    let output = encode_g1_point(result.into_affine());
-
-    Ok(output)
-}
-
-/// pairing_check performs a pairing check on a list of G1 and G2 point pairs and
-/// returns true if the result is equal to the identity element.
-///
-/// Note: If the input is empty, this function returns true.
-/// This is different to EIP2537 which disallows the empty input.
-#[inline]
-pub(crate) fn pairing_check(pairs: &[(&[u8], &[u8])]) -> Result<bool, PrecompileHalt> {
-    let mut g1_points = Vec::with_capacity(pairs.len());
-    let mut g2_points = Vec::with_capacity(pairs.len());
-
-    for (g1_bytes, g2_bytes) in pairs {
-        let g1 = read_g1_point(g1_bytes)?;
-        let g2 = read_g2_point(g2_bytes)?;
-
-        // Skip pairs where either point is at infinity
-        if !g1.is_zero() && !g2.is_zero() {
-            g1_points.push(g1);
-            g2_points.push(g2);
-        }
-    }
-
-    if g1_points.is_empty() {
-        return Ok(true);
-    }
-
-    let pairing_result = Bn254::multi_pairing(&g1_points, &g2_points);
-    Ok(pairing_result.0.is_one())
 }

--- a/crates/evm2/src/precompiles/bn254/mcl.rs
+++ b/crates/evm2/src/precompiles/bn254/mcl.rs
@@ -1,0 +1,175 @@
+//! BN254 precompile implementation using herumi/mcl via [`mcl_rust`].
+
+use super::{Bn254Ops, FQ_LEN, FQ2_LEN, G1_LEN, SCALAR_LEN};
+use crate::precompiles::PrecompileHalt;
+use mcl_rust::{CurveType, Fp, Fp2, Fr, G1, G2, GT};
+use std::sync::Once;
+
+#[inline]
+fn ensure_init() {
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        // CurveType::SNARK (MCL_BN_SNARK1) is the Ethereum-compatible BN254 (alt_bn128).
+        // CurveType::BN254 is a different, older BN254 parameterization.
+        assert!(mcl_rust::init(CurveType::SNARK), "mcl BN254 initialization failed");
+    });
+}
+
+pub(crate) struct MclOps;
+
+impl Bn254Ops for MclOps {
+    type G1 = G1;
+    type G2 = G2;
+    type Scalar = Fr;
+
+    #[inline]
+    fn read_g1(input: &[u8]) -> Result<Self::G1, PrecompileHalt> {
+        ensure_init();
+        let px = read_fp(&input[..FQ_LEN])?;
+        let py = read_fp(&input[FQ_LEN..G1_LEN])?;
+
+        if px.is_zero() && py.is_zero() {
+            return Ok(G1::zero());
+        }
+
+        let mut p = G1::zero();
+        p.x = px;
+        p.y = py;
+        p.z = Fp::from_int(1);
+
+        if !p.is_valid() {
+            return Err(PrecompileHalt::Bn254AffineGFailedToCreate);
+        }
+
+        Ok(p)
+    }
+
+    #[inline]
+    fn encode_g1(point: Self::G1) -> [u8; G1_LEN] {
+        if point.is_zero() {
+            return [0u8; G1_LEN];
+        }
+
+        // Normalize to affine coordinates (z = 1).
+        let mut affine = G1::zero();
+        G1::normalize(&mut affine, &point);
+
+        let mut output = [0u8; G1_LEN];
+        output[..FQ_LEN].copy_from_slice(&encode_fp(&affine.x));
+        output[FQ_LEN..].copy_from_slice(&encode_fp(&affine.y));
+        output
+    }
+
+    #[inline]
+    fn read_g2(input: &[u8]) -> Result<Self::G2, PrecompileHalt> {
+        ensure_init();
+        let x = read_fp2(&input[..FQ2_LEN])?;
+        let y = read_fp2(&input[FQ2_LEN..2 * FQ2_LEN])?;
+
+        if x.is_zero() && y.is_zero() {
+            return Ok(G2::zero());
+        }
+
+        let mut p = G2::zero();
+        p.x = x;
+        p.y = y;
+        p.z.d[0] = Fp::from_int(1);
+
+        if !p.is_valid() {
+            return Err(PrecompileHalt::Bn254AffineGFailedToCreate);
+        }
+
+        Ok(p)
+    }
+
+    #[inline]
+    fn read_scalar(input: &[u8]) -> Self::Scalar {
+        assert_eq!(
+            input.len(),
+            SCALAR_LEN,
+            "unexpected scalar length. got {}, expected {SCALAR_LEN}",
+            input.len()
+        );
+        ensure_init();
+
+        let mut le_bytes = [0u8; SCALAR_LEN];
+        le_bytes.copy_from_slice(input);
+        le_bytes.reverse();
+
+        let mut fr = Fr::zero();
+        fr.set_little_endian_mod(&le_bytes);
+        fr
+    }
+
+    #[inline]
+    fn g1_is_zero(p: &Self::G1) -> bool {
+        p.is_zero()
+    }
+
+    #[inline]
+    fn g2_is_zero(p: &Self::G2) -> bool {
+        p.is_zero()
+    }
+
+    #[inline]
+    fn g1_add(p1: Self::G1, p2: Self::G1) -> Self::G1 {
+        &p1 + &p2
+    }
+
+    #[inline]
+    fn g1_mul(p: Self::G1, s: Self::Scalar) -> Self::G1 {
+        let mut result = G1::zero();
+        G1::mul(&mut result, &p, &s);
+        result
+    }
+
+    #[inline]
+    fn pairing_check(g1: &[Self::G1], g2: &[Self::G2]) -> bool {
+        let mut acc = GT::zero();
+        mcl_rust::miller_loop(&mut acc, &g1[0], &g2[0]);
+
+        for i in 1..g1.len() {
+            let mut tmp = GT::zero();
+            mcl_rust::miller_loop(&mut tmp, &g1[i], &g2[i]);
+            acc *= &tmp;
+        }
+
+        let mut result = GT::zero();
+        mcl_rust::final_exp(&mut result, &acc);
+
+        result.is_one()
+    }
+}
+
+#[inline]
+fn read_fp(input: &[u8]) -> Result<Fp, PrecompileHalt> {
+    let mut le_bytes = [0u8; FQ_LEN];
+    le_bytes.copy_from_slice(&input[..FQ_LEN]);
+    le_bytes.reverse();
+
+    let mut fp = Fp::zero();
+    if !fp.set_little_endian(&le_bytes) {
+        return Err(PrecompileHalt::Bn254FieldPointNotAMember);
+    }
+    Ok(fp)
+}
+
+#[inline]
+fn encode_fp(fp: &Fp) -> [u8; FQ_LEN] {
+    let serialized = fp.serialize();
+    let mut result = [0u8; FQ_LEN];
+    let len = serialized.len().min(FQ_LEN);
+    result[..len].copy_from_slice(&serialized[..len]);
+    result[..FQ_LEN].reverse();
+    result
+}
+
+#[inline]
+fn read_fp2(input: &[u8]) -> Result<Fp2, PrecompileHalt> {
+    let imag = read_fp(&input[..FQ_LEN])?;
+    let real = read_fp(&input[FQ_LEN..2 * FQ_LEN])?;
+    let mut fp2 = Fp2::zero();
+    fp2.d[0] = real;
+    fp2.d[1] = imag;
+    Ok(fp2)
+}

--- a/crates/evm2/src/precompiles/bn254/mod.rs
+++ b/crates/evm2/src/precompiles/bn254/mod.rs
@@ -7,16 +7,81 @@ use crate::{
 };
 use alloc::vec::Vec;
 
-#[cfg_attr(feature = "bn", expect(dead_code))]
+#[cfg_attr(any(feature = "bn", feature = "bn254-mcl"), expect(dead_code))]
 pub(crate) mod arkworks;
 
 cfg_if::cfg_if! {
-    if #[cfg(feature = "bn")]{
+    if #[cfg(feature = "bn254-mcl")] {
+        pub(crate) mod mcl;
+        type ArithmeticOps = mcl::MclOps;
+        type PairingOps = arkworks::ArkworksOps;
+    } else if #[cfg(feature = "bn")]{
         pub(crate) mod substrate;
-        pub(crate) use substrate as crypto_backend;
+        type ArithmeticOps = substrate::SubstrateOps;
+        type PairingOps = substrate::SubstrateOps;
     } else {
-        pub(crate) use arkworks as crypto_backend;
+        type ArithmeticOps = arkworks::ArkworksOps;
+        type PairingOps = arkworks::ArkworksOps;
     }
+}
+
+pub(crate) trait Bn254Ops {
+    type G1;
+    type G2;
+    type Scalar;
+
+    fn read_g1(input: &[u8]) -> Result<Self::G1, PrecompileHalt>;
+    fn encode_g1(point: Self::G1) -> [u8; G1_LEN];
+    fn read_g2(input: &[u8]) -> Result<Self::G2, PrecompileHalt>;
+    fn read_scalar(input: &[u8]) -> Self::Scalar;
+    fn g1_is_zero(p: &Self::G1) -> bool;
+    fn g2_is_zero(p: &Self::G2) -> bool;
+    fn g1_add(p1: Self::G1, p2: Self::G1) -> Self::G1;
+    fn g1_mul(p: Self::G1, s: Self::Scalar) -> Self::G1;
+    fn pairing_check(g1: &[Self::G1], g2: &[Self::G2]) -> bool;
+}
+
+/// Performs point addition on two G1 points using the selected backend.
+#[inline]
+pub(crate) fn g1_point_add(p1_bytes: &[u8], p2_bytes: &[u8]) -> Result<[u8; 64], PrecompileHalt> {
+    let p1 = ArithmeticOps::read_g1(p1_bytes)?;
+    let p2 = ArithmeticOps::read_g1(p2_bytes)?;
+    Ok(ArithmeticOps::encode_g1(ArithmeticOps::g1_add(p1, p2)))
+}
+
+/// Performs a G1 scalar multiplication using the selected backend.
+#[inline]
+pub(crate) fn g1_point_mul(
+    point_bytes: &[u8],
+    fr_bytes: &[u8],
+) -> Result<[u8; 64], PrecompileHalt> {
+    let p = ArithmeticOps::read_g1(point_bytes)?;
+    let fr = ArithmeticOps::read_scalar(fr_bytes);
+    Ok(ArithmeticOps::encode_g1(ArithmeticOps::g1_mul(p, fr)))
+}
+
+/// Performs a pairing check on a list of G1 and G2 point pairs using the selected backend.
+#[inline]
+pub(crate) fn pairing_check(pairs: &[(&[u8], &[u8])]) -> Result<bool, PrecompileHalt> {
+    let mut g1_points = Vec::with_capacity(pairs.len());
+    let mut g2_points = Vec::with_capacity(pairs.len());
+
+    for (g1_bytes, g2_bytes) in pairs {
+        let g1 = PairingOps::read_g1(g1_bytes)?;
+        let g2 = PairingOps::read_g2(g2_bytes)?;
+
+        // Skip pairs where either point is at infinity
+        if !PairingOps::g1_is_zero(&g1) && !PairingOps::g2_is_zero(&g2) {
+            g1_points.push(g1);
+            g2_points.push(g2);
+        }
+    }
+
+    if g1_points.is_empty() {
+        return Ok(true);
+    }
+
+    Ok(PairingOps::pairing_check(&g1_points, &g2_points))
 }
 
 /// BN254 point addition precompile entrypoints.

--- a/crates/evm2/src/precompiles/bn254/substrate.rs
+++ b/crates/evm2/src/precompiles/bn254/substrate.rs
@@ -1,7 +1,61 @@
-use super::{FQ_LEN, FQ2_LEN, G1_LEN, SCALAR_LEN};
+use super::{Bn254Ops, FQ_LEN, FQ2_LEN, G1_LEN, SCALAR_LEN};
 use crate::precompiles::PrecompileHalt;
 use alloc::vec::Vec;
 use bn::{AffineG1, AffineG2, Fq, Fq2, G1, G2, Group, Gt};
+
+pub(crate) struct SubstrateOps;
+
+impl Bn254Ops for SubstrateOps {
+    type G1 = G1;
+    type G2 = G2;
+    type Scalar = bn::Fr;
+
+    #[inline]
+    fn read_g1(input: &[u8]) -> Result<Self::G1, PrecompileHalt> {
+        read_g1_point(input)
+    }
+
+    #[inline]
+    fn encode_g1(point: Self::G1) -> [u8; G1_LEN] {
+        encode_g1_point(point)
+    }
+
+    #[inline]
+    fn read_g2(input: &[u8]) -> Result<Self::G2, PrecompileHalt> {
+        read_g2_point(input)
+    }
+
+    #[inline]
+    fn read_scalar(input: &[u8]) -> Self::Scalar {
+        read_scalar(input)
+    }
+
+    #[inline]
+    fn g1_is_zero(p: &Self::G1) -> bool {
+        p.is_zero()
+    }
+
+    #[inline]
+    fn g2_is_zero(p: &Self::G2) -> bool {
+        p.is_zero()
+    }
+
+    #[inline]
+    fn g1_add(p1: Self::G1, p2: Self::G1) -> Self::G1 {
+        p1 + p2
+    }
+
+    #[inline]
+    fn g1_mul(p: Self::G1, s: Self::Scalar) -> Self::G1 {
+        p * s
+    }
+
+    #[inline]
+    fn pairing_check(g1: &[Self::G1], g2: &[Self::G2]) -> bool {
+        let pairs: Vec<(G1, G2)> = g1.iter().copied().zip(g2.iter().copied()).collect();
+        bn::pairing_batch(&pairs) == Gt::one()
+    }
+}
 
 /// Reads a single `Fq` field element from the input slice.
 ///
@@ -142,51 +196,4 @@ pub(super) fn read_scalar(input: &[u8]) -> bn::Fr {
     );
     // `Fr::from_slice` can only fail when the length is not `SCALAR_LEN`.
     bn::Fr::from_slice(input).unwrap()
-}
-
-/// Performs point addition on two G1 points.
-#[inline]
-pub(crate) fn g1_point_add(p1_bytes: &[u8], p2_bytes: &[u8]) -> Result<[u8; 64], PrecompileHalt> {
-    let p1 = read_g1_point(p1_bytes)?;
-    let p2 = read_g1_point(p2_bytes)?;
-    let result = p1 + p2;
-    Ok(encode_g1_point(result))
-}
-
-/// Performs a G1 scalar multiplication.
-#[inline]
-pub(crate) fn g1_point_mul(
-    point_bytes: &[u8],
-    fr_bytes: &[u8],
-) -> Result<[u8; 64], PrecompileHalt> {
-    let p = read_g1_point(point_bytes)?;
-    let fr = read_scalar(fr_bytes);
-    let result = p * fr;
-    Ok(encode_g1_point(result))
-}
-
-/// pairing_check performs a pairing check on a list of G1 and G2 point pairs and
-/// returns true if the result is equal to the identity element.
-///
-/// Note: If the input is empty, this function returns true.
-/// This is different to EIP2537 which disallows the empty input.
-#[inline]
-pub(crate) fn pairing_check(pairs: &[(&[u8], &[u8])]) -> Result<bool, PrecompileHalt> {
-    let mut parsed_pairs = Vec::with_capacity(pairs.len());
-
-    for (g1_bytes, g2_bytes) in pairs {
-        let g1 = read_g1_point(g1_bytes)?;
-        let g2 = read_g2_point(g2_bytes)?;
-
-        // Skip pairs where either point is at infinity
-        if !g1.is_zero() && !g2.is_zero() {
-            parsed_pairs.push((g1, g2));
-        }
-    }
-
-    if parsed_pairs.is_empty() {
-        return Ok(true);
-    }
-
-    Ok(bn::pairing_batch(&parsed_pairs) == Gt::one())
 }

--- a/crates/evm2/src/precompiles/crypto.rs
+++ b/crates/evm2/src/precompiles/crypto.rs
@@ -33,19 +33,19 @@ pub trait Crypto: Send + Sync + Debug {
     /// BN254 elliptic curve addition.
     #[inline]
     fn bn254_g1_add(&self, p1: &[u8], p2: &[u8]) -> Result<[u8; 64], PrecompileHalt> {
-        crate::precompiles::bn254::crypto_backend::g1_point_add(p1, p2)
+        crate::precompiles::bn254::g1_point_add(p1, p2)
     }
 
     /// BN254 elliptic curve scalar multiplication.
     #[inline]
     fn bn254_g1_mul(&self, point: &[u8], scalar: &[u8]) -> Result<[u8; 64], PrecompileHalt> {
-        crate::precompiles::bn254::crypto_backend::g1_point_mul(point, scalar)
+        crate::precompiles::bn254::g1_point_mul(point, scalar)
     }
 
     /// BN254 pairing check.
     #[inline]
     fn bn254_pairing_check(&self, pairs: &[(&[u8], &[u8])]) -> Result<bool, PrecompileHalt> {
-        crate::precompiles::bn254::crypto_backend::pairing_check(pairs)
+        crate::precompiles::bn254::pairing_check(pairs)
     }
 
     /// secp256k1 ECDSA signature recovery.


### PR DESCRIPTION
Ports the BN254 mcl backend from bluealloy/revm#3452 and enables it by default for G1 add and scalar multiplication.

The upstream PR showed mcl improving add and mul while regressing pairing, so this keeps pairing on arkworks when `bn254-mcl` is active. The existing arkworks and substrate implementations now share the same `Bn254Ops` dispatch shape as the upstream refactor, with mcl selected only for the arithmetic paths.
