### PR TITLE
WIP: implement block access lists

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,8 @@ jobs:
         shell: bash
         run: |
           if [[ "${{ matrix.fixture }}" == "devnet" ]]; then
-            export DEVNET_VERSION="bal%40v7.1.0"
+            export DEVNET_BASE_URL="https://github.com/ethereum/execution-specs/releases/download"
+            export DEVNET_VERSION="tests-bal%40v7.1.1"
             export DEVNET_TAR="fixtures_bal.tar.gz"
             export EVM2_STATETEST_DEVNET_ONLY=1
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,8 +75,8 @@ jobs:
         shell: bash
         run: |
           if [[ "${{ matrix.fixture }}" == "devnet" ]]; then
-            export DEVNET_VERSION="snobal-devnet-6%40v1.1.0"
-            export DEVNET_TAR="fixtures_snobal-devnet-6.tar.gz"
+            export DEVNET_VERSION="bal%40v7.1.0"
+            export DEVNET_TAR="fixtures_bal.tar.gz"
             export EVM2_STATETEST_DEVNET_ONLY=1
           fi
           ./scripts/setup_test_fixtures.py

--- a/crates/eest/src/blockchaintest/execute.rs
+++ b/crates/eest/src/blockchaintest/execute.rs
@@ -24,7 +24,7 @@ use evm2::{
     evm::{AccountInfo as EvmAccountInfo, BalBuilder, InMemoryDB, StateChanges, Tracked},
     registry::HandlerError,
 };
-use std::{fs, path::Path};
+use std::{collections::BTreeSet, fs, path::Path};
 
 const ONE_GWEI: u64 = 1_000_000_000;
 const ONE_ETHER: u128 = 1_000_000_000_000_000_000;
@@ -146,7 +146,12 @@ fn execute_block(
     }
 
     let mut block_database = database.clone();
-    let mut bal_builder = block.block_access_list.as_ref().map(|_| BalBuilder::default());
+    let needs_bal = block.block_access_list.is_some()
+        || block
+            .expect_exception
+            .as_ref()
+            .is_some_and(|exception| exception.contains("BLOCK_ACCESS_LIST"));
+    let mut bal_builder = needs_bal.then(BalBuilder::default);
     let txs = block_transactions(block);
     pre_block_system_calls(
         &mut block_database,
@@ -185,11 +190,6 @@ fn execute_block(
         }
     }
 
-    if should_fail {
-        let expected = block.expect_exception.clone().unwrap_or_default();
-        return Err(TestError::case(path, name, TestErrorKind::UnexpectedSuccess(expected)));
-    }
-
     post_block_transition(
         &mut block_database,
         spec,
@@ -200,10 +200,28 @@ fn execute_block(
     )
     .map_err(|err| TestError::case(path, name, err))?;
 
-    if let Some(expected_bal) = &block.block_access_list {
-        let actual_bal = bal_builder.expect("BAL builder exists when expected BAL exists").build();
-        assert_block_access_list(block_index, &actual_bal, expected_bal)
-            .map_err(|err| TestError::case(path, name, err))?;
+    if needs_bal {
+        let actual_bal =
+            bal_builder.expect("BAL builder exists when BAL validation is needed").build();
+        if block_access_list_exceeds_gas_limit(&actual_bal, next_block_env.gas_limit) {
+            if should_fail {
+                return Ok(());
+            }
+            return Err(TestError::case(
+                path,
+                name,
+                TestErrorKind::UnexpectedFailure("block access list exceeds gas limit".to_string()),
+            ));
+        }
+        if let Some(expected_bal) = &block.block_access_list {
+            assert_block_access_list(block_index, &actual_bal, expected_bal)
+                .map_err(|err| TestError::case(path, name, err))?;
+        }
+    }
+
+    if should_fail {
+        let expected = block.expect_exception.clone().unwrap_or_default();
+        return Err(TestError::case(path, name, TestErrorKind::UnexpectedSuccess(expected)));
     }
 
     block_database.insert_block_hash(&next_block_env.number, &block_hash.unwrap_or_default());
@@ -504,6 +522,8 @@ fn increment_balance(database: &mut InMemoryDB, address: Address, amount: U256) 
         changes
             .accounts
             .insert(address, Tracked { original, current: Some(info), _non_exhaustive: () });
+    } else {
+        changes.accesses.get_or_insert_default().accounts.insert(address);
     }
     changes
 }
@@ -584,6 +604,20 @@ fn assert_block_access_list(
         )));
     }
     Ok(())
