### PR TITLE
WIP: add BAL database read mode

### DIFF
--- a/crates/eest/src/blockchaintest/execute.rs
+++ b/crates/eest/src/blockchaintest/execute.rs
@@ -54,6 +54,13 @@ pub(crate) struct ExecuteSummary {
     pub(crate) skipped: usize,
 }
 
+#[derive(Clone, Copy, Debug)]
+struct BalExecution<'a> {
+    read_bal: Option<&'a Arc<Bal>>,
+    index: BlockAccessIndex,
+    track_accesses: bool,
+}
+
 /// Executes a single blockchain test JSON file using explicit execution options.
 pub(crate) fn execute_test_suite(
     path: &Path,
@@ -169,13 +176,18 @@ fn execute_block(
     let mut block_database = database.clone();
     let mut bal_builder = needs_bal.then(BalBuilder::default);
     let txs = block_transactions(block);
+    let pre_block_bal = BalExecution {
+        read_bal: read_bal.as_ref(),
+        index: BlockAccessIndex::PRE_EXECUTION,
+        track_accesses: bal_builder.is_some(),
+    };
     pre_block_system_calls(
         &mut block_database,
         spec,
         next_block_env,
         *parent_block_hash,
         beacon_root,
-        read_bal.as_ref(),
+        pre_block_bal,
         bal_builder.as_mut(),
     )
     .map_err(|err| TestError::case(path, name, err))?;
@@ -194,9 +206,11 @@ fn execute_block(
             next_block_env,
             block_database.clone(),
             &tx,
-            read_bal.as_ref(),
-            BlockAccessIndex::new(tx_index as u64 + 1),
-            bal_builder.is_some(),
+            BalExecution {
+                read_bal: read_bal.as_ref(),
+                index: BlockAccessIndex::new(tx_index as u64 + 1),
+                track_accesses: bal_builder.is_some(),
+            },
         ) {
             Ok(result) => {
                 if let Some(bal_builder) = &mut bal_builder {
@@ -220,7 +234,11 @@ fn execute_block(
         spec,
         next_block_env,
         block_withdrawals(block),
-        read_bal.as_ref(),
+        BalExecution {
+            read_bal: read_bal.as_ref(),
+            index: BlockAccessIndex::new(txs.len() as u64 + 1),
+            track_accesses: bal_builder.is_some(),
+        },
         bal_builder.as_mut(),
         BlockAccessIndex::new(txs.len() as u64 + 1),
     )
@@ -281,7 +299,7 @@ fn pre_block_system_calls(
     block: BlockEnv,
     parent_block_hash: Option<B256>,
     parent_beacon_block_root: Option<B256>,
-    read_bal: Option<&Arc<Bal>>,
+    bal_execution: BalExecution<'_>,
     mut bal_builder: Option<&mut BalBuilder>,
 ) -> Result<(), TestErrorKind> {
     if block.number.is_zero() {
@@ -297,9 +315,7 @@ fn pre_block_system_calls(
             HISTORY_STORAGE_ADDRESS,
             Bytes::copy_from_slice(hash.as_slice()),
             "eip2935",
-            read_bal,
-            BlockAccessIndex::PRE_EXECUTION,
-            bal_builder.is_some(),
+            bal_execution,
         )?;
         if let Some(bal_builder) = &mut bal_builder {
             bal_builder.push_state_changes(BlockAccessIndex::PRE_EXECUTION, &changes);
@@ -315,9 +331,7 @@ fn pre_block_system_calls(
             BEACON_ROOTS_ADDRESS,
             Bytes::copy_from_slice(root.as_slice()),
             "eip4788",
-            read_bal,
-            BlockAccessIndex::PRE_EXECUTION,
-            bal_builder.is_some(),
+            bal_execution,
         )?;
         if let Some(bal_builder) = &mut bal_builder {
             bal_builder.push_state_changes(BlockAccessIndex::PRE_EXECUTION, &changes);
@@ -331,7 +345,7 @@ fn post_block_transition(
     spec: SpecId,
     block: BlockEnv,
     withdrawals: &[Withdrawal],
-    read_bal: Option<&Arc<Bal>>,
+    bal_execution: BalExecution<'_>,
     mut bal_builder: Option<&mut BalBuilder>,
     bal_index: BlockAccessIndex,
 ) -> Result<(), TestErrorKind> {
@@ -364,9 +378,7 @@ fn post_block_transition(
             WITHDRAWAL_REQUEST_ADDRESS,
             Bytes::new(),
             "eip7002",
-            read_bal,
-            bal_index,
-            bal_builder.is_some(),
+            bal_execution,
         )?;
         if let Some(bal_builder) = &mut bal_builder {
             bal_builder.push_state_changes(bal_index, &changes);
@@ -378,9 +390,7 @@ fn post_block_transition(
             evm2::CONSOLIDATION_REQUEST_ADDRESS,
             Bytes::new(),
             "eip7251",
-            read_bal,
-            bal_index,
-            bal_builder.is_some(),
+            bal_execution,
         )?;
         if let Some(bal_builder) = &mut bal_builder {
             bal_builder.push_state_changes(bal_index, &changes);
@@ -396,14 +406,12 @@ fn run_system_call(
     address: Address,
     data: Bytes,
     label: &'static str,
-    read_bal: Option<&Arc<Bal>>,
-    bal_index: BlockAccessIndex,
-    track_accesses: bool,
+    bal_execution: BalExecution<'_>,
 ) -> Result<StateChanges, TestErrorKind> {
     let mut evm_database = BalDatabase::new(database.clone());
-    if let Some(read_bal) = read_bal {
+    if let Some(read_bal) = bal_execution.read_bal {
         evm_database.bal_state.set_bal(Some(Arc::clone(read_bal)));
-        evm_database.bal_state.set_bal_index(bal_index);
+        evm_database.bal_state.set_bal_index(bal_execution.index);
     }
     let mut evm = Evm::<BaseEvmTypes>::new(
         spec,
@@ -412,7 +420,7 @@ fn run_system_call(
         evm_database,
         Precompiles::base(spec),
     );
-    evm.set_access_tracking_enabled(track_accesses);
+    evm.set_access_tracking_enabled(bal_execution.track_accesses);
     let result = evm.system_call(address, data);
     if !result.status && system_contract_has_code(database, address) {
         return Err(TestErrorKind::SystemCall(label));
@@ -426,14 +434,12 @@ fn execute_tx(
     block: BlockEnv,
     database: InMemoryDB,
     tx: &RecoveredTxEnvelope,
-    read_bal: Option<&Arc<Bal>>,
-    bal_index: BlockAccessIndex,
-    track_accesses: bool,
+    bal_execution: BalExecution<'_>,
 ) -> Result<TxResult, HandlerError> {
     let mut database = BalDatabase::new(database);
-    if let Some(read_bal) = read_bal {
+    if let Some(read_bal) = bal_execution.read_bal {
         database.bal_state.set_bal(Some(Arc::clone(read_bal)));
-        database.bal_state.set_bal_index(bal_index);
+        database.bal_state.set_bal_index(bal_execution.index);
     }
     let mut evm = Evm::<BaseEvmTypes>::new(
         spec,
@@ -442,7 +448,7 @@ fn execute_tx(
         database,
         Precompiles::base(spec),
     );
-    evm.set_access_tracking_enabled(track_accesses);
+    evm.set_access_tracking_enabled(bal_execution.track_accesses);
     evm.transact(tx)
 }
 

--- a/crates/eest/src/blockchaintest/execute.rs
+++ b/crates/eest/src/blockchaintest/execute.rs
@@ -21,10 +21,13 @@ use evm2::{
     TxResult, WITHDRAWAL_REQUEST_ADDRESS,
     env::BlockEnv,
     ethereum::{RecoveredTxEnvelope, ethereum_tx_registry},
-    evm::{AccountInfo as EvmAccountInfo, BalBuilder, InMemoryDB, StateChanges, Tracked},
+    evm::{
+        AccountInfo as EvmAccountInfo, Bal, BalBuilder, BalDatabase, InMemoryDB, StateChanges,
+        Tracked,
+    },
     registry::HandlerError,
 };
-use std::{fs, path::Path};
+use std::{fs, path::Path, sync::Arc};
 
 const ONE_GWEI: u64 = 1_000_000_000;
 const ONE_ETHER: u128 = 1_000_000_000_000_000_000;
@@ -145,12 +148,25 @@ fn execute_block(
         this_excess_blob_gas = header.excess_blob_gas.map(|gas| gas.saturating_to::<u64>());
     }
 
-    let mut block_database = database.clone();
     let needs_bal = block.block_access_list.is_some()
         || block
             .expect_exception
             .as_ref()
             .is_some_and(|exception| exception.contains("BLOCK_ACCESS_LIST"));
+    let read_bal = block
+        .block_access_list
+        .as_ref()
+        .map(Bal::clone_from_alloy)
+        .transpose()
+        .map_err(|err| {
+            TestError::case(
+                path,
+                name,
+                TestErrorKind::UnexpectedFailure(format!("invalid block access list: {err}")),
+            )
+        })?
+        .map(Arc::new);
+    let mut block_database = database.clone();
     let mut bal_builder = needs_bal.then(BalBuilder::default);
     let txs = block_transactions(block);
     pre_block_system_calls(
@@ -159,6 +175,7 @@ fn execute_block(
         next_block_env,
         *parent_block_hash,
         beacon_root,
+        read_bal.as_ref(),
         bal_builder.as_mut(),
     )
     .map_err(|err| TestError::case(path, name, err))?;
@@ -172,7 +189,15 @@ fn execute_block(
             Err(err) => return Err(TestError::case(path, name, err)),
         };
 
-        match execute_tx(spec, next_block_env, block_database.clone(), &tx, bal_builder.is_some()) {
+        match execute_tx(
+            spec,
+            next_block_env,
+            block_database.clone(),
+            &tx,
+            read_bal.as_ref(),
+            BlockAccessIndex::new(tx_index as u64 + 1),
+            bal_builder.is_some(),
+        ) {
             Ok(result) => {
                 if let Some(bal_builder) = &mut bal_builder {
                     bal_builder.push_state_changes(
@@ -195,6 +220,7 @@ fn execute_block(
         spec,
         next_block_env,
         block_withdrawals(block),
+        read_bal.as_ref(),
         bal_builder.as_mut(),
         BlockAccessIndex::new(txs.len() as u64 + 1),
     )
@@ -255,6 +281,7 @@ fn pre_block_system_calls(
     block: BlockEnv,
     parent_block_hash: Option<B256>,
     parent_beacon_block_root: Option<B256>,
+    read_bal: Option<&Arc<Bal>>,
     mut bal_builder: Option<&mut BalBuilder>,
 ) -> Result<(), TestErrorKind> {
     if block.number.is_zero() {
@@ -270,6 +297,8 @@ fn pre_block_system_calls(
             HISTORY_STORAGE_ADDRESS,
             Bytes::copy_from_slice(hash.as_slice()),
             "eip2935",
+            read_bal,
+            BlockAccessIndex::PRE_EXECUTION,
             bal_builder.is_some(),
         )?;
         if let Some(bal_builder) = &mut bal_builder {
@@ -286,6 +315,8 @@ fn pre_block_system_calls(
             BEACON_ROOTS_ADDRESS,
             Bytes::copy_from_slice(root.as_slice()),
             "eip4788",
+            read_bal,
+            BlockAccessIndex::PRE_EXECUTION,
             bal_builder.is_some(),
         )?;
         if let Some(bal_builder) = &mut bal_builder {
@@ -300,6 +331,7 @@ fn post_block_transition(
     spec: SpecId,
     block: BlockEnv,
     withdrawals: &[Withdrawal],
+    read_bal: Option<&Arc<Bal>>,
     mut bal_builder: Option<&mut BalBuilder>,
     bal_index: BlockAccessIndex,
 ) -> Result<(), TestErrorKind> {
@@ -332,6 +364,8 @@ fn post_block_transition(
             WITHDRAWAL_REQUEST_ADDRESS,
             Bytes::new(),
             "eip7002",
+            read_bal,
+            bal_index,
             bal_builder.is_some(),
         )?;
         if let Some(bal_builder) = &mut bal_builder {
@@ -344,6 +378,8 @@ fn post_block_transition(
             evm2::CONSOLIDATION_REQUEST_ADDRESS,
             Bytes::new(),
             "eip7251",
+            read_bal,
+            bal_index,
             bal_builder.is_some(),
         )?;
         if let Some(bal_builder) = &mut bal_builder {
@@ -360,13 +396,20 @@ fn run_system_call(
     address: Address,
     data: Bytes,
     label: &'static str,
+    read_bal: Option<&Arc<Bal>>,
+    bal_index: BlockAccessIndex,
     track_accesses: bool,
 ) -> Result<StateChanges, TestErrorKind> {
+    let mut evm_database = BalDatabase::new(database.clone());
+    if let Some(read_bal) = read_bal {
+        evm_database.bal_state.set_bal(Some(Arc::clone(read_bal)));
+        evm_database.bal_state.set_bal_index(bal_index);
+    }
     let mut evm = Evm::<BaseEvmTypes>::new(
         spec,
         block,
         ethereum_tx_registry(spec),
-        database.clone(),
+        evm_database,
         Precompiles::base(spec),
     );
     evm.set_access_tracking_enabled(track_accesses);
@@ -383,8 +426,15 @@ fn execute_tx(
     block: BlockEnv,
     database: InMemoryDB,
     tx: &RecoveredTxEnvelope,
+    read_bal: Option<&Arc<Bal>>,
+    bal_index: BlockAccessIndex,
     track_accesses: bool,
 ) -> Result<TxResult, HandlerError> {
+    let mut database = BalDatabase::new(database);
+    if let Some(read_bal) = read_bal {
+        database.bal_state.set_bal(Some(Arc::clone(read_bal)));
+        database.bal_state.set_bal_index(bal_index);
+    }
     let mut evm = Evm::<BaseEvmTypes>::new(
         spec,
         block,

--- a/crates/evm2/src/evm/bal.rs
+++ b/crates/evm2/src/evm/bal.rs
@@ -1,167 +1,800 @@
-//! Block access list construction from transaction state changes.
+//! Block access list state and database support.
 
-use super::{AccountInfo, StateChanges};
-use crate::{bytecode::Bytecode, interpreter::Word};
-use alloc::vec::Vec;
+use super::{
+    AccountInfo, DatabaseCommit, DbErrorCode, DbResult, DynDatabase, StateChanges,
+    StorageChangeSet, db::bal_error_code,
+};
+use crate::{
+    bytecode::{Bytecode, BytecodeDecodeError},
+    interpreter::Word,
+};
+use alloc::{boxed::Box, collections::BTreeMap, sync::Arc, vec::Vec};
 use alloy_eip7928::{
-    AccountChanges, BalanceChange, BlockAccessIndex, BlockAccessList, CodeChange, NonceChange,
-    SlotChanges, StorageChange,
+    AccountChanges as AlloyAccountChanges, BalanceChange as AlloyBalanceChange, BlockAccessIndex,
+    BlockAccessList as AlloyBal, CodeChange as AlloyCodeChange, NonceChange as AlloyNonceChange,
+    SlotChanges as AlloySlotChanges, StorageChange as AlloyStorageChange,
 };
-use alloy_primitives::{
-    Address, Bytes,
-    map::{AddressMap, U256Map, U256Set},
-};
+use alloy_primitives::{Address, B256};
+use core::{error::Error, fmt};
 
-/// Builder for EIP-7928 block access lists.
-#[derive(Clone, Debug, Default, Eq, PartialEq)]
-pub struct BalBuilder {
-    accounts: AddressMap<AccountBalBuilder>,
+/// Positional account id inside a block access list.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct AccountId(usize);
+
+impl AccountId {
+    /// Creates a new account id.
+    #[inline]
+    pub const fn new(id: usize) -> Self {
+        Self(id)
+    }
+
+    /// Returns the raw account id.
+    #[inline]
+    pub const fn get(self) -> usize {
+        self.0
+    }
 }
 
-impl BalBuilder {
-    /// Pushes a transaction or system-call state transition into the block access list.
+/// Error returned when a BAL lookup cannot find expected data.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum BalError {
+    /// The address was not present in the BAL's accounts map.
+    AccountNotFound {
+        /// Address that was not found.
+        address: Address,
+    },
+    /// The supplied account id index is out of range for the BAL's accounts map.
+    InvalidAccountId {
+        /// Account id that was supplied.
+        account_id: AccountId,
+    },
+    /// The account exists in the BAL but the requested storage slot is not listed under it.
+    SlotNotFound {
+        /// Address of the account whose slot was missing.
+        address: Address,
+        /// Storage slot that was not found.
+        slot: Word,
+    },
+}
+
+impl fmt::Display for BalError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::AccountNotFound { address } => write!(f, "Account {address} not found in BAL"),
+            Self::InvalidAccountId { account_id } => {
+                write!(f, "Invalid BAL account id {}", account_id.get())
+            }
+            Self::SlotNotFound { address, slot } => {
+                write!(f, "Slot {slot:#x} not found in BAL for account {address}")
+            }
+        }
+    }
+}
+
+impl Error for BalError {}
+
+/// List of block-indexed writes for one state item.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct BalWrites<T: PartialEq + Clone> {
+    /// Writes keyed by block access index.
+    pub writes: Vec<(BlockAccessIndex, T)>,
+}
+
+impl<T: PartialEq + Clone> BalWrites<T> {
+    /// Creates a write list sorted by block access index.
+    pub fn new(mut writes: Vec<(BlockAccessIndex, T)>) -> Self {
+        writes.sort_unstable_by_key(|(index, _)| *index);
+        Self { writes }
+    }
+
+    #[inline(never)]
+    fn get_linear_search(&self, bal_index: BlockAccessIndex) -> Option<T> {
+        let mut last_item = None;
+        for (index, item) in &self.writes {
+            if index >= &bal_index {
+                return last_item;
+            }
+            last_item = Some(item.clone());
+        }
+        last_item
+    }
+
+    /// Returns the latest write before `bal_index`.
+    pub fn get(&self, bal_index: BlockAccessIndex) -> Option<T> {
+        if self.writes.len() < 5 {
+            return self.get_linear_search(bal_index);
+        }
+        let i = match self.writes.binary_search_by_key(&bal_index, |(index, _)| *index) {
+            Ok(i) | Err(i) => i,
+        };
+        (i != 0).then(|| self.writes[i - 1].1.clone())
+    }
+
+    /// Extends this write list with another one.
+    pub fn extend(&mut self, other: Self) {
+        self.writes.extend(other.writes);
+        self.writes.sort_unstable_by_key(|(index, _)| *index);
+    }
+
+    /// Returns whether this item has no writes.
+    #[inline]
+    pub const fn is_empty(&self) -> bool {
+        self.writes.is_empty()
+    }
+
+    /// Inserts a write without comparing to an original value.
+    #[inline]
+    pub fn force_update(&mut self, index: BlockAccessIndex, value: T) {
+        if let Some(last) = self.writes.last_mut()
+            && last.0 == index
+        {
+            last.1 = value;
+            return;
+        }
+        self.writes.push((index, value));
+    }
+
+    /// Inserts a write if `value` differs from the previous value.
+    pub fn update(&mut self, index: BlockAccessIndex, original_value: &T, value: T) {
+        self.update_with_key(index, original_value, value, |value| value);
+    }
+
+    /// Inserts a write, comparing by a projected key.
+    pub fn update_with_key<K: PartialEq, F>(
+        &mut self,
+        index: BlockAccessIndex,
+        original_subvalue: &K,
+        value: T,
+        f: F,
+    ) where
+        F: Fn(&T) -> &K,
+    {
+        if let Some(last) = self.writes.last_mut()
+            && last.0 != index
+        {
+            if f(&last.1) != f(&value) {
+                self.writes.push((index, value));
+            }
+            return;
+        }
+
+        let (previous, last) = match self.writes.as_mut_slice() {
+            [.., previous, last] => (f(&previous.1), last),
+            [last] => (original_subvalue, last),
+            [] => {
+                if original_subvalue != f(&value) {
+                    self.writes.push((index, value));
+                }
+                return;
+            }
+        };
+
+        if previous == f(&value) {
+            self.writes.pop();
+        } else {
+            last.1 = value;
+        }
+    }
+}
+
+impl From<Vec<AlloyBalanceChange>> for BalWrites<Word> {
+    fn from(changes: Vec<AlloyBalanceChange>) -> Self {
+        Self::new(
+            changes
+                .into_iter()
+                .map(|change| (change.block_access_index, change.post_balance))
+                .collect(),
+        )
+    }
+}
+
+impl From<Vec<AlloyNonceChange>> for BalWrites<u64> {
+    fn from(changes: Vec<AlloyNonceChange>) -> Self {
+        Self::new(
+            changes
+                .into_iter()
+                .map(|change| (change.block_access_index, change.new_nonce))
+                .collect(),
+        )
+    }
+}
+
+impl TryFrom<Vec<AlloyCodeChange>> for BalWrites<(B256, Bytecode)> {
+    type Error = BytecodeDecodeError;
+
+    fn try_from(changes: Vec<AlloyCodeChange>) -> Result<Self, Self::Error> {
+        let mut writes = Vec::with_capacity(changes.len());
+        for change in changes {
+            let code = Bytecode::new_raw_checked(change.new_code)?;
+            writes.push((change.block_access_index, (code.hash_slow(), code)));
+        }
+        Ok(Self::new(writes))
+    }
+}
+
+impl From<Vec<AlloyStorageChange>> for BalWrites<Word> {
+    fn from(changes: Vec<AlloyStorageChange>) -> Self {
+        Self::new(
+            changes
+                .into_iter()
+                .map(|change| (change.block_access_index, change.new_value))
+                .collect(),
+        )
+    }
+}
+
+/// Account-info BAL data.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct AccountInfoBal {
+    /// Nonce writes.
+    pub nonce: BalWrites<u64>,
+    /// Balance writes.
+    pub balance: BalWrites<Word>,
+    /// Code writes.
+    pub code: BalWrites<(B256, Bytecode)>,
+}
+
+impl AccountInfoBal {
+    /// Populates account info from BAL writes before `bal_index`.
+    pub fn populate_account_info(
+        &self,
+        bal_index: BlockAccessIndex,
+        account: &mut AccountInfo,
+    ) -> bool {
+        let mut changed = false;
+        if let Some(nonce) = self.nonce.get(bal_index) {
+            account.nonce = nonce;
+            changed = true;
+        }
+        if let Some(balance) = self.balance.get(bal_index) {
+            account.balance = balance;
+            changed = true;
+        }
+        if let Some((code_hash, code)) = self.code.get(bal_index) {
+            account.code_hash = code_hash;
+            account.code = Some(code);
+            changed = true;
+        }
+        changed
+    }
+
+    #[inline]
+    fn update(&mut self, index: BlockAccessIndex, original: &AccountInfo, current: &AccountInfo) {
+        self.nonce.update(index, &original.nonce, current.nonce);
+        self.balance.update(index, &original.balance, current.balance);
+        if original.code_hash != current.code_hash {
+            self.code.update_with_key(
+                index,
+                &original.code_hash,
+                (current.code_hash, current.code.clone().unwrap_or_default()),
+                |value| &value.0,
+            );
+        }
+    }
+}
+
+/// Storage BAL data for an account.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct StorageBal {
+    /// Storage slots with reads or writes.
+    pub storage: BTreeMap<Word, BalWrites<Word>>,
+}
+
+impl StorageBal {
+    /// Gets storage from BAL.
+    #[inline]
+    pub fn get(
+        &self,
+        address: &Address,
+        key: Word,
+        bal_index: BlockAccessIndex,
+    ) -> Result<Option<Word>, BalError> {
+        Ok(self.get_bal_writes(address, key)?.get(bal_index))
+    }
+
+    /// Gets storage writes for a slot.
+    #[inline]
+    pub fn get_bal_writes(
+        &self,
+        address: &Address,
+        key: Word,
+    ) -> Result<&BalWrites<Word>, BalError> {
+        self.storage.get(&key).ok_or(BalError::SlotNotFound { address: *address, slot: key })
+    }
+
+    #[inline]
+    fn update(&mut self, index: BlockAccessIndex, storage: &StorageChangeSet) {
+        for (&key, value) in &storage.slots {
+            self.storage.entry(key).or_default().update(index, &value.original, value.current);
+        }
+    }
+
+    #[inline]
+    fn update_reads(&mut self, storage: impl Iterator<Item = Word>) {
+        for key in storage {
+            self.storage.entry(key).or_default();
+        }
+    }
+}
+
+impl FromIterator<(Word, BalWrites<Word>)> for StorageBal {
+    fn from_iter<I: IntoIterator<Item = (Word, BalWrites<Word>)>>(iter: I) -> Self {
+        Self { storage: iter.into_iter().collect() }
+    }
+}
+
+/// BAL data for one account.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct AccountBal {
+    /// Account info changes.
+    pub account_info: AccountInfoBal,
+    /// Storage changes and reads.
+    pub storage: StorageBal,
+}
+
+impl AccountBal {
+    /// Populates account info from BAL.
+    #[inline]
+    pub fn populate_account_info(
+        &self,
+        bal_index: BlockAccessIndex,
+        account: &mut AccountInfo,
+    ) -> bool {
+        self.account_info.populate_account_info(bal_index, account)
+    }
+
+    /// Creates account BAL data from an Alloy account.
+    pub fn try_from_alloy(
+        account: AlloyAccountChanges,
+    ) -> Result<(Address, Self), BytecodeDecodeError> {
+        Ok((
+            account.address,
+            Self {
+                account_info: AccountInfoBal {
+                    nonce: account.nonce_changes.into(),
+                    balance: account.balance_changes.into(),
+                    code: account.code_changes.try_into()?,
+                },
+                storage: account
+                    .storage_changes
+                    .into_iter()
+                    .map(|slot| (slot.slot, slot.changes.into()))
+                    .chain(account.storage_reads.into_iter().map(|key| (key, BalWrites::default())))
+                    .collect(),
+            },
+        ))
+    }
+
+    /// Converts account BAL data into Alloy BAL data.
+    pub fn into_alloy_account(self, address: Address) -> AlloyAccountChanges {
+        let mut storage_changes = Vec::new();
+        let mut storage_reads = Vec::new();
+        for (slot, value) in self.storage.storage {
+            if value.writes.is_empty() {
+                storage_reads.push(slot);
+            } else {
+                let mut changes = value
+                    .writes
+                    .into_iter()
+                    .map(|(index, value)| AlloyStorageChange::new(index, value))
+                    .collect::<Vec<_>>();
+                changes.sort_unstable_by_key(|change| change.block_access_index);
+                storage_changes.push(AlloySlotChanges::new(slot, changes));
+            }
+        }
+        let mut account = AlloyAccountChanges {
+            address,
+            storage_changes,
+            storage_reads,
+            balance_changes: self
+                .account_info
+                .balance
+                .writes
+                .into_iter()
+                .map(|(index, value)| AlloyBalanceChange::new(index, value))
+                .collect(),
+            nonce_changes: self
+                .account_info
+                .nonce
+                .writes
+                .into_iter()
+                .map(|(index, value)| AlloyNonceChange::new(index, value))
+                .collect(),
+            code_changes: self
+                .account_info
+                .code
+                .writes
+                .into_iter()
+                .map(|(index, (_, value))| AlloyCodeChange::new(index, value.original_bytes()))
+                .collect(),
+        };
+        account.sort();
+        account
+    }
+}
+
+/// Block access list state.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct Bal {
+    /// Accounts keyed by address.
+    pub accounts: BTreeMap<Address, AccountBal>,
+}
+
+impl Bal {
+    /// Creates an empty BAL.
+    #[inline]
+    pub const fn new() -> Self {
+        Self { accounts: BTreeMap::new() }
+    }
+
+    /// Converts Alloy BAL data into BAL state.
+    pub fn try_from_alloy(alloy_bal: AlloyBal) -> Result<Self, BytecodeDecodeError> {
+        alloy_bal.into_iter().map(AccountBal::try_from_alloy).collect()
+    }
+
+    /// Clones Alloy BAL data into BAL state.
+    pub fn clone_from_alloy(alloy_bal: &AlloyBal) -> Result<Self, BytecodeDecodeError> {
+        alloy_bal.clone().into_iter().map(AccountBal::try_from_alloy).collect()
+    }
+
+    /// Updates this BAL from a transaction or system-call state transition.
     pub fn push_state_changes(&mut self, index: BlockAccessIndex, changes: &StateChanges) {
         for (&address, account) in &changes.accounts {
-            let builder = self.accounts.entry(address).or_default();
-            let current = account.current.as_ref();
+            let bal_account = self.accounts.entry(address).or_default();
             let empty = AccountInfo::default();
-            let post = current.unwrap_or(&empty);
-            let original = account.original.as_ref();
-
-            if original.map_or(!post.balance.is_zero(), |original| original.balance != post.balance)
-            {
-                builder.push_balance_change(index, post.balance);
-            }
-            if original.map_or(post.nonce != 0, |original| original.nonce != post.nonce) {
-                builder.push_nonce_change(index, post.nonce);
-            }
-            if original.map_or(post.code_hash != alloy_primitives::KECCAK256_EMPTY, |original| {
-                original.code_hash != post.code_hash
-            }) {
-                builder.push_code_change(index, code_bytes(current));
-            }
+            let original = account.original.as_ref().unwrap_or(&empty);
+            let current = account.current.as_ref().unwrap_or(&empty);
+            bal_account.account_info.update(index, original, current);
         }
 
         for (&address, storage) in &changes.storage {
-            let builder = self.accounts.entry(address).or_default();
-            for (&slot, change) in &storage.slots {
-                builder.push_storage_change(index, slot, change.current);
-            }
+            self.accounts.entry(address).or_default().storage.update(index, storage);
         }
 
         if let Some(accesses) = &changes.accesses {
             for &address in &accesses.accounts {
-                self.accounts.entry(address).or_default().accessed = true;
+                self.accounts.entry(address).or_default();
             }
             for (&address, slots) in &accesses.storage {
-                let changed_slots = changes.storage.get(&address);
-                let builder = self.accounts.entry(address).or_default();
-                builder.accessed = true;
-                for &slot in slots {
-                    let slot_was_written =
-                        changed_slots.is_some_and(|storage| storage.slots.contains_key(&slot));
-                    if slot_was_written {
-                        continue;
-                    }
-                    if !builder.storage_changes.contains_key(&slot) {
-                        builder.storage_reads.insert(slot);
-                    }
-                }
+                let written = changes.storage.get(&address);
+                let slots = slots.iter().copied().filter(|slot| {
+                    !written.is_some_and(|storage| storage.slots.contains_key(slot))
+                });
+                self.accounts.entry(address).or_default().storage.update_reads(slots);
             }
         }
     }
 
-    /// Consumes the builder and returns a canonical EIP-7928 block access list.
-    pub fn build(self) -> BlockAccessList {
-        let mut accounts: BlockAccessList = self
+    /// Populates account info from BAL.
+    pub fn populate_account_info(
+        &self,
+        address: &Address,
+        bal_index: BlockAccessIndex,
+        account: &mut AccountInfo,
+    ) -> Result<bool, BalError> {
+        let Some(bal_account) = self.accounts.get(address) else {
+            return Err(BalError::AccountNotFound { address: *address });
+        };
+        Ok(bal_account.populate_account_info(bal_index, account))
+    }
+
+    /// Populates storage from BAL.
+    pub fn populate_storage_slot(
+        &self,
+        address: Address,
+        bal_index: BlockAccessIndex,
+        key: Word,
+        value: &mut Word,
+    ) -> Result<(), BalError> {
+        let Some(bal_account) = self.accounts.get(&address) else {
+            return Err(BalError::AccountNotFound { address });
+        };
+        if let Some(bal_value) = bal_account.storage.get(&address, key, bal_index)? {
+            *value = bal_value;
+        }
+        Ok(())
+    }
+
+    /// Gets a storage value from BAL if a prior write exists.
+    pub fn storage(
+        &self,
+        address: &Address,
+        key: Word,
+        bal_index: BlockAccessIndex,
+    ) -> Result<Option<Word>, BalError> {
+        let Some(bal_account) = self.accounts.get(address) else {
+            return Err(BalError::AccountNotFound { address: *address });
+        };
+        bal_account.storage.get(address, key, bal_index)
+    }
+
+    /// Consumes this BAL and returns canonical Alloy BAL data.
+    pub fn into_alloy_bal(self) -> AlloyBal {
+        let mut bal = self
             .accounts
             .into_iter()
-            .filter_map(|(address, builder)| builder.build(address))
-            .collect();
-        accounts.sort_unstable_by_key(|account| account.address);
-        accounts
+            .map(|(address, account)| account.into_alloy_account(address))
+            .collect::<Vec<_>>();
+        bal.sort_unstable_by_key(|account| account.address);
+        bal
+    }
+
+    /// Consumes this BAL builder and returns canonical Alloy BAL data.
+    #[inline]
+    pub fn build(self) -> AlloyBal {
+        self.into_alloy_bal()
     }
 }
 
+impl FromIterator<(Address, AccountBal)> for Bal {
+    fn from_iter<I: IntoIterator<Item = (Address, AccountBal)>>(iter: I) -> Self {
+        Self { accounts: iter.into_iter().collect() }
+    }
+}
+
+/// Backwards-compatible name for building BALs.
+pub type BalBuilder = Bal;
+
+/// BAL read/build state for a database.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
-struct AccountBalBuilder {
-    accessed: bool,
-    storage_reads: U256Set,
-    storage_changes: U256Map<Vec<StorageChange>>,
-    balance_changes: Vec<BalanceChange>,
-    nonce_changes: Vec<NonceChange>,
-    code_changes: Vec<CodeChange>,
+pub struct BalState {
+    /// BAL used to execute transactions.
+    pub bal: Option<Arc<Bal>>,
+    /// BAL builder used to build a BAL from committed changes.
+    pub bal_builder: Option<Bal>,
+    /// Current block access index.
+    pub bal_index: BlockAccessIndex,
 }
 
-impl AccountBalBuilder {
-    fn push_storage_change(&mut self, index: BlockAccessIndex, slot: Word, value: Word) {
-        self.storage_reads.remove(&slot);
-        let changes = self.storage_changes.entry(slot).or_default();
-        if let Some(change) = changes.iter_mut().find(|change| change.block_access_index == index) {
-            change.new_value = value;
-        } else {
-            changes.push(StorageChange::new(index, value));
-        }
+impl BalState {
+    /// Creates empty BAL state.
+    #[inline]
+    pub const fn new() -> Self {
+        Self { bal: None, bal_builder: None, bal_index: BlockAccessIndex::PRE_EXECUTION }
     }
 
-    fn push_balance_change(&mut self, index: BlockAccessIndex, balance: Word) {
-        if let Some(change) =
-            self.balance_changes.iter_mut().find(|change| change.block_access_index == index)
-        {
-            change.post_balance = balance;
-        } else {
-            self.balance_changes.push(BalanceChange::new(index, balance));
-        }
+    /// Sets the read BAL.
+    #[inline]
+    pub fn set_bal(&mut self, bal: Option<Arc<Bal>>) {
+        self.bal = bal;
     }
 
-    fn push_nonce_change(&mut self, index: BlockAccessIndex, nonce: u64) {
-        if let Some(change) =
-            self.nonce_changes.iter_mut().find(|change| change.block_access_index == index)
-        {
-            change.new_nonce = change.new_nonce.max(nonce);
-        } else {
-            self.nonce_changes.push(NonceChange::new(index, nonce));
-        }
+    /// Enables BAL building.
+    #[inline]
+    pub fn enable_bal_builder(&mut self) {
+        self.bal_builder = Some(Bal::new());
     }
 
-    fn push_code_change(&mut self, index: BlockAccessIndex, code: Bytes) {
-        if let Some(change) =
-            self.code_changes.iter_mut().find(|change| change.block_access_index == index)
-        {
-            change.new_code = code;
-        } else {
-            self.code_changes.push(CodeChange::new(index, code));
-        }
+    /// Resets the current BAL index.
+    #[inline]
+    pub const fn reset_bal_index(&mut self) {
+        self.bal_index = BlockAccessIndex::PRE_EXECUTION;
     }
 
-    fn build(self, address: Address) -> Option<AccountChanges> {
-        if self.storage_reads.is_empty()
-            && self.storage_changes.is_empty()
-            && self.balance_changes.is_empty()
-            && self.nonce_changes.is_empty()
-            && self.code_changes.is_empty()
-            && !self.accessed
-        {
-            return None;
-        }
+    /// Sets the current BAL index.
+    #[inline]
+    pub const fn set_bal_index(&mut self, index: BlockAccessIndex) {
+        self.bal_index = index;
+    }
 
-        let mut account = AccountChanges {
-            address,
-            storage_changes: self
-                .storage_changes
-                .into_iter()
-                .map(|(slot, changes)| SlotChanges::new(slot, changes))
-                .collect(),
-            storage_reads: self.storage_reads.into_iter().collect(),
-            balance_changes: self.balance_changes,
-            nonce_changes: self.nonce_changes,
-            code_changes: self.code_changes,
+    /// Bumps the current BAL index.
+    #[inline]
+    pub const fn bump_bal_index(&mut self) {
+        self.bal_index.increment();
+    }
+
+    /// Takes the built BAL.
+    #[inline]
+    pub fn take_built_bal(&mut self) -> Option<Bal> {
+        self.reset_bal_index();
+        self.bal_builder.take()
+    }
+
+    /// Takes the built BAL as canonical Alloy BAL data.
+    #[inline]
+    pub fn take_built_alloy_bal(&mut self) -> Option<AlloyBal> {
+        self.take_built_bal().map(Bal::into_alloy_bal)
+    }
+
+    fn account(
+        &self,
+        address: &Address,
+        account: &mut Option<AccountInfo>,
+    ) -> Result<bool, BalError> {
+        let Some(bal) = &self.bal else {
+            return Ok(false);
         };
-        account.sort();
-        Some(account)
+        let is_none = account.is_none();
+        let mut bal_account = account.take().unwrap_or_default();
+        let changed = bal.populate_account_info(address, self.bal_index, &mut bal_account)?;
+        if !changed && is_none {
+            return Ok(true);
+        }
+        *account = Some(bal_account);
+        Ok(true)
+    }
+
+    fn storage(&self, address: &Address, key: &Word) -> Result<Option<Word>, BalError> {
+        let Some(bal) = &self.bal else {
+            return Ok(None);
+        };
+        bal.storage(address, *key, self.bal_index)
+    }
+
+    fn record_state_changes(&mut self, changes: &StateChanges) {
+        if let Some(bal_builder) = &mut self.bal_builder {
+            bal_builder.push_state_changes(self.bal_index, changes);
+        }
     }
 }
 
-fn code_bytes(account: Option<&AccountInfo>) -> Bytes {
-    account.and_then(|info| info.code.as_ref()).map(Bytecode::original_bytes).unwrap_or_default()
+/// Database wrapper with BAL read/build state.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BalDatabase<DB> {
+    /// BAL manager.
+    pub bal_state: BalState,
+    /// Wrapped backing database.
+    pub db: DB,
+    bal_error: Option<BalError>,
+}
+
+impl<DB> BalDatabase<DB> {
+    /// Creates a BAL database wrapper.
+    #[inline]
+    pub fn new(db: DB) -> Self {
+        Self { bal_state: BalState::default(), db, bal_error: None }
+    }
+
+    /// Sets the read BAL.
+    #[inline]
+    pub fn with_bal(mut self, bal: Arc<Bal>) -> Self {
+        self.bal_state.set_bal(Some(bal));
+        self
+    }
+
+    /// Enables BAL building.
+    #[inline]
+    pub fn with_bal_builder(mut self) -> Self {
+        self.bal_state.enable_bal_builder();
+        self
+    }
+
+    #[inline]
+    fn store_bal_error(&mut self, error: BalError) -> DbErrorCode {
+        self.bal_error = Some(error);
+        bal_error_code()
+    }
+}
+
+impl<DB: DynDatabase> DynDatabase for BalDatabase<DB> {
+    fn get_account(&mut self, address: &Address) -> DbResult<Option<AccountInfo>> {
+        let mut account = self.db.get_account(address)?;
+        self.bal_state
+            .account(address, &mut account)
+            .map_err(|error| self.store_bal_error(error))?;
+        Ok(account)
+    }
+
+    fn get_code_by_hash(&mut self, code_hash: &B256) -> DbResult<Bytecode> {
+        self.db.get_code_by_hash(code_hash)
+    }
+
+    fn get_storage(&mut self, address: &Address, key: &Word) -> DbResult<Word> {
+        if let Some(value) =
+            self.bal_state.storage(address, key).map_err(|error| self.store_bal_error(error))?
+        {
+            return Ok(value);
+        }
+        self.db.get_storage(address, key)
+    }
+
+    fn get_block_hash(&mut self, number: &Word) -> DbResult<Option<B256>> {
+        self.db.get_block_hash(number)
+    }
+
+    fn error(&mut self, code: DbErrorCode) -> Box<dyn Error> {
+        if code == bal_error_code()
+            && let Some(error) = self.bal_error.take()
+        {
+            return Box::new(error);
+        }
+        self.db.error(code)
+    }
+
+    fn set_bal(&mut self, bal: Option<Arc<Bal>>) {
+        self.bal_state.set_bal(bal);
+    }
+
+    fn enable_bal_builder(&mut self) {
+        self.bal_state.enable_bal_builder();
+    }
+
+    fn reset_bal_index(&mut self) {
+        self.bal_state.reset_bal_index();
+    }
+
+    fn set_bal_index(&mut self, index: BlockAccessIndex) {
+        self.bal_state.set_bal_index(index);
+    }
+
+    fn bump_bal_index(&mut self) {
+        self.bal_state.bump_bal_index();
+    }
+
+    fn take_built_bal(&mut self) -> Option<Bal> {
+        self.bal_state.take_built_bal()
+    }
+
+    fn take_built_alloy_bal(&mut self) -> Option<AlloyBal> {
+        self.bal_state.take_built_alloy_bal()
+    }
+
+    fn record_state_changes(&mut self, changes: &StateChanges) {
+        self.bal_state.record_state_changes(changes);
+        self.db.record_state_changes(changes);
+    }
+}
+
+impl<DB: DatabaseCommit> DatabaseCommit for BalDatabase<DB> {
+    fn commit(&mut self, changes: &StateChanges) {
+        self.bal_state.record_state_changes(changes);
+        self.db.commit(changes);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::evm::{CacheDB, EmptyDB, Tracked};
+
+    #[test]
+    fn bal_writes_return_previous_value() {
+        let writes = BalWrites::new(vec![
+            (BlockAccessIndex::new(1), Word::from(10)),
+            (BlockAccessIndex::new(3), Word::from(30)),
+        ]);
+
+        assert_eq!(writes.get(BlockAccessIndex::new(0)), None);
+        assert_eq!(writes.get(BlockAccessIndex::new(1)), None);
+        assert_eq!(writes.get(BlockAccessIndex::new(2)), Some(Word::from(10)));
+        assert_eq!(writes.get(BlockAccessIndex::new(3)), Some(Word::from(10)));
+        assert_eq!(writes.get(BlockAccessIndex::new(4)), Some(Word::from(30)));
+    }
+
+    #[test]
+    fn bal_database_overlays_prior_account_and_storage_writes() {
+        let address = Address::with_last_byte(0x11);
+        let slot = Word::from(1);
+        let mut bal = Bal::new();
+        let mut changes = StateChanges::default();
+        changes.accounts.insert(
+            address,
+            Tracked {
+                original: None,
+                current: Some(AccountInfo::default().with_balance(Word::from(7))),
+                _non_exhaustive: (),
+            },
+        );
+        changes.storage.insert(
+            address,
+            StorageChangeSet {
+                wipe: false,
+                slots: BTreeMap::from([(
+                    slot,
+                    Tracked { original: Word::ZERO, current: Word::from(9), _non_exhaustive: () },
+                )]),
+                _non_exhaustive: (),
+            },
+        );
+        bal.push_state_changes(BlockAccessIndex::new(1), &changes);
+
+        let mut db = BalDatabase::new(CacheDB::new(EmptyDB::default())).with_bal(Arc::new(bal));
+        db.set_bal_index(BlockAccessIndex::new(2));
+
+        assert_eq!(
+            db.get_account(&address).unwrap().map(|account| account.balance),
+            Some(Word::from(7))
+        );
+        assert_eq!(db.get_storage(&address, &slot).unwrap(), Word::from(9));
+    }
 }

--- a/crates/evm2/src/evm/bal.rs
+++ b/crates/evm2/src/evm/bal.rs
@@ -585,7 +585,7 @@ impl BalState {
 
     /// Takes the built BAL.
     #[inline]
-    pub fn take_built_bal(&mut self) -> Option<Bal> {
+    pub const fn take_built_bal(&mut self) -> Option<Bal> {
         self.reset_bal_index();
         self.bal_builder.take()
     }

--- a/crates/evm2/src/evm/db.rs
+++ b/crates/evm2/src/evm/db.rs
@@ -1,8 +1,12 @@
 //! Database helpers for the EVM state overlay.
 
-use super::state::{AccountInfo, StateChanges};
+use super::{
+    bal::{Bal, BalBuilder},
+    state::{AccountInfo, StateChanges},
+};
 use crate::{bytecode::Bytecode, interpreter::Word};
-use alloc::{boxed::Box, string::ToString};
+use alloc::{boxed::Box, string::ToString, sync::Arc};
+use alloy_eip7928::{BlockAccessIndex, BlockAccessList};
 use alloy_primitives::{Address, B256, keccak256};
 use core::{any::Any, error::Error, fmt, num::NonZeroUsize};
 
@@ -131,6 +135,14 @@ fn stored_error_code() -> DbErrorCode {
     }
 }
 
+#[inline]
+pub(crate) fn bal_error_code() -> DbErrorCode {
+    match DbErrorCode::new(2) {
+        Some(code) => code,
+        None => unreachable!("BAL database error code is non-zero"),
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct DbErrorUnavailable(DbErrorCode);
 
@@ -192,6 +204,34 @@ pub trait DynDatabase: Any {
     fn error(&mut self, code: DbErrorCode) -> Box<dyn Error> {
         Box::new(DbErrorUnavailable(code))
     }
+
+    /// Sets the BAL used for database reads.
+    fn set_bal(&mut self, _bal: Option<Arc<Bal>>) {}
+
+    /// Enables BAL building from accepted state changes.
+    fn enable_bal_builder(&mut self) {}
+
+    /// Resets the current BAL index.
+    fn reset_bal_index(&mut self) {}
+
+    /// Sets the current BAL index.
+    fn set_bal_index(&mut self, _index: BlockAccessIndex) {}
+
+    /// Bumps the current BAL index.
+    fn bump_bal_index(&mut self) {}
+
+    /// Takes the built BAL.
+    fn take_built_bal(&mut self) -> Option<BalBuilder> {
+        None
+    }
+
+    /// Takes the built BAL as canonical EIP-7928 data.
+    fn take_built_alloy_bal(&mut self) -> Option<BlockAccessList> {
+        self.take_built_bal().map(Bal::into_alloy_bal)
+    }
+
+    /// Records accepted state changes for BAL building.
+    fn record_state_changes(&mut self, _changes: &StateChanges) {}
 }
 
 impl DynDatabase for Box<dyn DynDatabase> {
@@ -218,6 +258,46 @@ impl DynDatabase for Box<dyn DynDatabase> {
     #[inline]
     fn error(&mut self, code: DbErrorCode) -> Box<dyn Error> {
         self.as_mut().error(code)
+    }
+
+    #[inline]
+    fn set_bal(&mut self, bal: Option<Arc<Bal>>) {
+        self.as_mut().set_bal(bal);
+    }
+
+    #[inline]
+    fn enable_bal_builder(&mut self) {
+        self.as_mut().enable_bal_builder();
+    }
+
+    #[inline]
+    fn reset_bal_index(&mut self) {
+        self.as_mut().reset_bal_index();
+    }
+
+    #[inline]
+    fn set_bal_index(&mut self, index: BlockAccessIndex) {
+        self.as_mut().set_bal_index(index);
+    }
+
+    #[inline]
+    fn bump_bal_index(&mut self) {
+        self.as_mut().bump_bal_index();
+    }
+
+    #[inline]
+    fn take_built_bal(&mut self) -> Option<BalBuilder> {
+        self.as_mut().take_built_bal()
+    }
+
+    #[inline]
+    fn take_built_alloy_bal(&mut self) -> Option<BlockAccessList> {
+        self.as_mut().take_built_alloy_bal()
+    }
+
+    #[inline]
+    fn record_state_changes(&mut self, changes: &StateChanges) {
+        self.as_mut().record_state_changes(changes);
     }
 }
 

--- a/crates/evm2/src/evm/db/cache.rs
+++ b/crates/evm2/src/evm/db/cache.rs
@@ -3,10 +3,15 @@
 use super::{DatabaseCommit, DbErrorCode, DbResult, DynDatabase, EmptyDB};
 use crate::{
     bytecode::Bytecode,
-    evm::state::{AccountInfo, StateChanges},
+    evm::{
+        bal::{Bal, BalBuilder},
+        state::{AccountInfo, StateChanges},
+    },
     interpreter::Word,
     storage_key::{StorageKey, StorageKeyMap},
 };
+use alloc::sync::Arc;
+use alloy_eip7928::{BlockAccessIndex, BlockAccessList};
 use alloy_primitives::{
     Address, B256, KECCAK256_EMPTY,
     map::{AddressMap, B256Map, U256Map, hash_map::Entry},
@@ -204,6 +209,46 @@ impl<ExtDB: DynDatabase> DynDatabase for CacheDB<ExtDB> {
     #[inline]
     fn error(&mut self, code: DbErrorCode) -> alloc::boxed::Box<dyn core::error::Error> {
         self.db.error(code)
+    }
+
+    #[inline]
+    fn set_bal(&mut self, bal: Option<Arc<Bal>>) {
+        self.db.set_bal(bal);
+    }
+
+    #[inline]
+    fn enable_bal_builder(&mut self) {
+        self.db.enable_bal_builder();
+    }
+
+    #[inline]
+    fn reset_bal_index(&mut self) {
+        self.db.reset_bal_index();
+    }
+
+    #[inline]
+    fn set_bal_index(&mut self, index: BlockAccessIndex) {
+        self.db.set_bal_index(index);
+    }
+
+    #[inline]
+    fn bump_bal_index(&mut self) {
+        self.db.bump_bal_index();
+    }
+
+    #[inline]
+    fn take_built_bal(&mut self) -> Option<BalBuilder> {
+        self.db.take_built_bal()
+    }
+
+    #[inline]
+    fn take_built_alloy_bal(&mut self) -> Option<BlockAccessList> {
+        self.db.take_built_alloy_bal()
+    }
+
+    #[inline]
+    fn record_state_changes(&mut self, changes: &StateChanges) {
+        self.db.record_state_changes(changes);
     }
 }
 

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -17,7 +17,8 @@ use crate::{
     trustme,
     version::{EvmFeatures, GasId},
 };
-use alloc::{boxed::Box, vec, vec::Vec};
+use alloc::{boxed::Box, sync::Arc, vec, vec::Vec};
+use alloy_eip7928::{BlockAccessIndex, BlockAccessList};
 use alloy_eips::eip2718::Typed2718;
 use alloy_primitives::{Address, B256, Bytes, Log, LogData};
 use derive_where::derive_where;
@@ -29,7 +30,10 @@ pub mod precompile;
 pub mod registry;
 
 mod bal;
-pub use bal::BalBuilder;
+pub use bal::{
+    AccountBal, AccountId, AccountInfoBal, Bal, BalBuilder, BalDatabase, BalError, BalState,
+    BalWrites, StorageBal,
+};
 
 mod system;
 pub use system::{
@@ -176,6 +180,48 @@ impl<T: EvmTypes> Evm<T> {
     #[inline]
     pub const fn access_tracking_enabled(&self) -> bool {
         self.state.access_tracking_enabled()
+    }
+
+    /// Sets the BAL used for database reads.
+    #[inline]
+    pub fn set_bal(&mut self, bal: Option<Arc<Bal>>) {
+        self.state.set_bal(bal);
+    }
+
+    /// Enables BAL building from accepted state changes.
+    #[inline]
+    pub fn enable_bal_builder(&mut self) {
+        self.state.enable_bal_builder();
+    }
+
+    /// Resets the current BAL index.
+    #[inline]
+    pub fn reset_bal_index(&mut self) {
+        self.state.reset_bal_index();
+    }
+
+    /// Sets the current BAL index.
+    #[inline]
+    pub fn set_bal_index(&mut self, index: BlockAccessIndex) {
+        self.state.set_bal_index(index);
+    }
+
+    /// Bumps the current BAL index.
+    #[inline]
+    pub fn bump_bal_index(&mut self) {
+        self.state.bump_bal_index();
+    }
+
+    /// Takes the built BAL.
+    #[inline]
+    pub fn take_built_bal(&mut self) -> Option<BalBuilder> {
+        self.state.take_built_bal()
+    }
+
+    /// Takes the built BAL as canonical EIP-7928 data.
+    #[inline]
+    pub fn take_built_alloy_bal(&mut self) -> Option<BlockAccessList> {
+        self.state.take_built_alloy_bal()
     }
 
     /// Returns the backing database.
@@ -369,6 +415,7 @@ impl<T: EvmTypes<Tx: Typed2718>> Evm<T> {
                 result.output = Bytes::new();
             } else {
                 result.state_changes = self.state.build_state_changes();
+                self.state.record_state_changes(&result.state_changes);
                 self.state.commit_transaction_overlay();
             }
             result.db_error_code = self.db_error_code;

--- a/crates/evm2/src/evm/state.rs
+++ b/crates/evm2/src/evm/state.rs
@@ -1,7 +1,7 @@
 //! Basic in-memory EVM host state.
 
 use super::{
-    SStore,
+    Bal, BalBuilder, SStore,
     db::{DbResult, DynDatabase},
     eip7708_burn_log,
 };
@@ -11,7 +11,8 @@ use crate::{
     interpreter::{InstrStop, Word},
     storage_key::{StorageKey, StorageKeyMap, StorageKeySet},
 };
-use alloc::{boxed::Box, collections::BTreeMap, vec::Vec};
+use alloc::{boxed::Box, collections::BTreeMap, sync::Arc, vec::Vec};
+use alloy_eip7928::{BlockAccessIndex, BlockAccessList};
 use alloy_primitives::{
     Address, B256, KECCAK256_EMPTY, Log, U256,
     map::{AddressMap, AddressSet, U256Map, U256Set, hash_map},
@@ -492,6 +493,54 @@ impl State {
     #[inline]
     pub const fn access_tracking_enabled(&self) -> bool {
         self.access_tracker.enabled()
+    }
+
+    /// Sets the BAL used for database reads.
+    #[inline]
+    pub fn set_bal(&mut self, bal: Option<Arc<Bal>>) {
+        self.initial.set_bal(bal);
+    }
+
+    /// Enables BAL building from accepted state changes.
+    #[inline]
+    pub fn enable_bal_builder(&mut self) {
+        self.initial.enable_bal_builder();
+    }
+
+    /// Resets the current BAL index.
+    #[inline]
+    pub fn reset_bal_index(&mut self) {
+        self.initial.reset_bal_index();
+    }
+
+    /// Sets the current BAL index.
+    #[inline]
+    pub fn set_bal_index(&mut self, index: BlockAccessIndex) {
+        self.initial.set_bal_index(index);
+    }
+
+    /// Bumps the current BAL index.
+    #[inline]
+    pub fn bump_bal_index(&mut self) {
+        self.initial.bump_bal_index();
+    }
+
+    /// Takes the built BAL.
+    #[inline]
+    pub fn take_built_bal(&mut self) -> Option<BalBuilder> {
+        self.initial.take_built_bal()
+    }
+
+    /// Takes the built BAL as canonical EIP-7928 data.
+    #[inline]
+    pub fn take_built_alloy_bal(&mut self) -> Option<BlockAccessList> {
+        self.initial.take_built_alloy_bal()
+    }
+
+    /// Records accepted state changes for BAL building.
+    #[inline]
+    pub(crate) fn record_state_changes(&mut self, changes: &StateChanges) {
+        self.initial.record_state_changes(changes);
     }
 
     #[inline]

--- a/crates/evm2/src/evm/system.rs
+++ b/crates/evm2/src/evm/system.rs
@@ -100,6 +100,7 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
             result.output = Bytes::new();
         } else {
             result.state_changes = self.state.build_state_changes();
+            self.state.record_state_changes(&result.state_changes);
             self.state.commit_transaction_overlay();
         }
         result.db_error_code = self.db_error_code();


### PR DESCRIPTION
This stacks on #140 and ports the BAL database/read-mode shape from revm devnet. It adds BAL state, BAL lookup errors, block-indexed writes, an EIP-7928 conversion path, and a database wrapper that can execute against a provided BAL while also building a BAL from accepted state changes.

The EEST blockchain runner now feeds provided block access lists through that read path at the correct block access index for pre-block calls, transactions, and post-block calls. The remaining devnet failures are unchanged from the parent BAL branch and are still the known Amsterdam gas/accounting and EIP-7702 state-gas cases.
