### PR TITLE
docs: add readme

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,8 @@ authors = ["DaniPopes <57450786+DaniPopes@users.noreply.github.com>"]
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/danipopes/evm2"
 repository = "https://github.com/danipopes/evm2"
+categories = ["cryptography::cryptocurrencies", "development-tools", "no-std"]
+keywords = ["bytecode", "ethereum", "evm", "execution", "interpreter"]
 
 [workspace.lints.clippy]
 dbg-macro = "warn"

--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -1,0 +1,176 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,0 +1,23 @@
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -37,11 +37,8 @@ fn l1_blocknumber(cx: _) -> out {
 
 fn main() -> Result<()> {
     let spec_id = CustomSpecId::Custom;
-    let mut evm = custom_evm(spec_id);
-    let tx = custom_tx(&[
-        opcode::L1_BLOCKNUMBER,
-        // ...
-    ]);
+    let mut evm = Evm::<CustomTypes>::new(.., spec_id, ..);
+    let tx = CustomTx { .. };
     let result = evm.transact(&tx)?;
     // ...
     Ok(())

--- a/README.md
+++ b/README.md
@@ -1,0 +1,66 @@
+# evm2
+
+Fast, customizable EVM implementation in Rust.
+
+evm2 keeps Ethereum execution small and direct while making forks, custom transactions, opcodes,
+environment extensions, and inspectors easy to wire in.
+
+## Highlights
+
+- up to **2x faster than revm**: a leaner interpreter, compile-time tables, compact instruction
+  definitions, and internals abstracted away at zero cost.
+- **Simpler customization**: the extensibility of revm, with a smaller surface for custom specs,
+  transactions, opcodes, precompiles, environment data, and inspectors.
+- **Mainnet behavior**: Ethereum gas accounting, host interaction shape, precompiles, and EEST
+  coverage stay aligned with upstream semantics.
+
+## Example
+
+Custom EVMs are just typed extension points plus normal transaction execution:
+
+```rust,ignore
+enum CustomSpecId {
+    Custom,
+    // ...
+}
+
+struct CustomTypes;
+
+impl EvmTypes for CustomTypes {
+    // ...
+}
+
+#[instruction(EvmTypes = CustomTypes)]
+fn l1_blocknumber(cx: _) -> out {
+    *out = Word::from(cx.state.host().block_env().ext.l1_block_number);
+}
+
+fn main() -> Result<()> {
+    let spec_id = CustomSpecId::Custom;
+    let mut evm = custom_evm(spec_id);
+    let tx = custom_tx(&[
+        opcode::L1_BLOCKNUMBER,
+        // ...
+    ]);
+    let result = evm.transact(&tx)?;
+    // ...
+    Ok(())
+}
+```
+
+See [`crates/evm2/examples/custom_evm`](crates/evm2/examples/custom_evm) for the complete version.
+
+## Benchmarks
+
+```sh
+cargo bench -p evm2 --bench evm
+EVM2_BENCH_REVM=1 cargo bench -p evm2 --bench evm
+```
+
+## Development
+
+```sh
+cargo fmt --all
+cargo cl
+cargo nextest run
+```

--- a/README.md
+++ b/README.md
@@ -2,21 +2,13 @@
 
 Fast, customizable EVM implementation in Rust.
 
-evm2 keeps Ethereum execution small and direct while making forks, custom transactions, opcodes,
-environment extensions, and inspectors easy to wire in.
-
 ## Highlights
 
-- up to **2x faster than revm**: a leaner interpreter, compile-time tables, compact instruction
-  definitions, and internals abstracted away at zero cost.
-- **Simpler customization**: the extensibility of revm, with a smaller surface for custom specs,
-  transactions, opcodes, precompiles, environment data, and inspectors.
-- **Mainnet behavior**: Ethereum gas accounting, host interaction shape, precompiles, and EEST
-  coverage stay aligned with upstream semantics.
+- up to **2x faster than revm** from a tighter interpreter, static dispatch tables, and cheaper instruction plumbing.
+- **Built for custom EVMs**: extend specs, opcodes, gas schedules, transactions, precompiles, environment data, and inspectors without reshaping the core.
+- **Clean extension boundaries**: typed configuration keeps fork logic, transaction handling, host state, and opcode definitions separate while compiling down to a small execution path.
 
 ## Example
-
-Custom EVMs are just typed extension points plus normal transaction execution:
 
 ```rust,ignore
 enum CustomSpecId {
@@ -37,7 +29,7 @@ fn l1_blocknumber(cx: _) -> out {
 
 fn main() -> Result<()> {
     let spec_id = CustomSpecId::Custom;
-    let mut evm = Evm::<CustomTypes>::new(.., spec_id, ..);
+    let mut evm = Evm::<CustomTypes>::new(spec_id, ..);
     let tx = CustomTx { .. };
     let result = evm.transact(&tx)?;
     // ...
@@ -61,3 +53,24 @@ cargo fmt --all
 cargo cl
 cargo nextest run
 ```
+
+## Supported Rust Versions (MSRV)
+
+evm2 always aims to stay up-to-date with the latest stable Rust release.
+
+The Minimum Supported Rust Version (MSRV) may be updated at any time, so we can take advantage of new features and improvements in Rust.
+
+#### License
+
+<sup>
+Licensed under either of <a href="LICENSE-APACHE">Apache License, Version
+2.0</a> or <a href="LICENSE-MIT">MIT license</a> at your option.
+</sup>
+
+<br>
+
+<sub>
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in these crates by you, as defined in the Apache-2.0 license,
+shall be dual licensed as above, without any additional terms or conditions.
+</sub>

--- a/crates/evm2/Cargo.toml
+++ b/crates/evm2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "evm2"
-description = "Experimental EVM interpreter."
+description = "Fast, customizable EVM implementation"
 
 version.workspace = true
 edition.workspace = true
@@ -9,6 +9,8 @@ authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
+categories.workspace = true
+keywords.workspace = true
 
 [lints]
 workspace = true

--- a/crates/evm2/README.md
+++ b/crates/evm2/README.md
@@ -1,3 +1,1 @@
-# evm2
-
-Experimental EVM interpreter.
+../../README.md


### PR DESCRIPTION
Adds a concise root README for evm2 with the project positioning, highlights, a minimal custom EVM example, and benchmark/development commands. It also adds the Apache-2.0 and MIT license files, updates the evm2 crate description, and shares package categories and keywords through workspace metadata.