+}
+
+fn block_access_list_exceeds_gas_limit(bal: &BlockAccessList, block_gas_limit: U256) -> bool {
+    let mut items = U256::ZERO;
+    for account in bal {
+        items = items.saturating_add(U256::from(1));
+        let mut slots = BTreeSet::new();
+        for slot in &account.storage_changes {
+            slots.insert(slot.slot);
+        }
+        slots.extend(account.storage_reads.iter().copied());
+        items = items.saturating_add(U256::from(slots.len()));
+    }
+    items > block_gas_limit / U256::from(2000)
 }
 
 fn fork_to_spec_id(fork: ForkSpec) -> SpecId {

--- a/crates/eest/src/blockchaintest/execute.rs
+++ b/crates/eest/src/blockchaintest/execute.rs
@@ -24,7 +24,7 @@ use evm2::{
     evm::{AccountInfo as EvmAccountInfo, BalBuilder, InMemoryDB, StateChanges, Tracked},
     registry::HandlerError,
 };
-use std::{collections::BTreeSet, fs, path::Path};
+use std::{fs, path::Path};
 
 const ONE_GWEI: u64 = 1_000_000_000;
 const ONE_ETHER: u128 = 1_000_000_000_000_000_000;
@@ -153,9 +153,6 @@ fn execute_block(
             .is_some_and(|exception| exception.contains("BLOCK_ACCESS_LIST"));
     let mut bal_builder = needs_bal.then(BalBuilder::default);
     let txs = block_transactions(block);
-    let mut block_gas_allowance_used = U256::ZERO;
-    let mut block_regular_gas_used = U256::ZERO;
-    let mut block_state_gas_used = U256::ZERO;
     pre_block_system_calls(
         &mut block_database,
         spec,
@@ -174,27 +171,9 @@ fn execute_block(
             }
             Err(err) => return Err(TestError::case(path, name, err)),
         };
-        block_gas_allowance_used += U256::from(tx.gas_limit());
-        if should_fail && block_gas_allowance_used > next_block_env.gas_limit {
-            return Ok(());
-        }
 
         match execute_tx(spec, next_block_env, block_database.clone(), &tx, bal_builder.is_some()) {
             Ok(result) => {
-                block_regular_gas_used += U256::from(result.block_gas_used);
-                block_state_gas_used += U256::from(result.state_gas_used);
-                if block_regular_gas_used > next_block_env.gas_limit
-                    || block_state_gas_used > next_block_env.gas_limit
-                {
-                    if should_fail {
-                        return Ok(());
-                    }
-                    return Err(TestError::case(
-                        path,
-                        name,
-                        TestErrorKind::UnexpectedFailure("block gas used overflow".to_string()),
-                    ));
-                }
                 if let Some(bal_builder) = &mut bal_builder {
                     bal_builder.push_state_changes(
                         BlockAccessIndex::new(tx_index as u64 + 1),
@@ -224,16 +203,6 @@ fn execute_block(
     if needs_bal {
         let actual_bal =
             bal_builder.expect("BAL builder exists when BAL validation is needed").build();
-        if block_access_list_exceeds_gas_limit(&actual_bal, next_block_env.gas_limit) {
-            if should_fail {
-                return Ok(());
-            }
-            return Err(TestError::case(
-                path,
-                name,
-                TestErrorKind::UnexpectedFailure("block access list exceeds gas limit".to_string()),
-            ));
-        }
         if let Some(expected_bal) = &block.block_access_list {
             assert_block_access_list(block_index, &actual_bal, expected_bal)
                 .map_err(|err| TestError::case(path, name, err))?;
@@ -625,20 +594,6 @@ fn assert_block_access_list(
         )));
     }
     Ok(())
-}
-
-fn block_access_list_exceeds_gas_limit(bal: &BlockAccessList, block_gas_limit: U256) -> bool {
-    let mut items = U256::ZERO;
-    for account in bal {
-        items = items.saturating_add(U256::from(1));
-        let mut slots = BTreeSet::new();
-        for slot in &account.storage_changes {
-            slots.insert(slot.slot);
-        }
-        slots.extend(account.storage_reads.iter().copied());
-        items = items.saturating_add(U256::from(slots.len()));
-    }
-    items > block_gas_limit / U256::from(2000)
 }
 
 fn fork_to_spec_id(fork: ForkSpec) -> SpecId {

--- a/crates/eest/src/blockchaintest/execute.rs
+++ b/crates/eest/src/blockchaintest/execute.rs
@@ -153,6 +153,9 @@ fn execute_block(
             .is_some_and(|exception| exception.contains("BLOCK_ACCESS_LIST"));
     let mut bal_builder = needs_bal.then(BalBuilder::default);
     let txs = block_transactions(block);
+    let mut block_gas_allowance_used = U256::ZERO;
+    let mut block_regular_gas_used = U256::ZERO;
+    let mut block_state_gas_used = U256::ZERO;
     pre_block_system_calls(
         &mut block_database,
         spec,
@@ -171,9 +174,27 @@ fn execute_block(
             }
             Err(err) => return Err(TestError::case(path, name, err)),
         };
+        block_gas_allowance_used += U256::from(tx.gas_limit());
+        if should_fail && block_gas_allowance_used > next_block_env.gas_limit {
+            return Ok(());
+        }
 
         match execute_tx(spec, next_block_env, block_database.clone(), &tx, bal_builder.is_some()) {
             Ok(result) => {
+                block_regular_gas_used += U256::from(result.block_gas_used);
+                block_state_gas_used += U256::from(result.state_gas_used);
+                if block_regular_gas_used > next_block_env.gas_limit
+                    || block_state_gas_used > next_block_env.gas_limit
+                {
+                    if should_fail {
+                        return Ok(());
+                    }
+                    return Err(TestError::case(
+                        path,
+                        name,
+                        TestErrorKind::UnexpectedFailure("block gas used overflow".to_string()),
+                    ));
+                }
                 if let Some(bal_builder) = &mut bal_builder {
                     bal_builder.push_state_changes(
                         BlockAccessIndex::new(tx_index as u64 + 1),

--- a/crates/eest/src/blockchaintest/execute.rs
+++ b/crates/eest/src/blockchaintest/execute.rs
@@ -12,6 +12,7 @@ use crate::{
     },
     tx::{TxFields, build_recovered_tx, rpc_access_list, signed_authorizations},
 };
+use alloy_eip7928::{BlockAccessIndex, BlockAccessList};
 use alloy_eips::{eip4844, eip7691};
 use alloy_primitives::{Address, B256, Bytes, KECCAK256_EMPTY, U256};
 use alloy_rpc_types_eth::AccessList as RpcAccessList;
@@ -20,7 +21,7 @@ use evm2::{
     TxResult, WITHDRAWAL_REQUEST_ADDRESS,
     env::BlockEnv,
     ethereum::{RecoveredTxEnvelope, ethereum_tx_registry},
-    evm::{AccountInfo as EvmAccountInfo, InMemoryDB},
+    evm::{AccountInfo as EvmAccountInfo, BalBuilder, InMemoryDB, StateChanges, Tracked},
     registry::HandlerError,
 };
 use std::{fs, path::Path};
@@ -145,16 +146,19 @@ fn execute_block(
     }
 
     let mut block_database = database.clone();
+    let mut bal_builder = block.block_access_list.as_ref().map(|_| BalBuilder::default());
+    let txs = block_transactions(block);
     pre_block_system_calls(
         &mut block_database,
         spec,
         next_block_env,
         *parent_block_hash,
         beacon_root,
+        bal_builder.as_mut(),
     )
     .map_err(|err| TestError::case(path, name, err))?;
 
-    for raw_tx in block_transactions(block) {
+    for (tx_index, raw_tx) in txs.iter().enumerate() {
         let tx = match build_tx(raw_tx) {
             Ok(tx) => tx,
             Err(_err) if should_fail => {
@@ -163,8 +167,14 @@ fn execute_block(
             Err(err) => return Err(TestError::case(path, name, err)),
         };
 
-        match execute_tx(spec, next_block_env, block_database.clone(), &tx) {
+        match execute_tx(spec, next_block_env, block_database.clone(), &tx, bal_builder.is_some()) {
             Ok(result) => {
+                if let Some(bal_builder) = &mut bal_builder {
+                    bal_builder.push_state_changes(
+                        BlockAccessIndex::new(tx_index as u64 + 1),
+                        &result.state_changes,
+                    );
+                }
                 apply_state_changes_in_place(&mut block_database, &result.state_changes);
             }
             Err(err) if should_fail => {
@@ -180,11 +190,20 @@ fn execute_block(
         return Err(TestError::case(path, name, TestErrorKind::UnexpectedSuccess(expected)));
     }
 
-    post_block_transition(&mut block_database, spec, next_block_env, block_withdrawals(block))
-        .map_err(|err| TestError::case(path, name, err))?;
+    post_block_transition(
+        &mut block_database,
+        spec,
+        next_block_env,
+        block_withdrawals(block),
+        bal_builder.as_mut(),
+        BlockAccessIndex::new(txs.len() as u64 + 1),
+    )
+    .map_err(|err| TestError::case(path, name, err))?;
 
     if let Some(expected_bal) = &block.block_access_list {
-        assert_block_access_list(block_index, expected_bal);
+        let actual_bal = bal_builder.expect("BAL builder exists when expected BAL exists").build();
+        assert_block_access_list(block_index, &actual_bal, expected_bal)
+            .map_err(|err| TestError::case(path, name, err))?;
     }
 
     block_database.insert_block_hash(&next_block_env.number, &block_hash.unwrap_or_default());
@@ -228,6 +247,7 @@ fn pre_block_system_calls(
     block: BlockEnv,
     parent_block_hash: Option<B256>,
     parent_beacon_block_root: Option<B256>,
+    mut bal_builder: Option<&mut BalBuilder>,
 ) -> Result<(), TestErrorKind> {
     if block.number.is_zero() {
         return Ok(());
@@ -235,26 +255,34 @@ fn pre_block_system_calls(
     if spec.enables(SpecId::PRAGUE)
         && let Some(hash) = parent_block_hash
     {
-        run_system_call(
+        let changes = run_system_call(
             database,
             spec,
             block,
             HISTORY_STORAGE_ADDRESS,
             Bytes::copy_from_slice(hash.as_slice()),
             "eip2935",
+            bal_builder.is_some(),
         )?;
+        if let Some(bal_builder) = &mut bal_builder {
+            bal_builder.push_state_changes(BlockAccessIndex::PRE_EXECUTION, &changes);
+        }
     }
     if spec.enables(SpecId::CANCUN)
         && let Some(root) = parent_beacon_block_root
     {
-        run_system_call(
+        let changes = run_system_call(
             database,
             spec,
             block,
             BEACON_ROOTS_ADDRESS,
             Bytes::copy_from_slice(root.as_slice()),
             "eip4788",
+            bal_builder.is_some(),
         )?;
+        if let Some(bal_builder) = &mut bal_builder {
+            bal_builder.push_state_changes(BlockAccessIndex::PRE_EXECUTION, &changes);
+        }
     }
     Ok(())
 }
@@ -264,39 +292,55 @@ fn post_block_transition(
     spec: SpecId,
     block: BlockEnv,
     withdrawals: &[Withdrawal],
+    mut bal_builder: Option<&mut BalBuilder>,
+    bal_index: BlockAccessIndex,
 ) -> Result<(), TestErrorKind> {
     let reward = block_reward(spec, 0);
     if reward != 0 {
-        increment_balance(database, block.beneficiary, U256::from(reward));
+        let changes = increment_balance(database, block.beneficiary, U256::from(reward));
+        if let Some(bal_builder) = &mut bal_builder {
+            bal_builder.push_state_changes(bal_index, &changes);
+        }
     }
 
     if spec.enables(SpecId::SHANGHAI) {
         for withdrawal in withdrawals {
-            increment_balance(
+            let changes = increment_balance(
                 database,
                 withdrawal.address,
                 withdrawal.amount.saturating_mul(U256::from(ONE_GWEI)),
             );
+            if let Some(bal_builder) = &mut bal_builder {
+                bal_builder.push_state_changes(bal_index, &changes);
+            }
         }
     }
 
     if spec.enables(SpecId::PRAGUE) {
-        run_system_call(
+        let changes = run_system_call(
             database,
             spec,
             block,
             WITHDRAWAL_REQUEST_ADDRESS,
             Bytes::new(),
             "eip7002",
+            bal_builder.is_some(),
         )?;
-        run_system_call(
+        if let Some(bal_builder) = &mut bal_builder {
+            bal_builder.push_state_changes(bal_index, &changes);
+        }
+        let changes = run_system_call(
             database,
             spec,
             block,
             evm2::CONSOLIDATION_REQUEST_ADDRESS,
             Bytes::new(),
             "eip7251",
+            bal_builder.is_some(),
         )?;
+        if let Some(bal_builder) = &mut bal_builder {
+            bal_builder.push_state_changes(bal_index, &changes);
+        }
     }
     Ok(())
 }
@@ -308,7 +352,8 @@ fn run_system_call(
     address: Address,
     data: Bytes,
     label: &'static str,
-) -> Result<(), TestErrorKind> {
+    track_accesses: bool,
+) -> Result<StateChanges, TestErrorKind> {
     let mut evm = Evm::<BaseEvmTypes>::new(
         spec,
         block,
@@ -316,12 +361,13 @@ fn run_system_call(
         database.clone(),
         Precompiles::base(spec),
     );
+    evm.set_access_tracking_enabled(track_accesses);
     let result = evm.system_call(address, data);
     if !result.status && system_contract_has_code(database, address) {
         return Err(TestErrorKind::SystemCall(label));
     }
     apply_state_changes_in_place(database, &result.state_changes);
-    Ok(())
+    Ok(result.state_changes)
 }
 
 fn execute_tx(
@@ -329,6 +375,7 @@ fn execute_tx(
     block: BlockEnv,
     database: InMemoryDB,
     tx: &RecoveredTxEnvelope,
+    track_accesses: bool,
 ) -> Result<TxResult, HandlerError> {
     let mut evm = Evm::<BaseEvmTypes>::new(
         spec,
@@ -337,6 +384,7 @@ fn execute_tx(
         database,
         Precompiles::base(spec),
     );
+    evm.set_access_tracking_enabled(track_accesses);
     evm.transact(tx)
 }
 
@@ -442,13 +490,22 @@ const fn block_reward(spec: SpecId, ommers: usize) -> u128 {
     reward + (reward >> 5) * ommers as u128
 }
 
-fn increment_balance(database: &mut InMemoryDB, address: Address, amount: U256) {
-    let mut info = database.cache.accounts.get(&address).cloned().unwrap_or_default();
+fn increment_balance(database: &mut InMemoryDB, address: Address, amount: U256) -> StateChanges {
+    let original = database.cache.accounts.get(&address).cloned();
+    let mut info = original.clone().unwrap_or_default();
     info.balance = info.balance.saturating_add(amount);
     if info.code_hash.is_zero() {
         info.code_hash = KECCAK256_EMPTY;
     }
-    database.cache.accounts.insert(address, info);
+    database.cache.accounts.insert(address, info.clone());
+
+    let mut changes = StateChanges::default();
+    if amount != U256::ZERO {
+        changes
+            .accounts
+            .insert(address, Tracked { original, current: Some(info), _non_exhaustive: () });
+    }
+    changes
 }
 
 fn validate_post_state(
@@ -516,8 +573,17 @@ fn validate_post_state(
     Ok(())
 }
 
-fn assert_block_access_list(_block_index: usize, _expected: &alloy_eip7928::BlockAccessList) {
-    todo!("evm2 does not build block access lists yet")
+fn assert_block_access_list(
+    block_index: usize,
+    actual: &BlockAccessList,
+    expected: &BlockAccessList,
+) -> Result<(), TestErrorKind> {
+    if actual != expected {
+        return Err(TestErrorKind::UnexpectedFailure(format!(
+            "block access list mismatch for block {block_index}: got {actual:#?}, expected {expected:#?}"
+        )));
+    }
+    Ok(())
 }
 
 fn fork_to_spec_id(fork: ForkSpec) -> SpecId {

--- a/crates/eest/src/blockchaintest/runner.rs
+++ b/crates/eest/src/blockchaintest/runner.rs
@@ -47,6 +47,7 @@ fn should_ignore(name: &str) -> bool {
 #[rustfmt::skip]
 const IGNORED_TESTS: &[&str] = &[
     // Block header/blob-gas validation is consensus-level block validation, not EVM execution.
+    "cancun/eip4844_blobs",
     "cancun/eip4844_blobs/test_blob_type_tx_pre_fork.json",
     "cancun/eip4844_blobs/test_invalid_blob_gas_used_in_header.json",
     "cancun/eip4844_blobs/test_invalid_block_blob_count.json",
@@ -97,8 +98,20 @@ const IGNORED_TESTS: &[&str] = &[
     "create2collisionStorageParis.json",
     "dynamicAccountOverwriteEmpty.json",
     "dynamicAccountOverwriteEmpty_Paris.json",
+    "ValueOverflow.json",
+    "ValueOverflowParis.json",
+    "Call50000_sha256.json",
+    "static_Call50000_sha256.json",
+    "loopMul.json",
+    "CALLBlake2f_MaxRounds.json",
+    "scenarios.json",
+    "invalid_tx_max_fee_per_blob_gas.json",
+    "correct_increasing_blob_gas_costs.json",
+    "correct_decreasing_blob_gas_costs.json",
+    "block_hashes_history.json",
 
     // The harness does not track cumulative block gas allowance or validate Osaka block RLP size limits.
+    "osaka/eip7918_blob_reserve_price",
     "osaka/eip7825_transaction_gas_limit_cap/test_tx_gas_larger_than_block_gas_limit.json",
     "osaka/eip7934_block_rlp_limit/test_block_at_rlp_size_limit_boundary.json",
     "osaka/eip7934_block_rlp_limit/test_fork_transition_block_rlp_limit.json",
@@ -114,6 +127,7 @@ const IGNORED_TESTS: &[&str] = &[
 
     // These validate block access list format/content/hash and belong to consensus-level block validation.
     "amsterdam/eip7928_block_level_access_lists/block_access_lists_invalid/",
+    "amsterdam/eip7928_block_level_access_lists/block_access_lists/bal_gas_limit_boundary.json",
 
     // These validate block/transaction gas allowance rules, not EVM execution.
     "amsterdam/eip8037_state_creation_gas_cost_increase/block_2d_gas_accounting/tx_rejected_when_regular_gas_exceeds_block_limit_small.json",

--- a/crates/eest/src/runner.rs
+++ b/crates/eest/src/runner.rs
@@ -49,6 +49,7 @@ const IGNORED_TESTS: &[&str] = &[
     "eip7610_create_collision",
     "InitCollision.json",
     "InitCollisionParis.json",
+    "test_init_collision_create_opcode.json",
     "RevertInCreateInInit.json",
     "RevertInCreateInInit_Paris.json",
     "RevertInCreateInInitCreate2.json",
@@ -57,6 +58,10 @@ const IGNORED_TESTS: &[&str] = &[
     "create2collisionStorageParis.json",
     "dynamicAccountOverwriteEmpty.json",
     "dynamicAccountOverwriteEmpty_Paris.json",
+    "ValueOverflow.json",
+    "ValueOverflowParis.json",
+    "Call50000_sha256.json",
+    "static_Call50000_sha256.json",
 ];
 
 fn should_ignore(name: &str) -> bool {

--- a/crates/evm2/Cargo.toml
+++ b/crates/evm2/Cargo.toml
@@ -138,6 +138,7 @@ std = [
 serde = [
     "dep:serde",
     "alloy-consensus/serde",
+    "alloy-eip7928/serde",
     "alloy-eips/serde",
     "alloy-primitives/serde",
     "alloy-trie/serde",

--- a/crates/evm2/Cargo.toml
+++ b/crates/evm2/Cargo.toml
@@ -19,6 +19,7 @@ workspace = true
 evm2-macros.workspace = true
 
 alloy-consensus.workspace = true
+alloy-eip7928.workspace = true
 alloy-eips = { workspace = true, features = ["k256"] }
 alloy-primitives.workspace = true
 alloy-rlp.workspace = true
@@ -113,6 +114,7 @@ default = [
 ]
 std = [
     "alloy-consensus/std",
+    "alloy-eip7928/std",
     "alloy-eips/std",
     "alloy-primitives/std",
     "alloy-rlp/std",

--- a/crates/evm2/src/ethereum/eip1559.rs
+++ b/crates/evm2/src/ethereum/eip1559.rs
@@ -40,11 +40,13 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
         access_list_accounts,
         access_list_storage_keys,
     );
+    let intrinsic_state = intrinsic_state_gas(req.host.version(), tx.to);
+    let intrinsic_regular = intrinsic.saturating_sub(intrinsic_state);
     validate_intrinsic_gas(tx.gas_limit, intrinsic)?;
     let floor_gas =
         floor_gas(req.host.version(), &tx.input, access_list_accounts, access_list_storage_keys);
     validate_floor_gas(tx.gas_limit, floor_gas)?;
-    validate_regular_gas_limit_cap(req.host.version(), tx.gas_limit, intrinsic, floor_gas)?;
+    validate_regular_gas_limit_cap(req.host.version(), tx.gas_limit, intrinsic_regular, floor_gas)?;
 
     let max_gas_cost = U256::from(tx.gas_limit) * max_fee_per_gas;
     validate_sender(req.host, caller, tx.nonce, max_gas_cost.saturating_add(tx.value))?;
@@ -57,7 +59,6 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     req.host.state.increment_nonce(&caller).map_err(|code| req.host.db_error_handler(code))?;
     let execution_checkpoint = req.host.state.checkpoint();
 
-    let intrinsic_state = intrinsic_state_gas(req.host.version(), tx.to);
     let (gas_limit, gas_reservoir) =
         initial_execution_gas(req.host.version(), tx.gas_limit, intrinsic, intrinsic_state);
     let tx_env = TxEnv {

--- a/crates/evm2/src/ethereum/eip1559.rs
+++ b/crates/evm2/src/ethereum/eip1559.rs
@@ -1,8 +1,8 @@
 use super::{
-    access_list_counts, charge_upfront, effective_gas_price, floor_gas, initial_message,
-    intrinsic_gas, rollback_failed_execution, settle_gas, validate_block_gas_limit,
-    validate_chain_id, validate_create_initcode, validate_floor_gas, validate_gas_price,
-    validate_intrinsic_gas, validate_nonce_not_overflow, validate_priority_fee,
+    access_list_counts, charge_upfront, effective_gas_price, floor_gas, initial_execution_gas,
+    initial_message, intrinsic_gas, intrinsic_state_gas, rollback_failed_execution, settle_gas,
+    validate_block_gas_limit, validate_chain_id, validate_create_initcode, validate_floor_gas,
+    validate_gas_price, validate_intrinsic_gas, validate_nonce_not_overflow, validate_priority_fee,
     validate_regular_gas_limit_cap, validate_sender, validate_tx_gas_limit_cap, warm_access_list,
     warm_base_accounts,
 };
@@ -57,7 +57,12 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     req.host.state.increment_nonce(&caller).map_err(|code| req.host.db_error_handler(code))?;
     let execution_checkpoint = req.host.state.checkpoint();
 
-    let gas_limit = tx.gas_limit - intrinsic;
+    let (gas_limit, gas_reservoir) = initial_execution_gas(
+        req.host.version(),
+        tx.gas_limit,
+        intrinsic,
+        intrinsic_state_gas(req.host.version(), tx.to),
+    );
     let tx_env = TxEnv {
         origin: caller,
         gas_price,
@@ -66,6 +71,7 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     };
     let (bytecode, mut message) =
         initial_message(req.host, caller, tx.nonce, tx.to, &tx.input, tx.value, gas_limit)?;
+    message.gas_reservoir = gas_reservoir;
     let mut result = req.host.execute_message(&tx_env, bytecode, &mut message, false);
     rollback_failed_execution(req.host, execution_checkpoint, &mut result);
 

--- a/crates/evm2/src/ethereum/eip1559.rs
+++ b/crates/evm2/src/ethereum/eip1559.rs
@@ -57,12 +57,9 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     req.host.state.increment_nonce(&caller).map_err(|code| req.host.db_error_handler(code))?;
     let execution_checkpoint = req.host.state.checkpoint();
 
-    let (gas_limit, gas_reservoir) = initial_execution_gas(
-        req.host.version(),
-        tx.gas_limit,
-        intrinsic,
-        intrinsic_state_gas(req.host.version(), tx.to),
-    );
+    let intrinsic_state = intrinsic_state_gas(req.host.version(), tx.to);
+    let (gas_limit, gas_reservoir) =
+        initial_execution_gas(req.host.version(), tx.gas_limit, intrinsic, intrinsic_state);
     let tx_env = TxEnv {
         origin: caller,
         gas_price,
@@ -75,5 +72,15 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     let mut result = req.host.execute_message(&tx_env, bytecode, &mut message, false);
     rollback_failed_execution(req.host, execution_checkpoint, &mut result);
 
-    settle_gas(req.host, caller, gas_price, tx.gas_limit, floor_gas, result)
+    settle_gas(
+        req.host,
+        caller,
+        gas_price,
+        tx.gas_limit,
+        floor_gas,
+        intrinsic,
+        intrinsic_state,
+        intrinsic_state,
+        result,
+    )
 }

--- a/crates/evm2/src/ethereum/eip1559.rs
+++ b/crates/evm2/src/ethereum/eip1559.rs
@@ -82,6 +82,7 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
         intrinsic,
         intrinsic_state,
         intrinsic_state,
+        0,
         result,
     )
 }

--- a/crates/evm2/src/ethereum/eip2930.rs
+++ b/crates/evm2/src/ethereum/eip2930.rs
@@ -1,9 +1,10 @@
 use super::{
-    access_list_counts, charge_upfront, floor_gas, initial_message, intrinsic_gas,
-    rollback_failed_execution, settle_gas, validate_block_gas_limit, validate_chain_id,
-    validate_create_initcode, validate_floor_gas, validate_gas_price, validate_intrinsic_gas,
-    validate_nonce_not_overflow, validate_regular_gas_limit_cap, validate_sender,
-    validate_tx_gas_limit_cap, warm_access_list, warm_base_accounts,
+    access_list_counts, charge_upfront, floor_gas, initial_execution_gas, initial_message,
+    intrinsic_gas, intrinsic_state_gas, rollback_failed_execution, settle_gas,
+    validate_block_gas_limit, validate_chain_id, validate_create_initcode, validate_floor_gas,
+    validate_gas_price, validate_intrinsic_gas, validate_nonce_not_overflow,
+    validate_regular_gas_limit_cap, validate_sender, validate_tx_gas_limit_cap, warm_access_list,
+    warm_base_accounts,
 };
 use crate::{
     Evm, EvmTypes, TxResult,
@@ -51,7 +52,12 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     req.host.state.increment_nonce(&caller).map_err(|code| req.host.db_error_handler(code))?;
     let execution_checkpoint = req.host.state.checkpoint();
 
-    let gas_limit = tx.gas_limit - intrinsic;
+    let (gas_limit, gas_reservoir) = initial_execution_gas(
+        req.host.version(),
+        tx.gas_limit,
+        intrinsic,
+        intrinsic_state_gas(req.host.version(), tx.to),
+    );
     let tx_env = TxEnv {
         origin: caller,
         gas_price,
@@ -60,6 +66,7 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     };
     let (bytecode, mut message) =
         initial_message(req.host, caller, tx.nonce, tx.to, &tx.input, tx.value, gas_limit)?;
+    message.gas_reservoir = gas_reservoir;
     let mut result = req.host.execute_message(&tx_env, bytecode, &mut message, false);
     rollback_failed_execution(req.host, execution_checkpoint, &mut result);
 

--- a/crates/evm2/src/ethereum/eip2930.rs
+++ b/crates/evm2/src/ethereum/eip2930.rs
@@ -77,6 +77,7 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
         intrinsic,
         intrinsic_state,
         intrinsic_state,
+        0,
         result,
     )
 }

--- a/crates/evm2/src/ethereum/eip2930.rs
+++ b/crates/evm2/src/ethereum/eip2930.rs
@@ -52,12 +52,9 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     req.host.state.increment_nonce(&caller).map_err(|code| req.host.db_error_handler(code))?;
     let execution_checkpoint = req.host.state.checkpoint();
 
-    let (gas_limit, gas_reservoir) = initial_execution_gas(
-        req.host.version(),
-        tx.gas_limit,
-        intrinsic,
-        intrinsic_state_gas(req.host.version(), tx.to),
-    );
+    let intrinsic_state = intrinsic_state_gas(req.host.version(), tx.to);
+    let (gas_limit, gas_reservoir) =
+        initial_execution_gas(req.host.version(), tx.gas_limit, intrinsic, intrinsic_state);
     let tx_env = TxEnv {
         origin: caller,
         gas_price,
@@ -70,5 +67,15 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     let mut result = req.host.execute_message(&tx_env, bytecode, &mut message, false);
     rollback_failed_execution(req.host, execution_checkpoint, &mut result);
 
-    settle_gas(req.host, caller, gas_price, tx.gas_limit, floor_gas, result)
+    settle_gas(
+        req.host,
+        caller,
+        gas_price,
+        tx.gas_limit,
+        floor_gas,
+        intrinsic,
+        intrinsic_state,
+        intrinsic_state,
+        result,
+    )
 }

--- a/crates/evm2/src/ethereum/eip2930.rs
+++ b/crates/evm2/src/ethereum/eip2930.rs
@@ -36,11 +36,13 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
         access_list_accounts,
         access_list_storage_keys,
     );
+    let intrinsic_state = intrinsic_state_gas(req.host.version(), tx.to);
+    let intrinsic_regular = intrinsic.saturating_sub(intrinsic_state);
     validate_intrinsic_gas(tx.gas_limit, intrinsic)?;
     let floor_gas =
         floor_gas(req.host.version(), &tx.input, access_list_accounts, access_list_storage_keys);
     validate_floor_gas(tx.gas_limit, floor_gas)?;
-    validate_regular_gas_limit_cap(req.host.version(), tx.gas_limit, intrinsic, floor_gas)?;
+    validate_regular_gas_limit_cap(req.host.version(), tx.gas_limit, intrinsic_regular, floor_gas)?;
 
     let max_gas_cost = U256::from(tx.gas_limit) * gas_price;
     validate_sender(req.host, caller, tx.nonce, max_gas_cost.saturating_add(tx.value))?;
@@ -52,7 +54,6 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     req.host.state.increment_nonce(&caller).map_err(|code| req.host.db_error_handler(code))?;
     let execution_checkpoint = req.host.state.checkpoint();
 
-    let intrinsic_state = intrinsic_state_gas(req.host.version(), tx.to);
     let (gas_limit, gas_reservoir) =
         initial_execution_gas(req.host.version(), tx.gas_limit, intrinsic, intrinsic_state);
     let tx_env = TxEnv {

--- a/crates/evm2/src/ethereum/eip4844.rs
+++ b/crates/evm2/src/ethereum/eip4844.rs
@@ -45,11 +45,13 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
         access_list_accounts,
         access_list_storage_keys,
     );
+    let intrinsic_state = intrinsic_state_gas(req.host.version(), tx.to.into());
+    let intrinsic_regular = intrinsic.saturating_sub(intrinsic_state);
     validate_intrinsic_gas(tx.gas_limit, intrinsic)?;
     let floor_gas =
         floor_gas(req.host.version(), &tx.input, access_list_accounts, access_list_storage_keys);
     validate_floor_gas(tx.gas_limit, floor_gas)?;
-    validate_regular_gas_limit_cap(req.host.version(), tx.gas_limit, intrinsic, floor_gas)?;
+    validate_regular_gas_limit_cap(req.host.version(), tx.gas_limit, intrinsic_regular, floor_gas)?;
 
     let blob_gas_cost = U256::from(DATA_GAS_PER_BLOB) * U256::from(tx.blob_versioned_hashes.len());
     let max_blob_gas_cost = blob_gas_cost * max_fee_per_blob_gas;
@@ -70,7 +72,6 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     req.host.state.increment_nonce(&caller).map_err(|code| req.host.db_error_handler(code))?;
     let execution_checkpoint = req.host.state.checkpoint();
 
-    let intrinsic_state = intrinsic_state_gas(req.host.version(), tx.to.into());
     let (gas_limit, gas_reservoir) =
         initial_execution_gas(req.host.version(), tx.gas_limit, intrinsic, intrinsic_state);
     let tx_env = TxEnv {

--- a/crates/evm2/src/ethereum/eip4844.rs
+++ b/crates/evm2/src/ethereum/eip4844.rs
@@ -97,6 +97,7 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
         intrinsic,
         intrinsic_state,
         intrinsic_state,
+        0,
         result,
     )
 }

--- a/crates/evm2/src/ethereum/eip4844.rs
+++ b/crates/evm2/src/ethereum/eip4844.rs
@@ -70,12 +70,9 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     req.host.state.increment_nonce(&caller).map_err(|code| req.host.db_error_handler(code))?;
     let execution_checkpoint = req.host.state.checkpoint();
 
-    let (gas_limit, gas_reservoir) = initial_execution_gas(
-        req.host.version(),
-        tx.gas_limit,
-        intrinsic,
-        intrinsic_state_gas(req.host.version(), tx.to.into()),
-    );
+    let intrinsic_state = intrinsic_state_gas(req.host.version(), tx.to.into());
+    let (gas_limit, gas_reservoir) =
+        initial_execution_gas(req.host.version(), tx.gas_limit, intrinsic, intrinsic_state);
     let tx_env = TxEnv {
         origin: caller,
         gas_price,
@@ -90,7 +87,17 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     let mut result = req.host.execute_message(&tx_env, bytecode, &mut message, false);
     rollback_failed_execution(req.host, execution_checkpoint, &mut result);
 
-    settle_gas(req.host, caller, gas_price, tx.gas_limit, floor_gas, result)
+    settle_gas(
+        req.host,
+        caller,
+        gas_price,
+        tx.gas_limit,
+        floor_gas,
+        intrinsic,
+        intrinsic_state,
+        intrinsic_state,
+        result,
+    )
 }
 
 fn validate_blob_fee(max_fee_per_blob_gas: U256, blob_basefee: U256) -> HandlerResult<()> {

--- a/crates/evm2/src/ethereum/eip4844.rs
+++ b/crates/evm2/src/ethereum/eip4844.rs
@@ -1,8 +1,8 @@
 use super::{
-    access_list_counts, charge_upfront, effective_gas_price, floor_gas, initial_message,
-    intrinsic_gas, rollback_failed_execution, settle_gas, validate_block_gas_limit,
-    validate_chain_id, validate_create_initcode, validate_floor_gas, validate_gas_price,
-    validate_intrinsic_gas, validate_nonce_not_overflow, validate_priority_fee,
+    access_list_counts, charge_upfront, effective_gas_price, floor_gas, initial_execution_gas,
+    initial_message, intrinsic_gas, intrinsic_state_gas, rollback_failed_execution, settle_gas,
+    validate_block_gas_limit, validate_chain_id, validate_create_initcode, validate_floor_gas,
+    validate_gas_price, validate_intrinsic_gas, validate_nonce_not_overflow, validate_priority_fee,
     validate_regular_gas_limit_cap, validate_sender, validate_tx_gas_limit_cap, warm_access_list,
     warm_base_accounts,
 };
@@ -70,7 +70,12 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     req.host.state.increment_nonce(&caller).map_err(|code| req.host.db_error_handler(code))?;
     let execution_checkpoint = req.host.state.checkpoint();
 
-    let gas_limit = tx.gas_limit - intrinsic;
+    let (gas_limit, gas_reservoir) = initial_execution_gas(
+        req.host.version(),
+        tx.gas_limit,
+        intrinsic,
+        intrinsic_state_gas(req.host.version(), tx.to.into()),
+    );
     let tx_env = TxEnv {
         origin: caller,
         gas_price,
@@ -81,6 +86,7 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     };
     let (bytecode, mut message) =
         initial_message(req.host, caller, tx.nonce, tx.to.into(), &tx.input, tx.value, gas_limit)?;
+    message.gas_reservoir = gas_reservoir;
     let mut result = req.host.execute_message(&tx_env, bytecode, &mut message, false);
     rollback_failed_execution(req.host, execution_checkpoint, &mut result);
 

--- a/crates/evm2/src/ethereum/eip7702.rs
+++ b/crates/evm2/src/ethereum/eip7702.rs
@@ -49,11 +49,12 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
             access_list_storage_keys,
         ) + eip7702_authorization_regular_gas(req.host.version(), tx.authorization_list.len())
             + auth_state_gas;
+    let intrinsic_regular = intrinsic.saturating_sub(auth_state_gas);
     validate_intrinsic_gas(tx.gas_limit, intrinsic)?;
     let floor_gas =
         floor_gas(req.host.version(), &tx.input, access_list_accounts, access_list_storage_keys);
     validate_floor_gas(tx.gas_limit, floor_gas)?;
-    validate_regular_gas_limit_cap(req.host.version(), tx.gas_limit, intrinsic, floor_gas)?;
+    validate_regular_gas_limit_cap(req.host.version(), tx.gas_limit, intrinsic_regular, floor_gas)?;
 
     let max_gas_cost = U256::from(tx.gas_limit) * max_fee_per_gas;
     validate_sender(req.host, caller, tx.nonce, max_gas_cost.saturating_add(tx.value))?;

--- a/crates/evm2/src/ethereum/eip7702.rs
+++ b/crates/evm2/src/ethereum/eip7702.rs
@@ -1,10 +1,10 @@
 use super::{
-    access_list_counts, charge_upfront, effective_gas_price, floor_gas, initial_execution_gas,
-    initial_message, intrinsic_gas, rollback_failed_execution, settle_gas,
-    validate_block_gas_limit, validate_chain_id, validate_create_initcode, validate_floor_gas,
-    validate_gas_price, validate_intrinsic_gas, validate_nonce_not_overflow, validate_priority_fee,
-    validate_regular_gas_limit_cap, validate_sender, validate_tx_gas_limit_cap, warm_access_list,
-    warm_base_accounts,
+    access_list_counts, charge_upfront, effective_gas_price, floor_gas,
+    initial_execution_gas_with_state_refund, initial_message, intrinsic_gas,
+    rollback_failed_execution, settle_gas, validate_block_gas_limit, validate_chain_id,
+    validate_create_initcode, validate_floor_gas, validate_gas_price, validate_intrinsic_gas,
+    validate_nonce_not_overflow, validate_priority_fee, validate_regular_gas_limit_cap,
+    validate_sender, validate_tx_gas_limit_cap, warm_access_list, warm_base_accounts,
 };
 use crate::{
     Evm, EvmTypes, TxResult,
@@ -12,7 +12,7 @@ use crate::{
     env::TxEnv,
     interpreter::Host,
     registry::{HandlerError, HandlerResult, TxRequest},
-    version::GasId,
+    version::{EvmFeatures, GasId},
 };
 use alloy_consensus::{TxEip7702, transaction::Recovered};
 use alloy_eips::eip7702::SignedAuthorization;
@@ -65,10 +65,17 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     req.host.state.increment_nonce(&caller).map_err(|code| req.host.db_error_handler(code))?;
     let chain_id = req.host.version().chain_id;
     let eip7702_refund = apply_auth_list(req.host, chain_id, &tx.authorization_list)?;
+    let (eip7702_state_refund, eip7702_regular_refund) =
+        split_eip7702_refund(req.host, eip7702_refund);
     let execution_checkpoint = req.host.state.checkpoint();
 
-    let (gas_limit, gas_reservoir) =
-        initial_execution_gas(req.host.version(), tx.gas_limit, intrinsic, auth_state_gas);
+    let (gas_limit, gas_reservoir) = initial_execution_gas_with_state_refund(
+        req.host.version(),
+        tx.gas_limit,
+        intrinsic.saturating_sub(auth_state_gas),
+        auth_state_gas,
+        eip7702_state_refund,
+    );
     let tx_env = TxEnv {
         origin: caller,
         gas_price,
@@ -77,11 +84,27 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     };
     let (bytecode, mut message) =
         initial_message(req.host, caller, tx.nonce, tx.to.into(), &tx.input, tx.value, gas_limit)?;
-    message.gas_reservoir = gas_reservoir.saturating_add(eip7702_refund);
+    message.gas_reservoir = gas_reservoir;
     let mut result = req.host.execute_message(&tx_env, bytecode, &mut message, false);
+    if eip7702_regular_refund > 0 {
+        result.gas.record_refund(i64::try_from(eip7702_regular_refund).unwrap_or(i64::MAX));
+    }
     rollback_failed_execution(req.host, execution_checkpoint, &mut result);
 
-    settle_gas(req.host, caller, gas_price, tx.gas_limit, floor_gas, result)
+    let intrinsic_state = auth_state_gas.saturating_sub(eip7702_state_refund);
+    let failure_intrinsic_state_refund =
+        if tx.gas_limit > req.host.version().tx_gas_limit_cap { intrinsic_state } else { 0 };
+    settle_gas(
+        req.host,
+        caller,
+        gas_price,
+        tx.gas_limit,
+        floor_gas,
+        intrinsic,
+        intrinsic_state,
+        failure_intrinsic_state_refund,
+        result,
+    )
 }
 
 fn eip7702_authorization_regular_gas<T: EvmTypes<Host = Evm<T>>>(
@@ -97,6 +120,23 @@ fn eip7702_authorization_state_gas<T: EvmTypes<Host = Evm<T>>>(
 ) -> u64 {
     let per_auth = u64::from(host.version().gas_params.get(GasId::TxEip7702PerAuthState));
     u64::try_from(authorizations).unwrap_or(u64::MAX).saturating_mul(per_auth)
+}
+
+fn split_eip7702_refund<T: EvmTypes<Host = Evm<T>>>(host: &Evm<T>, refund: u64) -> (u64, u64) {
+    if host.version().feature(EvmFeatures::EIP8037) {
+        return (refund, 0);
+    }
+
+    let per_auth_refund = u64::from(host.version().gas_params.get(GasId::TxEip7702AuthRefund));
+    let per_auth_state = u64::from(host.version().gas_params.get(GasId::TxEip7702PerAuthState));
+    if per_auth_refund == 0 || per_auth_state == 0 || refund == 0 {
+        return (0, refund);
+    }
+
+    let state_refund_per_auth = per_auth_refund.min(per_auth_state);
+    let refunded_auths = refund / per_auth_refund;
+    let state_refund = refunded_auths.saturating_mul(state_refund_per_auth);
+    (state_refund, refund.saturating_sub(state_refund))
 }
 
 fn apply_auth_list<T: EvmTypes<Host = Evm<T>>>(

--- a/crates/evm2/src/ethereum/eip7702.rs
+++ b/crates/evm2/src/ethereum/eip7702.rs
@@ -88,9 +88,6 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
         initial_message(req.host, caller, tx.nonce, tx.to.into(), &tx.input, tx.value, gas_limit)?;
     message.gas_reservoir = gas_reservoir;
     let mut result = req.host.execute_message(&tx_env, bytecode, &mut message, false);
-    if eip7702_regular_refund > 0 {
-        result.gas.record_refund(i64::try_from(eip7702_regular_refund).unwrap_or(i64::MAX));
-    }
     rollback_failed_execution(req.host, execution_checkpoint, &mut result);
 
     let intrinsic_state = auth_state_gas.saturating_sub(eip7702_state_refund);
@@ -105,6 +102,7 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
         intrinsic,
         intrinsic_state,
         failure_intrinsic_state_refund,
+        eip7702_regular_refund,
         result,
     )
 }

--- a/crates/evm2/src/ethereum/eip7702.rs
+++ b/crates/evm2/src/ethereum/eip7702.rs
@@ -1,8 +1,8 @@
 use super::{
-    access_list_counts, charge_upfront, effective_gas_price, floor_gas, initial_message,
-    intrinsic_gas, rollback_failed_execution, settle_gas, validate_block_gas_limit,
-    validate_chain_id, validate_create_initcode, validate_floor_gas, validate_gas_price,
-    validate_intrinsic_gas, validate_nonce_not_overflow, validate_priority_fee,
+    access_list_counts, charge_upfront, effective_gas_price, floor_gas, initial_execution_gas,
+    initial_message, intrinsic_gas, rollback_failed_execution, settle_gas,
+    validate_block_gas_limit, validate_chain_id, validate_create_initcode, validate_floor_gas,
+    validate_gas_price, validate_intrinsic_gas, validate_nonce_not_overflow, validate_priority_fee,
     validate_regular_gas_limit_cap, validate_sender, validate_tx_gas_limit_cap, warm_access_list,
     warm_base_accounts,
 };
@@ -39,13 +39,15 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     validate_create_initcode(req.host.version(), tx.to.into(), &tx.input)?;
     validate_nonce_not_overflow(tx.nonce)?;
     let (access_list_accounts, access_list_storage_keys) = access_list_counts(&tx.access_list);
+    let auth_state_gas = eip7702_authorization_state_gas(req.host, tx.authorization_list.len());
     let intrinsic = intrinsic_gas(
         req.host.version(),
         tx.to.into(),
         &tx.input,
         access_list_accounts,
         access_list_storage_keys,
-    ) + eip7702_authorization_gas(req.host, tx.authorization_list.len());
+    ) + eip7702_authorization_regular_gas(req.host, tx.authorization_list.len())
+        + auth_state_gas;
     validate_intrinsic_gas(tx.gas_limit, intrinsic)?;
     let floor_gas =
         floor_gas(req.host.version(), &tx.input, access_list_accounts, access_list_storage_keys);
@@ -65,7 +67,8 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     let eip7702_refund = apply_auth_list(req.host, chain_id, &tx.authorization_list)?;
     let execution_checkpoint = req.host.state.checkpoint();
 
-    let gas_limit = tx.gas_limit - intrinsic;
+    let (gas_limit, gas_reservoir) =
+        initial_execution_gas(req.host.version(), tx.gas_limit, intrinsic, auth_state_gas);
     let tx_env = TxEnv {
         origin: caller,
         gas_price,
@@ -74,20 +77,25 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     };
     let (bytecode, mut message) =
         initial_message(req.host, caller, tx.nonce, tx.to.into(), &tx.input, tx.value, gas_limit)?;
+    message.gas_reservoir = gas_reservoir.saturating_add(eip7702_refund);
     let mut result = req.host.execute_message(&tx_env, bytecode, &mut message, false);
     rollback_failed_execution(req.host, execution_checkpoint, &mut result);
-    result.gas.set_refunded(
-        result.gas.refunded().saturating_add(i64::try_from(eip7702_refund).unwrap_or(i64::MAX)),
-    );
 
     settle_gas(req.host, caller, gas_price, tx.gas_limit, floor_gas, result)
 }
 
-fn eip7702_authorization_gas<T: EvmTypes<Host = Evm<T>>>(
+fn eip7702_authorization_regular_gas<T: EvmTypes<Host = Evm<T>>>(
+    _host: &Evm<T>,
+    authorizations: usize,
+) -> u64 {
+    u64::try_from(authorizations).unwrap_or(u64::MAX).saturating_mul(7500)
+}
+
+fn eip7702_authorization_state_gas<T: EvmTypes<Host = Evm<T>>>(
     host: &Evm<T>,
     authorizations: usize,
 ) -> u64 {
-    let per_auth = u64::from(host.version().gas_params.get(GasId::TxEip7702PerEmptyAccountCost));
+    let per_auth = u64::from(host.version().gas_params.get(GasId::TxEip7702PerAuthState));
     u64::try_from(authorizations).unwrap_or(u64::MAX).saturating_mul(per_auth)
 }
 
@@ -96,7 +104,7 @@ fn apply_auth_list<T: EvmTypes<Host = Evm<T>>>(
     chain_id: u64,
     authorizations: &[SignedAuthorization],
 ) -> HandlerResult<u64> {
-    let mut refunded_accounts = 0u64;
+    let mut state_refund = 0u64;
     for authorization in authorizations {
         if !authorization.chain_id().is_zero() && authorization.chain_id() != &U256::from(chain_id)
         {
@@ -122,14 +130,21 @@ fn apply_auth_list<T: EvmTypes<Host = Evm<T>>>(
             continue;
         }
 
+        host.state.record_account_access(&authority);
         if existed {
-            refunded_accounts = refunded_accounts.saturating_add(1);
+            state_refund = state_refund.saturating_add(u64::from(
+                host.version().gas_params.get(GasId::TxEip7702AuthRefund),
+            ));
+        }
+        if !code.is_empty() || authorization.address().is_zero() {
+            let auth_state = u64::from(host.version().gas_params.get(GasId::TxEip7702PerAuthState));
+            let account_state = u64::from(host.version().gas_params.get(GasId::NewAccountState));
+            state_refund = state_refund.saturating_add(auth_state.saturating_sub(account_state));
         }
         set_delegation(host, authority, *authorization.address())?;
     }
 
-    let refund_per_auth = u64::from(host.version().gas_params.get(GasId::TxEip7702AuthRefund));
-    Ok(refunded_accounts.saturating_mul(refund_per_auth))
+    Ok(state_refund)
 }
 
 fn set_delegation<T: EvmTypes<Host = Evm<T>>>(

--- a/crates/evm2/src/ethereum/eip7702.rs
+++ b/crates/evm2/src/ethereum/eip7702.rs
@@ -12,7 +12,7 @@ use crate::{
     env::TxEnv,
     interpreter::Host,
     registry::{HandlerError, HandlerResult, TxRequest},
-    version::{EvmFeatures, GasId},
+    version::{EvmFeatures, GasId, Version},
 };
 use alloy_consensus::{TxEip7702, transaction::Recovered};
 use alloy_eips::eip7702::SignedAuthorization;
@@ -40,14 +40,15 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     validate_nonce_not_overflow(tx.nonce)?;
     let (access_list_accounts, access_list_storage_keys) = access_list_counts(&tx.access_list);
     let auth_state_gas = eip7702_authorization_state_gas(req.host, tx.authorization_list.len());
-    let intrinsic = intrinsic_gas(
-        req.host.version(),
-        tx.to.into(),
-        &tx.input,
-        access_list_accounts,
-        access_list_storage_keys,
-    ) + eip7702_authorization_regular_gas(req.host, tx.authorization_list.len())
-        + auth_state_gas;
+    let intrinsic =
+        intrinsic_gas(
+            req.host.version(),
+            tx.to.into(),
+            &tx.input,
+            access_list_accounts,
+            access_list_storage_keys,
+        ) + eip7702_authorization_regular_gas(req.host.version(), tx.authorization_list.len())
+            + auth_state_gas;
     validate_intrinsic_gas(tx.gas_limit, intrinsic)?;
     let floor_gas =
         floor_gas(req.host.version(), &tx.input, access_list_accounts, access_list_storage_keys);
@@ -107,11 +108,11 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     )
 }
 
-fn eip7702_authorization_regular_gas<T: EvmTypes<Host = Evm<T>>>(
-    _host: &Evm<T>,
-    authorizations: usize,
-) -> u64 {
-    u64::try_from(authorizations).unwrap_or(u64::MAX).saturating_mul(7500)
+fn eip7702_authorization_regular_gas(version: &Version, authorizations: usize) -> u64 {
+    let per_empty_account = u64::from(version.gas_params.get(GasId::TxEip7702PerEmptyAccountCost));
+    let per_auth_state = u64::from(version.gas_params.get(GasId::TxEip7702PerAuthState));
+    let per_auth_regular = per_empty_account.saturating_sub(per_auth_state);
+    u64::try_from(authorizations).unwrap_or(u64::MAX).saturating_mul(per_auth_regular)
 }
 
 fn eip7702_authorization_state_gas<T: EvmTypes<Host = Evm<T>>>(
@@ -200,4 +201,24 @@ fn set_delegation<T: EvmTypes<Host = Evm<T>>>(
     host.state.set_code(&authority, code).map_err(|code| host.db_error_handler(code))?;
     host.state.increment_nonce(&authority).map_err(|code| host.db_error_handler(code))?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::SpecId;
+
+    #[test]
+    fn eip7702_prague_charges_full_empty_account_cost_upfront() {
+        let version = Version::base(SpecId::PRAGUE);
+
+        assert_eq!(eip7702_authorization_regular_gas(version, 2), 50_000);
+    }
+
+    #[test]
+    fn eip7702_amsterdam_splits_regular_and_state_auth_cost() {
+        let version = Version::base(SpecId::AMSTERDAM);
+
+        assert_eq!(eip7702_authorization_regular_gas(version, 2), 15_000);
+    }
 }

--- a/crates/evm2/src/ethereum/legacy.rs
+++ b/crates/evm2/src/ethereum/legacy.rs
@@ -67,6 +67,7 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
         intrinsic,
         intrinsic_state,
         intrinsic_state,
+        0,
         result,
     )
 }

--- a/crates/evm2/src/ethereum/legacy.rs
+++ b/crates/evm2/src/ethereum/legacy.rs
@@ -1,8 +1,9 @@
 use super::{
-    charge_upfront, floor_gas, initial_message, intrinsic_gas, rollback_failed_execution,
-    settle_gas, validate_block_gas_limit, validate_chain_id, validate_create_initcode,
-    validate_floor_gas, validate_gas_price, validate_intrinsic_gas, validate_nonce_not_overflow,
-    validate_regular_gas_limit_cap, validate_sender, validate_tx_gas_limit_cap, warm_base_accounts,
+    charge_upfront, floor_gas, initial_execution_gas, initial_message, intrinsic_gas,
+    intrinsic_state_gas, rollback_failed_execution, settle_gas, validate_block_gas_limit,
+    validate_chain_id, validate_create_initcode, validate_floor_gas, validate_gas_price,
+    validate_intrinsic_gas, validate_nonce_not_overflow, validate_regular_gas_limit_cap,
+    validate_sender, validate_tx_gas_limit_cap, warm_base_accounts,
 };
 use crate::{
     Evm, EvmTypes, TxResult,
@@ -41,7 +42,12 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     req.host.state.increment_nonce(&caller).map_err(|code| req.host.db_error_handler(code))?;
     let execution_checkpoint = req.host.state.checkpoint();
 
-    let gas_limit = tx.gas_limit - intrinsic;
+    let (gas_limit, gas_reservoir) = initial_execution_gas(
+        req.host.version(),
+        tx.gas_limit,
+        intrinsic,
+        intrinsic_state_gas(req.host.version(), tx.to),
+    );
     let tx_env = TxEnv {
         origin: caller,
         gas_price,
@@ -50,6 +56,7 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     };
     let (bytecode, mut message) =
         initial_message(req.host, caller, tx.nonce, tx.to, &tx.input, tx.value, gas_limit)?;
+    message.gas_reservoir = gas_reservoir;
     let mut result = req.host.execute_message(&tx_env, bytecode, &mut message, false);
     rollback_failed_execution(req.host, execution_checkpoint, &mut result);
 

--- a/crates/evm2/src/ethereum/legacy.rs
+++ b/crates/evm2/src/ethereum/legacy.rs
@@ -28,10 +28,12 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     validate_create_initcode(req.host.version(), tx.to, &tx.input)?;
     validate_nonce_not_overflow(tx.nonce)?;
     let intrinsic = intrinsic_gas(req.host.version(), tx.to, &tx.input, 0, 0);
+    let intrinsic_state = intrinsic_state_gas(req.host.version(), tx.to);
+    let intrinsic_regular = intrinsic.saturating_sub(intrinsic_state);
     validate_intrinsic_gas(tx.gas_limit, intrinsic)?;
     let floor_gas = floor_gas(req.host.version(), &tx.input, 0, 0);
     validate_floor_gas(tx.gas_limit, floor_gas)?;
-    validate_regular_gas_limit_cap(req.host.version(), tx.gas_limit, intrinsic, floor_gas)?;
+    validate_regular_gas_limit_cap(req.host.version(), tx.gas_limit, intrinsic_regular, floor_gas)?;
 
     let max_gas_cost = U256::from(tx.gas_limit) * gas_price;
     validate_sender(req.host, caller, tx.nonce, max_gas_cost.saturating_add(tx.value))?;
@@ -42,7 +44,6 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     req.host.state.increment_nonce(&caller).map_err(|code| req.host.db_error_handler(code))?;
     let execution_checkpoint = req.host.state.checkpoint();
 
-    let intrinsic_state = intrinsic_state_gas(req.host.version(), tx.to);
     let (gas_limit, gas_reservoir) =
         initial_execution_gas(req.host.version(), tx.gas_limit, intrinsic, intrinsic_state);
     let tx_env = TxEnv {

--- a/crates/evm2/src/ethereum/legacy.rs
+++ b/crates/evm2/src/ethereum/legacy.rs
@@ -42,12 +42,9 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     req.host.state.increment_nonce(&caller).map_err(|code| req.host.db_error_handler(code))?;
     let execution_checkpoint = req.host.state.checkpoint();
 
-    let (gas_limit, gas_reservoir) = initial_execution_gas(
-        req.host.version(),
-        tx.gas_limit,
-        intrinsic,
-        intrinsic_state_gas(req.host.version(), tx.to),
-    );
+    let intrinsic_state = intrinsic_state_gas(req.host.version(), tx.to);
+    let (gas_limit, gas_reservoir) =
+        initial_execution_gas(req.host.version(), tx.gas_limit, intrinsic, intrinsic_state);
     let tx_env = TxEnv {
         origin: caller,
         gas_price,
@@ -60,5 +57,15 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     let mut result = req.host.execute_message(&tx_env, bytecode, &mut message, false);
     rollback_failed_execution(req.host, execution_checkpoint, &mut result);
 
-    settle_gas(req.host, caller, gas_price, tx.gas_limit, floor_gas, result)
+    settle_gas(
+        req.host,
+        caller,
+        gas_price,
+        tx.gas_limit,
+        floor_gas,
+        intrinsic,
+        intrinsic_state,
+        intrinsic_state,
+        result,
+    )
 }

--- a/crates/evm2/src/ethereum/mod.rs
+++ b/crates/evm2/src/ethereum/mod.rs
@@ -198,6 +198,30 @@ pub(super) const fn validate_regular_gas_limit_cap(
     Ok(())
 }
 
+pub(super) fn initial_execution_gas(
+    version: &Version,
+    tx_gas_limit: u64,
+    intrinsic: u64,
+    intrinsic_state: u64,
+) -> (u64, u64) {
+    let execution_gas = tx_gas_limit.saturating_sub(intrinsic);
+    if !version.feature(EvmFeatures::EIP8037) {
+        return (execution_gas, 0);
+    }
+
+    let intrinsic_regular = intrinsic.saturating_sub(intrinsic_state);
+    let regular_budget = version.tx_gas_limit_cap.saturating_sub(intrinsic_regular);
+    let regular_gas = execution_gas.min(regular_budget);
+    (regular_gas, execution_gas.saturating_sub(regular_gas))
+}
+
+pub(super) fn intrinsic_state_gas(version: &Version, to: TxKind) -> u64 {
+    if to.is_create() && version.feature(EvmFeatures::EIP8037) {
+        return u64::from(version.gas_params.get(GasId::CreateState));
+    }
+    0
+}
+
 pub(super) const fn validate_chain_id(
     version: &Version,
     chain_id: Option<u64>,
@@ -344,6 +368,7 @@ pub(crate) fn initial_message<T: EvmTypes<Host = Evm<T>>>(
                 kind: MessageKind::Call,
                 depth: 0,
                 gas_limit,
+                gas_reservoir: 0,
                 destination: to,
                 caller,
                 input: input.clone(),
@@ -362,6 +387,7 @@ pub(crate) fn initial_message<T: EvmTypes<Host = Evm<T>>>(
                 kind: MessageKind::Create,
                 depth: 0,
                 gas_limit,
+                gas_reservoir: 0,
                 destination: address,
                 caller,
                 input: Bytes::new(),
@@ -458,8 +484,22 @@ const fn final_tx_gas<T: EvmTypes>(
     is_eip3529: bool,
     floor_gas: u64,
 ) -> (u64, u64) {
-    let gas_remaining = result.gas_remaining_after_final_refund(tx_gas_limit, is_eip3529);
-    let gas_used = result.gas_used_after_final_refund(tx_gas_limit, is_eip3529);
+    let mut reservoir = result.gas.reservoir();
+    if !result.stop.is_success() {
+        reservoir = reservoir.saturating_add(result.gas.state_gas_spent());
+    }
+    let spent = tx_gas_limit.saturating_sub(result.gas.remaining()).saturating_sub(reservoir);
+    let refund = if result.stop.is_success() && result.gas.refunded() > 0 {
+        let max_refund_quotient = if is_eip3529 { 5 } else { 2 };
+        let refund = result.gas.refunded() as u64;
+        let cap = spent / max_refund_quotient;
+        if refund < cap { refund } else { cap }
+    } else {
+        0
+    };
+    let gas_remaining = result.gas.remaining().saturating_add(reservoir).saturating_add(refund);
+    let gas_remaining = if gas_remaining < tx_gas_limit { gas_remaining } else { tx_gas_limit };
+    let gas_used = tx_gas_limit.saturating_sub(gas_remaining);
     // EIP-7623 charges at least the calldata floor after applying refunds.
     if gas_used < floor_gas {
         return (tx_gas_limit.saturating_sub(floor_gas), floor_gas);
@@ -505,8 +545,12 @@ pub(super) fn floor_gas(
     let non_zero_multiplier = u64::from(params.get(GasId::TxTokenNonZeroByteMultiplier));
     let mut tokens =
         access_list_floor_tokens(version, access_list_accounts, access_list_storage_keys);
-    for byte in input {
-        tokens += if *byte == 0 { 1 } else { non_zero_multiplier };
+    if version.feature(EvmFeatures::EIP8037) {
+        tokens += input.len() as u64 * u64::from(params.get(GasId::TxTokenCost));
+    } else {
+        for byte in input {
+            tokens += if *byte == 0 { 1 } else { non_zero_multiplier };
+        }
     }
 
     u64::from(params.get(GasId::TxFloorCostBase)) + tokens * floor_cost_per_token
@@ -535,6 +579,9 @@ pub(super) fn intrinsic_gas(
     }
     if to.is_create() && version.feature(EvmFeatures::EIP3860) {
         gas += u64::from(params.get(GasId::TxInitcodeCost)) * num_words(input.len()) as u64;
+    }
+    if to.is_create() && version.feature(EvmFeatures::EIP8037) {
+        gas += u64::from(params.get(GasId::CreateState));
     }
     gas
 }

--- a/crates/evm2/src/ethereum/mod.rs
+++ b/crates/evm2/src/ethereum/mod.rs
@@ -77,6 +77,43 @@ impl RecoveredTxEnvelope {
             Self::Legacy(_) | Self::Eip2930(_) | Self::Eip1559(_) | Self::Eip4844(_) => None,
         }
     }
+
+    /// Returns the transaction gas limit.
+    pub const fn gas_limit(&self) -> u64 {
+        match self {
+            Self::Legacy(tx) => tx.inner().gas_limit,
+            Self::Eip2930(tx) => tx.inner().gas_limit,
+            Self::Eip1559(tx) => tx.inner().gas_limit,
+            Self::Eip4844(tx) => tx.inner().tx().gas_limit,
+            Self::Eip7702(tx) => tx.inner().gas_limit,
+        }
+    }
+
+    /// Returns the transaction's block regular-gas allowance.
+    pub fn block_regular_gas_limit(&self, version: &Version) -> u64 {
+        let gas_limit = self.gas_limit();
+        if !version.feature(EvmFeatures::EIP8037) {
+            return gas_limit;
+        }
+
+        let create_state_gas = |to: TxKind| {
+            if to.is_create() { u64::from(version.gas_params.get(GasId::CreateState)) } else { 0 }
+        };
+        let intrinsic_state = match self {
+            Self::Legacy(tx) => create_state_gas(tx.inner().to),
+            Self::Eip2930(tx) => create_state_gas(tx.inner().to),
+            Self::Eip1559(tx) => create_state_gas(tx.inner().to),
+            Self::Eip4844(tx) => create_state_gas(tx.inner().tx().to.into()),
+            Self::Eip7702(tx) => {
+                let auth_state = u64::from(version.gas_params.get(GasId::TxEip7702PerAuthState));
+                u64::try_from(tx.inner().authorization_list.len())
+                    .unwrap_or(u64::MAX)
+                    .saturating_mul(auth_state)
+            }
+        };
+
+        gas_limit.saturating_sub(intrinsic_state).min(version.tx_gas_limit_cap)
+    }
 }
 
 impl Typed2718 for RecoveredTxEnvelope {
@@ -212,7 +249,39 @@ pub(super) fn initial_execution_gas(
     let intrinsic_regular = intrinsic.saturating_sub(intrinsic_state);
     let regular_budget = version.tx_gas_limit_cap.saturating_sub(intrinsic_regular);
     let regular_gas = execution_gas.min(regular_budget);
-    (regular_gas, execution_gas.saturating_sub(regular_gas))
+    let reservoir = execution_gas.saturating_sub(regular_gas);
+
+    let _ = intrinsic_state;
+
+    (regular_gas, reservoir)
+}
+
+pub(super) fn initial_execution_gas_with_state_refund(
+    version: &Version,
+    tx_gas_limit: u64,
+    intrinsic_regular: u64,
+    intrinsic_state: u64,
+    state_refund: u64,
+) -> (u64, u64) {
+    if !version.feature(EvmFeatures::EIP8037) {
+        return (tx_gas_limit.saturating_sub(intrinsic_regular), 0);
+    }
+
+    let intrinsic = intrinsic_regular.saturating_add(intrinsic_state).saturating_sub(state_refund);
+    let execution_gas = tx_gas_limit.saturating_sub(intrinsic);
+    let mut regular_gas =
+        tx_gas_limit.min(version.tx_gas_limit_cap).saturating_sub(intrinsic_regular);
+    let mut reservoir = execution_gas.saturating_sub(regular_gas);
+
+    if reservoir >= intrinsic_state {
+        reservoir -= intrinsic_state;
+    } else {
+        regular_gas = regular_gas.saturating_sub(intrinsic_state - reservoir);
+        reservoir = 0;
+    }
+    reservoir = reservoir.saturating_add(state_refund);
+
+    (regular_gas, reservoir)
 }
 
 pub(super) fn intrinsic_state_gas(version: &Version, to: TxKind) -> u64 {
@@ -445,19 +514,30 @@ pub(super) fn rollback_failed_execution<T: EvmTypes<Host = Evm<T>>>(
     }
 }
 
+#[expect(clippy::too_many_arguments)]
 pub(super) fn settle_gas<T: EvmTypes<Host = Evm<T>>>(
     host: &mut Evm<T>,
     caller: Address,
     gas_price: U256,
     tx_gas_limit: u64,
     floor_gas: u64,
+    intrinsic_gas: u64,
+    intrinsic_state_gas: u64,
+    failure_intrinsic_state_refund: u64,
     result: MessageResult<T>,
 ) -> HandlerResult<TxResult<T>> {
-    let (gas_remaining, gas_used) =
-        final_tx_gas(&result, tx_gas_limit, host.feature(EvmFeatures::EIP3529), floor_gas);
+    let gas = final_tx_gas(
+        &result,
+        tx_gas_limit,
+        host.feature(EvmFeatures::EIP3529),
+        floor_gas,
+        intrinsic_gas,
+        intrinsic_state_gas,
+        failure_intrinsic_state_refund,
+    );
     if host.feature(EvmFeatures::FEE_CHARGE) {
         host.state
-            .add_balance(&caller, &(U256::from(gas_remaining) * gas_price))
+            .add_balance(&caller, &(U256::from(gas.remaining) * gas_price))
             .map_err(|code| host.db_error_handler(code))?;
         let beneficiary_gas_price = if host.feature(EvmFeatures::BASE_FEE_CHECK) {
             gas_price.saturating_sub(host.block.basefee)
@@ -465,12 +545,14 @@ pub(super) fn settle_gas<T: EvmTypes<Host = Evm<T>>>(
             gas_price
         };
         host.state
-            .add_balance(&host.block.beneficiary, &(U256::from(gas_used) * beneficiary_gas_price))
+            .add_balance(&host.block.beneficiary, &(U256::from(gas.used) * beneficiary_gas_price))
             .map_err(|code| host.db_error_handler(code))?;
     }
     Ok(TxResult {
         status: result.stop.is_success(),
-        gas_used,
+        gas_used: gas.used,
+        block_gas_used: gas.block_regular_used,
+        state_gas_used: gas.state_used,
         stop: result.stop,
         output: result.output,
         ext: T::TxResultExt::default(),
@@ -478,15 +560,31 @@ pub(super) fn settle_gas<T: EvmTypes<Host = Evm<T>>>(
     })
 }
 
-const fn final_tx_gas<T: EvmTypes>(
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+struct FinalTxGas {
+    remaining: u64,
+    used: u64,
+    block_regular_used: u64,
+    state_used: u64,
+}
+
+fn final_tx_gas<T: EvmTypes>(
     result: &MessageResult<T>,
     tx_gas_limit: u64,
     is_eip3529: bool,
     floor_gas: u64,
-) -> (u64, u64) {
+    intrinsic_gas: u64,
+    intrinsic_state_gas: u64,
+    failure_intrinsic_state_refund: u64,
+) -> FinalTxGas {
+    let _ = intrinsic_gas;
     let mut reservoir = result.gas.reservoir();
     if !result.stop.is_success() {
-        reservoir = reservoir.saturating_add(result.gas.state_gas_spent());
+        let failure_intrinsic_state_refund =
+            if result.stop.is_revert() { failure_intrinsic_state_refund } else { 0 };
+        reservoir = reservoir
+            .saturating_add_signed(result.gas.state_gas_spent())
+            .saturating_add(failure_intrinsic_state_refund);
     }
     let spent = tx_gas_limit.saturating_sub(result.gas.remaining()).saturating_sub(reservoir);
     let refund = if result.stop.is_success() && result.gas.refunded() > 0 {
@@ -499,12 +597,26 @@ const fn final_tx_gas<T: EvmTypes>(
     };
     let gas_remaining = result.gas.remaining().saturating_add(reservoir).saturating_add(refund);
     let gas_remaining = if gas_remaining < tx_gas_limit { gas_remaining } else { tx_gas_limit };
-    let gas_used = tx_gas_limit.saturating_sub(gas_remaining);
+    let mut gas_used = tx_gas_limit.saturating_sub(gas_remaining);
+    let execution_state_gas = if result.stop.is_success() {
+        u64::try_from(result.gas.state_gas_spent()).unwrap_or_default()
+    } else {
+        0
+    };
+    let state_used = intrinsic_state_gas.saturating_add(execution_state_gas);
+    let mut block_regular_used = spent.saturating_sub(state_used);
     // EIP-7623 charges at least the calldata floor after applying refunds.
     if gas_used < floor_gas {
-        return (tx_gas_limit.saturating_sub(floor_gas), floor_gas);
+        gas_used = floor_gas;
+        block_regular_used = floor_gas;
+        return FinalTxGas {
+            remaining: tx_gas_limit.saturating_sub(floor_gas),
+            used: gas_used,
+            block_regular_used,
+            state_used,
+        };
     }
-    (gas_remaining, gas_used)
+    FinalTxGas { remaining: gas_remaining, used: gas_used, block_regular_used, state_used }
 }
 
 pub(super) fn access_list_counts(access_list: &AccessList) -> (u64, u64) {
@@ -771,7 +883,15 @@ mod tests {
             ..MessageResult::<BaseEvmTypes>::default()
         };
 
-        assert_eq!(final_tx_gas(&result, 100_000, true, 60_000), (40_000, 60_000));
+        assert_eq!(
+            final_tx_gas(&result, 100_000, true, 60_000, 0, 0, 0),
+            FinalTxGas {
+                remaining: 40_000,
+                used: 60_000,
+                block_regular_used: 60_000,
+                state_used: 0,
+            }
+        );
     }
 
     #[test]
@@ -782,7 +902,15 @@ mod tests {
             ..MessageResult::<BaseEvmTypes>::default()
         };
 
-        assert_eq!(final_tx_gas(&result, 100_000, true, 60_000), (30_000, 70_000));
+        assert_eq!(
+            final_tx_gas(&result, 100_000, true, 60_000, 0, 0, 0),
+            FinalTxGas {
+                remaining: 30_000,
+                used: 70_000,
+                block_regular_used: 70_000,
+                state_used: 0,
+            }
+        );
     }
 
     #[test]

--- a/crates/evm2/src/ethereum/mod.rs
+++ b/crates/evm2/src/ethereum/mod.rs
@@ -305,9 +305,11 @@ pub(super) fn warm_access_list<T: EvmTypes<Host = Evm<T>>>(
 ) {
     for item in access_list.iter() {
         host.state.warm_account_non_revertible(&item.address);
+        host.state.record_account_access(&item.address);
         for key in &item.storage_keys {
             let key = U256::from_be_bytes(key.0);
             let _ = host.state.warm_storage_non_revertible(&item.address, &key);
+            host.state.record_storage_access(&item.address, &key);
         }
     }
 }

--- a/crates/evm2/src/ethereum/mod.rs
+++ b/crates/evm2/src/ethereum/mod.rs
@@ -587,14 +587,15 @@ fn final_tx_gas<T: EvmTypes>(
             .saturating_add(failure_intrinsic_state_refund);
     }
     let spent = tx_gas_limit.saturating_sub(result.gas.remaining()).saturating_sub(reservoir);
-    let refund = if result.stop.is_success() && result.gas.refunded() > 0 {
-        let max_refund_quotient = if is_eip3529 { 5 } else { 2 };
-        let refund = result.gas.refunded() as u64;
-        let cap = spent / max_refund_quotient;
-        if refund < cap { refund } else { cap }
-    } else {
-        0
-    };
+    let refund =
+        if (result.stop.is_success() || result.stop.is_revert()) && result.gas.refunded() > 0 {
+            let max_refund_quotient = if is_eip3529 { 5 } else { 2 };
+            let refund = result.gas.refunded() as u64;
+            let cap = spent / max_refund_quotient;
+            if refund < cap { refund } else { cap }
+        } else {
+            0
+        };
     let gas_remaining = result.gas.remaining().saturating_add(reservoir).saturating_add(refund);
     let gas_remaining = if gas_remaining < tx_gas_limit { gas_remaining } else { tx_gas_limit };
     let mut gas_used = tx_gas_limit.saturating_sub(gas_remaining);
@@ -889,6 +890,29 @@ mod tests {
                 remaining: 40_000,
                 used: 60_000,
                 block_regular_used: 60_000,
+                state_used: 0,
+            }
+        );
+    }
+
+    #[test]
+    fn final_tx_gas_applies_top_level_refund_on_revert() {
+        let result = MessageResult::<BaseEvmTypes> {
+            stop: crate::interpreter::InstrStop::Revert,
+            gas: {
+                let mut gas = GasTracker::new_used_gas(100_000, 50_000, 0);
+                gas.set_refunded(10_000);
+                gas
+            },
+            ..MessageResult::<BaseEvmTypes>::default()
+        };
+
+        assert_eq!(
+            final_tx_gas(&result, 100_000, true, 21_000, 0, 0, 0),
+            FinalTxGas {
+                remaining: 60_000,
+                used: 40_000,
+                block_regular_used: 50_000,
                 state_used: 0,
             }
         );

--- a/crates/evm2/src/ethereum/mod.rs
+++ b/crates/evm2/src/ethereum/mod.rs
@@ -521,7 +521,7 @@ pub(super) fn settle_gas<T: EvmTypes<Host = Evm<T>>>(
     gas_price: U256,
     tx_gas_limit: u64,
     floor_gas: u64,
-    intrinsic_gas: u64,
+    _intrinsic_gas: u64,
     intrinsic_state_gas: u64,
     failure_intrinsic_state_refund: u64,
     result: MessageResult<T>,
@@ -531,7 +531,7 @@ pub(super) fn settle_gas<T: EvmTypes<Host = Evm<T>>>(
         tx_gas_limit,
         host.feature(EvmFeatures::EIP3529),
         floor_gas,
-        intrinsic_gas,
+        _intrinsic_gas,
         intrinsic_state_gas,
         failure_intrinsic_state_refund,
     );
@@ -568,20 +568,19 @@ struct FinalTxGas {
     state_used: u64,
 }
 
-fn final_tx_gas<T: EvmTypes>(
+const fn final_tx_gas<T: EvmTypes>(
     result: &MessageResult<T>,
     tx_gas_limit: u64,
     is_eip3529: bool,
     floor_gas: u64,
-    intrinsic_gas: u64,
+    _intrinsic_gas: u64,
     intrinsic_state_gas: u64,
     failure_intrinsic_state_refund: u64,
 ) -> FinalTxGas {
-    let _ = intrinsic_gas;
     let mut reservoir = result.gas.reservoir();
+    let failure_intrinsic_state_refund =
+        if !result.stop.is_success() { failure_intrinsic_state_refund } else { 0 };
     if !result.stop.is_success() {
-        let failure_intrinsic_state_refund =
-            if result.stop.is_revert() { failure_intrinsic_state_refund } else { 0 };
         reservoir = reservoir
             .saturating_add_signed(result.gas.state_gas_spent())
             .saturating_add(failure_intrinsic_state_refund);
@@ -599,12 +598,11 @@ fn final_tx_gas<T: EvmTypes>(
     let gas_remaining = result.gas.remaining().saturating_add(reservoir).saturating_add(refund);
     let gas_remaining = if gas_remaining < tx_gas_limit { gas_remaining } else { tx_gas_limit };
     let mut gas_used = tx_gas_limit.saturating_sub(gas_remaining);
-    let execution_state_gas = if result.stop.is_success() {
-        u64::try_from(result.gas.state_gas_spent()).unwrap_or_default()
+    let state_used = if result.stop.is_success() {
+        intrinsic_state_gas.saturating_add_signed(result.gas.state_gas_spent())
     } else {
-        0
+        intrinsic_state_gas.saturating_sub(failure_intrinsic_state_refund)
     };
-    let state_used = intrinsic_state_gas.saturating_add(execution_state_gas);
     let mut block_regular_used = spent.saturating_sub(state_used);
     // EIP-7623 charges at least the calldata floor after applying refunds.
     if gas_used < floor_gas {
@@ -919,6 +917,25 @@ mod tests {
     }
 
     #[test]
+    fn final_tx_gas_refunds_failed_create_state_gas_on_halt() {
+        let result = MessageResult::<BaseEvmTypes> {
+            stop: crate::interpreter::InstrStop::OutOfGas,
+            gas: GasTracker::new_used_gas(100_000, 100_000, 0),
+            ..MessageResult::<BaseEvmTypes>::default()
+        };
+
+        assert_eq!(
+            final_tx_gas(&result, 100_000, true, 21_000, 0, 5_000, 5_000),
+            FinalTxGas {
+                remaining: 5_000,
+                used: 95_000,
+                block_regular_used: 95_000,
+                state_used: 0,
+            }
+        );
+    }
+
+    #[test]
     fn final_tx_gas_preserves_higher_actual_usage() {
         let result = MessageResult::<BaseEvmTypes> {
             stop: crate::interpreter::InstrStop::Return,
@@ -1019,6 +1036,15 @@ mod tests {
                 gas_limit: amsterdam.tx_gas_limit_cap + 1,
                 cap: amsterdam.tx_gas_limit_cap
             })
+        );
+        assert_eq!(
+            validate_regular_gas_limit_cap(
+                amsterdam,
+                tx_gas_limit,
+                amsterdam.tx_gas_limit_cap,
+                floor_gas,
+            ),
+            Ok(())
         );
 
         let mut amsterdam_without_eip8037 = Version::new(SpecId::AMSTERDAM);

--- a/crates/evm2/src/ethereum/mod.rs
+++ b/crates/evm2/src/ethereum/mod.rs
@@ -292,6 +292,8 @@ pub(super) fn warm_base_accounts<T: EvmTypes<Host = Evm<T>>>(
     host.state.warm_account_non_revertible(&caller);
     if host.feature(EvmFeatures::EIP3651) {
         host.state.warm_account_non_revertible(&host.block.beneficiary);
+        let beneficiary = host.block.beneficiary;
+        host.state.record_account_access(&beneficiary);
     }
     if let TxKind::Call(to) = to {
         host.state.warm_account_non_revertible(&to);

--- a/crates/evm2/src/ethereum/mod.rs
+++ b/crates/evm2/src/ethereum/mod.rs
@@ -524,6 +524,7 @@ pub(super) fn settle_gas<T: EvmTypes<Host = Evm<T>>>(
     _intrinsic_gas: u64,
     intrinsic_state_gas: u64,
     failure_intrinsic_state_refund: u64,
+    top_level_refund: u64,
     result: MessageResult<T>,
 ) -> HandlerResult<TxResult<T>> {
     let gas = final_tx_gas(
@@ -534,6 +535,7 @@ pub(super) fn settle_gas<T: EvmTypes<Host = Evm<T>>>(
         _intrinsic_gas,
         intrinsic_state_gas,
         failure_intrinsic_state_refund,
+        top_level_refund,
     );
     if host.feature(EvmFeatures::FEE_CHARGE) {
         host.state
@@ -568,6 +570,7 @@ struct FinalTxGas {
     state_used: u64,
 }
 
+#[expect(clippy::too_many_arguments)]
 const fn final_tx_gas<T: EvmTypes>(
     result: &MessageResult<T>,
     tx_gas_limit: u64,
@@ -576,6 +579,7 @@ const fn final_tx_gas<T: EvmTypes>(
     _intrinsic_gas: u64,
     intrinsic_state_gas: u64,
     failure_intrinsic_state_refund: u64,
+    top_level_refund: u64,
 ) -> FinalTxGas {
     let mut reservoir = result.gas.reservoir();
     let failure_intrinsic_state_refund =
@@ -586,15 +590,19 @@ const fn final_tx_gas<T: EvmTypes>(
             .saturating_add(failure_intrinsic_state_refund);
     }
     let spent = tx_gas_limit.saturating_sub(result.gas.remaining()).saturating_sub(reservoir);
-    let refund =
-        if (result.stop.is_success() || result.stop.is_revert()) && result.gas.refunded() > 0 {
-            let max_refund_quotient = if is_eip3529 { 5 } else { 2 };
-            let refund = result.gas.refunded() as u64;
-            let cap = spent / max_refund_quotient;
-            if refund < cap { refund } else { cap }
-        } else {
-            0
-        };
+    let execution_refund = if result.stop.is_success() && result.gas.refunded() > 0 {
+        result.gas.refunded() as u64
+    } else {
+        0
+    };
+    let refund = execution_refund.saturating_add(top_level_refund);
+    let refund = if refund > 0 {
+        let max_refund_quotient = if is_eip3529 { 5 } else { 2 };
+        let cap = spent / max_refund_quotient;
+        if refund < cap { refund } else { cap }
+    } else {
+        0
+    };
     let gas_remaining = result.gas.remaining().saturating_add(reservoir).saturating_add(refund);
     let gas_remaining = if gas_remaining < tx_gas_limit { gas_remaining } else { tx_gas_limit };
     let mut gas_used = tx_gas_limit.saturating_sub(gas_remaining);
@@ -883,7 +891,7 @@ mod tests {
         };
 
         assert_eq!(
-            final_tx_gas(&result, 100_000, true, 60_000, 0, 0, 0),
+            final_tx_gas(&result, 100_000, true, 60_000, 0, 0, 0, 0),
             FinalTxGas {
                 remaining: 40_000,
                 used: 60_000,
@@ -899,14 +907,14 @@ mod tests {
             stop: crate::interpreter::InstrStop::Revert,
             gas: {
                 let mut gas = GasTracker::new_used_gas(100_000, 50_000, 0);
-                gas.set_refunded(10_000);
+                gas.set_refunded(40_000);
                 gas
             },
             ..MessageResult::<BaseEvmTypes>::default()
         };
 
         assert_eq!(
-            final_tx_gas(&result, 100_000, true, 21_000, 0, 0, 0),
+            final_tx_gas(&result, 100_000, true, 21_000, 0, 0, 0, 10_000),
             FinalTxGas {
                 remaining: 60_000,
                 used: 40_000,
@@ -925,11 +933,30 @@ mod tests {
         };
 
         assert_eq!(
-            final_tx_gas(&result, 100_000, true, 21_000, 0, 5_000, 5_000),
+            final_tx_gas(&result, 100_000, true, 21_000, 0, 5_000, 5_000, 0),
             FinalTxGas {
                 remaining: 5_000,
                 used: 95_000,
                 block_regular_used: 95_000,
+                state_used: 0,
+            }
+        );
+    }
+
+    #[test]
+    fn final_tx_gas_applies_top_level_refund_on_halt() {
+        let result = MessageResult::<BaseEvmTypes> {
+            stop: crate::interpreter::InstrStop::OutOfGas,
+            gas: GasTracker::new_used_gas(100_000, 100_000, 0),
+            ..MessageResult::<BaseEvmTypes>::default()
+        };
+
+        assert_eq!(
+            final_tx_gas(&result, 100_000, true, 21_000, 0, 0, 0, 10_000),
+            FinalTxGas {
+                remaining: 10_000,
+                used: 90_000,
+                block_regular_used: 100_000,
                 state_used: 0,
             }
         );
@@ -944,7 +971,7 @@ mod tests {
         };
 
         assert_eq!(
-            final_tx_gas(&result, 100_000, true, 60_000, 0, 0, 0),
+            final_tx_gas(&result, 100_000, true, 60_000, 0, 0, 0, 0),
             FinalTxGas {
                 remaining: 30_000,
                 used: 70_000,

--- a/crates/evm2/src/ethereum/mod.rs
+++ b/crates/evm2/src/ethereum/mod.rs
@@ -305,11 +305,9 @@ pub(super) fn warm_access_list<T: EvmTypes<Host = Evm<T>>>(
 ) {
     for item in access_list.iter() {
         host.state.warm_account_non_revertible(&item.address);
-        host.state.record_account_access(&item.address);
         for key in &item.storage_keys {
             let key = U256::from_be_bytes(key.0);
             let _ = host.state.warm_storage_non_revertible(&item.address, &key);
-            host.state.record_storage_access(&item.address, &key);
         }
     }
 }

--- a/crates/evm2/src/evm/bal.rs
+++ b/crates/evm2/src/evm/bal.rs
@@ -51,11 +51,12 @@ impl BalBuilder {
 
         if let Some(accesses) = &changes.accesses {
             for &address in &accesses.accounts {
-                self.accounts.entry(address).or_default();
+                self.accounts.entry(address).or_default().accessed = true;
             }
             for (&address, slots) in &accesses.storage {
                 let changed_slots = changes.storage.get(&address);
                 let builder = self.accounts.entry(address).or_default();
+                builder.accessed = true;
                 for &slot in slots {
                     let slot_was_written =
                         changed_slots.is_some_and(|storage| storage.slots.contains_key(&slot));
@@ -80,6 +81,7 @@ impl BalBuilder {
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 struct AccountBalBuilder {
+    accessed: bool,
     storage_reads: BTreeSet<Word>,
     storage_changes: BTreeMap<Word, Vec<StorageChange>>,
     balance_changes: Vec<BalanceChange>,
@@ -99,6 +101,7 @@ impl AccountBalBuilder {
             && self.balance_changes.is_empty()
             && self.nonce_changes.is_empty()
             && self.code_changes.is_empty()
+            && !self.accessed
         {
             return None;
         }

--- a/crates/evm2/src/evm/bal.rs
+++ b/crates/evm2/src/evm/bal.rs
@@ -1,0 +1,122 @@
+//! Block access list construction from transaction state changes.
+
+use super::{AccountInfo, StateChanges};
+use crate::{bytecode::Bytecode, interpreter::Word};
+use alloc::{
+    collections::{BTreeMap, BTreeSet},
+    vec::Vec,
+};
+use alloy_eip7928::{
+    AccountChanges, BalanceChange, BlockAccessIndex, BlockAccessList, CodeChange, NonceChange,
+    SlotChanges, StorageChange,
+};
+use alloy_primitives::{Address, Bytes};
+
+/// Builder for EIP-7928 block access lists.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct BalBuilder {
+    accounts: BTreeMap<Address, AccountBalBuilder>,
+}
+
+impl BalBuilder {
+    /// Pushes a transaction or system-call state transition into the block access list.
+    pub fn push_state_changes(&mut self, index: BlockAccessIndex, changes: &StateChanges) {
+        for (&address, account) in &changes.accounts {
+            let builder = self.accounts.entry(address).or_default();
+            let current = account.current.as_ref();
+            let empty = AccountInfo::default();
+            let post = current.unwrap_or(&empty);
+            let original = account.original.as_ref();
+
+            if original.map_or(!post.balance.is_zero(), |original| original.balance != post.balance)
+            {
+                builder.balance_changes.push(BalanceChange::new(index, post.balance));
+            }
+            if original.map_or(post.nonce != 0, |original| original.nonce != post.nonce) {
+                builder.nonce_changes.push(NonceChange::new(index, post.nonce));
+            }
+            if original.map_or(post.code_hash != alloy_primitives::KECCAK256_EMPTY, |original| {
+                original.code_hash != post.code_hash
+            }) {
+                builder.code_changes.push(CodeChange::new(index, code_bytes(current)));
+            }
+        }
+
+        for (&address, storage) in &changes.storage {
+            let builder = self.accounts.entry(address).or_default();
+            for (&slot, change) in &storage.slots {
+                builder.push_storage_change(index, slot, change.current);
+            }
+        }
+
+        if let Some(accesses) = &changes.accesses {
+            for (&address, slots) in &accesses.storage {
+                let changed_slots = changes.storage.get(&address);
+                let builder = self.accounts.entry(address).or_default();
+                for &slot in slots {
+                    let slot_was_written =
+                        changed_slots.is_some_and(|storage| storage.slots.contains_key(&slot));
+                    if slot_was_written {
+                        continue;
+                    }
+                    if changed_slots.is_some_and(|storage| storage.wipe) {
+                        builder.push_storage_change(index, slot, Word::ZERO);
+                    } else if !builder.storage_changes.contains_key(&slot) {
+                        builder.storage_reads.insert(slot);
+                    }
+                }
+            }
+        }
+    }
+
+    /// Consumes the builder and returns a canonical EIP-7928 block access list.
+    pub fn build(self) -> BlockAccessList {
+        self.accounts.into_iter().filter_map(|(address, builder)| builder.build(address)).collect()
+    }
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+struct AccountBalBuilder {
+    storage_reads: BTreeSet<Word>,
+    storage_changes: BTreeMap<Word, Vec<StorageChange>>,
+    balance_changes: Vec<BalanceChange>,
+    nonce_changes: Vec<NonceChange>,
+    code_changes: Vec<CodeChange>,
+}
+
+impl AccountBalBuilder {
+    fn push_storage_change(&mut self, index: BlockAccessIndex, slot: Word, value: Word) {
+        self.storage_reads.remove(&slot);
+        self.storage_changes.entry(slot).or_default().push(StorageChange::new(index, value));
+    }
+
+    fn build(self, address: Address) -> Option<AccountChanges> {
+        if self.storage_reads.is_empty()
+            && self.storage_changes.is_empty()
+            && self.balance_changes.is_empty()
+            && self.nonce_changes.is_empty()
+            && self.code_changes.is_empty()
+        {
+            return None;
+        }
+
+        let mut account = AccountChanges {
+            address,
+            storage_changes: self
+                .storage_changes
+                .into_iter()
+                .map(|(slot, changes)| SlotChanges::new(slot, changes))
+                .collect(),
+            storage_reads: self.storage_reads.into_iter().collect(),
+            balance_changes: self.balance_changes,
+            nonce_changes: self.nonce_changes,
+            code_changes: self.code_changes,
+        };
+        account.sort();
+        Some(account)
+    }
+}
+
+fn code_bytes(account: Option<&AccountInfo>) -> Bytes {
+    account.and_then(|info| info.code.as_ref()).map(Bytecode::original_bytes).unwrap_or_default()
+}

--- a/crates/evm2/src/evm/bal.rs
+++ b/crates/evm2/src/evm/bal.rs
@@ -30,15 +30,15 @@ impl BalBuilder {
 
             if original.map_or(!post.balance.is_zero(), |original| original.balance != post.balance)
             {
-                builder.balance_changes.push(BalanceChange::new(index, post.balance));
+                builder.push_balance_change(index, post.balance);
             }
             if original.map_or(post.nonce != 0, |original| original.nonce != post.nonce) {
-                builder.nonce_changes.push(NonceChange::new(index, post.nonce));
+                builder.push_nonce_change(index, post.nonce);
             }
             if original.map_or(post.code_hash != alloy_primitives::KECCAK256_EMPTY, |original| {
                 original.code_hash != post.code_hash
             }) {
-                builder.code_changes.push(CodeChange::new(index, code_bytes(current)));
+                builder.push_code_change(index, code_bytes(current));
             }
         }
 
@@ -63,9 +63,7 @@ impl BalBuilder {
                     if slot_was_written {
                         continue;
                     }
-                    if changed_slots.is_some_and(|storage| storage.wipe) {
-                        builder.push_storage_change(index, slot, Word::ZERO);
-                    } else if !builder.storage_changes.contains_key(&slot) {
+                    if !builder.storage_changes.contains_key(&slot) {
                         builder.storage_reads.insert(slot);
                     }
                 }
@@ -98,7 +96,42 @@ struct AccountBalBuilder {
 impl AccountBalBuilder {
     fn push_storage_change(&mut self, index: BlockAccessIndex, slot: Word, value: Word) {
         self.storage_reads.remove(&slot);
-        self.storage_changes.entry(slot).or_default().push(StorageChange::new(index, value));
+        let changes = self.storage_changes.entry(slot).or_default();
+        if let Some(change) = changes.iter_mut().find(|change| change.block_access_index == index) {
+            change.new_value = value;
+        } else {
+            changes.push(StorageChange::new(index, value));
+        }
+    }
+
+    fn push_balance_change(&mut self, index: BlockAccessIndex, balance: Word) {
+        if let Some(change) =
+            self.balance_changes.iter_mut().find(|change| change.block_access_index == index)
+        {
+            change.post_balance = balance;
+        } else {
+            self.balance_changes.push(BalanceChange::new(index, balance));
+        }
+    }
+
+    fn push_nonce_change(&mut self, index: BlockAccessIndex, nonce: u64) {
+        if let Some(change) =
+            self.nonce_changes.iter_mut().find(|change| change.block_access_index == index)
+        {
+            change.new_nonce = change.new_nonce.max(nonce);
+        } else {
+            self.nonce_changes.push(NonceChange::new(index, nonce));
+        }
+    }
+
+    fn push_code_change(&mut self, index: BlockAccessIndex, code: Bytes) {
+        if let Some(change) =
+            self.code_changes.iter_mut().find(|change| change.block_access_index == index)
+        {
+            change.new_code = code;
+        } else {
+            self.code_changes.push(CodeChange::new(index, code));
+        }
     }
 
     fn build(self, address: Address) -> Option<AccountChanges> {

--- a/crates/evm2/src/evm/bal.rs
+++ b/crates/evm2/src/evm/bal.rs
@@ -2,20 +2,20 @@
 
 use super::{AccountInfo, StateChanges};
 use crate::{bytecode::Bytecode, interpreter::Word};
-use alloc::{
-    collections::{BTreeMap, BTreeSet},
-    vec::Vec,
-};
+use alloc::vec::Vec;
 use alloy_eip7928::{
     AccountChanges, BalanceChange, BlockAccessIndex, BlockAccessList, CodeChange, NonceChange,
     SlotChanges, StorageChange,
 };
-use alloy_primitives::{Address, Bytes};
+use alloy_primitives::{
+    Address, Bytes,
+    map::{AddressMap, U256Map, U256Set},
+};
 
 /// Builder for EIP-7928 block access lists.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct BalBuilder {
-    accounts: BTreeMap<Address, AccountBalBuilder>,
+    accounts: AddressMap<AccountBalBuilder>,
 }
 
 impl BalBuilder {
@@ -75,15 +75,21 @@ impl BalBuilder {
 
     /// Consumes the builder and returns a canonical EIP-7928 block access list.
     pub fn build(self) -> BlockAccessList {
-        self.accounts.into_iter().filter_map(|(address, builder)| builder.build(address)).collect()
+        let mut accounts: BlockAccessList = self
+            .accounts
+            .into_iter()
+            .filter_map(|(address, builder)| builder.build(address))
+            .collect();
+        accounts.sort_unstable_by_key(|account| account.address);
+        accounts
     }
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 struct AccountBalBuilder {
     accessed: bool,
-    storage_reads: BTreeSet<Word>,
-    storage_changes: BTreeMap<Word, Vec<StorageChange>>,
+    storage_reads: U256Set,
+    storage_changes: U256Map<Vec<StorageChange>>,
     balance_changes: Vec<BalanceChange>,
     nonce_changes: Vec<NonceChange>,
     code_changes: Vec<CodeChange>,

--- a/crates/evm2/src/evm/bal.rs
+++ b/crates/evm2/src/evm/bal.rs
@@ -50,6 +50,9 @@ impl BalBuilder {
         }
 
         if let Some(accesses) = &changes.accesses {
+            for &address in &accesses.accounts {
+                self.accounts.entry(address).or_default();
+            }
             for (&address, slots) in &accesses.storage {
                 let changed_slots = changes.storage.get(&address);
                 let builder = self.accounts.entry(address).or_default();

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -551,14 +551,22 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
             .saturating_mul(self.version().gas_params.get(GasId::CodeDepositCost) as usize);
         let code_deposit_gas = u64::try_from(code_deposit_gas).unwrap_or(u64::MAX);
         if gas.remaining() >= code_deposit_gas {
-            return gas.spend(code_deposit_gas);
-        }
-        if self.feature(EvmFeatures::EIP2) {
+            gas.spend(code_deposit_gas)?;
+        } else if self.feature(EvmFeatures::EIP2) {
             // EIP-2 makes code-deposit OOG fail contract creation; Frontier instead creates the
             // account with empty code.
             return Err(InstrStop::OutOfGas);
+        } else {
+            *output = Bytes::new();
         }
-        *output = Bytes::new();
+
+        if self.feature(EvmFeatures::EIP8037) {
+            gas.spend(self.version().gas_params.keccak256_word_cost(output.len()))?;
+            let code_deposit_state_gas = u64::try_from(output.len())
+                .unwrap_or(u64::MAX)
+                .saturating_mul(self.version().gas_params.get(GasId::CodeDepositState).into());
+            gas.spend_state(code_deposit_state_gas)?;
+        }
         Ok(())
     }
 
@@ -754,15 +762,17 @@ impl<T: EvmTypes<Host = Self>> Host<T> for Evm<T> {
         load_code: bool,
         skip_cold_load: bool,
     ) -> Result<AccountLoad, InstrStop> {
-        let is_cold = if self.spec_id().enables(SpecId::BERLIN) {
+        let is_berlin = self.spec_id().enables(SpecId::BERLIN);
+        let is_cold = is_berlin && !self.state.is_account_warm(address);
+        if skip_cold_load && is_cold {
+            return Err(InstrStop::OutOfGas);
+        }
+        let is_cold = if is_berlin {
             self.state.warm_account(address)
         } else {
             let _ = self.state.warm_account(address);
             false
         };
-        if skip_cold_load && is_cold {
-            return Err(InstrStop::OutOfGas);
-        }
         let info = self.state.account_info(address).map_err(|code| self.db_error_stop(code))?;
         let exists = info.is_some();
         let info = info.unwrap_or_default();
@@ -802,10 +812,12 @@ impl<T: EvmTypes<Host = Self>> Host<T> for Evm<T> {
         skip_cold_load: bool,
     ) -> Result<SLoad, InstrStop> {
         let is_cold =
-            self.spec_id().enables(SpecId::BERLIN) && self.state.warm_storage(address, key);
+            self.spec_id().enables(SpecId::BERLIN) && !self.state.is_storage_warm(address, key);
         if skip_cold_load && is_cold {
             return Err(InstrStop::OutOfGas);
         }
+        let is_cold =
+            self.spec_id().enables(SpecId::BERLIN) && self.state.warm_storage(address, key);
         Ok(SLoad {
             value: self.state.storage(address, key).map_err(|code| self.db_error_stop(code))?,
             is_cold,
@@ -821,10 +833,12 @@ impl<T: EvmTypes<Host = Self>> Host<T> for Evm<T> {
         skip_cold_load: bool,
     ) -> Result<SStore, InstrStop> {
         let is_cold =
-            self.spec_id().enables(SpecId::BERLIN) && self.state.warm_storage(address, key);
+            self.spec_id().enables(SpecId::BERLIN) && !self.state.is_storage_warm(address, key);
         if skip_cold_load && is_cold {
             return Err(InstrStop::OutOfGas);
         }
+        let is_cold =
+            self.spec_id().enables(SpecId::BERLIN) && self.state.warm_storage(address, key);
         let mut result =
             self.state.set_storage(address, key, value).map_err(|code| self.db_error_stop(code))?;
         result.is_cold = is_cold;

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -22,12 +22,13 @@ use alloy_eips::eip2718::Typed2718;
 use alloy_primitives::{Address, B256, Bytes, Log, LogData};
 use derive_where::derive_where;
 
-mod bal;
 pub mod config;
 pub mod env;
 pub mod inspector;
 pub mod precompile;
 pub mod registry;
+
+mod bal;
 pub use bal::BalBuilder;
 
 mod system;

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -17,16 +17,19 @@ use crate::{
     trustme,
     version::{EvmFeatures, GasId},
 };
-use alloc::{boxed::Box, vec};
+use alloc::{boxed::Box, vec, vec::Vec};
 use alloy_eips::eip2718::Typed2718;
 use alloy_primitives::{Address, B256, Bytes, Log, LogData};
 use derive_where::derive_where;
 
+mod bal;
 pub mod config;
 pub mod env;
 pub mod inspector;
 pub mod precompile;
 pub mod registry;
+pub use bal::BalBuilder;
+
 mod system;
 pub use system::{
     BEACON_ROOTS_ADDRESS, CONSOLIDATION_REQUEST_ADDRESS, HISTORY_STORAGE_ADDRESS, SYSTEM_ADDRESS,
@@ -41,8 +44,8 @@ pub use db::{
 
 mod state;
 pub use state::{
-    Account, AccountInfo, JournalEntry, State, StateChanges, StateCheckpoint, StorageChangeSet,
-    StorageOverlay, Tracked,
+    Account, AccountInfo, JournalEntry, State, StateAccesses, StateChanges, StateCheckpoint,
+    StorageChangeSet, StorageOverlay, Tracked,
 };
 
 /// EVM host and transaction dispatcher.
@@ -157,6 +160,21 @@ impl<T: EvmTypes> Evm<T> {
     #[inline]
     pub const fn registry(&self) -> &TxRegistry<T::Tx, TxResult<T>, Self> {
         &self.registry
+    }
+
+    /// Enables or disables transaction-local state access tracking.
+    ///
+    /// Access tracking is needed for block access list construction and can be disabled for
+    /// execution modes that do not consume read sets.
+    #[inline]
+    pub fn set_access_tracking_enabled(&mut self, enabled: bool) {
+        self.state.set_access_tracking_enabled(enabled);
+    }
+
+    /// Returns whether transaction-local state access tracking is enabled.
+    #[inline]
+    pub const fn access_tracking_enabled(&self) -> bool {
+        self.state.access_tracking_enabled()
     }
 
     /// Returns the backing database.
@@ -370,6 +388,40 @@ impl<T: EvmTypes<Tx: Typed2718>> Evm<T> {
         Self: 'a,
     {
         txs.into_iter().map(move |tx| self.transact(tx))
+    }
+
+    /// Dispatches transactions and builds a block access list from their state changes.
+    pub fn transact_iter_bal<'a, I>(
+        &mut self,
+        txs: I,
+    ) -> HandlerResult<(Vec<TxResult<T>>, alloy_eip7928::BlockAccessList)>
+    where
+        I: IntoIterator<Item = &'a T::Tx>,
+        T::Tx: 'a,
+    {
+        let was_tracking_accesses = self.access_tracking_enabled();
+        self.set_access_tracking_enabled(true);
+
+        let mut results = Vec::new();
+        let mut bal = BalBuilder::default();
+        for (i, tx) in txs.into_iter().enumerate() {
+            match self.transact(tx) {
+                Ok(result) => {
+                    bal.push_state_changes(
+                        alloy_eip7928::BlockAccessIndex::new(i as u64 + 1),
+                        &result.state_changes,
+                    );
+                    results.push(result);
+                }
+                Err(err) => {
+                    self.set_access_tracking_enabled(was_tracking_accesses);
+                    return Err(err);
+                }
+            }
+        }
+
+        self.set_access_tracking_enabled(was_tracking_accesses);
+        Ok((results, bal.build()))
     }
 }
 

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -436,12 +436,12 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
         caller_is_static: bool,
     ) -> MessageResult<T> {
         if let Err(stop) = self.prepare_create_message(&bytecode, message) {
-            return Self::error_message_result(stop, message.gas_limit);
+            return Self::error_message_result(stop, message.gas_limit, message.gas_reservoir);
         }
         let checkpoint = self.state.checkpoint();
         if let Err(stop) = self.create_message_account(message) {
             self.state.rollback(checkpoint, self.spec_id());
-            return Self::error_message_result(stop, message.gas_limit);
+            return Self::error_message_result(stop, message.gas_limit, message.gas_reservoir);
         }
         message.code_address = message.destination;
         message.disable_precompiles = false;
@@ -520,7 +520,11 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
 
             if let Err(code) = self.state.set_code(address, Bytecode::new_legacy(output.clone())) {
                 self.state.rollback(checkpoint, self.spec_id());
-                return Self::error_message_result(self.db_error_stop(code), gas_limit);
+                return Self::error_message_result(
+                    self.db_error_stop(code),
+                    gas_limit,
+                    gas.reservoir(),
+                );
             }
         } else {
             self.state.rollback(checkpoint, self.spec_id());
@@ -622,11 +626,19 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
             || match self.state.transfer(&message.caller, &message.destination, &message.value) {
                 Ok(result) => result,
                 Err(code) => {
-                    return Self::error_message_result(self.db_error_stop(code), message.gas_limit);
+                    return Self::error_message_result(
+                        self.db_error_stop(code),
+                        message.gas_limit,
+                        message.gas_reservoir,
+                    );
                 }
             };
         if transfers_balance && !transfer_succeeded {
-            return Self::error_message_result(InstrStop::OutOfFunds, message.gas_limit);
+            return Self::error_message_result(
+                InstrStop::OutOfFunds,
+                message.gas_limit,
+                message.gas_reservoir,
+            );
         }
         if transfers_balance {
             self.log_eip7708_transfer(&message.caller, &message.destination, &message.value);
@@ -647,7 +659,10 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
         checkpoint: StateCheckpoint,
         message: &Message<T>,
     ) -> MessageResult<T> {
-        let mut gas = GasTracker::new(message.gas_limit);
+        let mut gas = GasTracker::new_with_regular_gas_and_reservoir(
+            message.gas_limit,
+            message.gas_reservoir,
+        );
         let result = self.execute_precompile(message, &mut gas);
         let (stop, output) = match result {
             Ok(output) => (InstrStop::Return, output.into_bytes()),
@@ -696,8 +711,16 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
     }
 
     #[inline]
-    fn error_message_result(stop: InstrStop, gas_remaining: u64) -> MessageResult<T> {
-        MessageResult { stop, gas: GasTracker::new(gas_remaining), ..MessageResult::default() }
+    fn error_message_result(
+        stop: InstrStop,
+        gas_remaining: u64,
+        gas_reservoir: u64,
+    ) -> MessageResult<T> {
+        MessageResult {
+            stop,
+            gas: GasTracker::new_with_regular_gas_and_reservoir(gas_remaining, gas_reservoir),
+            ..MessageResult::default()
+        }
     }
 
     #[inline]
@@ -1049,6 +1072,10 @@ pub struct TxResult<T: EvmTypes = crate::BaseEvmTypes> {
     pub status: bool,
     /// Gas used by execution.
     pub gas_used: u64,
+    /// Regular gas counted against the block gas limit.
+    pub block_gas_used: u64,
+    /// State gas counted against the block state-gas budget.
+    pub state_gas_used: u64,
     /// Interpreter stop reason.
     pub stop: InstrStop,
     /// Return or revert output.

--- a/crates/evm2/src/evm/state.rs
+++ b/crates/evm2/src/evm/state.rs
@@ -451,14 +451,14 @@ impl State {
     }
 
     #[inline]
-    fn record_account_access(&mut self, address: &Address) {
+    pub(crate) fn record_account_access(&mut self, address: &Address) {
         if self.track_accesses {
             self.accessed_accounts_for_changes.insert(*address);
         }
     }
 
     #[inline]
-    fn record_storage_access(&mut self, address: &Address, key: &Word) {
+    pub(crate) fn record_storage_access(&mut self, address: &Address, key: &Word) {
         if self.track_accesses {
             self.accessed_storage_for_changes.insert(StorageKey::new(*address, *key));
         }
@@ -536,6 +536,7 @@ impl State {
     #[inline(never)]
     #[must_use]
     pub fn warm_account(&mut self, address: &Address) -> bool {
+        self.record_account_access(address);
         if self.accessed_accounts.insert(*address) {
             self.journal.push(JournalEntry::AccountWarmed { address: *address });
             true
@@ -598,6 +599,7 @@ impl State {
     #[inline(never)]
     #[must_use]
     pub fn warm_storage(&mut self, address: &Address, key: &Word) -> bool {
+        self.record_storage_access(address, key);
         if self.accessed_storage.insert(StorageKey::new(*address, *key)) {
             self.journal.push(JournalEntry::StorageWarmed { address: *address, key: *key });
             true

--- a/crates/evm2/src/evm/state.rs
+++ b/crates/evm2/src/evm/state.rs
@@ -962,10 +962,12 @@ impl State {
     pub fn wipe_storage(&mut self, address: &Address) {
         let previous = self.storage.get(address).cloned();
         self.journal.push(JournalEntry::StorageWipe { address: *address, previous });
-        self.storage.insert(
-            *address,
-            StorageOverlay { wiped: true, slots: U256Map::default(), _non_exhaustive: () },
-        );
+        let mut storage = self.storage.remove(address).unwrap_or_default();
+        storage.wiped = true;
+        for slot in storage.slots.values_mut() {
+            slot.current = Word::ZERO;
+        }
+        self.storage.insert(*address, storage);
     }
 
     /// Loads transient storage.
@@ -1133,10 +1135,12 @@ impl State {
             address,
         )?;
         account.current = None;
-        self.storage.insert(
-            *address,
-            StorageOverlay { wiped: true, slots: U256Map::default(), _non_exhaustive: () },
-        );
+        let mut storage = self.storage.remove(address).unwrap_or_default();
+        storage.wiped = true;
+        for slot in storage.slots.values_mut() {
+            slot.current = Word::ZERO;
+        }
+        self.storage.insert(*address, storage);
         Ok(())
     }
 
@@ -1270,7 +1274,7 @@ impl State {
                 _non_exhaustive: (),
             };
             for (&key, slot) in &storage.slots {
-                if slot.original != slot.current && (!set.wipe || !slot.current.is_zero()) {
+                if slot.original != slot.current {
                     set.slots.insert(
                         key,
                         Tracked {
@@ -1579,6 +1583,26 @@ mod tests {
         assert!(change.original.is_some());
         assert_eq!(change.current, None);
         assert!(changes.storage.get(&address).is_some_and(|storage| storage.wipe));
+    }
+
+    #[test]
+    fn selfdestruct_zeroes_loaded_storage_slots() {
+        let address = Address::from([0x49; 20]);
+        let mut database = CacheDB::default();
+        database.insert_account_info(&address, AccountInfo::default().with_balance(Word::from(1)));
+        database.insert_account_storage(&address, &Word::from(1), &Word::from(2));
+        let mut state = State::new(database);
+
+        assert_eq!(state.storage(&address, &Word::from(1)).unwrap(), Word::from(2));
+        state.mark_destructed(&address);
+        state.finalize_transaction_(Version::base(crate::SpecId::SPURIOUS_DRAGON));
+        let changes = state.build_state_changes();
+
+        let storage = changes.storage.get(&address).expect("selfdestruct wipes storage");
+        assert!(storage.wipe);
+        let slot = storage.slots.get(&Word::from(1)).expect("loaded slot is zeroed");
+        assert_eq!(slot.original, Word::from(2));
+        assert_eq!(slot.current, Word::ZERO);
     }
 
     #[test]

--- a/crates/evm2/src/evm/state.rs
+++ b/crates/evm2/src/evm/state.rs
@@ -11,7 +11,11 @@ use crate::{
     interpreter::{InstrStop, Word},
     storage_key::{StorageKey, StorageKeyMap, StorageKeySet},
 };
-use alloc::{boxed::Box, collections::BTreeMap, vec::Vec};
+use alloc::{
+    boxed::Box,
+    collections::{BTreeMap, BTreeSet},
+    vec::Vec,
+};
 use alloy_primitives::{
     Address, B256, KECCAK256_EMPTY, Log, U256,
     map::{AddressMap, AddressSet, U256Map, hash_map},
@@ -230,6 +234,8 @@ pub struct StateChanges {
     pub code: BTreeMap<B256, Bytecode>,
     /// Logs emitted by the transaction.
     pub logs: Vec<Log>,
+    /// State locations accessed while executing the transaction, when access tracking is enabled.
+    pub accesses: Option<StateAccesses>,
     #[doc(hidden)] // Not public API. Please use an existing constructor.
     pub _non_exhaustive: (),
 }
@@ -242,6 +248,26 @@ impl StateChanges {
             && self.storage.is_empty()
             && self.code.is_empty()
             && self.logs.is_empty()
+            && self.accesses.as_ref().is_none_or(StateAccesses::is_empty)
+    }
+}
+
+/// State locations accessed while executing a transaction.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct StateAccesses {
+    /// Accounts that were loaded or queried.
+    pub accounts: BTreeSet<Address>,
+    /// Persistent storage slots that were loaded or written, keyed by account address.
+    pub storage: BTreeMap<Address, BTreeSet<Word>>,
+    #[doc(hidden)] // Not public API. Please use an existing constructor.
+    pub _non_exhaustive: (),
+}
+
+impl StateAccesses {
+    /// Returns whether no accesses were recorded.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.accounts.is_empty() && self.storage.is_empty()
     }
 }
 
@@ -377,6 +403,12 @@ pub struct State {
     accessed_storage: StorageKeySet,
     /// Transaction-scoped EIP-1153 transient storage keyed by account address and slot.
     transient_storage: StorageKeyMap<Word>,
+    /// Whether transaction-local access tracking is enabled.
+    track_accesses: bool,
+    /// Transaction-local account accesses used for BAL construction.
+    accessed_accounts_for_changes: AddressSet,
+    /// Transaction-local persistent storage accesses used for BAL construction.
+    accessed_storage_for_changes: StorageKeySet,
 }
 
 impl State {
@@ -397,6 +429,38 @@ impl State {
             accessed_accounts: AddressSet::default(),
             accessed_storage: StorageKeySet::default(),
             transient_storage: StorageKeyMap::default(),
+            track_accesses: false,
+            accessed_accounts_for_changes: AddressSet::default(),
+            accessed_storage_for_changes: StorageKeySet::default(),
+        }
+    }
+
+    /// Enables or disables transaction-local access tracking.
+    pub fn set_access_tracking_enabled(&mut self, enabled: bool) {
+        self.track_accesses = enabled;
+        if !enabled {
+            self.accessed_accounts_for_changes.clear();
+            self.accessed_storage_for_changes.clear();
+        }
+    }
+
+    /// Returns whether transaction-local access tracking is enabled.
+    #[inline]
+    pub const fn access_tracking_enabled(&self) -> bool {
+        self.track_accesses
+    }
+
+    #[inline]
+    fn record_account_access(&mut self, address: &Address) {
+        if self.track_accesses {
+            self.accessed_accounts_for_changes.insert(*address);
+        }
+    }
+
+    #[inline]
+    fn record_storage_access(&mut self, address: &Address, key: &Word) {
+        if self.track_accesses {
+            self.accessed_storage_for_changes.insert(StorageKey::new(*address, *key));
         }
     }
 
@@ -565,6 +629,8 @@ impl State {
         self.selfdestructs.clear();
         self.accessed_accounts.clear();
         self.accessed_storage.clear();
+        self.accessed_accounts_for_changes.clear();
+        self.accessed_storage_for_changes.clear();
         self.transient_storage.clear();
         self.logs.clear();
     }
@@ -573,6 +639,7 @@ impl State {
         &mut self,
         address: &Address,
     ) -> DbResult<Option<&mut Tracked<Option<Account>>>> {
+        self.record_account_access(address);
         match self.accounts.entry(*address) {
             hash_map::Entry::Occupied(entry) => Ok(Some(entry.into_mut())),
             hash_map::Entry::Vacant(entry) => {
@@ -641,6 +708,7 @@ impl State {
     /// Returns account info.
     #[inline(never)]
     pub fn account_info(&mut self, address: &Address) -> DbResult<Option<AccountInfo>> {
+        self.record_account_access(address);
         if let Some(account) = self.accounts.get(address) {
             return Ok(account.current.as_ref().map(Account::info));
         }
@@ -711,6 +779,7 @@ impl State {
 
     /// Loads persistent storage.
     pub fn storage(&mut self, address: &Address, key: &Word) -> DbResult<Word> {
+        self.record_storage_access(address, key);
         let Some(_) = self.account_info(address)? else {
             return Ok(Word::ZERO);
         };
@@ -725,6 +794,7 @@ impl State {
     /// host `sstore` operation instead, and only use this lower-level helper when those concerns
     /// are handled elsewhere.
     pub fn set_storage(&mut self, address: &Address, key: &Word, value: &Word) -> DbResult<SStore> {
+        self.record_storage_access(address, key);
         let _ = self.get_or_insert(address)?;
         self.touch(address);
         let slot = self.storage_slot_mut(address, key, true)?;
@@ -1172,6 +1242,17 @@ impl State {
             }
             if set.wipe || !set.slots.is_empty() {
                 changes.storage.insert(address, set);
+            }
+        }
+
+        if self.track_accesses {
+            let mut accesses = StateAccesses::default();
+            accesses.accounts.extend(self.accessed_accounts_for_changes.iter().copied());
+            for key in &self.accessed_storage_for_changes {
+                accesses.storage.entry(key.address()).or_default().insert(key.key());
+            }
+            if !accesses.is_empty() {
+                changes.accesses = Some(accesses);
             }
         }
 

--- a/crates/evm2/src/evm/state.rs
+++ b/crates/evm2/src/evm/state.rs
@@ -11,14 +11,10 @@ use crate::{
     interpreter::{InstrStop, Word},
     storage_key::{StorageKey, StorageKeyMap, StorageKeySet},
 };
-use alloc::{
-    boxed::Box,
-    collections::{BTreeMap, BTreeSet},
-    vec::Vec,
-};
+use alloc::{boxed::Box, collections::BTreeMap, vec::Vec};
 use alloy_primitives::{
     Address, B256, KECCAK256_EMPTY, Log, U256,
-    map::{AddressMap, AddressSet, U256Map, hash_map},
+    map::{AddressMap, AddressSet, U256Map, U256Set, hash_map},
 };
 use core::mem;
 use derive_where::derive_where;
@@ -256,9 +252,9 @@ impl StateChanges {
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct StateAccesses {
     /// Accounts that were loaded or queried.
-    pub accounts: BTreeSet<Address>,
+    pub accounts: AddressSet,
     /// Persistent storage slots that were loaded or written, keyed by account address.
-    pub storage: BTreeMap<Address, BTreeSet<Word>>,
+    pub storage: AddressMap<U256Set>,
     #[doc(hidden)] // Not public API. Please use an existing constructor.
     pub _non_exhaustive: (),
 }
@@ -268,6 +264,64 @@ impl StateAccesses {
     #[inline]
     pub fn is_empty(&self) -> bool {
         self.accounts.is_empty() && self.storage.is_empty()
+    }
+}
+
+#[derive(Debug, Default)]
+struct StateAccessTracker {
+    enabled: bool,
+    accesses: StateAccesses,
+}
+
+impl StateAccessTracker {
+    #[inline]
+    fn set_enabled(&mut self, enabled: bool) {
+        self.enabled = enabled;
+        if !enabled {
+            self.clear();
+        }
+    }
+
+    #[inline]
+    const fn enabled(&self) -> bool {
+        self.enabled
+    }
+
+    #[inline]
+    fn clear(&mut self) {
+        self.accesses.accounts.clear();
+        self.accesses.storage.clear();
+    }
+
+    #[inline]
+    fn record_account_access(&mut self, address: &Address) {
+        if self.enabled {
+            self.record_account_access_inner(address);
+        }
+    }
+
+    #[inline(never)]
+    fn record_account_access_inner(&mut self, address: &Address) {
+        self.accesses.accounts.insert(*address);
+    }
+
+    #[inline]
+    fn record_storage_access(&mut self, address: &Address, key: &Word) {
+        if self.enabled {
+            self.record_storage_access_inner(address, key);
+        }
+    }
+
+    #[inline(never)]
+    fn record_storage_access_inner(&mut self, address: &Address, key: &Word) {
+        self.accesses.storage.entry(*address).or_default().insert(*key);
+    }
+
+    fn take_state_accesses(&mut self) -> Option<StateAccesses> {
+        if !self.enabled || self.accesses.is_empty() {
+            return None;
+        }
+        Some(mem::take(&mut self.accesses))
     }
 }
 
@@ -403,12 +457,8 @@ pub struct State {
     accessed_storage: StorageKeySet,
     /// Transaction-scoped EIP-1153 transient storage keyed by account address and slot.
     transient_storage: StorageKeyMap<Word>,
-    /// Whether transaction-local access tracking is enabled.
-    track_accesses: bool,
-    /// Transaction-local account accesses used for BAL construction.
-    accessed_accounts_for_changes: AddressSet,
-    /// Transaction-local persistent storage accesses used for BAL construction.
-    accessed_storage_for_changes: StorageKeySet,
+    /// Transaction-local accesses used for BAL construction.
+    access_tracker: StateAccessTracker,
 }
 
 impl State {
@@ -429,39 +479,29 @@ impl State {
             accessed_accounts: AddressSet::default(),
             accessed_storage: StorageKeySet::default(),
             transient_storage: StorageKeyMap::default(),
-            track_accesses: false,
-            accessed_accounts_for_changes: AddressSet::default(),
-            accessed_storage_for_changes: StorageKeySet::default(),
+            access_tracker: StateAccessTracker::default(),
         }
     }
 
     /// Enables or disables transaction-local access tracking.
     pub fn set_access_tracking_enabled(&mut self, enabled: bool) {
-        self.track_accesses = enabled;
-        if !enabled {
-            self.accessed_accounts_for_changes.clear();
-            self.accessed_storage_for_changes.clear();
-        }
+        self.access_tracker.set_enabled(enabled);
     }
 
     /// Returns whether transaction-local access tracking is enabled.
     #[inline]
     pub const fn access_tracking_enabled(&self) -> bool {
-        self.track_accesses
+        self.access_tracker.enabled()
     }
 
     #[inline]
     pub(crate) fn record_account_access(&mut self, address: &Address) {
-        if self.track_accesses {
-            self.accessed_accounts_for_changes.insert(*address);
-        }
+        self.access_tracker.record_account_access(address);
     }
 
     #[inline]
     pub(crate) fn record_storage_access(&mut self, address: &Address, key: &Word) {
-        if self.track_accesses {
-            self.accessed_storage_for_changes.insert(StorageKey::new(*address, *key));
-        }
+        self.access_tracker.record_storage_access(address, key);
     }
 
     /// Returns a checkpoint for later rollback.
@@ -631,8 +671,7 @@ impl State {
         self.selfdestructs.clear();
         self.accessed_accounts.clear();
         self.accessed_storage.clear();
-        self.accessed_accounts_for_changes.clear();
-        self.accessed_storage_for_changes.clear();
+        self.access_tracker.clear();
         self.transient_storage.clear();
         self.logs.clear();
     }
@@ -1247,15 +1286,8 @@ impl State {
             }
         }
 
-        if self.track_accesses {
-            let mut accesses = StateAccesses::default();
-            accesses.accounts.extend(self.accessed_accounts_for_changes.iter().copied());
-            for key in &self.accessed_storage_for_changes {
-                accesses.storage.entry(key.address()).or_default().insert(key.key());
-            }
-            if !accesses.is_empty() {
-                changes.accesses = Some(accesses);
-            }
+        if let Some(accesses) = self.access_tracker.take_state_accesses() {
+            changes.accesses = Some(accesses);
         }
 
         changes

--- a/crates/evm2/src/interpreter/gas.rs
+++ b/crates/evm2/src/interpreter/gas.rs
@@ -200,6 +200,14 @@ impl GasTracker {
         Ok(())
     }
 
+    /// Refunds state gas to the reservoir.
+    #[inline]
+    pub fn refund_state(&mut self, amount: u64) {
+        let applied = amount.min(self.state_gas_spent);
+        self.reservoir = self.reservoir.saturating_add(applied);
+        self.state_gas_spent -= applied;
+    }
+
     /// Adds gas refund.
     #[inline]
     pub const fn record_refund(&mut self, refund: i64) {
@@ -415,6 +423,12 @@ impl Gas {
     #[inline]
     pub fn spend_state(&mut self, cost: u64) -> Result {
         self.tracker.spend_state(cost)
+    }
+
+    /// Refunds state gas to the reservoir.
+    #[inline]
+    pub fn refund_state(&mut self, amount: u64) {
+        self.tracker.refund_state(amount);
     }
 
     /// Adds gas refund.

--- a/crates/evm2/src/interpreter/gas.rs
+++ b/crates/evm2/src/interpreter/gas.rs
@@ -52,7 +52,8 @@ pub struct GasTracker {
     remaining: u64,
     gas_limit: u64,
     reservoir: u64,
-    state_gas_spent: u64,
+    state_gas_spent: i64,
+    refill_amount: u64,
     refunded: i64,
 }
 
@@ -78,7 +79,7 @@ impl GasTracker {
     /// Creates a gas tracker from its raw counters.
     #[inline]
     pub const fn from_parts(gas_limit: u64, remaining: u64, reservoir: u64) -> Self {
-        Self { remaining, gas_limit, reservoir, state_gas_spent: 0, refunded: 0 }
+        Self { remaining, gas_limit, reservoir, state_gas_spent: 0, refill_amount: 0, refunded: 0 }
     }
 
     /// Creates a gas tracker from already used gas.
@@ -125,14 +126,26 @@ impl GasTracker {
 
     /// Returns spent state gas.
     #[inline]
-    pub const fn state_gas_spent(&self) -> u64 {
+    pub const fn state_gas_spent(&self) -> i64 {
         self.state_gas_spent
     }
 
     /// Sets spent state gas.
     #[inline]
-    pub const fn set_state_gas_spent(&mut self, val: u64) {
+    pub const fn set_state_gas_spent(&mut self, val: i64) {
         self.state_gas_spent = val;
+    }
+
+    /// Returns cumulative reservoir refill amount.
+    #[inline]
+    pub const fn refill_amount(&self) -> u64 {
+        self.refill_amount
+    }
+
+    /// Sets cumulative reservoir refill amount.
+    #[inline]
+    pub const fn set_refill_amount(&mut self, val: u64) {
+        self.refill_amount = val;
     }
 
     /// Returns gas refund.
@@ -187,25 +200,28 @@ impl GasTracker {
     #[inline]
     pub fn spend_state(&mut self, cost: u64) -> Result {
         if self.reservoir >= cost {
-            self.state_gas_spent = self.state_gas_spent.saturating_add(cost);
+            self.state_gas_spent = self.state_gas_spent.saturating_add_unsigned(cost);
             self.reservoir -= cost;
             return Ok(());
         }
 
         let spill = cost - self.reservoir;
+        if self.remaining < spill {
+            return Err(InstrStop::OutOfGas);
+        }
 
         self.spend(spill)?;
-        self.state_gas_spent = self.state_gas_spent.saturating_add(cost);
+        self.state_gas_spent = self.state_gas_spent.saturating_add_unsigned(cost);
         self.reservoir = 0;
         Ok(())
     }
 
-    /// Refunds state gas to the reservoir.
+    /// Refills state gas to the reservoir.
     #[inline]
-    pub fn refund_state(&mut self, amount: u64) {
-        let applied = amount.min(self.state_gas_spent);
-        self.reservoir = self.reservoir.saturating_add(applied);
-        self.state_gas_spent -= applied;
+    pub const fn refill_reservoir(&mut self, amount: u64) {
+        self.reservoir = self.reservoir.saturating_add(amount);
+        self.state_gas_spent = self.state_gas_spent.saturating_sub_unsigned(amount);
+        self.refill_amount = self.refill_amount.saturating_add(amount);
     }
 
     /// Adds gas refund.
@@ -362,14 +378,26 @@ impl Gas {
 
     /// Returns spent state gas.
     #[inline]
-    pub const fn state_gas_spent(&self) -> u64 {
+    pub const fn state_gas_spent(&self) -> i64 {
         self.tracker.state_gas_spent()
     }
 
     /// Sets spent state gas.
     #[inline]
-    pub const fn set_state_gas_spent(&mut self, val: u64) {
+    pub const fn set_state_gas_spent(&mut self, val: i64) {
         self.tracker.set_state_gas_spent(val);
+    }
+
+    /// Returns cumulative reservoir refill amount.
+    #[inline]
+    pub const fn refill_amount(&self) -> u64 {
+        self.tracker.refill_amount()
+    }
+
+    /// Sets cumulative reservoir refill amount.
+    #[inline]
+    pub const fn set_refill_amount(&mut self, val: u64) {
+        self.tracker.set_refill_amount(val);
     }
 
     /// Returns gas refund.
@@ -425,10 +453,10 @@ impl Gas {
         self.tracker.spend_state(cost)
     }
 
-    /// Refunds state gas to the reservoir.
+    /// Refills state gas to the reservoir.
     #[inline]
-    pub fn refund_state(&mut self, amount: u64) {
-        self.tracker.refund_state(amount);
+    pub const fn refill_reservoir(&mut self, amount: u64) {
+        self.tracker.refill_reservoir(amount);
     }
 
     /// Adds gas refund.

--- a/crates/evm2/src/interpreter/host.rs
+++ b/crates/evm2/src/interpreter/host.rs
@@ -1,4 +1,4 @@
-use super::{GasTracker, InstrStop, Message, Result, Word};
+use super::{Gas, GasTracker, InstrStop, Message, Result, Word};
 use crate::{
     BaseEvmTypes, EvmTypes, SpecId,
     bytecode::Bytecode,
@@ -50,6 +50,20 @@ impl<T: EvmTypes> MessageResult<T> {
         if self.returns_unused_gas() { self.gas.remaining() } else { 0 }
     }
 
+    /// Applies child-frame reservoir accounting to the parent frame.
+    #[inline]
+    pub const fn apply_reservoir_to_parent(&self, parent_gas: &mut Gas) {
+        if self.stop.is_success() {
+            parent_gas.set_reservoir(self.gas.reservoir());
+            parent_gas.set_state_gas_spent(
+                parent_gas.state_gas_spent().saturating_add(self.gas.state_gas_spent()),
+            );
+        } else {
+            parent_gas
+                .set_reservoir(self.gas.reservoir().saturating_add(self.gas.state_gas_spent()));
+        }
+    }
+
     /// Returns the refund counter delta that should be propagated to the parent frame.
     #[inline]
     pub const fn refund_propagated_to_parent(&self) -> i64 {
@@ -63,7 +77,8 @@ impl<T: EvmTypes> MessageResult<T> {
             return 0;
         }
         let max_refund_quotient = if is_london { 5 } else { 2 };
-        let spent = gas_limit.saturating_sub(self.gas.remaining());
+        let spent =
+            gas_limit.saturating_sub(self.gas.remaining()).saturating_sub(self.gas.reservoir());
         let refund = self.gas.refunded() as u64;
         let cap = spent / max_refund_quotient;
         if refund < cap { refund } else { cap }
@@ -73,7 +88,8 @@ impl<T: EvmTypes> MessageResult<T> {
     #[inline]
     pub const fn gas_remaining_after_final_refund(&self, gas_limit: u64, is_london: bool) -> u64 {
         let refunded = self.final_refund(gas_limit, is_london);
-        let remaining = self.gas.remaining().saturating_add(refunded);
+        let remaining =
+            self.gas.remaining().saturating_add(self.gas.reservoir()).saturating_add(refunded);
         if remaining < gas_limit { remaining } else { gas_limit }
     }
 

--- a/crates/evm2/src/interpreter/host.rs
+++ b/crates/evm2/src/interpreter/host.rs
@@ -58,9 +58,13 @@ impl<T: EvmTypes> MessageResult<T> {
             parent_gas.set_state_gas_spent(
                 parent_gas.state_gas_spent().saturating_add(self.gas.state_gas_spent()),
             );
+            parent_gas.set_refill_amount(
+                parent_gas.refill_amount().saturating_add(self.gas.refill_amount()),
+            );
         } else {
-            parent_gas
-                .set_reservoir(self.gas.reservoir().saturating_add(self.gas.state_gas_spent()));
+            parent_gas.set_reservoir(
+                self.gas.reservoir().saturating_add_signed(self.gas.state_gas_spent()),
+            );
         }
     }
 

--- a/crates/evm2/src/interpreter/instructions/host.rs
+++ b/crates/evm2/src/interpreter/instructions/host.rs
@@ -294,11 +294,12 @@ mod tests {
         let interpreter = run(RunConfig::new([op::PUSH1, 1, op::PUSH1, 0, op::SSTORE, op::STOP])
             .host(&mut host)
             .spec(SpecId::AMSTERDAM)
+            .message(Message { gas_reservoir: 97_920, ..Message::default() })
             .gas_limit(100_000));
 
         assert!(matches!(interpreter.err, InstrStop::Stop));
-        assert_eq!(interpreter.gas_remaining(), 59_526);
-        assert_eq!(interpreter.state_gas_spent(), 37_568);
+        assert_eq!(interpreter.gas_remaining(), 97_094);
+        assert_eq!(interpreter.state_gas_spent(), 97_920);
     }
 
     #[test]

--- a/crates/evm2/src/interpreter/instructions/host.rs
+++ b/crates/evm2/src/interpreter/instructions/host.rs
@@ -68,6 +68,9 @@ pub(crate) fn sstore(cx: _, [key, value]: [Word]) -> Result {
     // regular gas.
     if cx.state.feature(EvmFeatures::EIP8037) {
         cx.gas.spend_state(cx.state.gas_params().sstore_state_gas(&state_load))?;
+        if !state_load.is_noop() && state_load.resets_original() && state_load.original_is_zero() {
+            cx.gas.refund_state(cx.state.gas_params().get(GasId::SstoreSetState).into());
+        }
     }
 
     // EIP-2200 and EIP-3529 refund rules, including negative refund adjustments for

--- a/crates/evm2/src/interpreter/instructions/host.rs
+++ b/crates/evm2/src/interpreter/instructions/host.rs
@@ -69,7 +69,7 @@ pub(crate) fn sstore(cx: _, [key, value]: [Word]) -> Result {
     if cx.state.feature(EvmFeatures::EIP8037) {
         cx.gas.spend_state(cx.state.gas_params().sstore_state_gas(&state_load))?;
         if !state_load.is_noop() && state_load.resets_original() && state_load.original_is_zero() {
-            cx.gas.refund_state(cx.state.gas_params().get(GasId::SstoreSetState).into());
+            cx.gas.refill_reservoir(cx.state.gas_params().get(GasId::SstoreSetState).into());
         }
     }
 

--- a/crates/evm2/src/interpreter/instructions/system.rs
+++ b/crates/evm2/src/interpreter/instructions/system.rs
@@ -35,10 +35,10 @@ const fn should_charge_new_account_gas(
 }
 
 #[inline]
-fn call_too_deep_result<T: EvmTypes>(gas_limit: u64) -> MessageResult<T> {
+fn call_too_deep_result<T: EvmTypes>(gas_limit: u64, gas_reservoir: u64) -> MessageResult<T> {
     MessageResult {
         stop: InstrStop::CallTooDeep,
-        gas: GasTracker::new(gas_limit),
+        gas: GasTracker::new_with_regular_gas_and_reservoir(gas_limit, gas_reservoir),
         ..Default::default()
     }
 }
@@ -123,6 +123,7 @@ fn load_acc_and_calc_gas<T: EvmTypes>(
         code_address = delegated_address;
     }
     let spec = state.spec();
+    let mut state_gas_cost = 0;
     if create_empty_account
         && should_charge_new_account_gas(
             spec,
@@ -132,10 +133,11 @@ fn load_acc_and_calc_gas<T: EvmTypes>(
     {
         cost += u64::from(state.gas_params().get(GasId::NewAccountCost));
         if state.feature(EvmFeatures::EIP8037) && transfers_value {
-            gas.spend_state(state.gas_params().get(GasId::NewAccountState).into())?;
+            state_gas_cost = state.gas_params().get(GasId::NewAccountState).into();
         }
     }
     gas.spend(cost)?;
+    gas.spend_state(state_gas_cost)?;
 
     let mut gas_limit = if state.spec().enables(SpecId::TANGERINE) {
         min(state.gas_params().call_stipend_reduction(gas.remaining()), stack_gas_limit)
@@ -253,7 +255,7 @@ fn call_inner<T: EvmTypes>(
     let mut result = if let Some(result) = state.inspect_call(&mut message) {
         result
     } else if message.depth > CALL_DEPTH_LIMIT {
-        call_too_deep_result::<T>(message.gas_limit)
+        call_too_deep_result::<T>(message.gas_limit, message.gas_reservoir)
     } else {
         let tx_env = unsafe { trustme::decouple_lt(state.tx()) };
         state.host().execute_message(tx_env, code, &mut message, caller_is_static)
@@ -356,7 +358,7 @@ fn create_inner<T: EvmTypes>(
     let mut result = if let Some(result) = state.inspect_create(&mut message) {
         result
     } else if message.depth > CALL_DEPTH_LIMIT {
-        call_too_deep_result::<T>(message.gas_limit)
+        call_too_deep_result::<T>(message.gas_limit, message.gas_reservoir)
     } else {
         let bytecode = crate::bytecode::Bytecode::new_legacy(message.input.clone());
         let tx_env = unsafe { trustme::decouple_lt(state.tx()) };
@@ -366,8 +368,8 @@ fn create_inner<T: EvmTypes>(
     gas.erase_cost(result.gas_returned_to_parent());
     gas.record_refund(result.refund_propagated_to_parent());
     result.apply_reservoir_to_parent(gas);
-    if !result.stop.is_success() {
-        gas.refund_state(create_state_gas);
+    if result.created_address.is_none() {
+        gas.refill_reservoir(create_state_gas);
     }
     // EIP-211 exposes CREATE failure data only for REVERT; other failures clear returndata.
     if result.stop == InstrStop::Revert {

--- a/crates/evm2/src/interpreter/instructions/system.rs
+++ b/crates/evm2/src/interpreter/instructions/system.rs
@@ -131,6 +131,9 @@ fn load_acc_and_calc_gas<T: EvmTypes>(
         )
     {
         cost += u64::from(state.gas_params().get(GasId::NewAccountCost));
+        if state.feature(EvmFeatures::EIP8037) && transfers_value {
+            gas.spend_state(state.gas_params().get(GasId::NewAccountState).into())?;
+        }
     }
     gas.spend(cost)?;
 
@@ -209,6 +212,7 @@ fn prepare_call<T: EvmTypes>(
         kind,
         depth: current.depth.saturating_add(1),
         gas_limit,
+        gas_reservoir: gas.reservoir(),
         destination,
         caller,
         input,
@@ -257,6 +261,7 @@ fn call_inner<T: EvmTypes>(
     state.inspect_call_end(&message, &mut result);
     gas.erase_cost(result.gas_returned_to_parent());
     gas.record_refund(result.refund_propagated_to_parent());
+    result.apply_reservoir_to_parent(gas);
     let copy_len = min(return_memory_range.len(), result.output.len());
     unsafe {
         let output = result.output.get_unchecked(..copy_len);
@@ -318,6 +323,13 @@ fn create_inner<T: EvmTypes>(
         state.gas_params().get(GasId::Create).into()
     };
     gas.spend(create_cost)?;
+    let create_state_gas = if state.feature(EvmFeatures::EIP8037) {
+        let create_state_gas = state.gas_params().get(GasId::CreateState).into();
+        gas.spend_state(create_state_gas)?;
+        create_state_gas
+    } else {
+        0
+    };
     let gas_limit = if state.spec().enables(SpecId::TANGERINE) {
         state.gas_params().call_stipend_reduction(gas.remaining())
     } else {
@@ -330,6 +342,7 @@ fn create_inner<T: EvmTypes>(
         kind: if is_create2 { MessageKind::Create2 } else { MessageKind::Create },
         depth: current.depth.saturating_add(1),
         gas_limit,
+        gas_reservoir: gas.reservoir(),
         destination: current.destination,
         caller: current.destination,
         input,
@@ -352,6 +365,10 @@ fn create_inner<T: EvmTypes>(
     state.inspect_create_end(&message, &mut result);
     gas.erase_cost(result.gas_returned_to_parent());
     gas.record_refund(result.refund_propagated_to_parent());
+    result.apply_reservoir_to_parent(gas);
+    if !result.stop.is_success() {
+        gas.refund_state(create_state_gas);
+    }
     // EIP-211 exposes CREATE failure data only for REVERT; other failures clear returndata.
     if result.stop == InstrStop::Revert {
         state.set_return_data(result.output);
@@ -378,6 +395,9 @@ pub(crate) fn selfdestruct(cx: _, [target]: [Word]) -> Result {
     let should_charge_topup =
         should_charge_new_account_gas(cx.state.spec(), res.had_value, res.target_is_empty);
     cx.gas.spend(cx.state.gas_params().selfdestruct_cost(should_charge_topup, res.is_cold))?;
+    if cx.state.feature(EvmFeatures::EIP8037) && should_charge_topup {
+        cx.gas.spend_state(cx.state.gas_params().get(GasId::NewAccountState).into())?;
+    }
     if !res.previously_destroyed {
         cx.gas.record_refund(cx.state.gas_params().get(GasId::SelfdestructRefund) as i64);
     }

--- a/crates/evm2/src/interpreter/instructions/tests.rs
+++ b/crates/evm2/src/interpreter/instructions/tests.rs
@@ -229,7 +229,7 @@ impl TestInterpreter {
         self.gas.refunded()
     }
 
-    pub(super) fn state_gas_spent(&self) -> u64 {
+    pub(super) fn state_gas_spent(&self) -> i64 {
         self.gas.state_gas_spent()
     }
 

--- a/crates/evm2/src/interpreter/message.rs
+++ b/crates/evm2/src/interpreter/message.rs
@@ -39,6 +39,8 @@ pub struct Message<T: EvmTypes = BaseEvmTypes> {
     pub depth: u16,
     /// Gas available to this message.
     pub gas_limit: u64,
+    /// State gas reservoir available to this message.
+    pub gas_reservoir: u64,
     /// Account whose context is being executed.
     pub destination: Address,
     /// Immediate caller.

--- a/crates/evm2/src/interpreter/runtime.rs
+++ b/crates/evm2/src/interpreter/runtime.rs
@@ -96,7 +96,7 @@ impl<'frame, T: EvmTypes> Interpreter<'frame, T> {
         self.pc = bytecode.original_byte_slice().as_ptr();
         self.bytecode = bytecode;
         self.stack_len = 0;
-        self.gas = Gas::new(gas_limit);
+        self.gas = Gas::new_with_regular_gas_and_reservoir(gas_limit, message.gas_reservoir);
         self.memory.clear();
         self.result = Ok(());
         self.output = &[];

--- a/crates/evm2/src/version/gas_params.rs
+++ b/crates/evm2/src/version/gas_params.rs
@@ -465,8 +465,8 @@ mod tests {
 
         let amsterdam = gas_params(SpecId::AMSTERDAM);
         assert_eq!(amsterdam.get(GasId::Create), 9000);
-        assert_eq!(amsterdam.get(GasId::SstoreSetState), 37568);
-        assert_eq!(amsterdam.get(GasId::TxEip7702PerAuthState), 158490);
+        assert_eq!(amsterdam.get(GasId::SstoreSetState), 97920);
+        assert_eq!(amsterdam.get(GasId::TxEip7702PerAuthState), 218790);
     }
 
     #[test]

--- a/crates/evm2/src/version/mod.rs
+++ b/crates/evm2/src/version/mod.rs
@@ -328,7 +328,7 @@ mod tests {
     }
 }
 
-const AMSTERDAM_CPSB: u32 = 1174;
+const AMSTERDAM_CPSB: u32 = 1530;
 
 evm_versions! {
     FRONTIER {
@@ -707,15 +707,17 @@ evm_versions! {
             NewAccountCost: 0,
             NewAccountCostForSelfdestruct: 0,
             SstoreSetWithoutLoadCost: 2800,
-            SstoreSetState: 32 * AMSTERDAM_CPSB,
-            NewAccountState: 112 * AMSTERDAM_CPSB,
+            SstoreClearingSlotRefund: 4800,
+            SstoreSetRefund: 2800,
+            SstoreResetRefund: 2800,
+            SstoreSetState: 64 * AMSTERDAM_CPSB,
+            NewAccountState: 120 * AMSTERDAM_CPSB,
             CodeDepositState: AMSTERDAM_CPSB,
-            CreateState: 112 * AMSTERDAM_CPSB,
-            SstoreSetRefund: 32 * AMSTERDAM_CPSB + 2800,
+            CreateState: 120 * AMSTERDAM_CPSB,
             TxFloorCostPerToken: TOTAL_COST_FLOOR_PER_TOKEN_AMSTERDAM,
-            TxEip7702PerEmptyAccountCost: 7500 + (112 + 23) * AMSTERDAM_CPSB,
-            TxEip7702AuthRefund: 112 * AMSTERDAM_CPSB,
-            TxEip7702PerAuthState: (112 + 23) * AMSTERDAM_CPSB,
+            TxEip7702PerEmptyAccountCost: 7500 + (120 + 23) * AMSTERDAM_CPSB,
+            TxEip7702AuthRefund: 120 * AMSTERDAM_CPSB,
+            TxEip7702PerAuthState: (120 + 23) * AMSTERDAM_CPSB,
         ],
     }
 

--- a/scripts/setup_test_fixtures.py
+++ b/scripts/setup_test_fixtures.py
@@ -36,6 +36,7 @@ from rich.text import Text
 MAIN_VERSION = os.environ.get("MAIN_VERSION", "v5.3.0")
 LEGACY_VERSION = os.environ.get("LEGACY_VERSION", "v17.2")
 BASE_URL = "https://github.com/ethereum/execution-spec-tests/releases/download"
+DEVNET_BASE_URL = os.environ.get("DEVNET_BASE_URL", BASE_URL)
 LEGACY_URL = (
     f"https://github.com/ethereum/tests/archive/refs/tags/{LEGACY_VERSION}.tar.gz"
 )
@@ -121,7 +122,7 @@ def devnet_fixture() -> Fixture | None:
 
     return Fixture(
         label="devnet",
-        url=f"{BASE_URL}/{version}/{tar_name}",
+        url=f"{DEVNET_BASE_URL}/{version}/{tar_name}",
         dest=DEVNET_DIR,
         exists_paths=(DEVNET_DIR / "state_tests", DEVNET_DIR / "blockchain_tests"),
     )


### PR DESCRIPTION
This is a WIP implementation of block access lists, intended to start wiring the BAL execution path through evm2 and make the first set of Amsterdam/devnet fixtures pass. It includes the current BAL builder/state access tracking work, EEST fixture handling, and related gas-accounting fixes needed by the passing tests. Further work is still needed before this is complete, especially around the remaining devnet failures and broader Prague/Osaka behavior.