### PR TITLE
perf(macros): borrow stack slots directly

### DIFF
--- a/crates/evm2/src/interpreter/instructions/arithmetic.rs
+++ b/crates/evm2/src/interpreter/instructions/arithmetic.rs
@@ -4,61 +4,61 @@ use evm2_macros::instruction;
 
 #[instruction]
 pub(crate) fn add([a, b]: [Word]) -> out {
-    *out = a.wrapping_add(b);
+    *out = a.wrapping_add(*b);
 }
 
 #[instruction]
 pub(crate) fn mul([a, b]: [Word]) -> out {
-    *out = a.wrapping_mul(b);
+    *out = a.wrapping_mul(*b);
 }
 
 #[instruction]
 pub(crate) fn sub([a, b]: [Word]) -> out {
-    *out = a.wrapping_sub(b);
+    *out = a.wrapping_sub(*b);
 }
 
 #[instruction]
 pub(crate) fn div([a, b]: [Word]) -> out {
-    *out = if b.is_zero() { Word::ZERO } else { a.wrapping_div(b) };
+    *out = if b.is_zero() { Word::ZERO } else { a.wrapping_div(*b) };
 }
 
 #[instruction]
 pub(crate) fn sdiv([a, b]: [Word]) -> out {
-    *out = i256_div(a, b);
+    *out = i256_div(*a, *b);
 }
 
 #[instruction]
 pub(crate) fn rem([a, b]: [Word]) -> out {
-    *out = if b.is_zero() { Word::ZERO } else { a.wrapping_rem(b) };
+    *out = if b.is_zero() { Word::ZERO } else { a.wrapping_rem(*b) };
 }
 
 #[instruction]
 pub(crate) fn smod([a, b]: [Word]) -> out {
-    *out = i256_mod(a, b);
+    *out = i256_mod(*a, *b);
 }
 
 #[instruction]
 pub(crate) fn addmod([a, b, n]: [Word]) -> out {
-    *out = a.add_mod(b, n);
+    *out = a.add_mod(*b, *n);
 }
 
 #[instruction]
 pub(crate) fn mulmod([a, b, n]: [Word]) -> out {
-    *out = a.mul_mod(b, n);
+    *out = a.mul_mod(*b, *n);
 }
 
 #[instruction(dynamic_gas)]
 pub(crate) fn exp(cx: _, [a, b]: [Word]) -> Result<out> {
-    cx.gas.spend(cx.state.gas_params().exp_cost(b))?;
-    *out = a.wrapping_pow(b);
+    cx.gas.spend(cx.state.gas_params().exp_cost(*b))?;
+    *out = a.wrapping_pow(*b);
 }
 
 #[instruction]
 pub(crate) fn signextend([ext, value]: [Word]) -> out {
-    if ext < 31 {
+    if *ext < 31 {
         let bit_index = (8 * ext.as_limbs()[0] + 7) as usize;
         let mask = (Word::ONE << bit_index) - Word::ONE;
-        *out = if value.bit(bit_index) { value | !mask } else { value & mask };
+        *out = if value.bit(bit_index) { *value | !mask } else { *value & mask };
     }
 }
 

--- a/crates/evm2/src/interpreter/instructions/bitwise.rs
+++ b/crates/evm2/src/interpreter/instructions/bitwise.rs
@@ -15,12 +15,12 @@ pub(crate) fn gt([a, b]: [Word]) -> out {
 
 #[instruction]
 pub(crate) fn slt([a, b]: [Word]) -> out {
-    *out = Word::from(i256_cmp(&a, &b) == Ordering::Less);
+    *out = Word::from(i256_cmp(a, b) == Ordering::Less);
 }
 
 #[instruction]
 pub(crate) fn sgt([a, b]: [Word]) -> out {
-    *out = Word::from(i256_cmp(&a, &b) == Ordering::Greater);
+    *out = Word::from(i256_cmp(a, b) == Ordering::Greater);
 }
 
 #[instruction]
@@ -35,45 +35,45 @@ pub(crate) fn iszero([value]: [Word]) -> out {
 
 #[instruction]
 pub(crate) fn bitand([a, b]: [Word]) -> out {
-    *out = a & b;
+    *out = *a & *b;
 }
 
 #[instruction]
 pub(crate) fn bitor([a, b]: [Word]) -> out {
-    *out = a | b;
+    *out = *a | *b;
 }
 
 #[instruction]
 pub(crate) fn bitxor([a, b]: [Word]) -> out {
-    *out = a ^ b;
+    *out = *a ^ *b;
 }
 
 #[instruction]
 pub(crate) fn not([value]: [Word]) -> out {
-    *out = !value;
+    *out = !*value;
 }
 
 #[instruction]
 pub(crate) fn byte([index, value]: [Word]) -> out {
-    let index = word_to_usize_saturated(index);
+    let index = word_to_usize_saturated(*index);
     *out = if index < 32 { Word::from(value.byte(31 - index)) } else { Word::ZERO };
 }
 
 #[instruction]
 pub(crate) fn shl([shift, value]: [Word]) -> out {
-    let shift = word_to_usize_saturated(shift);
-    *out = if shift < 256 { value << shift } else { Word::ZERO };
+    let shift = word_to_usize_saturated(*shift);
+    *out = if shift < 256 { *value << shift } else { Word::ZERO };
 }
 
 #[instruction]
 pub(crate) fn shr([shift, value]: [Word]) -> out {
-    let shift = word_to_usize_saturated(shift);
-    *out = if shift < 256 { value >> shift } else { Word::ZERO };
+    let shift = word_to_usize_saturated(*shift);
+    *out = if shift < 256 { *value >> shift } else { Word::ZERO };
 }
 
 #[instruction]
 pub(crate) fn sar([shift, value]: [Word]) -> out {
-    let shift = word_to_usize_saturated(shift);
+    let shift = word_to_usize_saturated(*shift);
     *out = if shift < 256 {
         value.arithmetic_shr(shift)
     } else if value.bit(255) {

--- a/crates/evm2/src/interpreter/instructions/block.rs
+++ b/crates/evm2/src/interpreter/instructions/block.rs
@@ -8,13 +8,13 @@ use evm2_macros::instruction;
 
 #[instruction]
 pub(crate) fn blockhash(cx: _, [number]: [Word]) -> Result<out> {
-    *out = if let Some(diff) = cx.state.host().block_env().number.checked_sub(number) {
+    *out = if let Some(diff) = cx.state.host().block_env().number.checked_sub(*number) {
         if diff == 0 || diff > BLOCK_HASH_HISTORY {
             Word::ZERO
         } else {
             cx.state
                 .host()
-                .block_hash(&number)?
+                .block_hash(number)?
                 .map(b256_to_word)
                 .ok_or(InstrStop::FatalExternalError)?
         }
@@ -70,7 +70,7 @@ pub(crate) fn basefee(cx: _) -> Result<out> {
 
 #[instruction]
 pub(crate) fn blobhash(cx: _, [index]: [Word]) -> Result<out> {
-    let index = word_to_usize_saturated(index);
+    let index = word_to_usize_saturated(*index);
     *out = cx.state.tx().blob_hashes.get(index).copied().unwrap_or_default();
 }
 

--- a/crates/evm2/src/interpreter/instructions/control.rs
+++ b/crates/evm2/src/interpreter/instructions/control.rs
@@ -18,13 +18,13 @@ pub(crate) fn stop() -> Result {
 
 #[instruction]
 pub(crate) fn jump(cx: _, [target]: [Word]) -> Result {
-    jump_inner(target, &mut cx)
+    jump_inner(*target, &mut cx)
 }
 
 #[instruction]
 pub(crate) fn jumpi(cx: _, [target, cond]: [Word]) -> Result {
     if !cond.is_zero() {
-        jump_inner(target, &mut cx)?;
+        jump_inner(*target, &mut cx)?;
     } else {
         unsafe { cx.pc.advance_unchecked(1) };
     };
@@ -56,12 +56,12 @@ pub(crate) fn jumpdest() {}
 
 #[instruction(dynamic_gas)]
 pub(crate) fn r#return(cx: _, [offset, len]: [Word]) -> Result {
-    return_inner(cx, offset, len, InstrStop::Return)
+    return_inner(cx, *offset, *len, InstrStop::Return)
 }
 
 #[instruction(dynamic_gas)]
 pub(crate) fn revert(cx: _, [offset, len]: [Word]) -> Result {
-    return_inner(cx, offset, len, InstrStop::Revert)
+    return_inner(cx, *offset, *len, InstrStop::Revert)
 }
 
 #[inline]

--- a/crates/evm2/src/interpreter/instructions/control.rs
+++ b/crates/evm2/src/interpreter/instructions/control.rs
@@ -56,24 +56,24 @@ pub(crate) fn jumpdest() {}
 
 #[instruction(dynamic_gas)]
 pub(crate) fn r#return(cx: _, [offset, len]: [Word]) -> Result {
-    return_inner(cx, *offset, *len, InstrStop::Return)
+    return_inner(cx, offset, len, InstrStop::Return)
 }
 
 #[instruction(dynamic_gas)]
 pub(crate) fn revert(cx: _, [offset, len]: [Word]) -> Result {
-    return_inner(cx, *offset, *len, InstrStop::Revert)
+    return_inner(cx, offset, len, InstrStop::Revert)
 }
 
 #[inline]
 fn return_inner<T: EvmTypes>(
     cx: GasInstructionCx<'_, '_, T>,
-    offset: Word,
-    len: Word,
+    offset: &Word,
+    len: &Word,
     result: InstrStop,
 ) -> Result {
-    let len = word_to_usize(len)?;
+    let len = word_to_usize(*len)?;
     let offset = if len != 0 {
-        let offset = word_to_usize(offset)?;
+        let offset = word_to_usize(*offset)?;
         resize_memory(cx.gas, cx.state.memory(), offset, len)?;
         offset
     } else {

--- a/crates/evm2/src/interpreter/instructions/crypto.rs
+++ b/crates/evm2/src/interpreter/instructions/crypto.rs
@@ -7,12 +7,12 @@ use evm2_macros::instruction;
 
 #[instruction(dynamic_gas)]
 pub(crate) fn keccak256(cx: _, [offset, len]: [Word]) -> Result<out> {
-    let len = word_to_usize(len)?;
+    let len = word_to_usize(*len)?;
     cx.gas.spend(cx.state.gas_params().keccak256_word_cost(len))?;
     let hash = if len == 0 {
         keccak256_hash([])
     } else {
-        let offset = word_to_usize(offset)?;
+        let offset = word_to_usize(*offset)?;
         resize_memory(cx.gas, cx.state.memory(), offset, len)?;
         keccak256_hash(cx.state.memory().slice(offset, len))
     };

--- a/crates/evm2/src/interpreter/instructions/crypto.rs
+++ b/crates/evm2/src/interpreter/instructions/crypto.rs
@@ -1,5 +1,5 @@
 use crate::{
-    interpreter::{Word, memory::resize_memory},
+    interpreter::memory::resize_memory,
     utils::{b256_to_word, word_to_usize},
 };
 use alloy_primitives::keccak256 as keccak256_hash;

--- a/crates/evm2/src/interpreter/instructions/env.rs
+++ b/crates/evm2/src/interpreter/instructions/env.rs
@@ -82,7 +82,7 @@ pub(crate) fn address(cx: _) -> out {
 
 #[instruction(dynamic_gas)]
 pub(crate) fn balance(cx: _, [addr]: [Word]) -> Result<out> {
-    *out = load_account(&mut cx, addr, false)?.balance;
+    *out = load_account(&mut cx, *addr, false)?.balance;
 }
 
 #[instruction]
@@ -102,7 +102,7 @@ pub(crate) fn callvalue(cx: _) -> out {
 
 #[instruction]
 pub(crate) fn calldataload(cx: _, [offset]: [Word]) -> out {
-    let offset = word_to_usize_saturated(offset);
+    let offset = word_to_usize_saturated(*offset);
     let input = cx.state.message().input.as_ref();
     let mut word = B256::ZERO;
     if offset < input.len() {
@@ -119,9 +119,9 @@ pub(crate) fn calldatasize(cx: _) -> out {
 
 #[instruction(dynamic_gas)]
 pub(crate) fn calldatacopy(cx: _, [memory_offset, data_offset, len]: [Word]) -> Result {
-    let len = word_to_usize(len)?;
+    let len = word_to_usize(*len)?;
     let input = cx.state.message().input.clone();
-    copy_data(&mut cx, memory_offset, data_offset, len, &input)
+    copy_data(&mut cx, *memory_offset, *data_offset, len, &input)
 }
 
 #[instruction]
@@ -131,10 +131,10 @@ pub(crate) fn codesize(cx: _) -> out {
 
 #[instruction(dynamic_gas)]
 pub(crate) fn codecopy(cx: _, [memory_offset, code_offset, len]: [Word]) -> Result {
-    let len = word_to_usize(len)?;
+    let len = word_to_usize(*len)?;
     let code = cx.state.bytecode().as_slice() as *const [u8];
     // SAFETY: The interpreter owns bytecode for the duration of this instruction.
-    copy_data(&mut cx, memory_offset, code_offset, len, unsafe { &*code })
+    copy_data(&mut cx, *memory_offset, *code_offset, len, unsafe { &*code })
 }
 
 #[instruction]
@@ -144,23 +144,23 @@ pub(crate) fn gasprice(cx: _) -> out {
 
 #[instruction(dynamic_gas)]
 pub(crate) fn extcodesize(cx: _, [addr]: [Word]) -> Result<out> {
-    *out = Word::from(load_account(&mut cx, addr, true)?.code.len());
+    *out = Word::from(load_account(&mut cx, *addr, true)?.code.len());
 }
 
 #[instruction(dynamic_gas)]
 pub(crate) fn extcodehash(cx: _, [addr]: [Word]) -> Result<out> {
-    let account = load_account(&mut cx, addr, false)?;
+    let account = load_account(&mut cx, *addr, false)?;
     *out = if account.is_empty { Word::ZERO } else { b256_to_word(account.code_hash) };
 }
 
 #[instruction(dynamic_gas)]
 pub(crate) fn extcodecopy(cx: _, [addr, memory_offset, code_offset, len]: [Word]) -> Result {
-    let len = word_to_usize(len)?;
+    let len = word_to_usize(*len)?;
     cx.gas.spend(cx.state.gas_params().extcodecopy_cost(len))?;
-    let memory_offset = copy_memory_resize(&mut cx, memory_offset, len)?.unwrap_or(0);
+    let memory_offset = copy_memory_resize(&mut cx, *memory_offset, len)?.unwrap_or(0);
 
-    let code = load_account(&mut cx, addr, true)?.code;
-    set_copy_data(&mut cx, memory_offset, code_offset, len, code.original_byte_slice());
+    let code = load_account(&mut cx, *addr, true)?.code;
+    set_copy_data(&mut cx, memory_offset, *code_offset, len, code.original_byte_slice());
 }
 
 #[instruction]
@@ -170,14 +170,14 @@ pub(crate) fn returndatasize(cx: _) -> Result<out> {
 
 #[instruction(dynamic_gas)]
 pub(crate) fn returndatacopy(cx: _, [memory_offset, data_offset, len]: [Word]) -> Result {
-    let len = word_to_usize(len)?;
-    let data_offset = word_to_usize_saturated(data_offset);
+    let len = word_to_usize(*len)?;
+    let data_offset = word_to_usize_saturated(*data_offset);
     if data_offset.saturating_add(len) > cx.state.return_data().len() {
         return Err(InstrStop::OutOfOffset);
     }
 
     let return_data = cx.state.return_data().clone();
-    copy_data(&mut cx, memory_offset, Word::from(data_offset), len, &return_data)
+    copy_data(&mut cx, *memory_offset, Word::from(data_offset), len, &return_data)
 }
 
 #[cfg(test)]

--- a/crates/evm2/src/interpreter/instructions/host.rs
+++ b/crates/evm2/src/interpreter/instructions/host.rs
@@ -1,7 +1,7 @@
 use crate::{
     EvmFeatures, EvmTypes, SpecId,
     interpreter::{
-        Host, InstrStop, InterpreterState, Result, StackMut, Word, memory::resize_memory,
+        Host, InstrStop, InterpreterState, Result, StackMut, memory::resize_memory,
         private::GasInstructionCx,
     },
     utils::word_to_usize,

--- a/crates/evm2/src/interpreter/instructions/host.rs
+++ b/crates/evm2/src/interpreter/instructions/host.rs
@@ -27,7 +27,7 @@ pub(crate) fn sload(cx: _, [key]: [Word]) -> Result<out> {
     let skip_cold_load =
         cx.state.spec().enables(SpecId::BERLIN) && cx.gas.remaining() < additional_cold_cost;
     let destination = cx.state.message().destination;
-    let load = cx.state.host().sload(&destination, &key, skip_cold_load)?;
+    let load = cx.state.host().sload(&destination, key, skip_cold_load)?;
     if load.is_cold {
         cx.gas.spend(additional_cold_cost)?;
     }
@@ -56,7 +56,7 @@ pub(crate) fn sstore(cx: _, [key, value]: [Word]) -> Result {
     let skip_cold_load = cx.state.spec().enables(SpecId::BERLIN)
         && cx.gas.remaining() < cx.state.gas_params().get(GasId::ColdStorageAdditionalCost).into();
     let destination = cx.state.message().destination;
-    let state_load = cx.state.host().sstore(&destination, &key, &value, skip_cold_load)?;
+    let state_load = cx.state.host().sstore(&destination, key, value, skip_cold_load)?;
 
     // EIP-2200 net gas metering depends on original, present, and new slot values:
     // clean slots pay set/reset costs, dirty slots generally only pay the load cost,
@@ -79,14 +79,14 @@ pub(crate) fn sstore(cx: _, [key, value]: [Word]) -> Result {
 #[instruction]
 pub(crate) fn tload(cx: _, [key]: [Word]) -> out {
     let destination = cx.state.message().destination;
-    *out = cx.state.host().tload(&destination, &key);
+    *out = cx.state.host().tload(&destination, key);
 }
 
 #[instruction]
 pub(crate) fn tstore(cx: _, [key, value]: [Word]) -> Result {
     require_non_staticcall(cx.state)?;
     let destination = cx.state.message().destination;
-    cx.state.host().tstore(&destination, &key, &value);
+    cx.state.host().tstore(&destination, key, value);
 }
 
 #[instruction(no_stack_preamble, dynamic_gas)]

--- a/crates/evm2/src/interpreter/instructions/macro_tests.rs
+++ b/crates/evm2/src/interpreter/instructions/macro_tests.rs
@@ -19,7 +19,7 @@ const ASSOC_BOUND_OPCODE: u8 = 0x1e;
 
 #[instruction]
 fn macro_add([a, b]: [Word]) -> out {
-    *out = a + b;
+    *out = *a + *b;
 }
 
 #[instruction(dynamic_gas)]

--- a/crates/evm2/src/interpreter/instructions/memory.rs
+++ b/crates/evm2/src/interpreter/instructions/memory.rs
@@ -6,21 +6,21 @@ use evm2_macros::instruction;
 
 #[instruction(dynamic_gas)]
 pub(crate) fn mload(cx: _, [offset]: [Word]) -> Result<out> {
-    let offset = word_to_usize(offset)?;
+    let offset = word_to_usize(*offset)?;
     resize_memory(cx.gas, cx.state.memory(), offset, 32)?;
     *out = cx.state.memory().get_word(offset);
 }
 
 #[instruction(dynamic_gas)]
 pub(crate) fn mstore(cx: _, [offset, value]: [Word]) -> Result {
-    let offset = word_to_usize(offset)?;
+    let offset = word_to_usize(*offset)?;
     resize_memory(cx.gas, cx.state.memory(), offset, 32)?;
     cx.state.memory().set(offset, &value.to_be_bytes::<32>());
 }
 
 #[instruction(dynamic_gas)]
 pub(crate) fn mstore8(cx: _, [offset, value]: [Word]) -> Result {
-    let offset = word_to_usize(offset)?;
+    let offset = word_to_usize(*offset)?;
     resize_memory(cx.gas, cx.state.memory(), offset, 1)?;
     cx.state.memory().set(offset, &[value.byte(0)]);
 }
@@ -32,11 +32,11 @@ pub(crate) fn msize(cx: _) -> out {
 
 #[instruction(dynamic_gas)]
 pub(crate) fn mcopy(cx: _, [dst, src, len]: [Word]) -> Result {
-    let len = word_to_usize(len)?;
+    let len = word_to_usize(*len)?;
     cx.gas.spend(cx.state.gas_params().mcopy_cost(len))?;
     if len != 0 {
-        let dst = word_to_usize(dst)?;
-        let src = word_to_usize(src)?;
+        let dst = word_to_usize(*dst)?;
+        let src = word_to_usize(*src)?;
         resize_memory(cx.gas, cx.state.memory(), dst.max(src), len)?;
         cx.state.memory().copy(dst, src, len);
     };

--- a/crates/evm2/src/interpreter/instructions/system.rs
+++ b/crates/evm2/src/interpreter/instructions/system.rs
@@ -369,7 +369,7 @@ fn create_inner<T: EvmTypes>(
 #[instruction(dynamic_gas)]
 pub(crate) fn selfdestruct(cx: _, [target]: [Word]) -> Result {
     require_non_staticcall(cx.state)?;
-    let target = word_to_address(target);
+    let target = word_to_address(*target);
     let cold_load_gas = cx.state.gas_params().selfdestruct_cold_cost();
     let skip_cold_load = cx.gas.remaining() < cold_load_gas;
     let destination = cx.state.message().destination;

--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -20,8 +20,10 @@ use syn::{
 /// - `cx: _`: Optional instruction context. It exposes `pc`, `gas`, and `state`, which are needed
 ///   for immediates, memory, host access, dynamic gas, active version data, and message or
 ///   transaction state.
-/// - `[a, b]: [Word]`: Automatic stack inputs. The macro checks stack bounds, pops one word per
-///   binding, and creates local `Word` values with those names.
+/// - `[a, b]: [Word]`: Automatic stack inputs. The macro checks stack bounds and binds one
+///   reference per non-`_` pattern. Inputs that overlap output slots are shared reborrows of the
+///   output slot; other inputs are shared references. Use reference patterns like `[&x]: [Word]` to
+///   copy.
 /// - `-> out`: Automatic stack output. The output name is a mutable `Word` slot. Multiple outputs
 ///   can be written as `-> Result<out1, out2>` for fallible instructions.
 /// - `-> Result`: Fallible instruction with no automatic outputs. The body must evaluate to
@@ -54,7 +56,7 @@ use syn::{
 /// #[instruction]
 /// fn opcode_name(cx: _, [a, b, c]: [Word]) -> Result<out> {
 ///     cx.gas.spend(3)?;
-///     *out = a.wrapping_add(b).wrapping_add(c);
+///     *out = a.wrapping_add(*b).wrapping_add(*c);
 /// }
 /// ```
 ///
@@ -68,7 +70,7 @@ use syn::{
 ///
 /// #[instruction]
 /// fn add([a, b]: [Word]) -> out {
-///     *out = a.wrapping_add(b);
+///     *out = a.wrapping_add(*b);
 /// }
 /// ```
 ///
@@ -235,7 +237,6 @@ fn expand_instruction(instruction_attrs: InstructionAttrs, input: ItemFn) -> Tok
         quote! { where #evm_types: #evm_types_bound #( + #evm_types_bounds)* }
     };
     let (_, outputs) = parse_return(sig.output);
-    let body = body(input.block.stmts, outputs.is_empty());
 
     let mut has_cx = false;
     let mut cx_arg = None;
@@ -248,12 +249,11 @@ fn expand_instruction(instruction_attrs: InstructionAttrs, input: ItemFn) -> Tok
             cx_arg = Some(ident);
         } else if is_word_slice(&arg.ty) {
             let Pat::Slice(PatSlice { elems, .. }) = *arg.pat else { continue };
-            inputs.extend(elems.into_iter().filter_map(|pat| {
-                let Pat::Ident(PatIdent { ident, .. }) = pat else {
-                    return None;
-                };
-                Some(ident)
-            }));
+            if let Some(rest) = elems.iter().find(|pat| matches!(pat, Pat::Rest(_))) {
+                return syn::Error::new_spanned(rest, "`..` is not supported in stack inputs")
+                    .to_compile_error();
+            }
+            inputs.extend(elems);
         } else {
             return syn::Error::new_spanned(
                 arg,
@@ -263,8 +263,12 @@ fn expand_instruction(instruction_attrs: InstructionAttrs, input: ItemFn) -> Tok
         }
     }
 
-    let stack_setup =
-        (!instruction_attrs.no_stack_preamble).then(|| stack_setup(&inputs, &outputs));
+    let body = body(input.block.stmts, outputs.is_empty());
+    let stack_setup = if instruction_attrs.no_stack_preamble {
+        None
+    } else {
+        Some(stack_setup(&inputs, &outputs))
+    };
     let cx_setup = has_cx.then(|| {
         let cx = cx_arg.unwrap_or_else(|| Ident::new("cx", ident.span()));
         if instruction_attrs.dynamic_gas {
@@ -393,11 +397,10 @@ fn body(stmts: Vec<Stmt>, allow_final_result: bool) -> TokenStream2 {
     }
 }
 
-fn stack_setup(inputs: &[Ident], outputs: &[Ident]) -> TokenStream2 {
+fn stack_setup(inputs: &[Pat], outputs: &[Ident]) -> TokenStream2 {
     let input_count = inputs.len();
     let output_count = outputs.len();
-    let input_setup = stack_bindings(inputs, false);
-    let output_setup = stack_bindings(outputs, true);
+    let stack_bindings = stack_bindings(inputs, outputs);
 
     quote! {
         let ptr = evm2::interpreter::private::instr_stack_setup(
@@ -405,27 +408,54 @@ fn stack_setup(inputs: &[Ident], outputs: &[Ident]) -> TokenStream2 {
             #input_count,
             #output_count,
         )?;
-        #input_setup
-        #output_setup
+        #stack_bindings
     }
 }
 
-fn stack_bindings(bindings: &[Ident], mutable: bool) -> Option<TokenStream2> {
-    if bindings.is_empty() {
-        return None;
+fn stack_bindings(inputs: &[Pat], outputs: &[Ident]) -> TokenStream2 {
+    let count = inputs.len().max(outputs.len());
+    let mut bindings = Vec::with_capacity(count);
+    for i in 0..count {
+        let input = inputs.iter().rev().nth(i);
+        let output = outputs.iter().rev().nth(i);
+        let binding = match (input, output) {
+            (Some(Pat::Wild(_)), None) => TokenStream2::new(),
+            (Some(Pat::Wild(_)), Some(output)) | (None, Some(output)) => {
+                quote! {
+                    let #output = unsafe { &mut *ptr.add(#i) };
+                }
+            }
+            (Some(input), None) => {
+                quote! {
+                    let #input = unsafe { &*ptr.add(#i) };
+                }
+            }
+            (Some(input), Some(output)) => {
+                if simple_ident(input).is_some_and(|input| input == *output) {
+                    quote! {
+                        let #output = unsafe { &mut *ptr.add(#i) };
+                    }
+                } else {
+                    quote! {
+                        let #output = unsafe { &mut *ptr.add(#i) };
+                        let #input = &*#output;
+                    }
+                }
+            }
+            (None, None) => TokenStream2::new(),
+        };
+        bindings.push(binding);
     }
 
-    let bindings = bindings.iter().rev().enumerate().map(|(i, binding)| {
-        let value = if mutable {
-            quote! { &mut *ptr.add(#i) }
-        } else {
-            quote! { *ptr.add(#i) }
-        };
-        quote! {
-            let #binding = unsafe { #value };
-        }
-    });
-    Some(quote! {
+    quote! {
         #(#bindings)*
-    })
+    }
+}
+
+fn simple_ident(input: &Pat) -> Option<Ident> {
+    let Pat::Ident(PatIdent { by_ref: None, mutability: None, ident, subpat: None, .. }) = input
+    else {
+        return None;
+    };
+    Some(ident.clone())
 }

--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -3,7 +3,7 @@
 
 use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
-use quote::quote;
+use quote::{quote, quote_spanned};
 use syn::{
     AngleBracketedGenericArguments, FnArg, GenericArgument, GenericParam, Ident, ItemFn, LitStr,
     Pat, PatIdent, PatSlice, PathArguments, ReturnType, Stmt, Token, Type, TypeInfer,
@@ -11,6 +11,7 @@ use syn::{
     parse::{Parse, ParseStream},
     parse_macro_input,
     punctuated::Punctuated,
+    spanned::Spanned,
 };
 
 /// Generates an `Instruction` impl for an instruction function definition.
@@ -421,24 +422,18 @@ fn stack_bindings(inputs: &[Pat], outputs: &[Ident]) -> TokenStream2 {
         let binding = match (input, output) {
             (Some(Pat::Wild(_)), None) => TokenStream2::new(),
             (Some(Pat::Wild(_)), Some(output)) | (None, Some(output)) => {
-                quote! {
-                    let #output = unsafe { &mut *ptr.add(#i) };
-                }
+                output_binding(output, stack_slot_ptr(i, output.span()))
             }
-            (Some(input), None) => {
-                quote! {
-                    let #input = unsafe { &*ptr.add(#i) };
-                }
-            }
+            (Some(input), None) => input_binding(input, stack_slot_ptr(i, input.span())),
             (Some(input), Some(output)) => {
                 if simple_ident(input).is_some_and(|input| input == *output) {
-                    quote! {
-                        let #output = unsafe { &mut *ptr.add(#i) };
-                    }
+                    output_binding(output, stack_slot_ptr(i, output.span()))
                 } else {
+                    let output_binding = output_binding(output, stack_slot_ptr(i, output.span()));
+                    let input_binding = input_reborrow_binding(input, output);
                     quote! {
-                        let #output = unsafe { &mut *ptr.add(#i) };
-                        let #input = &*#output;
+                        #output_binding
+                        #input_binding
                     }
                 }
             }
@@ -449,6 +444,35 @@ fn stack_bindings(inputs: &[Pat], outputs: &[Ident]) -> TokenStream2 {
 
     quote! {
         #(#bindings)*
+    }
+}
+
+fn output_binding(output: &Ident, ptr: TokenStream2) -> TokenStream2 {
+    let span = output.span();
+    quote_spanned! {
+        span=> let #output = unsafe { &mut *#ptr };
+    }
+}
+
+fn input_binding(input: &Pat, ptr: TokenStream2) -> TokenStream2 {
+    let span = input.span();
+    quote_spanned! {
+        span=> let #input = unsafe { &*#ptr };
+    }
+}
+
+fn input_reborrow_binding(input: &Pat, output: &Ident) -> TokenStream2 {
+    let span = input.span();
+    quote_spanned! {
+        span=> let #input = &*#output;
+    }
+}
+
+fn stack_slot_ptr(i: usize, span: proc_macro2::Span) -> TokenStream2 {
+    if i == 0 {
+        quote_spanned! { span=> ptr }
+    } else {
+        quote_spanned! { span=> ptr.add(#i) }
     }
 }
 

--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -395,20 +395,9 @@ fn body(stmts: Vec<Stmt>, allow_final_result: bool) -> TokenStream2 {
 
 fn stack_setup(inputs: &[Ident], outputs: &[Ident]) -> TokenStream2 {
     let input_count = inputs.len();
-    let input_setup = (input_count > 0).then(|| {
-        let input_bindings = inputs.iter().rev();
-        quote! {
-            let [#(#input_bindings),*] = unsafe { ptr.cast::<[Word; #input_count]>().read() };
-        }
-    });
-
     let output_count = outputs.len();
-    let output_setup = (output_count > 0).then(|| {
-        let output_bindings = outputs.iter().rev();
-        quote! {
-            let [#(#output_bindings),*] = unsafe { &mut *ptr.cast::<[Word; #output_count]>() };
-        }
-    });
+    let input_setup = stack_bindings(inputs, false);
+    let output_setup = stack_bindings(outputs, true);
 
     quote! {
         let ptr = evm2::interpreter::private::instr_stack_setup(
@@ -419,4 +408,24 @@ fn stack_setup(inputs: &[Ident], outputs: &[Ident]) -> TokenStream2 {
         #input_setup
         #output_setup
     }
+}
+
+fn stack_bindings(bindings: &[Ident], mutable: bool) -> Option<TokenStream2> {
+    if bindings.is_empty() {
+        return None;
+    }
+
+    let bindings = bindings.iter().rev().enumerate().map(|(i, binding)| {
+        let value = if mutable {
+            quote! { &mut *ptr.add(#i) }
+        } else {
+            quote! { *ptr.add(#i) }
+        };
+        quote! {
+            let #binding = unsafe { #value };
+        }
+    });
+    Some(quote! {
+        #(#bindings)*
+    })
 }


### PR DESCRIPTION
This changes the instruction macro stack preamble to bind directly to stack slots instead of materializing temporary `[Word; N]` arrays. Stack inputs are now borrowed from the stack layout the macro already knows about, while output slots remain mutable references.

For overlapping input and output slots, the macro binds the output slot once and gives the input a shared reborrow, so instruction bodies do not need to care which input position maps to the output slot. Reference patterns such as `[&x]: [Word]` still opt into copying, and `_` skips an input binding entirely.

The generated bindings also avoid emitting `ptr.add(0)` for the top slot and carry spans from the corresponding input pattern or output ident, which should make macro diagnostics point back at the relevant signature piece.
