### PR TITLE
refactor(interpreter): route unknown ops to invalid

### DIFF
--- a/.github/scripts/matrices.py
+++ b/.github/scripts/matrices.py
@@ -158,14 +158,14 @@ t_linux_armv7 = Target(
 
 targets = [
     t_linux_x86,
-    # t_macos_arm,
-    # t_linux_arm,
-    # t_windows,
-    # t_wasm_unknown,
-    # t_wasm_wasi,
-    # t_wasm_wasi_tail,
-    # t_linux_i686,
-    # t_linux_armv7,
+    t_macos_arm,
+    t_linux_arm,
+    t_windows,
+    t_wasm_unknown,
+    t_wasm_wasi,
+    t_wasm_wasi_tail,
+    t_linux_i686,
+    t_linux_armv7,
 ]
 
 config = [

--- a/.github/scripts/matrices.py
+++ b/.github/scripts/matrices.py
@@ -158,14 +158,14 @@ t_linux_armv7 = Target(
 
 targets = [
     t_linux_x86,
-    t_macos_arm,
-    t_linux_arm,
-    t_windows,
-    t_wasm_unknown,
-    t_wasm_wasi,
-    t_wasm_wasi_tail,
-    t_linux_i686,
-    t_linux_armv7,
+    # t_macos_arm,
+    # t_linux_arm,
+    # t_windows,
+    # t_wasm_unknown,
+    # t_wasm_wasi,
+    # t_wasm_wasi_tail,
+    # t_linux_i686,
+    # t_linux_armv7,
 ]
 
 config = [

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,14 @@ cargo nextest run -E "not (test(glob*)) | package(/regex.*/)" # further filter t
 cargo nextest run -p evm2-eest --test eest --ignore-default-filter # include EEST fixtures
 ```
 
+Use `EVM2_DISPATCH_BACKEND` to force an interpreter dispatch backend for manual
+testing. Accepted values are `auto` (default), `tco`, `packed`, `single_return`,
+and `unpacked`, for example:
+
+```bash
+EVM2_DISPATCH_BACKEND=packed cargo nextest run -p evm2-eest --test eest --ignore-default-filter
+```
+
 ## EEST Fixtures
 
 `./scripts/setup_test_fixtures.py` downloads fixtures into `test-fixtures/`.

--- a/crates/evm2/build.rs
+++ b/crates/evm2/build.rs
@@ -14,7 +14,7 @@ fn main() {
     let is_wasm = target_is_wasm();
     let target_pointer_width = target_pointer_width();
     let no_tco = env("CARGO_FEATURE_NO_TCO");
-    match dispatch_backend().resolve(is_wasm, target_pointer_width, no_tco.is_some()) {
+    match DispatchBackend::load().resolve(is_wasm, target_pointer_width, no_tco.is_some()) {
         DispatchBackend::Auto => unreachable!("auto backend must resolve to a concrete backend"),
         DispatchBackend::Tco => println!("cargo:rustc-cfg=tco"),
         DispatchBackend::Packed => println!("cargo:rustc-cfg=dispatch_packed"),
@@ -32,6 +32,23 @@ enum DispatchBackend {
 }
 
 impl DispatchBackend {
+    fn load() -> Self {
+        let Some(value) = env("EVM2_DISPATCH_BACKEND") else {
+            return Self::Auto;
+        };
+        let value = value.to_str().expect("EVM2_DISPATCH_BACKEND must be valid UTF-8");
+        match value {
+            "" | "auto" => Self::Auto,
+            "tco" => Self::Tco,
+            "packed" => Self::Packed,
+            "single_return" | "single-return" => Self::SingleReturn,
+            "unpacked" => Self::Unpacked,
+            _ => panic!(
+                "invalid EVM2_DISPATCH_BACKEND={value:?}; expected auto, tco, packed, single_return, or unpacked"
+            ),
+        }
+    }
+
     fn resolve(self, is_wasm: bool, target_pointer_width: Option<u32>, no_tco: bool) -> Self {
         match self {
             Self::Auto => {
@@ -39,7 +56,7 @@ impl DispatchBackend {
                     Self::Tco
                 } else if is_wasm {
                     Self::SingleReturn
-                } else if target_pointer_width == Some(64) {
+                } else if false && target_pointer_width == Some(64) {
                     Self::Packed
                 } else {
                     Self::Unpacked
@@ -47,23 +64,6 @@ impl DispatchBackend {
             }
             concrete => concrete,
         }
-    }
-}
-
-fn dispatch_backend() -> DispatchBackend {
-    let Some(value) = env("EVM2_DISPATCH_BACKEND") else {
-        return DispatchBackend::Auto;
-    };
-    let value = value.to_str().expect("EVM2_DISPATCH_BACKEND must be valid UTF-8");
-    match value {
-        "" | "auto" => DispatchBackend::Auto,
-        "tco" => DispatchBackend::Tco,
-        "packed" => DispatchBackend::Packed,
-        "single_return" | "single-return" => DispatchBackend::SingleReturn,
-        "unpacked" => DispatchBackend::Unpacked,
-        _ => panic!(
-            "invalid EVM2_DISPATCH_BACKEND={value:?}; expected auto, tco, packed, single_return, or unpacked"
-        ),
     }
 }
 

--- a/crates/evm2/build.rs
+++ b/crates/evm2/build.rs
@@ -14,17 +14,45 @@ fn main() {
     let is_wasm = target_is_wasm();
     let target_pointer_width = target_pointer_width();
     let no_tco = env("CARGO_FEATURE_NO_TCO");
-    let is_nightly = rustc_is_nightly();
-    if is_wasm {
-        println!("cargo:rustc-cfg=dispatch_single_return");
-    } else if target_pointer_width == Some(64) {
-        println!("cargo:rustc-cfg=dispatch_packed");
-    } else {
-        println!("cargo:rustc-cfg=dispatch_unpacked");
+    match dispatch_backend_override() {
+        Some(DispatchBackend::Tco) => println!("cargo:rustc-cfg=tco"),
+        Some(DispatchBackend::Packed) => println!("cargo:rustc-cfg=dispatch_packed"),
+        Some(DispatchBackend::SingleReturn) => println!("cargo:rustc-cfg=dispatch_single_return"),
+        Some(DispatchBackend::Unpacked) => println!("cargo:rustc-cfg=dispatch_unpacked"),
+        None => {
+            if is_wasm {
+                println!("cargo:rustc-cfg=dispatch_single_return");
+            } else if target_pointer_width == Some(64) {
+                println!("cargo:rustc-cfg=dispatch_packed");
+            } else {
+                println!("cargo:rustc-cfg=dispatch_unpacked");
+            }
+            if no_tco.is_none() && rustc_is_nightly() {
+                println!("cargo:rustc-cfg=tco");
+            }
+        }
     }
-    if no_tco.is_some() {
-    } else if is_nightly {
-        println!("cargo:rustc-cfg=tco");
+}
+
+enum DispatchBackend {
+    Tco,
+    Packed,
+    SingleReturn,
+    Unpacked,
+}
+
+fn dispatch_backend_override() -> Option<DispatchBackend> {
+    let value = env("EVM2_DISPATCH_BACKEND")?;
+    let value = value.to_str().expect("EVM2_DISPATCH_BACKEND must be valid UTF-8");
+    match value {
+        "" | "auto" => None,
+        "tco" => Some(DispatchBackend::Tco),
+        "packed" => Some(DispatchBackend::Packed),
+        "single_return" | "single-return" => Some(DispatchBackend::SingleReturn),
+        "unpacked" => Some(DispatchBackend::Unpacked),
+        _ => panic!(
+            "invalid EVM2_DISPATCH_BACKEND={value:?}; expected auto, tco, packed, single_return, or unpacked"
+        ),
     }
 }
 

--- a/crates/evm2/build.rs
+++ b/crates/evm2/build.rs
@@ -56,7 +56,7 @@ impl DispatchBackend {
                     Self::Tco
                 } else if is_wasm {
                     Self::SingleReturn
-                } else if false && target_pointer_width == Some(64) {
+                } else if target_pointer_width == Some(64) {
                     Self::Packed
                 } else {
                     Self::Unpacked

--- a/crates/evm2/build.rs
+++ b/crates/evm2/build.rs
@@ -14,42 +14,53 @@ fn main() {
     let is_wasm = target_is_wasm();
     let target_pointer_width = target_pointer_width();
     let no_tco = env("CARGO_FEATURE_NO_TCO");
-    match dispatch_backend_override() {
-        Some(DispatchBackend::Tco) => println!("cargo:rustc-cfg=tco"),
-        Some(DispatchBackend::Packed) => println!("cargo:rustc-cfg=dispatch_packed"),
-        Some(DispatchBackend::SingleReturn) => println!("cargo:rustc-cfg=dispatch_single_return"),
-        Some(DispatchBackend::Unpacked) => println!("cargo:rustc-cfg=dispatch_unpacked"),
-        None => {
-            if is_wasm {
-                println!("cargo:rustc-cfg=dispatch_single_return");
-            } else if target_pointer_width == Some(64) {
-                println!("cargo:rustc-cfg=dispatch_packed");
-            } else {
-                println!("cargo:rustc-cfg=dispatch_unpacked");
-            }
-            if no_tco.is_none() && rustc_is_nightly() {
-                println!("cargo:rustc-cfg=tco");
-            }
-        }
+    match dispatch_backend().resolve(is_wasm, target_pointer_width, no_tco.is_some()) {
+        DispatchBackend::Auto => unreachable!("auto backend must resolve to a concrete backend"),
+        DispatchBackend::Tco => println!("cargo:rustc-cfg=tco"),
+        DispatchBackend::Packed => println!("cargo:rustc-cfg=dispatch_packed"),
+        DispatchBackend::SingleReturn => println!("cargo:rustc-cfg=dispatch_single_return"),
+        DispatchBackend::Unpacked => println!("cargo:rustc-cfg=dispatch_unpacked"),
     }
 }
 
 enum DispatchBackend {
+    Auto,
     Tco,
     Packed,
     SingleReturn,
     Unpacked,
 }
 
-fn dispatch_backend_override() -> Option<DispatchBackend> {
-    let value = env("EVM2_DISPATCH_BACKEND")?;
+impl DispatchBackend {
+    fn resolve(self, is_wasm: bool, target_pointer_width: Option<u32>, no_tco: bool) -> Self {
+        match self {
+            Self::Auto => {
+                if !no_tco && rustc_is_nightly() {
+                    Self::Tco
+                } else if is_wasm {
+                    Self::SingleReturn
+                } else if target_pointer_width == Some(64) {
+                    Self::Packed
+                } else {
+                    Self::Unpacked
+                }
+            }
+            concrete => concrete,
+        }
+    }
+}
+
+fn dispatch_backend() -> DispatchBackend {
+    let Some(value) = env("EVM2_DISPATCH_BACKEND") else {
+        return DispatchBackend::Auto;
+    };
     let value = value.to_str().expect("EVM2_DISPATCH_BACKEND must be valid UTF-8");
     match value {
-        "" | "auto" => None,
-        "tco" => Some(DispatchBackend::Tco),
-        "packed" => Some(DispatchBackend::Packed),
-        "single_return" | "single-return" => Some(DispatchBackend::SingleReturn),
-        "unpacked" => Some(DispatchBackend::Unpacked),
+        "" | "auto" => DispatchBackend::Auto,
+        "tco" => DispatchBackend::Tco,
+        "packed" => DispatchBackend::Packed,
+        "single_return" | "single-return" => DispatchBackend::SingleReturn,
+        "unpacked" => DispatchBackend::Unpacked,
         _ => panic!(
             "invalid EVM2_DISPATCH_BACKEND={value:?}; expected auto, tco, packed, single_return, or unpacked"
         ),

--- a/crates/evm2/examples/custom_evm/main.rs
+++ b/crates/evm2/examples/custom_evm/main.rs
@@ -95,11 +95,11 @@ fn mainnet_fallback() -> HandlerResult<()> {
     let result = evm.transact(&tx)?;
 
     println!(
-        "mainnet fallback: expected status=false stop=OpcodeNotFound; got status={} stop={:?}",
+        "mainnet fallback: expected status=false stop=InvalidOpcode; got status={} stop={:?}",
         result.status, result.stop,
     );
 
-    assert_eq!(result.stop, InstrStop::OpcodeNotFound);
+    assert_eq!(result.stop, InstrStop::InvalidOpcode);
     assert!(!result.status);
     Ok(())
 }

--- a/crates/evm2/src/evm/inspector.rs
+++ b/crates/evm2/src/evm/inspector.rs
@@ -630,7 +630,7 @@ mod tests {
             &mut inspector,
         );
 
-        assert_eq!(stop, InstrStop::InvalidFEOpcode);
+        assert_eq!(stop, InstrStop::InvalidOpcode);
         assert_eq!(inspector.steps, 1);
         assert_eq!(inspector.step_ends, 1);
     }

--- a/crates/evm2/src/evm/inspector.rs
+++ b/crates/evm2/src/evm/inspector.rs
@@ -109,6 +109,46 @@ mod tests {
         }
     }
 
+    struct StopOnStepInspector {
+        opcode: u8,
+        steps: usize,
+        step_ends: usize,
+    }
+
+    impl Inspector<TestTypes> for StopOnStepInspector {
+        fn step(&mut self, interp: &mut Interpreter<'_, TestTypes>) {
+            self.steps += 1;
+            if interp.opcode() == self.opcode {
+                interp.set_stop(InstrStop::Revert);
+            }
+        }
+
+        fn step_end(&mut self, _interp: &mut Interpreter<'_, TestTypes>) {
+            self.step_ends += 1;
+        }
+    }
+
+    struct StopOnStepEndInspector {
+        opcode: u8,
+        last_opcode: Option<u8>,
+        steps: usize,
+        step_ends: usize,
+    }
+
+    impl Inspector<TestTypes> for StopOnStepEndInspector {
+        fn step(&mut self, interp: &mut Interpreter<'_, TestTypes>) {
+            self.steps += 1;
+            self.last_opcode = Some(interp.opcode());
+        }
+
+        fn step_end(&mut self, interp: &mut Interpreter<'_, TestTypes>) {
+            self.step_ends += 1;
+            if self.last_opcode == Some(self.opcode) {
+                interp.set_stop(InstrStop::Revert);
+            }
+        }
+    }
+
     #[derive(Default)]
     struct MessageInspector {
         call_depth: Option<u16>,
@@ -389,6 +429,45 @@ mod tests {
         );
 
         assert_eq!(stop, InstrStop::Stop);
+        assert_eq!(inspector.steps, 1);
+        assert_eq!(inspector.step_ends, 1);
+    }
+
+    #[test]
+    fn step_can_stop_before_current_opcode_executes() {
+        let mut host = TestHost::default();
+        let mut inspector = StopOnStepInspector { opcode: op::ADD, steps: 0, step_ends: 0 };
+
+        let (stop, stack) = run_with_inspector(
+            Vec::from([op::PUSH1, 1, op::PUSH1, 2, op::ADD, op::STOP]),
+            &mut host,
+            &Message::default(),
+            10_000,
+            &mut inspector,
+        );
+
+        assert_eq!(stop, InstrStop::Revert);
+        assert_eq!(stack, [Word::from(1), Word::from(2)]);
+        assert_eq!(inspector.steps, 3);
+        assert_eq!(inspector.step_ends, 2);
+    }
+
+    #[test]
+    fn step_end_can_stop_before_next_opcode_executes() {
+        let mut host = TestHost::default();
+        let mut inspector =
+            StopOnStepEndInspector { opcode: op::PUSH1, last_opcode: None, steps: 0, step_ends: 0 };
+
+        let (stop, stack) = run_with_inspector(
+            Vec::from([op::PUSH1, 1, op::PUSH1, 2, op::ADD, op::STOP]),
+            &mut host,
+            &Message::default(),
+            10_000,
+            &mut inspector,
+        );
+
+        assert_eq!(stop, InstrStop::Revert);
+        assert_eq!(stack, [Word::from(1)]);
         assert_eq!(inspector.steps, 1);
         assert_eq!(inspector.step_ends, 1);
     }

--- a/crates/evm2/src/interpreter/dispatch/mod.rs
+++ b/crates/evm2/src/interpreter/dispatch/mod.rs
@@ -69,8 +69,7 @@ where
             }
             #[cfg(not(tco))]
             {
-                let _ = core::marker::PhantomData::<$inspect>;
-                imp::dispatch::<T, $config, $op> as imp::RawInstrFn<T>
+                imp::dispatch::<T, $config, $inspect, $op> as imp::RawInstrFn<T>
             }
         }};
     }
@@ -229,45 +228,36 @@ const fn instruction_changed<T: EvmTypes>(
 }
 
 trait InspectMode<T: EvmTypes> {
-    #[cfg(tco)]
     const INSPECT: bool;
 
-    #[cfg(tco)]
     fn step(state: &mut InterpreterState<'_, T>, pc: Pc, stack_len: usize);
 
-    #[cfg(tco)]
     fn step_end(state: &mut InterpreterState<'_, T>, pc: Pc, stack_len: usize);
 }
 
 struct NoInspector;
 
 impl<T: EvmTypes> InspectMode<T> for NoInspector {
-    #[cfg(tco)]
     const INSPECT: bool = false;
 
     #[inline(always)]
-    #[cfg(tco)]
     fn step(_state: &mut InterpreterState<'_, T>, _pc: Pc, _stack_len: usize) {}
 
     #[inline(always)]
-    #[cfg(tco)]
     fn step_end(_state: &mut InterpreterState<'_, T>, _pc: Pc, _stack_len: usize) {}
 }
 
 struct DynInspector;
 
 impl<T: EvmTypes> InspectMode<T> for DynInspector {
-    #[cfg(tco)]
     const INSPECT: bool = true;
 
     #[inline(always)]
-    #[cfg(tco)]
     fn step(state: &mut InterpreterState<'_, T>, pc: Pc, stack_len: usize) {
         state.inspect_step(pc, stack_len);
     }
 
     #[inline(always)]
-    #[cfg(tco)]
     fn step_end(state: &mut InterpreterState<'_, T>, pc: Pc, stack_len: usize) {
         state.inspect_step_end(pc, stack_len);
     }

--- a/crates/evm2/src/interpreter/dispatch/mod.rs
+++ b/crates/evm2/src/interpreter/dispatch/mod.rs
@@ -61,9 +61,23 @@ where
     C: EvmConfig<T>,
     M: InspectMode<T>,
 {
+    macro_rules! dispatch_fn {
+        ($config:ty, $inspect:ty, $op:expr) => {{
+            #[cfg(tco)]
+            {
+                imp::dispatch::<T, $config, $inspect, $op> as imp::RawInstrFn<T>
+            }
+            #[cfg(not(tco))]
+            {
+                let _ = core::marker::PhantomData::<$inspect>;
+                imp::dispatch::<T, $config, $op> as imp::RawInstrFn<T>
+            }
+        }};
+    }
+
     let mut table = match previous {
         Some(previous) => *previous,
-        None => [imp::dispatch::<T, C, M, { op::INVALID }> as imp::RawInstrFn<T>; 256],
+        None => [dispatch_fn!(C, M, { op::INVALID }); 256],
     };
     let vt = C::VERSION_TABLES;
 
@@ -71,7 +85,7 @@ where
         ($($op:literal,)*) => {
             $(
                 if instruction_changed(vt, previous_version_tables, $op) && !vt.is_unknown_opcode($op) {
-                    table[$op] = imp::dispatch::<T, C, M, $op> as imp::RawInstrFn<T>;
+                    table[$op] = dispatch_fn!(C, M, $op);
                 }
             )*
         };
@@ -215,36 +229,45 @@ const fn instruction_changed<T: EvmTypes>(
 }
 
 trait InspectMode<T: EvmTypes> {
+    #[cfg(tco)]
     const INSPECT: bool;
 
+    #[cfg(tco)]
     fn step(state: &mut InterpreterState<'_, T>, pc: Pc, stack_len: usize);
 
+    #[cfg(tco)]
     fn step_end(state: &mut InterpreterState<'_, T>, pc: Pc, stack_len: usize);
 }
 
 struct NoInspector;
 
 impl<T: EvmTypes> InspectMode<T> for NoInspector {
+    #[cfg(tco)]
     const INSPECT: bool = false;
 
     #[inline(always)]
+    #[cfg(tco)]
     fn step(_state: &mut InterpreterState<'_, T>, _pc: Pc, _stack_len: usize) {}
 
     #[inline(always)]
+    #[cfg(tco)]
     fn step_end(_state: &mut InterpreterState<'_, T>, _pc: Pc, _stack_len: usize) {}
 }
 
 struct DynInspector;
 
 impl<T: EvmTypes> InspectMode<T> for DynInspector {
+    #[cfg(tco)]
     const INSPECT: bool = true;
 
     #[inline(always)]
+    #[cfg(tco)]
     fn step(state: &mut InterpreterState<'_, T>, pc: Pc, stack_len: usize) {
         state.inspect_step(pc, stack_len);
     }
 
     #[inline(always)]
+    #[cfg(tco)]
     fn step_end(state: &mut InterpreterState<'_, T>, pc: Pc, stack_len: usize) {
         state.inspect_step_end(pc, stack_len);
     }

--- a/crates/evm2/src/interpreter/dispatch/mod.rs
+++ b/crates/evm2/src/interpreter/dispatch/mod.rs
@@ -3,20 +3,9 @@
 use crate::{
     BaseEvmConfigSelector, EvmConfig, EvmConfigSelector, EvmTypes, VersionTables,
     evm::config::SelectorVersionTables,
-    interpreter::{InstrStop, Interpreter, InterpreterState, Pc, Result, Stack, StackMut, op},
+    interpreter::{Interpreter, InterpreterState, Pc, Stack, op},
     trustme,
 };
-
-#[cold]
-pub(crate) const fn unknown_instruction<T: EvmTypes>(
-    _pc: &mut Pc,
-    _stack: StackMut<'_>,
-    _state: &mut InterpreterState<'_, T>,
-) -> Result {
-    Err(InstrStop::OpcodeNotFound)
-}
-
-const UNKNOWN_OP: u8 = op::INVALID;
 
 cfg_if::cfg_if! {
     if #[cfg(tco)] {
@@ -74,7 +63,7 @@ where
 {
     let mut table = match previous {
         Some(previous) => *previous,
-        None => [imp::unknown_dispatch::<T, C, M> as imp::RawInstrFn<T>; 256],
+        None => [imp::dispatch::<T, C, M, { op::INVALID }> as imp::RawInstrFn<T>; 256],
     };
     let vt = C::VERSION_TABLES;
 
@@ -82,14 +71,7 @@ where
         ($($op:literal,)*) => {
             $(
                 if instruction_changed(vt, previous_version_tables, $op) && !vt.is_unknown_opcode($op) {
-                    table[$op] = {
-                        let instruction = vt.instruction($op);
-                        if instruction.dynamic_gas {
-                            imp::dispatch::<T, C, M, $op, true> as imp::RawInstrFn<T>
-                        } else {
-                            imp::dispatch::<T, C, M, $op, false> as imp::RawInstrFn<T>
-                        }
-                    };
+                    table[$op] = imp::dispatch::<T, C, M, $op> as imp::RawInstrFn<T>;
                 }
             )*
         };

--- a/crates/evm2/src/interpreter/dispatch/table/mod.rs
+++ b/crates/evm2/src/interpreter/dispatch/table/mod.rs
@@ -114,6 +114,7 @@ pub(in crate::interpreter) fn run<T: EvmTypes>(
     run_inner::<T, NoInspector>(state, pc, stack, instructions)
 }
 
+#[allow(clippy::let_unit_value)]
 fn run_inner<T: EvmTypes, M: InspectMode<T>>(
     state: &mut InterpreterState<'_, T>,
     mut pc: Pc,

--- a/crates/evm2/src/interpreter/dispatch/table/mod.rs
+++ b/crates/evm2/src/interpreter/dispatch/table/mod.rs
@@ -1,9 +1,7 @@
 use super::{inc_pc, run_state};
-#[cfg(dispatch_packed)]
-use crate::interpreter::gas::RemainingGas;
 use crate::{
     EvmConfig, EvmTypes,
-    interpreter::{InstrStop, Interpreter, InterpreterState, Pc, Result, StackMut, gas::Gas},
+    interpreter::{InstrStop, Interpreter, InterpreterState, Pc, Result, StackMut},
 };
 use core::hint::cold_path;
 
@@ -24,32 +22,6 @@ pub(super) use imp::{RawInstrFn, dispatch};
 
 /// Table instruction dispatch table.
 pub(super) type RawInstrTable<T> = [RawInstrFn<T>; 256];
-
-#[cfg(dispatch_packed)]
-type LoopState = RemainingGas;
-
-#[cfg(not(dispatch_packed))]
-type LoopState = ();
-
-#[inline(always)]
-#[cfg(dispatch_packed)]
-const fn loop_state(gas: &Gas) -> LoopState {
-    RemainingGas::new(gas.remaining())
-}
-
-#[inline(always)]
-#[cfg(not(dispatch_packed))]
-const fn loop_state(_gas: &Gas) -> LoopState {}
-
-#[inline(always)]
-#[cfg(dispatch_packed)]
-const fn finish_loop(gas: &mut Gas, remaining_gas: LoopState) {
-    gas.set_remaining(remaining_gas.get());
-}
-
-#[inline(always)]
-#[cfg(not(dispatch_packed))]
-const fn finish_loop(_gas: &mut Gas, _loop_state: LoopState) {}
 
 trait DispatchGas: Copy {
     fn pre_step<T: EvmTypes, C: EvmConfig<T>>(
@@ -94,40 +66,6 @@ impl DispatchGas for () {
     }
 }
 
-#[cfg(dispatch_packed)]
-impl DispatchGas for RemainingGas {
-    #[inline(always)]
-    fn pre_step<T: EvmTypes, C: EvmConfig<T>>(
-        &mut self,
-        _state: &mut InterpreterState<'_, T>,
-        op: u8,
-    ) -> Result {
-        self.spend(C::VERSION_TABLES.static_gas(op) as _)
-    }
-
-    #[inline(always)]
-    fn sync_before_exec<T: EvmTypes>(
-        &self,
-        state: &mut InterpreterState<'_, T>,
-        dynamic_gas: bool,
-    ) {
-        if dynamic_gas {
-            state.gas_mut().set_remaining(self.get());
-        }
-    }
-
-    #[inline(always)]
-    fn sync_after_exec<T: EvmTypes>(
-        &mut self,
-        state: &mut InterpreterState<'_, T>,
-        dynamic_gas: bool,
-    ) {
-        if dynamic_gas {
-            self.set(state.gas_mut().remaining());
-        }
-    }
-}
-
 #[cold] // Not cold, but avoids MIR inlining.
 #[inline(always)]
 fn dispatch_inner<T: EvmTypes, C: EvmConfig<T>, G: DispatchGas>(
@@ -166,17 +104,17 @@ pub(in crate::interpreter) fn run<T: EvmTypes>(
     instructions: &RawInstrTable<T>,
 ) -> InstrStop {
     let (state, mut pc, mut stack) = run_state(interpreter);
-    let mut loop_state = loop_state(state.gas_mut());
+    let mut loop_state = imp::loop_state(state.gas_mut());
     let inspect = state.is_inspecting();
     loop {
         let op = pc.op();
         if inspect {
-            sync_loop_state(state, loop_state);
+            imp::sync_loop_state(state, loop_state);
             state.inspect_step(pc, stack.len);
             if let Err(stop) = state.result() {
                 cold_path();
                 state.set_pc_stack_len(pc.as_ptr(), stack.len);
-                finish_loop(state.gas_mut(), loop_state);
+                imp::finish_loop(state.gas_mut(), loop_state);
                 return stop;
             }
         }
@@ -187,25 +125,15 @@ pub(in crate::interpreter) fn run<T: EvmTypes>(
         stack.len = next_stack_len;
 
         if inspect {
-            sync_loop_state(state, loop_state);
+            imp::sync_loop_state(state, loop_state);
             state.inspect_step_end(pc, stack.len);
         }
 
         if let Err(stop) = state.result() {
             cold_path();
             state.set_pc_stack_len(pc.as_ptr(), stack.len);
-            finish_loop(state.gas_mut(), loop_state);
+            imp::finish_loop(state.gas_mut(), loop_state);
             return stop;
         }
     }
 }
-
-#[inline(always)]
-#[cfg(dispatch_packed)]
-const fn sync_loop_state<T: EvmTypes>(state: &mut InterpreterState<'_, T>, loop_state: LoopState) {
-    state.gas_mut().set_remaining(loop_state.get());
-}
-
-#[inline(always)]
-#[cfg(not(dispatch_packed))]
-fn sync_loop_state<T: EvmTypes>(_state: &mut InterpreterState<'_, T>, _loop_state: LoopState) {}

--- a/crates/evm2/src/interpreter/dispatch/table/mod.rs
+++ b/crates/evm2/src/interpreter/dispatch/table/mod.rs
@@ -23,7 +23,7 @@ pub(super) use imp::{RawInstrFn, dispatch};
 /// Table instruction dispatch table.
 pub(super) type RawInstrTable<T> = [RawInstrFn<T>; 256];
 
-trait DispatchGas {
+trait DispatchGas: Copy {
     fn pre_step<T: EvmTypes, C: EvmConfig<T>>(
         &mut self,
         state: &mut InterpreterState<'_, T>,

--- a/crates/evm2/src/interpreter/dispatch/table/mod.rs
+++ b/crates/evm2/src/interpreter/dispatch/table/mod.rs
@@ -1,4 +1,4 @@
-use super::{InspectMode, UNKNOWN_OP, inc_pc, run_state, unknown_instruction};
+use super::{InspectMode, inc_pc, run_state};
 #[cfg(dispatch_packed)]
 use crate::interpreter::gas::RemainingGas;
 use crate::{
@@ -20,7 +20,7 @@ cfg_if::cfg_if! {
     }
 }
 
-pub(super) use imp::{RawInstrFn, dispatch, unknown_dispatch};
+pub(super) use imp::{RawInstrFn, dispatch};
 
 /// Table instruction dispatch table.
 pub(super) type RawInstrTable<T> = [RawInstrFn<T>; 256];
@@ -137,30 +137,25 @@ impl DispatchGas for RemainingGas {
 
 #[cold] // Not cold, but avoids MIR inlining.
 #[inline(always)]
-fn dispatch_inner<
-    T: EvmTypes,
-    C: EvmConfig<T>,
-    M: InspectMode<T>,
-    G: DispatchGas,
-    const DYNAMIC_GAS: bool,
-    const UNKNOWN: bool,
->(
+fn dispatch_inner<T: EvmTypes, C: EvmConfig<T>, M: InspectMode<T>, G: DispatchGas>(
     mut pc: Pc,
     mut stack: StackMut<'_>,
     mut gas: G,
     state: &mut InterpreterState<'_, T>,
     op: u8,
 ) -> (Pc, G) {
-    let instr = if UNKNOWN { unknown_instruction } else { C::VERSION_TABLES.instruction(op).instr };
+    let instruction = C::VERSION_TABLES.instruction(op);
+    let instr = instruction.instr;
+    let dynamic_gas = instruction.dynamic_gas;
     if M::INSPECT {
         M::step(state, pc, *stack.len);
     }
     let r;
     match gas.pre_step::<T, C>(state, op) {
         Ok(()) => {
-            gas.sync_before_exec(state, DYNAMIC_GAS, M::INSPECT);
+            gas.sync_before_exec(state, dynamic_gas, M::INSPECT);
             r = instr(&mut pc, stack.reborrow(), state);
-            gas.sync_after_exec(state, DYNAMIC_GAS);
+            gas.sync_after_exec(state, dynamic_gas);
             if !M::INSPECT || r.is_ok() {
                 inc_pc(&mut pc, op);
             }

--- a/crates/evm2/src/interpreter/dispatch/table/mod.rs
+++ b/crates/evm2/src/interpreter/dispatch/table/mod.rs
@@ -1,7 +1,7 @@
-use super::{inc_pc, run_state};
+use super::{DynInspector, InspectMode, NoInspector, inc_pc, run_state};
 use crate::{
     EvmConfig, EvmTypes,
-    interpreter::{InstrStop, Interpreter, InterpreterState, Pc, Result, StackMut},
+    interpreter::{InstrStop, Interpreter, InterpreterState, Pc, Result, Stack, StackMut},
 };
 use core::hint::cold_path;
 
@@ -30,7 +30,12 @@ trait DispatchGas: Copy {
         op: u8,
     ) -> Result;
 
-    fn sync_before_exec<T: EvmTypes>(&self, state: &mut InterpreterState<'_, T>, dynamic_gas: bool);
+    fn sync_before_exec<T: EvmTypes>(
+        &self,
+        state: &mut InterpreterState<'_, T>,
+        dynamic_gas: bool,
+        inspect: bool,
+    );
 
     fn sync_after_exec<T: EvmTypes>(
         &mut self,
@@ -54,6 +59,7 @@ impl DispatchGas for () {
         &self,
         _state: &mut InterpreterState<'_, T>,
         _dynamic_gas: bool,
+        _inspect: bool,
     ) {
     }
 
@@ -68,7 +74,7 @@ impl DispatchGas for () {
 
 #[cold] // Not cold, but avoids MIR inlining.
 #[inline(always)]
-fn dispatch_inner<T: EvmTypes, C: EvmConfig<T>, G: DispatchGas>(
+fn dispatch_inner<T: EvmTypes, C: EvmConfig<T>, M: InspectMode<T>, G: DispatchGas>(
     mut pc: Pc,
     mut stack: StackMut<'_>,
     mut gas: G,
@@ -78,23 +84,39 @@ fn dispatch_inner<T: EvmTypes, C: EvmConfig<T>, G: DispatchGas>(
     let instruction = C::VERSION_TABLES.instruction(op);
     let instr = instruction.instr;
     let dynamic_gas = instruction.dynamic_gas;
+    if M::INSPECT {
+        M::step(state, pc, *stack.len);
+        if state.result().is_err() {
+            cold_path();
+            return (Pc::new(core::ptr::null()), gas);
+        }
+    }
     let r;
     match gas.pre_step::<T, C>(state, op) {
         Ok(()) => {
-            gas.sync_before_exec(state, dynamic_gas);
+            gas.sync_before_exec(state, dynamic_gas, M::INSPECT);
             r = instr(&mut pc, stack.reborrow(), state);
-            gas.sync_after_exec(state, dynamic_gas);
             if r.is_ok() {
                 inc_pc(&mut pc, op);
             }
+            gas.sync_after_exec(state, dynamic_gas);
         }
         Err(e) => {
+            gas.sync_before_exec(state, false, M::INSPECT);
             r = Err(e);
         }
     }
-    state.set_result(r);
-    if r.is_err() {
+    if M::INSPECT {
+        state.set_result(r);
+        M::step_end(state, pc, *stack.len);
+        if state.result().is_err() {
+            cold_path();
+            return (Pc::new(core::ptr::null()), gas);
+        }
+    } else if let Err(e) = r {
+        state.set_result(Err(e));
         cold_path();
+        return (Pc::new(core::ptr::null()), gas);
     }
     (pc, gas)
 }
@@ -103,37 +125,33 @@ pub(in crate::interpreter) fn run<T: EvmTypes>(
     interpreter: &mut Interpreter<'_, T>,
     instructions: &RawInstrTable<T>,
 ) -> InstrStop {
-    let (state, mut pc, mut stack) = run_state(interpreter);
+    let (state, pc, stack) = run_state(interpreter);
+    if state.is_inspecting() {
+        return run_inner::<T, DynInspector>(state, pc, stack, instructions);
+    }
+    run_inner::<T, NoInspector>(state, pc, stack, instructions)
+}
+
+fn run_inner<T: EvmTypes, M: InspectMode<T>>(
+    state: &mut InterpreterState<'_, T>,
+    mut pc: Pc,
+    mut stack: Stack<'_>,
+    instructions: &RawInstrTable<T>,
+) -> InstrStop {
     let mut loop_state = imp::loop_state(state.gas_mut());
-    let inspect = state.is_inspecting();
     loop {
         let op = pc.op();
-        if inspect {
-            imp::sync_loop_state(state, loop_state);
-            state.inspect_step(pc, stack.len);
-            if let Err(stop) = state.result() {
-                cold_path();
-                state.set_pc_stack_len(pc.as_ptr(), stack.len);
-                imp::finish_loop(state.gas_mut(), loop_state);
-                return stop;
-            }
-        }
         let instr = instructions[op as usize];
         let (next_pc, next_stack_len) =
             imp::dispatch_loop_call(instr, pc, stack.reborrow(), state, &mut loop_state);
         pc = next_pc;
         stack.len = next_stack_len;
 
-        if inspect {
-            imp::sync_loop_state(state, loop_state);
-            state.inspect_step_end(pc, stack.len);
-        }
-
-        if let Err(stop) = state.result() {
+        if pc.as_ptr().is_null() {
             cold_path();
             state.set_pc_stack_len(pc.as_ptr(), stack.len);
             imp::finish_loop(state.gas_mut(), loop_state);
-            return stop;
+            return state.result().unwrap_err();
         }
     }
 }

--- a/crates/evm2/src/interpreter/dispatch/table/mod.rs
+++ b/crates/evm2/src/interpreter/dispatch/table/mod.rs
@@ -126,10 +126,7 @@ fn run_inner<T: EvmTypes, M: InspectMode<T>>(
             imp::sync_loop_state(state, loop_state);
             M::step(state, pc, stack.len);
             if state.result().is_err() {
-                cold_path();
-                state.set_pc_stack_len(pc.as_ptr(), stack.len);
-                imp::finish_loop(state.gas_mut(), loop_state);
-                return state.result().unwrap_err();
+                return finish_run(state, pc, stack.len, loop_state);
             }
         }
 
@@ -144,16 +141,23 @@ fn run_inner<T: EvmTypes, M: InspectMode<T>>(
             imp::sync_loop_state(state, loop_state);
             M::step_end(state, pc, stack.len);
             if state.result().is_err() {
-                cold_path();
-                state.set_pc_stack_len(pc.as_ptr(), stack.len);
-                imp::finish_loop(state.gas_mut(), loop_state);
-                return state.result().unwrap_err();
+                return finish_run(state, pc, stack.len, loop_state);
             }
         } else if pc.as_ptr().is_null() {
-            cold_path();
-            state.set_pc_stack_len(pc.as_ptr(), stack.len);
-            imp::finish_loop(state.gas_mut(), loop_state);
-            return state.result().unwrap_err();
+            return finish_run(state, pc, stack.len, loop_state);
         }
     }
+}
+
+#[inline(always)]
+fn finish_run<T: EvmTypes>(
+    state: &mut InterpreterState<'_, T>,
+    pc: Pc,
+    stack_len: usize,
+    loop_state: imp::LoopState,
+) -> InstrStop {
+    cold_path();
+    state.set_pc_stack_len(pc.as_ptr(), stack_len);
+    imp::finish_loop(state.gas_mut(), loop_state);
+    state.result().unwrap_err()
 }

--- a/crates/evm2/src/interpreter/dispatch/table/mod.rs
+++ b/crates/evm2/src/interpreter/dispatch/table/mod.rs
@@ -1,4 +1,4 @@
-use super::{InspectMode, inc_pc, run_state};
+use super::{inc_pc, run_state};
 #[cfg(dispatch_packed)]
 use crate::interpreter::gas::RemainingGas;
 use crate::{
@@ -58,12 +58,7 @@ trait DispatchGas: Copy {
         op: u8,
     ) -> Result;
 
-    fn sync_before_exec<T: EvmTypes>(
-        &self,
-        state: &mut InterpreterState<'_, T>,
-        dynamic_gas: bool,
-        inspect: bool,
-    );
+    fn sync_before_exec<T: EvmTypes>(&self, state: &mut InterpreterState<'_, T>, dynamic_gas: bool);
 
     fn sync_after_exec<T: EvmTypes>(
         &mut self,
@@ -87,7 +82,6 @@ impl DispatchGas for () {
         &self,
         _state: &mut InterpreterState<'_, T>,
         _dynamic_gas: bool,
-        _inspect: bool,
     ) {
     }
 
@@ -116,9 +110,8 @@ impl DispatchGas for RemainingGas {
         &self,
         state: &mut InterpreterState<'_, T>,
         dynamic_gas: bool,
-        inspect: bool,
     ) {
-        if inspect || dynamic_gas {
+        if dynamic_gas {
             state.gas_mut().set_remaining(self.get());
         }
     }
@@ -137,7 +130,7 @@ impl DispatchGas for RemainingGas {
 
 #[cold] // Not cold, but avoids MIR inlining.
 #[inline(always)]
-fn dispatch_inner<T: EvmTypes, C: EvmConfig<T>, M: InspectMode<T>, G: DispatchGas>(
+fn dispatch_inner<T: EvmTypes, C: EvmConfig<T>, G: DispatchGas>(
     mut pc: Pc,
     mut stack: StackMut<'_>,
     mut gas: G,
@@ -147,34 +140,23 @@ fn dispatch_inner<T: EvmTypes, C: EvmConfig<T>, M: InspectMode<T>, G: DispatchGa
     let instruction = C::VERSION_TABLES.instruction(op);
     let instr = instruction.instr;
     let dynamic_gas = instruction.dynamic_gas;
-    if M::INSPECT {
-        M::step(state, pc, *stack.len);
-    }
     let r;
     match gas.pre_step::<T, C>(state, op) {
         Ok(()) => {
-            gas.sync_before_exec(state, dynamic_gas, M::INSPECT);
+            gas.sync_before_exec(state, dynamic_gas);
             r = instr(&mut pc, stack.reborrow(), state);
             gas.sync_after_exec(state, dynamic_gas);
-            if !M::INSPECT || r.is_ok() {
+            if r.is_ok() {
                 inc_pc(&mut pc, op);
             }
         }
         Err(e) => {
-            gas.sync_before_exec(state, false, M::INSPECT);
             r = Err(e);
         }
     }
-    if M::INSPECT {
-        state.set_result(r);
-        M::step_end(state, pc, *stack.len);
-    }
+    state.set_result(r);
     if r.is_err() {
         cold_path();
-        if !M::INSPECT {
-            state.set_result(r);
-        }
-        return (Pc::new(core::ptr::null()), gas);
     }
     (pc, gas)
 }
@@ -185,19 +167,39 @@ pub(in crate::interpreter) fn run<T: EvmTypes>(
 ) -> InstrStop {
     let (state, mut pc, mut stack) = run_state(interpreter);
     let mut loop_state = loop_state(state.gas_mut());
+    let inspect = state.is_inspecting();
     loop {
         let op = pc.op();
+        if inspect {
+            sync_loop_state(state, loop_state);
+            state.inspect_step(pc, stack.len);
+        }
         let instr = instructions[op as usize];
         let (next_pc, next_stack_len) =
             imp::dispatch_loop_call(instr, pc, stack.reborrow(), state, &mut loop_state);
         pc = next_pc;
         stack.len = next_stack_len;
 
-        if pc.as_ptr().is_null() {
+        if inspect {
+            sync_loop_state(state, loop_state);
+            state.inspect_step_end(pc, stack.len);
+        }
+
+        if let Err(stop) = state.result() {
             cold_path();
             state.set_pc_stack_len(pc.as_ptr(), stack.len);
             finish_loop(state.gas_mut(), loop_state);
-            return state.result().unwrap_err();
+            return stop;
         }
     }
 }
+
+#[inline(always)]
+#[cfg(dispatch_packed)]
+const fn sync_loop_state<T: EvmTypes>(state: &mut InterpreterState<'_, T>, loop_state: LoopState) {
+    state.gas_mut().set_remaining(loop_state.get());
+}
+
+#[inline(always)]
+#[cfg(not(dispatch_packed))]
+fn sync_loop_state<T: EvmTypes>(_state: &mut InterpreterState<'_, T>, _loop_state: LoopState) {}

--- a/crates/evm2/src/interpreter/dispatch/table/mod.rs
+++ b/crates/evm2/src/interpreter/dispatch/table/mod.rs
@@ -173,6 +173,12 @@ pub(in crate::interpreter) fn run<T: EvmTypes>(
         if inspect {
             sync_loop_state(state, loop_state);
             state.inspect_step(pc, stack.len);
+            if let Err(stop) = state.result() {
+                cold_path();
+                state.set_pc_stack_len(pc.as_ptr(), stack.len);
+                finish_loop(state.gas_mut(), loop_state);
+                return stop;
+            }
         }
         let instr = instructions[op as usize];
         let (next_pc, next_stack_len) =

--- a/crates/evm2/src/interpreter/dispatch/table/mod.rs
+++ b/crates/evm2/src/interpreter/dispatch/table/mod.rs
@@ -30,12 +30,7 @@ trait DispatchGas: Copy {
         op: u8,
     ) -> Result;
 
-    fn sync_before_exec<T: EvmTypes>(
-        &self,
-        state: &mut InterpreterState<'_, T>,
-        dynamic_gas: bool,
-        inspect: bool,
-    );
+    fn sync_before_exec<T: EvmTypes>(&self, state: &mut InterpreterState<'_, T>, dynamic_gas: bool);
 
     fn sync_after_exec<T: EvmTypes>(
         &mut self,
@@ -59,7 +54,6 @@ impl DispatchGas for () {
         &self,
         _state: &mut InterpreterState<'_, T>,
         _dynamic_gas: bool,
-        _inspect: bool,
     ) {
     }
 
@@ -84,17 +78,10 @@ fn dispatch_inner<T: EvmTypes, C: EvmConfig<T>, M: InspectMode<T>, G: DispatchGa
     let instruction = C::VERSION_TABLES.instruction(op);
     let instr = instruction.instr;
     let dynamic_gas = instruction.dynamic_gas;
-    if M::INSPECT {
-        M::step(state, pc, *stack.len);
-        if state.result().is_err() {
-            cold_path();
-            return (Pc::new(core::ptr::null()), gas);
-        }
-    }
     let r;
     match gas.pre_step::<T, C>(state, op) {
         Ok(()) => {
-            gas.sync_before_exec(state, dynamic_gas, M::INSPECT);
+            gas.sync_before_exec(state, dynamic_gas);
             r = instr(&mut pc, stack.reborrow(), state);
             if r.is_ok() {
                 inc_pc(&mut pc, op);
@@ -102,17 +89,12 @@ fn dispatch_inner<T: EvmTypes, C: EvmConfig<T>, M: InspectMode<T>, G: DispatchGa
             gas.sync_after_exec(state, dynamic_gas);
         }
         Err(e) => {
-            gas.sync_before_exec(state, false, M::INSPECT);
+            gas.sync_before_exec(state, false);
             r = Err(e);
         }
     }
     if M::INSPECT {
         state.set_result(r);
-        M::step_end(state, pc, *stack.len);
-        if state.result().is_err() {
-            cold_path();
-            return (Pc::new(core::ptr::null()), gas);
-        }
     } else if let Err(e) = r {
         state.set_result(Err(e));
         cold_path();
@@ -140,6 +122,17 @@ fn run_inner<T: EvmTypes, M: InspectMode<T>>(
 ) -> InstrStop {
     let mut loop_state = imp::loop_state(state.gas_mut());
     loop {
+        if M::INSPECT {
+            imp::sync_loop_state(state, loop_state);
+            M::step(state, pc, stack.len);
+            if state.result().is_err() {
+                cold_path();
+                state.set_pc_stack_len(pc.as_ptr(), stack.len);
+                imp::finish_loop(state.gas_mut(), loop_state);
+                return state.result().unwrap_err();
+            }
+        }
+
         let op = pc.op();
         let instr = instructions[op as usize];
         let (next_pc, next_stack_len) =
@@ -147,7 +140,16 @@ fn run_inner<T: EvmTypes, M: InspectMode<T>>(
         pc = next_pc;
         stack.len = next_stack_len;
 
-        if pc.as_ptr().is_null() {
+        if M::INSPECT {
+            imp::sync_loop_state(state, loop_state);
+            M::step_end(state, pc, stack.len);
+            if state.result().is_err() {
+                cold_path();
+                state.set_pc_stack_len(pc.as_ptr(), stack.len);
+                imp::finish_loop(state.gas_mut(), loop_state);
+                return state.result().unwrap_err();
+            }
+        } else if pc.as_ptr().is_null() {
             cold_path();
             state.set_pc_stack_len(pc.as_ptr(), stack.len);
             imp::finish_loop(state.gas_mut(), loop_state);

--- a/crates/evm2/src/interpreter/dispatch/table/mod.rs
+++ b/crates/evm2/src/interpreter/dispatch/table/mod.rs
@@ -23,7 +23,7 @@ pub(super) use imp::{RawInstrFn, dispatch};
 /// Table instruction dispatch table.
 pub(super) type RawInstrTable<T> = [RawInstrFn<T>; 256];
 
-trait DispatchGas: Copy {
+trait DispatchGas {
     fn pre_step<T: EvmTypes, C: EvmConfig<T>>(
         &mut self,
         state: &mut InterpreterState<'_, T>,

--- a/crates/evm2/src/interpreter/dispatch/table/packed.rs
+++ b/crates/evm2/src/interpreter/dispatch/table/packed.rs
@@ -1,6 +1,5 @@
 use crate::{
     EvmConfig, EvmTypes,
-    constants::STACK_LIMIT,
     interpreter::{
         InterpreterState, Pc, Result, Stack,
         gas::{Gas, RemainingGas},
@@ -10,14 +9,14 @@ use crate::{
 pub(super) type LoopState = RemainingGas;
 
 /// Packed instruction return value.
-pub(crate) type InstrFnRet = (Pc, PackedGasStackLen);
+pub(crate) type InstrFnRet = (Pc, usize);
 
 /// Packed instruction function pointer.
 pub(in crate::interpreter::dispatch) type RawInstrFn<T> = extern_table!(
     fn(
         pc: Pc,
         stack: Stack<'_>,
-        remaining_gas: RemainingGas,
+        remaining_gas: &mut RemainingGas,
         state: &mut InterpreterState<'_, T>,
     ) -> InstrFnRet
 );
@@ -30,10 +29,7 @@ pub(super) fn dispatch_loop_call<T: EvmTypes>(
     state: &mut InterpreterState<'_, T>,
     remaining_gas: &mut LoopState,
 ) -> (Pc, usize) {
-    let (next_pc, gas_stack_len) = instr(pc, stack, *remaining_gas, state);
-    let (next_remaining_gas, next_stack_len) = gas_stack_len.unpack();
-    *remaining_gas = RemainingGas::new(next_remaining_gas);
-    (next_pc, next_stack_len)
+    instr(pc, stack, remaining_gas, state)
 }
 
 #[inline(always)]
@@ -54,14 +50,14 @@ pub(super) const fn sync_loop_state<T: EvmTypes>(
     state.gas_mut().set_remaining(loop_state.get());
 }
 
-impl super::DispatchGas for RemainingGas {
+impl super::DispatchGas for &mut RemainingGas {
     #[inline(always)]
     fn pre_step<T: EvmTypes, C: EvmConfig<T>>(
         &mut self,
         _state: &mut InterpreterState<'_, T>,
         op: u8,
     ) -> Result {
-        self.spend(C::VERSION_TABLES.static_gas(op) as _)
+        (*self).spend(C::VERSION_TABLES.static_gas(op) as _)
     }
 
     #[inline(always)]
@@ -71,7 +67,7 @@ impl super::DispatchGas for RemainingGas {
         dynamic_gas: bool,
     ) {
         if dynamic_gas {
-            state.gas_mut().set_remaining(self.get());
+            state.gas_mut().set_remaining((**self).get());
         }
     }
 
@@ -82,7 +78,7 @@ impl super::DispatchGas for RemainingGas {
         dynamic_gas: bool,
     ) {
         if dynamic_gas {
-            self.set(state.gas_mut().remaining());
+            (*self).set(state.gas_mut().remaining());
         }
     }
 }
@@ -96,43 +92,17 @@ extern_table! {
     >(
         pc: Pc,
         mut stack: Stack<'_>,
-        remaining_gas: RemainingGas,
+        remaining_gas: &mut RemainingGas,
         state: &mut InterpreterState<'_, T>,
     ) -> InstrFnRet {
-        let (pc, remaining_gas) =
-            super::dispatch_inner::<T, C, M, RemainingGas>(
+        let (pc, _) =
+            super::dispatch_inner::<T, C, M, _>(
                 pc,
                 stack.as_mut(),
                 remaining_gas,
                 state,
                 OP,
             );
-        (
-            pc,
-            PackedGasStackLen::new(remaining_gas.get(), stack.len),
-        )
-    }
-}
-
-const STACK_LEN_BITS: u32 = usize::BITS - STACK_LIMIT.leading_zeros();
-const GAS_BITS: u32 = usize::BITS - STACK_LEN_BITS;
-const GAS_MASK: usize = usize::MAX >> STACK_LEN_BITS;
-
-const _: () = assert!(STACK_LIMIT <= (1 << STACK_LEN_BITS));
-
-/// Dispatch remaining gas and stack length, packed into one word on 64-bit native targets.
-#[derive(Clone, Copy)]
-#[repr(transparent)]
-pub(crate) struct PackedGasStackLen(usize);
-
-impl PackedGasStackLen {
-    #[inline(always)]
-    const fn new(remaining_gas: u64, stack_len: usize) -> Self {
-        Self((stack_len << GAS_BITS) | (remaining_gas as usize & GAS_MASK))
-    }
-
-    #[inline(always)]
-    const fn unpack(self) -> (u64, usize) {
-        ((self.0 & GAS_MASK) as u64, self.0 >> GAS_BITS)
+        (pc, stack.len)
     }
 }

--- a/crates/evm2/src/interpreter/dispatch/table/packed.rs
+++ b/crates/evm2/src/interpreter/dispatch/table/packed.rs
@@ -31,8 +31,8 @@ pub(super) fn dispatch_loop_call<T: EvmTypes>(
     remaining_gas: &mut LoopState,
 ) -> (Pc, usize) {
     let (next_pc, gas_stack_len) = instr(pc, stack, *remaining_gas, state);
-    let (next_remaining_gas, next_stack_len) = gas_stack_len.unpack();
-    *remaining_gas = RemainingGas::new(next_remaining_gas);
+    let (gas_spent, next_stack_len) = gas_stack_len.unpack();
+    *remaining_gas = RemainingGas::new(remaining_gas.get().wrapping_sub(gas_spent));
     (next_pc, next_stack_len)
 }
 
@@ -99,6 +99,7 @@ extern_table! {
         remaining_gas: RemainingGas,
         state: &mut InterpreterState<'_, T>,
     ) -> InstrFnRet {
+        let initial_remaining_gas = remaining_gas;
         let (pc, remaining_gas) =
             super::dispatch_inner::<T, C, M, RemainingGas>(
                 pc,
@@ -109,7 +110,10 @@ extern_table! {
             );
         (
             pc,
-            PackedGasStackLen::new(remaining_gas.get(), stack.len),
+            PackedGasStackLen::new(
+                initial_remaining_gas.get().wrapping_sub(remaining_gas.get()),
+                stack.len,
+            ),
         )
     }
 }
@@ -120,15 +124,15 @@ const GAS_MASK: usize = usize::MAX >> STACK_LEN_BITS;
 
 const _: () = assert!(STACK_LIMIT <= (1 << STACK_LEN_BITS));
 
-/// Dispatch remaining gas and stack length, packed into one word on 64-bit native targets.
+/// Dispatch gas spent and stack length, packed into one word on 64-bit native targets.
 #[derive(Clone, Copy)]
 #[repr(transparent)]
 pub(crate) struct PackedGasStackLen(usize);
 
 impl PackedGasStackLen {
     #[inline(always)]
-    const fn new(remaining_gas: u64, stack_len: usize) -> Self {
-        Self((stack_len << GAS_BITS) | (remaining_gas as usize & GAS_MASK))
+    const fn new(gas_spent: u64, stack_len: usize) -> Self {
+        Self((stack_len << GAS_BITS) | (gas_spent as usize & GAS_MASK))
     }
 
     #[inline(always)]

--- a/crates/evm2/src/interpreter/dispatch/table/packed.rs
+++ b/crates/evm2/src/interpreter/dispatch/table/packed.rs
@@ -1,5 +1,6 @@
 use crate::{
     EvmConfig, EvmTypes,
+    constants::STACK_LIMIT,
     interpreter::{
         InterpreterState, Pc, Result, Stack,
         gas::{Gas, RemainingGas},
@@ -9,14 +10,14 @@ use crate::{
 pub(super) type LoopState = RemainingGas;
 
 /// Packed instruction return value.
-pub(crate) type InstrFnRet = (Pc, usize);
+pub(crate) type InstrFnRet = (Pc, PackedGasStackLen);
 
 /// Packed instruction function pointer.
 pub(in crate::interpreter::dispatch) type RawInstrFn<T> = extern_table!(
     fn(
         pc: Pc,
         stack: Stack<'_>,
-        remaining_gas: &mut RemainingGas,
+        remaining_gas: RemainingGas,
         state: &mut InterpreterState<'_, T>,
     ) -> InstrFnRet
 );
@@ -29,7 +30,10 @@ pub(super) fn dispatch_loop_call<T: EvmTypes>(
     state: &mut InterpreterState<'_, T>,
     remaining_gas: &mut LoopState,
 ) -> (Pc, usize) {
-    instr(pc, stack, remaining_gas, state)
+    let (next_pc, gas_stack_len) = instr(pc, stack, *remaining_gas, state);
+    let (next_remaining_gas, next_stack_len) = gas_stack_len.unpack();
+    *remaining_gas = RemainingGas::new(next_remaining_gas);
+    (next_pc, next_stack_len)
 }
 
 #[inline(always)]
@@ -50,14 +54,14 @@ pub(super) const fn sync_loop_state<T: EvmTypes>(
     state.gas_mut().set_remaining(loop_state.get());
 }
 
-impl super::DispatchGas for &mut RemainingGas {
+impl super::DispatchGas for RemainingGas {
     #[inline(always)]
     fn pre_step<T: EvmTypes, C: EvmConfig<T>>(
         &mut self,
         _state: &mut InterpreterState<'_, T>,
         op: u8,
     ) -> Result {
-        (*self).spend(C::VERSION_TABLES.static_gas(op) as _)
+        self.spend(C::VERSION_TABLES.static_gas(op) as _)
     }
 
     #[inline(always)]
@@ -67,7 +71,7 @@ impl super::DispatchGas for &mut RemainingGas {
         dynamic_gas: bool,
     ) {
         if dynamic_gas {
-            state.gas_mut().set_remaining((**self).get());
+            state.gas_mut().set_remaining(self.get());
         }
     }
 
@@ -78,7 +82,7 @@ impl super::DispatchGas for &mut RemainingGas {
         dynamic_gas: bool,
     ) {
         if dynamic_gas {
-            (*self).set(state.gas_mut().remaining());
+            self.set(state.gas_mut().remaining());
         }
     }
 }
@@ -92,17 +96,43 @@ extern_table! {
     >(
         pc: Pc,
         mut stack: Stack<'_>,
-        remaining_gas: &mut RemainingGas,
+        remaining_gas: RemainingGas,
         state: &mut InterpreterState<'_, T>,
     ) -> InstrFnRet {
-        let (pc, _) =
-            super::dispatch_inner::<T, C, M, _>(
+        let (pc, remaining_gas) =
+            super::dispatch_inner::<T, C, M, RemainingGas>(
                 pc,
                 stack.as_mut(),
                 remaining_gas,
                 state,
                 OP,
             );
-        (pc, stack.len)
+        (
+            pc,
+            PackedGasStackLen::new(remaining_gas.get(), stack.len),
+        )
+    }
+}
+
+const STACK_LEN_BITS: u32 = usize::BITS - STACK_LIMIT.leading_zeros();
+const GAS_BITS: u32 = usize::BITS - STACK_LEN_BITS;
+const GAS_MASK: usize = usize::MAX >> STACK_LEN_BITS;
+
+const _: () = assert!(STACK_LIMIT <= (1 << STACK_LEN_BITS));
+
+/// Dispatch remaining gas and stack length, packed into one word on 64-bit native targets.
+#[derive(Clone, Copy)]
+#[repr(transparent)]
+pub(crate) struct PackedGasStackLen(usize);
+
+impl PackedGasStackLen {
+    #[inline(always)]
+    const fn new(remaining_gas: u64, stack_len: usize) -> Self {
+        Self((stack_len << GAS_BITS) | (remaining_gas as usize & GAS_MASK))
+    }
+
+    #[inline(always)]
+    const fn unpack(self) -> (u64, usize) {
+        ((self.0 & GAS_MASK) as u64, self.0 >> GAS_BITS)
     }
 }

--- a/crates/evm2/src/interpreter/dispatch/table/packed.rs
+++ b/crates/evm2/src/interpreter/dispatch/table/packed.rs
@@ -113,7 +113,7 @@ extern_table! {
     }
 }
 
-const STACK_LEN_BITS: u32 = 11;
+const STACK_LEN_BITS: u32 = usize::BITS - STACK_LIMIT.leading_zeros();
 const GAS_BITS: u32 = usize::BITS - STACK_LEN_BITS;
 const GAS_MASK: usize = usize::MAX >> STACK_LEN_BITS;
 

--- a/crates/evm2/src/interpreter/dispatch/table/packed.rs
+++ b/crates/evm2/src/interpreter/dispatch/table/packed.rs
@@ -46,14 +46,6 @@ pub(super) const fn finish_loop(gas: &mut Gas, remaining_gas: LoopState) {
     gas.set_remaining(remaining_gas.get());
 }
 
-#[inline(always)]
-pub(super) const fn sync_loop_state<T: EvmTypes>(
-    state: &mut InterpreterState<'_, T>,
-    loop_state: LoopState,
-) {
-    state.gas_mut().set_remaining(loop_state.get());
-}
-
 impl super::DispatchGas for RemainingGas {
     #[inline(always)]
     fn pre_step<T: EvmTypes, C: EvmConfig<T>>(
@@ -69,8 +61,9 @@ impl super::DispatchGas for RemainingGas {
         &self,
         state: &mut InterpreterState<'_, T>,
         dynamic_gas: bool,
+        inspect: bool,
     ) {
-        if dynamic_gas {
+        if inspect || dynamic_gas {
             state.gas_mut().set_remaining(self.get());
         }
     }
@@ -91,6 +84,7 @@ extern_table! {
     pub(in crate::interpreter::dispatch) fn dispatch<
         T: EvmTypes,
         C: EvmConfig<T>,
+        M: super::InspectMode<T>,
         const OP: u8,
     >(
         pc: Pc,
@@ -99,7 +93,7 @@ extern_table! {
         state: &mut InterpreterState<'_, T>,
     ) -> InstrFnRet {
         let (pc, remaining_gas) =
-            super::dispatch_inner::<T, C, RemainingGas>(
+            super::dispatch_inner::<T, C, M, RemainingGas>(
                 pc,
                 stack.as_mut(),
                 remaining_gas,

--- a/crates/evm2/src/interpreter/dispatch/table/packed.rs
+++ b/crates/evm2/src/interpreter/dispatch/table/packed.rs
@@ -1,8 +1,13 @@
 use crate::{
     EvmConfig, EvmTypes,
     constants::STACK_LIMIT,
-    interpreter::{InterpreterState, Pc, Stack, gas::RemainingGas},
+    interpreter::{
+        InterpreterState, Pc, Result, Stack,
+        gas::{Gas, RemainingGas},
+    },
 };
+
+pub(super) type LoopState = RemainingGas;
 
 /// Packed instruction return value.
 pub(crate) type InstrFnRet = (Pc, PackedGasStackLen);
@@ -23,12 +28,63 @@ pub(super) fn dispatch_loop_call<T: EvmTypes>(
     pc: Pc,
     stack: Stack<'_>,
     state: &mut InterpreterState<'_, T>,
-    remaining_gas: &mut super::LoopState,
+    remaining_gas: &mut LoopState,
 ) -> (Pc, usize) {
     let (next_pc, gas_stack_len) = instr(pc, stack, *remaining_gas, state);
     let (next_remaining_gas, next_stack_len) = gas_stack_len.unpack();
     *remaining_gas = RemainingGas::new(next_remaining_gas);
     (next_pc, next_stack_len)
+}
+
+#[inline(always)]
+pub(super) const fn loop_state(gas: &Gas) -> LoopState {
+    RemainingGas::new(gas.remaining())
+}
+
+#[inline(always)]
+pub(super) const fn finish_loop(gas: &mut Gas, remaining_gas: LoopState) {
+    gas.set_remaining(remaining_gas.get());
+}
+
+#[inline(always)]
+pub(super) const fn sync_loop_state<T: EvmTypes>(
+    state: &mut InterpreterState<'_, T>,
+    loop_state: LoopState,
+) {
+    state.gas_mut().set_remaining(loop_state.get());
+}
+
+impl super::DispatchGas for RemainingGas {
+    #[inline(always)]
+    fn pre_step<T: EvmTypes, C: EvmConfig<T>>(
+        &mut self,
+        _state: &mut InterpreterState<'_, T>,
+        op: u8,
+    ) -> Result {
+        self.spend(C::VERSION_TABLES.static_gas(op) as _)
+    }
+
+    #[inline(always)]
+    fn sync_before_exec<T: EvmTypes>(
+        &self,
+        state: &mut InterpreterState<'_, T>,
+        dynamic_gas: bool,
+    ) {
+        if dynamic_gas {
+            state.gas_mut().set_remaining(self.get());
+        }
+    }
+
+    #[inline(always)]
+    fn sync_after_exec<T: EvmTypes>(
+        &mut self,
+        state: &mut InterpreterState<'_, T>,
+        dynamic_gas: bool,
+    ) {
+        if dynamic_gas {
+            self.set(state.gas_mut().remaining());
+        }
+    }
 }
 
 extern_table! {

--- a/crates/evm2/src/interpreter/dispatch/table/packed.rs
+++ b/crates/evm2/src/interpreter/dispatch/table/packed.rs
@@ -1,4 +1,3 @@
-use super::InspectMode;
 use crate::{
     EvmConfig, EvmTypes,
     constants::STACK_LIMIT,
@@ -36,7 +35,6 @@ extern_table! {
     pub(in crate::interpreter::dispatch) fn dispatch<
         T: EvmTypes,
         C: EvmConfig<T>,
-        M: InspectMode<T>,
         const OP: u8,
     >(
         pc: Pc,
@@ -46,7 +44,7 @@ extern_table! {
     ) -> InstrFnRet {
         let opcode = OP;
         let (pc, remaining_gas) =
-            super::dispatch_inner::<T, C, M, RemainingGas>(
+            super::dispatch_inner::<T, C, RemainingGas>(
                 pc,
                 stack.as_mut(),
                 remaining_gas,

--- a/crates/evm2/src/interpreter/dispatch/table/packed.rs
+++ b/crates/evm2/src/interpreter/dispatch/table/packed.rs
@@ -10,7 +10,7 @@ use crate::{
 pub(super) type LoopState = RemainingGas;
 
 /// Packed instruction return value.
-pub(crate) type InstrFnRet = (Pc, PackedGasStackLen);
+pub(crate) type InstrFnRet = (PackedPc, u64);
 
 /// Packed instruction function pointer.
 pub(in crate::interpreter::dispatch) type RawInstrFn<T> = extern_table!(
@@ -30,10 +30,9 @@ pub(super) fn dispatch_loop_call<T: EvmTypes>(
     state: &mut InterpreterState<'_, T>,
     remaining_gas: &mut LoopState,
 ) -> (Pc, usize) {
-    let (next_pc, gas_stack_len) = instr(pc, stack, *remaining_gas, state);
-    let (gas_spent, next_stack_len) = gas_stack_len.unpack();
+    let (next_pc, gas_spent) = instr(pc, stack, *remaining_gas, state);
     *remaining_gas = RemainingGas::new(remaining_gas.get().wrapping_sub(gas_spent));
-    (next_pc, next_stack_len)
+    next_pc.unpack()
 }
 
 #[inline(always)]
@@ -109,34 +108,33 @@ extern_table! {
                 OP,
             );
         (
-            pc,
-            PackedGasStackLen::new(
-                initial_remaining_gas.get().wrapping_sub(remaining_gas.get()),
-                stack.len,
-            ),
+            PackedPc::new(pc, stack.len),
+            initial_remaining_gas.get().wrapping_sub(remaining_gas.get()),
         )
     }
 }
 
-const STACK_LEN_BITS: u32 = usize::BITS - STACK_LIMIT.leading_zeros();
-const GAS_BITS: u32 = usize::BITS - STACK_LEN_BITS;
-const GAS_MASK: usize = usize::MAX >> STACK_LEN_BITS;
+const STACK_LEN_BITS: u32 = STACK_LIMIT.ilog2() + 1;
+const STACK_LEN_SHIFT: u32 = usize::BITS - STACK_LEN_BITS;
+const PC_MASK: usize = (1 << STACK_LEN_SHIFT) - 1;
 
-const _: () = assert!(STACK_LIMIT <= (1 << STACK_LEN_BITS));
+const _: () = assert!(usize::BITS == 64);
+const _: () = assert!(STACK_LIMIT < (1 << STACK_LEN_BITS));
 
-/// Dispatch gas spent and stack length, packed into one word on 64-bit native targets.
+/// Program counter with stack length packed into its upper bits.
 #[derive(Clone, Copy)]
 #[repr(transparent)]
-pub(crate) struct PackedGasStackLen(usize);
+pub(crate) struct PackedPc(usize);
 
-impl PackedGasStackLen {
+impl PackedPc {
     #[inline(always)]
-    const fn new(gas_spent: u64, stack_len: usize) -> Self {
-        Self((stack_len << GAS_BITS) | (gas_spent as usize & GAS_MASK))
+    fn new(pc: Pc, stack_len: usize) -> Self {
+        Self((stack_len << STACK_LEN_SHIFT) | pc.as_ptr() as usize)
     }
 
     #[inline(always)]
-    const fn unpack(self) -> (u64, usize) {
-        ((self.0 & GAS_MASK) as u64, self.0 >> GAS_BITS)
+    const fn unpack(self) -> (Pc, usize) {
+        let pc = (self.0 & PC_MASK) as *const u8;
+        (Pc::new(pc), self.0 >> STACK_LEN_SHIFT)
     }
 }

--- a/crates/evm2/src/interpreter/dispatch/table/packed.rs
+++ b/crates/evm2/src/interpreter/dispatch/table/packed.rs
@@ -42,14 +42,13 @@ extern_table! {
         remaining_gas: RemainingGas,
         state: &mut InterpreterState<'_, T>,
     ) -> InstrFnRet {
-        let opcode = OP;
         let (pc, remaining_gas) =
             super::dispatch_inner::<T, C, RemainingGas>(
                 pc,
                 stack.as_mut(),
                 remaining_gas,
                 state,
-                opcode,
+                OP,
             );
         (
             pc,

--- a/crates/evm2/src/interpreter/dispatch/table/packed.rs
+++ b/crates/evm2/src/interpreter/dispatch/table/packed.rs
@@ -46,6 +46,14 @@ pub(super) const fn finish_loop(gas: &mut Gas, remaining_gas: LoopState) {
     gas.set_remaining(remaining_gas.get());
 }
 
+#[inline(always)]
+pub(super) const fn sync_loop_state<T: EvmTypes>(
+    state: &mut InterpreterState<'_, T>,
+    loop_state: LoopState,
+) {
+    state.gas_mut().set_remaining(loop_state.get());
+}
+
 impl super::DispatchGas for RemainingGas {
     #[inline(always)]
     fn pre_step<T: EvmTypes, C: EvmConfig<T>>(
@@ -61,9 +69,8 @@ impl super::DispatchGas for RemainingGas {
         &self,
         state: &mut InterpreterState<'_, T>,
         dynamic_gas: bool,
-        inspect: bool,
     ) {
-        if inspect || dynamic_gas {
+        if dynamic_gas {
             state.gas_mut().set_remaining(self.get());
         }
     }

--- a/crates/evm2/src/interpreter/dispatch/table/packed.rs
+++ b/crates/evm2/src/interpreter/dispatch/table/packed.rs
@@ -26,8 +26,9 @@ pub(super) fn dispatch_loop_call<T: EvmTypes>(
     state: &mut InterpreterState<'_, T>,
     remaining_gas: &mut super::LoopState,
 ) -> (Pc, usize) {
-    let (next_pc, gas_spent, next_stack_len) = unpack_ret(instr(pc, stack, *remaining_gas, state));
-    *remaining_gas = RemainingGas::new(remaining_gas.get().wrapping_sub(gas_spent));
+    let (next_pc, gas_stack_len) = instr(pc, stack, *remaining_gas, state);
+    let (next_remaining_gas, next_stack_len) = gas_stack_len.unpack();
+    *remaining_gas = RemainingGas::new(next_remaining_gas);
     (next_pc, next_stack_len)
 }
 
@@ -37,52 +38,24 @@ extern_table! {
         C: EvmConfig<T>,
         M: InspectMode<T>,
         const OP: u8,
-        const DYNAMIC_GAS: bool,
     >(
         pc: Pc,
         mut stack: Stack<'_>,
         remaining_gas: RemainingGas,
         state: &mut InterpreterState<'_, T>,
     ) -> InstrFnRet {
-        let initial_remaining_gas = remaining_gas;
+        let opcode = OP;
         let (pc, remaining_gas) =
-            super::dispatch_inner::<T, C, M, RemainingGas, DYNAMIC_GAS, false>(
+            super::dispatch_inner::<T, C, M, RemainingGas>(
                 pc,
                 stack.as_mut(),
                 remaining_gas,
                 state,
-                OP,
+                opcode,
             );
-        dispatch_return(
+        (
             pc,
-            initial_remaining_gas.get().wrapping_sub(remaining_gas.get()),
-            stack.len,
-        )
-    }
-
-    pub(in crate::interpreter::dispatch) fn unknown_dispatch<
-        T: EvmTypes,
-        C: EvmConfig<T>,
-        M: InspectMode<T>,
-    >(
-        pc: Pc,
-        mut stack: Stack<'_>,
-        remaining_gas: RemainingGas,
-        state: &mut InterpreterState<'_, T>,
-    ) -> InstrFnRet {
-        let initial_remaining_gas = remaining_gas;
-        let (pc, remaining_gas) =
-            super::dispatch_inner::<T, C, M, RemainingGas, false, true>(
-                pc,
-                stack.as_mut(),
-                remaining_gas,
-                state,
-                super::UNKNOWN_OP,
-            );
-        dispatch_return(
-            pc,
-            initial_remaining_gas.get().wrapping_sub(remaining_gas.get()),
-            stack.len,
+            PackedGasStackLen::new(remaining_gas.get(), stack.len),
         )
     }
 }
@@ -93,27 +66,15 @@ const GAS_MASK: usize = usize::MAX >> STACK_LEN_BITS;
 
 const _: () = assert!(STACK_LIMIT <= (1 << STACK_LEN_BITS));
 
-#[inline(always)]
-const fn dispatch_return(pc: Pc, gas_spent: u64, stack_len: usize) -> InstrFnRet {
-    (pc, PackedGasStackLen::new(gas_spent, stack_len))
-}
-
-#[inline(always)]
-const fn unpack_ret(ret: InstrFnRet) -> (Pc, u64, usize) {
-    let (pc, gas_stack_len) = ret;
-    let (gas_spent, stack_len) = gas_stack_len.unpack();
-    (pc, gas_spent, stack_len)
-}
-
-/// Dispatch gas spent and stack length, packed into one word on 64-bit native targets.
+/// Dispatch remaining gas and stack length, packed into one word on 64-bit native targets.
 #[derive(Clone, Copy)]
 #[repr(transparent)]
 pub(crate) struct PackedGasStackLen(usize);
 
 impl PackedGasStackLen {
     #[inline(always)]
-    const fn new(gas_spent: u64, stack_len: usize) -> Self {
-        Self((stack_len << GAS_BITS) | (gas_spent as usize & GAS_MASK))
+    const fn new(remaining_gas: u64, stack_len: usize) -> Self {
+        Self((stack_len << GAS_BITS) | (remaining_gas as usize & GAS_MASK))
     }
 
     #[inline(always)]

--- a/crates/evm2/src/interpreter/dispatch/table/single_return.rs
+++ b/crates/evm2/src/interpreter/dispatch/table/single_return.rs
@@ -3,7 +3,8 @@ use crate::{
     interpreter::{InterpreterState, Pc, Stack, StackMut, gas::Gas},
 };
 
-pub(super) type LoopState = ();
+#[derive(Clone, Copy)]
+pub(super) struct LoopState;
 
 /// Single-return instruction function pointer.
 pub(in crate::interpreter::dispatch) type RawInstrFn<T> =
@@ -22,7 +23,9 @@ pub(super) fn dispatch_loop_call<T: EvmTypes>(
 }
 
 #[inline(always)]
-pub(super) const fn loop_state(_gas: &Gas) -> LoopState {}
+pub(super) const fn loop_state(_gas: &Gas) -> LoopState {
+    LoopState
+}
 
 #[inline(always)]
 pub(super) const fn finish_loop(_gas: &mut Gas, _loop_state: LoopState) {}

--- a/crates/evm2/src/interpreter/dispatch/table/single_return.rs
+++ b/crates/evm2/src/interpreter/dispatch/table/single_return.rs
@@ -29,8 +29,7 @@ extern_table! {
         stack: StackMut<'_>,
         state: &mut InterpreterState<'_, T>,
     ) -> Pc {
-        let opcode = OP;
-        let (pc, ()) = super::dispatch_inner::<T, C, ()>(pc, stack, (), state, opcode);
+        let (pc, ()) = super::dispatch_inner::<T, C, ()>(pc, stack, (), state, OP);
         pc
     }
 }

--- a/crates/evm2/src/interpreter/dispatch/table/single_return.rs
+++ b/crates/evm2/src/interpreter/dispatch/table/single_return.rs
@@ -1,4 +1,3 @@
-use super::InspectMode;
 use crate::{
     EvmConfig, EvmTypes,
     interpreter::{InterpreterState, Pc, Stack, StackMut},
@@ -24,7 +23,6 @@ extern_table! {
     pub(in crate::interpreter::dispatch) fn dispatch<
         T: EvmTypes,
         C: EvmConfig<T>,
-        M: InspectMode<T>,
         const OP: u8,
     >(
         pc: Pc,
@@ -32,7 +30,7 @@ extern_table! {
         state: &mut InterpreterState<'_, T>,
     ) -> Pc {
         let opcode = OP;
-        let (pc, ()) = super::dispatch_inner::<T, C, M, ()>(pc, stack, (), state, opcode);
+        let (pc, ()) = super::dispatch_inner::<T, C, ()>(pc, stack, (), state, opcode);
         pc
     }
 }

--- a/crates/evm2/src/interpreter/dispatch/table/single_return.rs
+++ b/crates/evm2/src/interpreter/dispatch/table/single_return.rs
@@ -3,8 +3,7 @@ use crate::{
     interpreter::{InterpreterState, Pc, Stack, StackMut, gas::Gas},
 };
 
-#[derive(Clone, Copy)]
-pub(super) struct LoopState;
+pub(super) type LoopState = ();
 
 /// Single-return instruction function pointer.
 pub(in crate::interpreter::dispatch) type RawInstrFn<T> =
@@ -23,9 +22,7 @@ pub(super) fn dispatch_loop_call<T: EvmTypes>(
 }
 
 #[inline(always)]
-pub(super) const fn loop_state(_gas: &Gas) -> LoopState {
-    LoopState
-}
+pub(super) const fn loop_state(_gas: &Gas) -> LoopState {}
 
 #[inline(always)]
 pub(super) const fn finish_loop(_gas: &mut Gas, _loop_state: LoopState) {}

--- a/crates/evm2/src/interpreter/dispatch/table/single_return.rs
+++ b/crates/evm2/src/interpreter/dispatch/table/single_return.rs
@@ -27,24 +27,18 @@ pub(super) const fn loop_state(_gas: &Gas) -> LoopState {}
 #[inline(always)]
 pub(super) const fn finish_loop(_gas: &mut Gas, _loop_state: LoopState) {}
 
-#[inline(always)]
-pub(super) const fn sync_loop_state<T: EvmTypes>(
-    _state: &mut InterpreterState<'_, T>,
-    _loop_state: LoopState,
-) {
-}
-
 extern_table! {
     pub(in crate::interpreter::dispatch) fn dispatch<
         T: EvmTypes,
         C: EvmConfig<T>,
+        M: super::InspectMode<T>,
         const OP: u8,
     >(
         pc: Pc,
         stack: StackMut<'_>,
         state: &mut InterpreterState<'_, T>,
     ) -> Pc {
-        let (pc, ()) = super::dispatch_inner::<T, C, ()>(pc, stack, (), state, OP);
+        let (pc, ()) = super::dispatch_inner::<T, C, M, ()>(pc, stack, (), state, OP);
         pc
     }
 }

--- a/crates/evm2/src/interpreter/dispatch/table/single_return.rs
+++ b/crates/evm2/src/interpreter/dispatch/table/single_return.rs
@@ -27,6 +27,13 @@ pub(super) const fn loop_state(_gas: &Gas) -> LoopState {}
 #[inline(always)]
 pub(super) const fn finish_loop(_gas: &mut Gas, _loop_state: LoopState) {}
 
+#[inline(always)]
+pub(super) const fn sync_loop_state<T: EvmTypes>(
+    _state: &mut InterpreterState<'_, T>,
+    _loop_state: LoopState,
+) {
+}
+
 extern_table! {
     pub(in crate::interpreter::dispatch) fn dispatch<
         T: EvmTypes,

--- a/crates/evm2/src/interpreter/dispatch/table/single_return.rs
+++ b/crates/evm2/src/interpreter/dispatch/table/single_return.rs
@@ -1,7 +1,9 @@
 use crate::{
     EvmConfig, EvmTypes,
-    interpreter::{InterpreterState, Pc, Stack, StackMut},
+    interpreter::{InterpreterState, Pc, Stack, StackMut, gas::Gas},
 };
+
+pub(super) type LoopState = ();
 
 /// Single-return instruction function pointer.
 pub(in crate::interpreter::dispatch) type RawInstrFn<T> =
@@ -13,10 +15,23 @@ pub(super) fn dispatch_loop_call<T: EvmTypes>(
     pc: Pc,
     mut stack: Stack<'_>,
     state: &mut InterpreterState<'_, T>,
-    _loop_state: &mut super::LoopState,
+    _loop_state: &mut LoopState,
 ) -> (Pc, usize) {
     let next_pc = instr(pc, stack.as_mut(), state);
     (next_pc, stack.len)
+}
+
+#[inline(always)]
+pub(super) const fn loop_state(_gas: &Gas) -> LoopState {}
+
+#[inline(always)]
+pub(super) const fn finish_loop(_gas: &mut Gas, _loop_state: LoopState) {}
+
+#[inline(always)]
+pub(super) const fn sync_loop_state<T: EvmTypes>(
+    _state: &mut InterpreterState<'_, T>,
+    _loop_state: LoopState,
+) {
 }
 
 extern_table! {

--- a/crates/evm2/src/interpreter/dispatch/table/single_return.rs
+++ b/crates/evm2/src/interpreter/dispatch/table/single_return.rs
@@ -26,35 +26,13 @@ extern_table! {
         C: EvmConfig<T>,
         M: InspectMode<T>,
         const OP: u8,
-        const DYNAMIC_GAS: bool,
     >(
         pc: Pc,
         stack: StackMut<'_>,
         state: &mut InterpreterState<'_, T>,
     ) -> Pc {
-        let _ = DYNAMIC_GAS;
-        let (pc, ()) =
-            super::dispatch_inner::<T, C, M, (), false, false>(pc, stack, (), state, OP);
-        pc
-    }
-
-    pub(in crate::interpreter::dispatch) fn unknown_dispatch<
-        T: EvmTypes,
-        C: EvmConfig<T>,
-        M: InspectMode<T>,
-    >(
-        pc: Pc,
-        stack: StackMut<'_>,
-        state: &mut InterpreterState<'_, T>,
-    ) -> Pc {
-        let (pc, ()) =
-            super::dispatch_inner::<T, C, M, (), false, true>(
-                pc,
-                stack,
-                (),
-                state,
-                super::UNKNOWN_OP,
-            );
+        let opcode = OP;
+        let (pc, ()) = super::dispatch_inner::<T, C, M, ()>(pc, stack, (), state, opcode);
         pc
     }
 }

--- a/crates/evm2/src/interpreter/dispatch/table/unpacked.rs
+++ b/crates/evm2/src/interpreter/dispatch/table/unpacked.rs
@@ -29,24 +29,18 @@ pub(super) const fn loop_state(_gas: &Gas) -> LoopState {}
 #[inline(always)]
 pub(super) const fn finish_loop(_gas: &mut Gas, _loop_state: LoopState) {}
 
-#[inline(always)]
-pub(super) const fn sync_loop_state<T: EvmTypes>(
-    _state: &mut InterpreterState<'_, T>,
-    _loop_state: LoopState,
-) {
-}
-
 extern_table! {
     pub(in crate::interpreter::dispatch) fn dispatch<
         T: EvmTypes,
         C: EvmConfig<T>,
+        M: super::InspectMode<T>,
         const OP: u8,
     >(
         pc: Pc,
         mut stack: Stack<'_>,
         state: &mut InterpreterState<'_, T>,
     ) -> InstrFnRet {
-        let (pc, ()) = super::dispatch_inner::<T, C, ()>(pc, stack.as_mut(), (), state, OP);
+        let (pc, ()) = super::dispatch_inner::<T, C, M, ()>(pc, stack.as_mut(), (), state, OP);
         (pc, stack.len)
     }
 }

--- a/crates/evm2/src/interpreter/dispatch/table/unpacked.rs
+++ b/crates/evm2/src/interpreter/dispatch/table/unpacked.rs
@@ -28,41 +28,13 @@ extern_table! {
         C: EvmConfig<T>,
         M: InspectMode<T>,
         const OP: u8,
-        const DYNAMIC_GAS: bool,
     >(
         pc: Pc,
         mut stack: Stack<'_>,
         state: &mut InterpreterState<'_, T>,
     ) -> InstrFnRet {
-        let _ = DYNAMIC_GAS;
-        let (pc, ()) =
-            super::dispatch_inner::<T, C, M, (), false, false>(
-                pc,
-                stack.as_mut(),
-                (),
-                state,
-                OP,
-            );
-        (pc, stack.len)
-    }
-
-    pub(in crate::interpreter::dispatch) fn unknown_dispatch<
-        T: EvmTypes,
-        C: EvmConfig<T>,
-        M: InspectMode<T>,
-    >(
-        pc: Pc,
-        mut stack: Stack<'_>,
-        state: &mut InterpreterState<'_, T>,
-    ) -> InstrFnRet {
-        let (pc, ()) =
-            super::dispatch_inner::<T, C, M, (), false, true>(
-                pc,
-                stack.as_mut(),
-                (),
-                state,
-                super::UNKNOWN_OP,
-            );
+        let opcode = OP;
+        let (pc, ()) = super::dispatch_inner::<T, C, M, ()>(pc, stack.as_mut(), (), state, opcode);
         (pc, stack.len)
     }
 }

--- a/crates/evm2/src/interpreter/dispatch/table/unpacked.rs
+++ b/crates/evm2/src/interpreter/dispatch/table/unpacked.rs
@@ -1,7 +1,9 @@
 use crate::{
     EvmConfig, EvmTypes,
-    interpreter::{InterpreterState, Pc, Stack},
+    interpreter::{InterpreterState, Pc, Stack, gas::Gas},
 };
+
+pub(super) type LoopState = ();
 
 /// Unpacked instruction return value.
 type InstrFnRet = (Pc, usize);
@@ -16,9 +18,22 @@ pub(super) fn dispatch_loop_call<T: EvmTypes>(
     pc: Pc,
     stack: Stack<'_>,
     state: &mut InterpreterState<'_, T>,
-    _loop_state: &mut super::LoopState,
+    _loop_state: &mut LoopState,
 ) -> (Pc, usize) {
     instr(pc, stack, state)
+}
+
+#[inline(always)]
+pub(super) const fn loop_state(_gas: &Gas) -> LoopState {}
+
+#[inline(always)]
+pub(super) const fn finish_loop(_gas: &mut Gas, _loop_state: LoopState) {}
+
+#[inline(always)]
+pub(super) const fn sync_loop_state<T: EvmTypes>(
+    _state: &mut InterpreterState<'_, T>,
+    _loop_state: LoopState,
+) {
 }
 
 extern_table! {

--- a/crates/evm2/src/interpreter/dispatch/table/unpacked.rs
+++ b/crates/evm2/src/interpreter/dispatch/table/unpacked.rs
@@ -3,7 +3,8 @@ use crate::{
     interpreter::{InterpreterState, Pc, Stack, gas::Gas},
 };
 
-pub(super) type LoopState = ();
+#[derive(Clone, Copy)]
+pub(super) struct LoopState;
 
 /// Unpacked instruction return value.
 type InstrFnRet = (Pc, usize);
@@ -24,7 +25,9 @@ pub(super) fn dispatch_loop_call<T: EvmTypes>(
 }
 
 #[inline(always)]
-pub(super) const fn loop_state(_gas: &Gas) -> LoopState {}
+pub(super) const fn loop_state(_gas: &Gas) -> LoopState {
+    LoopState
+}
 
 #[inline(always)]
 pub(super) const fn finish_loop(_gas: &mut Gas, _loop_state: LoopState) {}

--- a/crates/evm2/src/interpreter/dispatch/table/unpacked.rs
+++ b/crates/evm2/src/interpreter/dispatch/table/unpacked.rs
@@ -1,4 +1,3 @@
-use super::InspectMode;
 use crate::{
     EvmConfig, EvmTypes,
     interpreter::{InterpreterState, Pc, Stack},
@@ -26,7 +25,6 @@ extern_table! {
     pub(in crate::interpreter::dispatch) fn dispatch<
         T: EvmTypes,
         C: EvmConfig<T>,
-        M: InspectMode<T>,
         const OP: u8,
     >(
         pc: Pc,
@@ -34,7 +32,7 @@ extern_table! {
         state: &mut InterpreterState<'_, T>,
     ) -> InstrFnRet {
         let opcode = OP;
-        let (pc, ()) = super::dispatch_inner::<T, C, M, ()>(pc, stack.as_mut(), (), state, opcode);
+        let (pc, ()) = super::dispatch_inner::<T, C, ()>(pc, stack.as_mut(), (), state, opcode);
         (pc, stack.len)
     }
 }

--- a/crates/evm2/src/interpreter/dispatch/table/unpacked.rs
+++ b/crates/evm2/src/interpreter/dispatch/table/unpacked.rs
@@ -3,8 +3,7 @@ use crate::{
     interpreter::{InterpreterState, Pc, Stack, gas::Gas},
 };
 
-#[derive(Clone, Copy)]
-pub(super) struct LoopState;
+pub(super) type LoopState = ();
 
 /// Unpacked instruction return value.
 type InstrFnRet = (Pc, usize);
@@ -25,9 +24,7 @@ pub(super) fn dispatch_loop_call<T: EvmTypes>(
 }
 
 #[inline(always)]
-pub(super) const fn loop_state(_gas: &Gas) -> LoopState {
-    LoopState
-}
+pub(super) const fn loop_state(_gas: &Gas) -> LoopState {}
 
 #[inline(always)]
 pub(super) const fn finish_loop(_gas: &mut Gas, _loop_state: LoopState) {}

--- a/crates/evm2/src/interpreter/dispatch/table/unpacked.rs
+++ b/crates/evm2/src/interpreter/dispatch/table/unpacked.rs
@@ -29,6 +29,13 @@ pub(super) const fn loop_state(_gas: &Gas) -> LoopState {}
 #[inline(always)]
 pub(super) const fn finish_loop(_gas: &mut Gas, _loop_state: LoopState) {}
 
+#[inline(always)]
+pub(super) const fn sync_loop_state<T: EvmTypes>(
+    _state: &mut InterpreterState<'_, T>,
+    _loop_state: LoopState,
+) {
+}
+
 extern_table! {
     pub(in crate::interpreter::dispatch) fn dispatch<
         T: EvmTypes,

--- a/crates/evm2/src/interpreter/dispatch/table/unpacked.rs
+++ b/crates/evm2/src/interpreter/dispatch/table/unpacked.rs
@@ -31,8 +31,7 @@ extern_table! {
         mut stack: Stack<'_>,
         state: &mut InterpreterState<'_, T>,
     ) -> InstrFnRet {
-        let opcode = OP;
-        let (pc, ()) = super::dispatch_inner::<T, C, ()>(pc, stack.as_mut(), (), state, opcode);
+        let (pc, ()) = super::dispatch_inner::<T, C, ()>(pc, stack.as_mut(), (), state, OP);
         (pc, stack.len)
     }
 }

--- a/crates/evm2/src/interpreter/dispatch/tco.rs
+++ b/crates/evm2/src/interpreter/dispatch/tco.rs
@@ -2,7 +2,7 @@ use super::{InspectMode, run_state};
 use crate::{
     EvmConfig, EvmTypes,
     interpreter::{
-        InstrStop, Interpreter, InterpreterState, Pc, Result, Stack, gas::RemainingGas,
+        InstrStop, Interpreter, InterpreterState, Pc, Result, Stack, gas::RemainingGas, op,
         private::InstructionImplFn,
     },
 };
@@ -45,55 +45,6 @@ extern_table! {
         C: EvmConfig<T>,
         M: InspectMode<T>,
         const OP: u8,
-        const DYNAMIC_GAS: bool,
-    >(
-        pc: Pc,
-        stack: Stack<'_>,
-        remaining_gas: RemainingGas,
-        state: &mut InterpreterState<'_, T>,
-        instructions: *const (),
-    ) {
-        tail_return!(tail_dispatch_mono::<T, C, M, DYNAMIC_GAS, false, OP>(
-            pc,
-            stack,
-            remaining_gas,
-            state,
-            instructions
-        ));
-    }
-}
-
-extern_table! {
-    pub(super) fn unknown_dispatch<
-        T: EvmTypes,
-        C: EvmConfig<T>,
-        M: InspectMode<T>,
-    >(
-        pc: Pc,
-        stack: Stack<'_>,
-        remaining_gas: RemainingGas,
-        state: &mut InterpreterState<'_, T>,
-        instructions: *const (),
-    ) {
-        tail_return!(tail_dispatch_mono::<T, C, M, false, true, { super::UNKNOWN_OP }>(
-            pc,
-            stack,
-            remaining_gas,
-            state,
-            instructions
-        ));
-    }
-}
-
-extern_table! {
-    #[inline(always)]
-    fn tail_dispatch_mono<
-        T: EvmTypes,
-        C: EvmConfig<T>,
-        M: InspectMode<T>,
-        const DYNAMIC_GAS: bool,
-        const UNKNOWN: bool,
-        const OP: u8,
     >(
         mut pc: Pc,
         mut stack: Stack<'_>,
@@ -101,30 +52,29 @@ extern_table! {
         state: &mut InterpreterState<'_, T>,
         instructions: *const (),
     ) {
-        if !UNKNOWN {
-            unsafe { core::hint::assert_unchecked(pc.op() == OP) };
+        let opcode = OP;
+        if opcode != op::INVALID {
+            unsafe { core::hint::assert_unchecked(pc.op() == opcode) };
         }
-        let instr: InstructionImplFn<T> = if UNKNOWN {
-            super::unknown_instruction
-        } else {
-            C::VERSION_TABLES.instruction(OP).instr
-        };
+        let instruction = C::VERSION_TABLES.instruction(opcode);
+        let instr: InstructionImplFn<T> = instruction.instr;
+        let dynamic_gas = instruction.dynamic_gas;
         if M::INSPECT {
             M::step(state, pc, stack.len);
         }
-        if let Err(e) = pre_step::<T, C, OP>(&mut remaining_gas) {
+        if let Err(e) = pre_step::<T, C>(&mut remaining_gas, opcode) {
             cold_path();
             state.set_result(Err(e));
             if M::INSPECT {
                 M::step_end(state, pc, stack.len);
             }
-            tail_return!(tail_call_restore::<T>(pc, stack, remaining_gas, state, instructions));
+            tail_return!(tail_call_restore(pc, stack, remaining_gas, state, instructions));
         }
-        if DYNAMIC_GAS {
+        if dynamic_gas {
             state.gas_mut().set_remaining(remaining_gas.get());
         }
         let r = instr(&mut pc, stack.as_mut(), state);
-        if DYNAMIC_GAS {
+        if dynamic_gas {
             remaining_gas.set(state.gas_mut().remaining());
         }
         if let Err(e) = r {
@@ -133,20 +83,21 @@ extern_table! {
             if M::INSPECT {
                 M::step_end(state, pc, stack.len);
             }
-            tail_return!(tail_call_restore::<T>(pc, stack, remaining_gas, state, instructions));
+            tail_return!(tail_call_restore(pc, stack, remaining_gas, state, instructions));
         }
-        super::inc_pc(&mut pc, OP);
+        super::inc_pc(&mut pc, opcode);
         if M::INSPECT {
             M::step_end(state, pc, stack.len);
         }
-        let instructions = instructions.cast::<TailInstrTable<T>>();
-        let instr = unsafe { (*instructions)[pc.op() as usize] };
-        tail_return!(instr(pc, stack, remaining_gas, state, instructions.cast()));
+        // SAFETY: `instructions` is a pointer to a `TailInstrTable`.
+        let instructions_t = unsafe { &*instructions.cast::<TailInstrTable<T>>() };
+        let instr = instructions_t[pc.op() as usize];
+        tail_return!(instr(pc, stack, remaining_gas, state, instructions));
     }
 }
 
 extern_table! {
-    #[inline(never)] // TODO
+    #[inline(never)]
     #[cold]
     fn tail_call_restore<T: EvmTypes>(
         pc: Pc,
@@ -163,8 +114,6 @@ extern_table! {
 }
 
 #[inline(always)]
-const fn pre_step<T: EvmTypes, C: EvmConfig<T>, const OP: u8>(
-    remaining_gas: &mut RemainingGas,
-) -> Result {
-    remaining_gas.spend(C::VERSION_TABLES.static_gas(OP) as _)
+fn pre_step<T: EvmTypes, C: EvmConfig<T>>(remaining_gas: &mut RemainingGas, opcode: u8) -> Result {
+    remaining_gas.spend(C::VERSION_TABLES.static_gas(opcode) as _)
 }

--- a/crates/evm2/src/interpreter/dispatch/tco.rs
+++ b/crates/evm2/src/interpreter/dispatch/tco.rs
@@ -118,6 +118,9 @@ extern_table! {
 }
 
 #[inline(always)]
-fn pre_step<T: EvmTypes, C: EvmConfig<T>>(remaining_gas: &mut RemainingGas, opcode: u8) -> Result {
+const fn pre_step<T: EvmTypes, C: EvmConfig<T>>(
+    remaining_gas: &mut RemainingGas,
+    opcode: u8,
+) -> Result {
     remaining_gas.spend(C::VERSION_TABLES.static_gas(opcode) as _)
 }

--- a/crates/evm2/src/interpreter/dispatch/tco.rs
+++ b/crates/evm2/src/interpreter/dispatch/tco.rs
@@ -2,7 +2,7 @@ use super::{InspectMode, run_state};
 use crate::{
     EvmConfig, EvmTypes,
     interpreter::{
-        InstrStop, Interpreter, InterpreterState, Pc, Result, Stack, gas::RemainingGas, op,
+        InstrStop, Interpreter, InterpreterState, Pc, Result, Stack, gas::RemainingGas,
         private::InstructionImplFn,
     },
 };
@@ -52,17 +52,17 @@ extern_table! {
         state: &mut InterpreterState<'_, T>,
         instructions: *const (),
     ) {
-        let opcode = OP;
-        if opcode != op::INVALID {
-            unsafe { core::hint::assert_unchecked(pc.op() == opcode) };
-        }
-        let instruction = C::VERSION_TABLES.instruction(opcode);
+        let instruction = C::VERSION_TABLES.instruction(OP);
         let instr: InstructionImplFn<T> = instruction.instr;
         let dynamic_gas = instruction.dynamic_gas;
         if M::INSPECT {
             M::step(state, pc, stack.len);
+            if state.result().is_err() {
+                cold_path();
+                tail_return!(tail_call_restore(pc, stack, remaining_gas, state, instructions));
+            }
         }
-        if let Err(e) = pre_step::<T, C>(&mut remaining_gas, opcode) {
+        if let Err(e) = pre_step::<T, C>(&mut remaining_gas, OP) {
             cold_path();
             state.set_result(Err(e));
             if M::INSPECT {
@@ -85,9 +85,13 @@ extern_table! {
             }
             tail_return!(tail_call_restore(pc, stack, remaining_gas, state, instructions));
         }
-        super::inc_pc(&mut pc, opcode);
+        super::inc_pc(&mut pc, OP);
         if M::INSPECT {
             M::step_end(state, pc, stack.len);
+            if state.result().is_err() {
+                cold_path();
+                tail_return!(tail_call_restore(pc, stack, remaining_gas, state, instructions));
+            }
         }
         // SAFETY: `instructions` is a pointer to a `TailInstrTable`.
         let instructions_t = unsafe { &*instructions.cast::<TailInstrTable<T>>() };

--- a/crates/evm2/src/interpreter/instructions/control.rs
+++ b/crates/evm2/src/interpreter/instructions/control.rs
@@ -87,13 +87,7 @@ fn return_inner<T: EvmTypes>(
 #[instruction]
 pub(crate) fn invalid() -> Result {
     cold_path();
-    Err(InstrStop::InvalidFEOpcode)
-}
-
-#[instruction]
-pub(crate) fn unknown() -> Result {
-    cold_path();
-    Err(InstrStop::OpcodeNotFound)
+    Err(InstrStop::InvalidOpcode)
 }
 
 #[cfg(test)]
@@ -117,10 +111,10 @@ mod tests {
     #[test]
     fn invalid_opcode() {
         let interpreter = run(RunConfig::new([op::INVALID]));
-        assert!(matches!(interpreter.err, InstrStop::InvalidFEOpcode));
+        assert!(matches!(interpreter.err, InstrStop::InvalidOpcode));
 
         let interpreter = run(RunConfig::new([0x0c]));
-        assert!(matches!(interpreter.err, InstrStop::OpcodeNotFound));
+        assert!(matches!(interpreter.err, InstrStop::InvalidOpcode));
     }
 
     #[test]

--- a/crates/evm2/src/interpreter/instructions/env.rs
+++ b/crates/evm2/src/interpreter/instructions/env.rs
@@ -471,7 +471,7 @@ mod tests {
         assert_eq!(interpreter.stack(), [Word::from(3)]);
 
         let interpreter = run(RunConfig::new([op::RETURNDATASIZE]).spec(SpecId::FRONTIER));
-        assert!(matches!(interpreter.err, InstrStop::OpcodeNotFound));
+        assert!(matches!(interpreter.err, InstrStop::InvalidOpcode));
     }
 
     #[test]
@@ -521,7 +521,7 @@ mod tests {
             op::RETURNDATACOPY,
         ))
         .spec(SpecId::FRONTIER));
-        assert!(matches!(interpreter.err, InstrStop::OpcodeNotFound));
+        assert!(matches!(interpreter.err, InstrStop::InvalidOpcode));
     }
 
     #[test]
@@ -537,6 +537,6 @@ mod tests {
         let interpreter = run(RunConfig::new([op::PUSH1, 0xbe, op::EXTCODEHASH, op::STOP])
             .host(&mut host)
             .spec(SpecId::BYZANTIUM));
-        assert!(matches!(interpreter.err, InstrStop::OpcodeNotFound));
+        assert!(matches!(interpreter.err, InstrStop::InvalidOpcode));
     }
 }

--- a/crates/evm2/src/interpreter/instructions/host.rs
+++ b/crates/evm2/src/interpreter/instructions/host.rs
@@ -316,7 +316,7 @@ mod tests {
         let interpreter = run(RunConfig::new([op::PUSH1, 0, op::TLOAD, op::STOP])
             .host(&mut host)
             .spec(SpecId::SHANGHAI));
-        assert!(matches!(interpreter.err, InstrStop::OpcodeNotFound));
+        assert!(matches!(interpreter.err, InstrStop::InvalidOpcode));
         assert_eq!(interpreter.stack(), [0]);
     }
 
@@ -341,7 +341,7 @@ mod tests {
         let interpreter = run(RunConfig::new([op::PUSH1, 0, op::PUSH1, 0, op::TSTORE, op::STOP])
             .host(&mut host)
             .spec(SpecId::SHANGHAI));
-        assert!(matches!(interpreter.err, InstrStop::OpcodeNotFound));
+        assert!(matches!(interpreter.err, InstrStop::InvalidOpcode));
         assert_eq!(interpreter.stack(), [0, 0]);
     }
 

--- a/crates/evm2/src/interpreter/instructions/stack.rs
+++ b/crates/evm2/src/interpreter/instructions/stack.rs
@@ -369,12 +369,12 @@ mod tests {
     #[test]
     fn relative_stack_opcodes_are_not_enabled_before_amsterdam() {
         let interpreter = run(RunConfig::new([op::DUPN, 0x80]).spec(SpecId::OSAKA));
-        assert!(matches!(interpreter.err, InstrStop::OpcodeNotFound));
+        assert!(matches!(interpreter.err, InstrStop::InvalidOpcode));
 
         let interpreter = run(RunConfig::new([op::SWAPN, 0x80]).spec(SpecId::OSAKA));
-        assert!(matches!(interpreter.err, InstrStop::OpcodeNotFound));
+        assert!(matches!(interpreter.err, InstrStop::InvalidOpcode));
 
         let interpreter = run(RunConfig::new([op::EXCHANGE, 0x8e]).spec(SpecId::OSAKA));
-        assert!(matches!(interpreter.err, InstrStop::OpcodeNotFound));
+        assert!(matches!(interpreter.err, InstrStop::InvalidOpcode));
     }
 }

--- a/crates/evm2/src/interpreter/instructions/system.rs
+++ b/crates/evm2/src/interpreter/instructions/system.rs
@@ -695,7 +695,7 @@ mod tests {
             op::DELEGATECALL,
         ])
         .spec(SpecId::FRONTIER));
-        assert!(matches!(interpreter.err, InstrStop::OpcodeNotFound));
+        assert!(matches!(interpreter.err, InstrStop::InvalidOpcode));
     }
 
     #[test]
@@ -738,7 +738,7 @@ mod tests {
             op::STATICCALL,
         ])
         .spec(SpecId::HOMESTEAD));
-        assert!(matches!(interpreter.err, InstrStop::OpcodeNotFound));
+        assert!(matches!(interpreter.err, InstrStop::InvalidOpcode));
     }
 
     #[test]
@@ -866,7 +866,7 @@ mod tests {
             op::CREATE2,
         ])
         .spec(SpecId::BYZANTIUM));
-        assert!(matches!(interpreter.err, InstrStop::OpcodeNotFound));
+        assert!(matches!(interpreter.err, InstrStop::InvalidOpcode));
     }
 
     #[test]

--- a/crates/evm2/src/interpreter/mod.rs
+++ b/crates/evm2/src/interpreter/mod.rs
@@ -79,14 +79,12 @@ pub enum InstrStop {
     InvalidOperandOOG,
     /// Out of gas error encountered while checking for reentrancy sentry.
     ReentrancySentryOOG,
-    /// Unknown or invalid opcode.
-    OpcodeNotFound,
     /// Invalid `CALL` with value transfer in static context.
     CallNotAllowedInsideStatic,
     /// Invalid state modification in static call.
     StateChangeDuringStaticCall,
-    /// An undefined bytecode value encountered during execution.
-    InvalidFEOpcode,
+    /// Invalid or undefined opcode.
+    InvalidOpcode,
     /// Invalid jump destination. Dynamic jumps points to invalid not jumpdest opcode.
     InvalidJump,
     /// The feature or opcode is not activated in this version of the EVM.

--- a/crates/evm2/src/interpreter/runtime.rs
+++ b/crates/evm2/src/interpreter/runtime.rs
@@ -150,6 +150,12 @@ impl<'frame, T: EvmTypes> Interpreter<'frame, T> {
         unsafe { core::slice::from_raw_parts(self.stack.as_ptr().cast(), self.stack_len) }
     }
 
+    /// Stops the interpreter with `stop`.
+    #[inline]
+    pub const fn set_stop(&mut self, stop: InstrStop) {
+        self.result = Err(stop);
+    }
+
     /// Returns the current linear memory.
     #[inline]
     pub const fn memory_ref(&self) -> &Memory {

--- a/crates/evm2/src/interpreter/runtime.rs
+++ b/crates/evm2/src/interpreter/runtime.rs
@@ -250,6 +250,12 @@ impl<'frame, T: EvmTypes> InterpreterState<'frame, T> {
     }
 
     #[inline]
+    #[cfg(not(tco))]
+    pub(crate) const fn is_inspecting(&self) -> bool {
+        self.0.inspector.is_some()
+    }
+
+    #[inline]
     pub(crate) const fn set_pc_stack_len(&mut self, pc: *const u8, stack_len: usize) {
         self.0.pc = pc;
         self.0.stack_len = stack_len;

--- a/crates/evm2/src/version/mod.rs
+++ b/crates/evm2/src/version/mod.rs
@@ -470,7 +470,6 @@ evm_versions! {
             CALL: 40,
             CALLCODE: 40,
             RETURN: ZERO,
-            INVALID: ZERO,
             SELFDESTRUCT: ZERO,
         ],
         dynamic_gas: [

--- a/crates/evm2/src/version/tables.rs
+++ b/crates/evm2/src/version/tables.rs
@@ -44,7 +44,7 @@ impl<T: EvmTypes> VersionTables<T> {
     pub(super) const fn empty() -> Self {
         Self {
             static_gas_table: StaticGasTable::empty(),
-            instruction_impls: InstructionImplTable::empty_with_invalid(),
+            instruction_impls: InstructionImplTable::empty(),
             revisions: [0; 256],
         }
     }
@@ -141,14 +141,6 @@ impl<T: EvmTypes> InstructionImplTable<T> {
     #[inline]
     const fn empty() -> Self {
         Self { instrs: [None; 256], dynamic_gas: [false; 256] }
-    }
-
-    /// Creates an instruction implementation table with immutable `INVALID`.
-    #[inline]
-    const fn empty_with_invalid() -> Self {
-        let mut table = Self::empty();
-        table.instrs[op::INVALID as usize] = Some(instr::invalid::<T>::execute);
-        table
     }
 
     /// Returns the instruction implementation for `opcode`.

--- a/crates/evm2/src/version/tables.rs
+++ b/crates/evm2/src/version/tables.rs
@@ -1,7 +1,8 @@
 use crate::{
     EvmConfig, EvmTypes,
     interpreter::{
-        dispatch::unknown_instruction,
+        instructions as instr,
+        opcode::op,
         private::{Instruction, InstructionImplFn},
     },
 };
@@ -43,7 +44,7 @@ impl<T: EvmTypes> VersionTables<T> {
     pub(super) const fn empty() -> Self {
         Self {
             static_gas_table: StaticGasTable::empty(),
-            instruction_impls: InstructionImplTable::empty(),
+            instruction_impls: InstructionImplTable::empty_with_invalid(),
             revisions: [0; 256],
         }
     }
@@ -63,6 +64,7 @@ impl<T: EvmTypes> VersionTables<T> {
     /// Sets the static gas cost for `opcode`.
     #[inline(always)]
     pub const fn set_static_gas(&mut self, opcode: u8, cost: u16) {
+        assert!(opcode != op::INVALID, "INVALID opcode cannot be overridden");
         if self.static_gas_table.set(opcode, cost) {
             self.bump_revision(opcode);
         }
@@ -86,6 +88,7 @@ impl<T: EvmTypes> VersionTables<T> {
     /// proc macro.
     #[inline(always)]
     pub const fn set_instruction<I: Instruction<T>>(&mut self, opcode: u8, gas: u16) {
+        assert!(opcode != op::INVALID, "INVALID opcode cannot be overridden");
         self.set_static_gas(opcode, gas);
         if self.instruction_impls.set(opcode, I::execute, I::DYNAMIC_GAS) {
             self.bump_revision(opcode);
@@ -140,6 +143,14 @@ impl<T: EvmTypes> InstructionImplTable<T> {
         Self { instrs: [None; 256], dynamic_gas: [false; 256] }
     }
 
+    /// Creates an instruction implementation table with immutable `INVALID`.
+    #[inline]
+    const fn empty_with_invalid() -> Self {
+        let mut table = Self::empty();
+        table.instrs[op::INVALID as usize] = Some(instr::invalid::<T>::execute);
+        table
+    }
+
     /// Returns the instruction implementation for `opcode`.
     #[inline(always)]
     const fn get(&self, opcode: u8) -> InstructionInfo<T> {
@@ -147,7 +158,7 @@ impl<T: EvmTypes> InstructionImplTable<T> {
             Some(instr) => {
                 InstructionInfo { instr, dynamic_gas: self.dynamic_gas[opcode as usize] }
             }
-            None => InstructionInfo { instr: unknown_instruction::<T>, dynamic_gas: true },
+            None => InstructionInfo { instr: instr::invalid::<T>::execute, dynamic_gas: false },
         }
     }
 
@@ -164,5 +175,25 @@ impl<T: EvmTypes> InstructionImplTable<T> {
         self.instrs[index] = Some(instr);
         self.dynamic_gas[index] = dynamic_gas;
         true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::evm::config::BaseEvmTypes;
+
+    #[test]
+    #[should_panic(expected = "INVALID opcode cannot be overridden")]
+    fn invalid_static_gas_cannot_be_overridden() {
+        let mut tables = VersionTables::<BaseEvmTypes>::empty();
+        tables.set_static_gas(op::INVALID, 1);
+    }
+
+    #[test]
+    #[should_panic(expected = "INVALID opcode cannot be overridden")]
+    fn invalid_instruction_cannot_be_overridden() {
+        let mut tables = VersionTables::<BaseEvmTypes>::empty();
+        tables.set_instruction::<instr::stop<BaseEvmTypes>>(op::INVALID, 0);
     }
 }

--- a/scripts/dump_asm.py
+++ b/scripts/dump_asm.py
@@ -33,12 +33,15 @@ ROOT = Path(repo_root())
 OPCODE_RS = ROOT / "crates" / "evm2" / "src" / "interpreter" / "opcode.rs"
 DEFAULT_OUT = ROOT / "tmp" / "dump"
 DISPATCH_SYMBOLS = (
+    "evm2::interpreter::dispatch::table::packed::dispatch::<",
+    "evm2::interpreter::dispatch::table::single_return::dispatch::<",
+    "evm2::interpreter::dispatch::table::unpacked::dispatch::<",
     "evm2::interpreter::dispatch::packed::dispatch::<",
     "evm2::interpreter::dispatch::single_return::dispatch::<",
     "evm2::interpreter::dispatch::unpacked::dispatch::<",
     "evm2::interpreter::dispatch::tco::dispatch::<",
 )
-DISPATCH_OPCODE = re.compile(r",\s*(\d+)(?:,\s*(?:true|false))*?>")
+DISPATCH_OPCODE = re.compile(r",\s*(\d+)(?:,\s*(?:true|false))?\s*>")
 DISPATCH_OUTPUTS = (
     ("NoInspector", "op"),
     ("DynInspector", "op-inspector"),
@@ -199,19 +202,21 @@ def dispatch_output(text: str) -> str | None:
     for symbol, directory in DISPATCH_OUTPUTS:
         if symbol in text:
             return directory
+    if any(symbol in text for symbol in DISPATCH_SYMBOLS):
+        return "op"
     return None
 
 
 def dispatch_metadata(text: str) -> tuple[int, str] | None:
     if not any(symbol in text for symbol in DISPATCH_SYMBOLS):
         return None
-    match = DISPATCH_OPCODE.search(text)
-    if match is None:
+    matches = DISPATCH_OPCODE.findall(text)
+    if not matches:
         return None
     directory = dispatch_output(text)
     if directory is None:
         return None
-    return int(match.group(1)), directory
+    return int(matches[-1]), directory
 
 
 def is_run_inner_symbol(text: str) -> bool:
@@ -388,6 +393,16 @@ def dump_output(
     return path
 
 
+def dispatch_directories(dumps: dict[str, dict[int, dict[str, list[str]]]]) -> list[str]:
+    directories = {
+        directory
+        for blocks_by_opcode in dumps.values()
+        for blocks_by_directory in blocks_by_opcode.values()
+        for directory in blocks_by_directory
+    }
+    return [directory for _, directory in DISPATCH_OUTPUTS if directory in directories]
+
+
 def main() -> int:
     args = parse_args()
     logging.basicConfig(
@@ -450,7 +465,7 @@ def main() -> int:
         (mnemonic, opcode, output, directory)
         for mnemonic, opcode in selected
         for output in ("asm", "llvm")
-        for _, directory in DISPATCH_OUTPUTS
+        for directory in dispatch_directories(dumps)
     ]
     dispatch_files = 0
     for mnemonic, opcode, output, directory in tasks:


### PR DESCRIPTION
This removes the separate unknown-opcode dispatch path and makes unset opcodes execute the canonical INVALID instruction. The INVALID opcode is now immutable in version tables, and the halt name reflects the unified invalid-opcode behavior.
