### PR TITLE
refactor(interpreter): avoid instruction copies

### DIFF
--- a/crates/evm2/src/evm/inspector.rs
+++ b/crates/evm2/src/evm/inspector.rs
@@ -402,7 +402,7 @@ mod tests {
                 Word::ZERO,
                 Word::ZERO,
                 Word::ZERO,
-                address_to_word(target),
+                address_to_word(&target),
                 Word::from(1000),
             ],
         );
@@ -616,7 +616,7 @@ mod tests {
             run_with_inspector(code, &mut host, &Message::default(), 50_000, &mut inspector);
 
         assert!(matches!(stop, InstrStop::Stop));
-        assert_eq!(stack, [address_to_word(created)]);
+        assert_eq!(stack, [address_to_word(&created)]);
         assert_eq!(inspector.create_depth, Some(1));
         assert_eq!(inspector.create_end_stop, Some(InstrStop::Return));
         assert!(host.calls.is_empty());
@@ -640,7 +640,7 @@ mod tests {
         );
 
         assert!(matches!(stop, InstrStop::Stop));
-        assert_eq!(stack, [address_to_word(created)]);
+        assert_eq!(stack, [address_to_word(&created)]);
         assert_eq!(inspector.create_depth, Some(CALL_DEPTH_LIMIT + 1));
         assert_eq!(inspector.create_end_stop, Some(InstrStop::Return));
         assert!(host.calls.is_empty());
@@ -658,7 +658,7 @@ mod tests {
             run_with_inspector(code, &mut host, &Message::default(), 50_000, &mut inspector);
 
         assert!(matches!(stop, InstrStop::Stop));
-        assert_eq!(stack, [address_to_word(created)]);
+        assert_eq!(stack, [address_to_word(&created)]);
         assert!(host.calls.is_empty());
     }
 
@@ -724,7 +724,7 @@ mod tests {
             SelfDestructResult { had_value: true, value, ..Default::default() };
         let mut inspector = MessageInspector::default();
         let mut code = Vec::new();
-        push(&mut code, address_to_word(target));
+        push(&mut code, address_to_word(&target));
         code.push(op::SELFDESTRUCT);
 
         let (stop, _) = run_with_inspector(
@@ -746,7 +746,7 @@ mod tests {
         host.selfdestruct_error = Some(InstrStop::FatalExternalError);
         let mut inspector = MessageInspector::default();
         let mut code = Vec::new();
-        push(&mut code, address_to_word(target));
+        push(&mut code, address_to_word(&target));
         code.push(op::SELFDESTRUCT);
 
         let (stop, _) = run_with_inspector(

--- a/crates/evm2/src/interpreter/instructions/block.rs
+++ b/crates/evm2/src/interpreter/instructions/block.rs
@@ -25,7 +25,7 @@ pub(crate) fn blockhash(cx: _, [number]: [Word]) -> Result<out> {
 
 #[instruction]
 pub(crate) fn coinbase(cx: _) -> out {
-    *out = address_to_word(cx.state.host().block_env().beneficiary);
+    *out = address_to_word(&cx.state.host().block_env().beneficiary);
 }
 
 #[instruction]
@@ -59,8 +59,8 @@ pub(crate) fn chainid(cx: _) -> Result<out> {
 
 #[instruction]
 pub(crate) fn selfbalance(cx: _) -> Result<out> {
-    let destination = cx.state.message().destination;
-    *out = cx.state.host().load_account(&destination, false, false)?.balance;
+    let destination = &cx.state.message().destination;
+    *out = cx.state.host().load_account(destination, false, false)?.balance;
 }
 
 #[instruction]
@@ -130,7 +130,7 @@ mod tests {
         let mut host = test_host(BlockEnv { beneficiary, ..BlockEnv::default() });
         let interpreter = run(RunConfig::new([op::COINBASE, op::STOP]).host(&mut host));
         assert!(matches!(interpreter.err, InstrStop::Stop));
-        assert_eq!(interpreter.stack(), [address_to_word(beneficiary)]);
+        assert_eq!(interpreter.stack(), [address_to_word(&beneficiary)]);
     }
 
     #[test]
@@ -196,7 +196,7 @@ mod tests {
         let interpreter =
             run(RunConfig::new([op::SELFBALANCE, op::STOP]).host(&mut host).message(message));
         assert!(matches!(interpreter.err, InstrStop::Stop));
-        assert_eq!(interpreter.stack(), [address_to_word(address)]);
+        assert_eq!(interpreter.stack(), [address_to_word(&address)]);
     }
 
     #[test]

--- a/crates/evm2/src/interpreter/instructions/env.rs
+++ b/crates/evm2/src/interpreter/instructions/env.rs
@@ -2,7 +2,8 @@ use crate::{
     EvmTypes,
     evm::AccountLoad,
     interpreter::{
-        Host, InstrStop, Result, Word, memory::resize_memory, private::GasInstructionCx,
+        Gas, Host, InstrStop, Memory, Result, Word, memory::resize_memory,
+        private::GasInstructionCx,
     },
     utils::{
         address_to_word, b256_to_word, word_to_address, word_to_usize, word_to_usize_saturated,
@@ -27,8 +28,9 @@ fn load_account<T: EvmTypes>(
 }
 
 #[inline]
-fn copy_memory_resize<T: EvmTypes>(
-    cx: &mut GasInstructionCx<'_, '_, T>,
+fn copy_memory_resize(
+    gas: &mut Gas,
+    memory: &mut Memory,
     memory_offset: Word,
     len: usize,
 ) -> Result<Option<usize>> {
@@ -36,48 +38,54 @@ fn copy_memory_resize<T: EvmTypes>(
         return Ok(None);
     }
     let memory_offset = word_to_usize(memory_offset)?;
-    resize_memory(cx.gas, cx.state.memory(), memory_offset, len)?;
+    resize_memory(gas, memory, memory_offset, len)?;
     Ok(Some(memory_offset))
 }
 
 #[inline]
-fn copy_cost_and_memory_resize<T: EvmTypes>(
-    cx: &mut GasInstructionCx<'_, '_, T>,
+fn copy_cost_and_memory_resize(
+    gas: &mut Gas,
+    memory: &mut Memory,
+    copy_cost: u64,
     memory_offset: Word,
     len: usize,
 ) -> Result<Option<usize>> {
-    cx.gas.spend(cx.state.gas_params().copy_cost(len))?;
-    copy_memory_resize(cx, memory_offset, len)
+    gas.spend(copy_cost)?;
+    copy_memory_resize(gas, memory, memory_offset, len)
 }
 
 #[inline]
-fn set_copy_data<T: EvmTypes>(
-    cx: &mut GasInstructionCx<'_, '_, T>,
+fn set_copy_data(
+    memory: &mut Memory,
     memory_offset: usize,
     data_offset: Word,
     len: usize,
     data: &[u8],
 ) {
-    cx.state.memory().set_data(memory_offset, word_to_usize_saturated(data_offset), len, data);
+    memory.set_data(memory_offset, word_to_usize_saturated(data_offset), len, data);
 }
 
 #[inline]
-fn copy_data<T: EvmTypes>(
-    cx: &mut GasInstructionCx<'_, '_, T>,
+fn copy_data(
+    gas: &mut Gas,
+    memory: &mut Memory,
+    copy_cost: u64,
     memory_offset: Word,
     data_offset: Word,
     len: usize,
     data: &[u8],
 ) -> Result {
-    if let Some(memory_offset) = copy_cost_and_memory_resize(cx, memory_offset, len)? {
-        set_copy_data(cx, memory_offset, data_offset, len, data);
+    if let Some(memory_offset) =
+        copy_cost_and_memory_resize(gas, memory, copy_cost, memory_offset, len)?
+    {
+        set_copy_data(memory, memory_offset, data_offset, len, data);
     }
     Ok(())
 }
 
 #[instruction]
 pub(crate) fn address(cx: _) -> out {
-    *out = address_to_word(cx.state.message().destination);
+    *out = address_to_word(&cx.state.message().destination);
 }
 
 #[instruction(dynamic_gas)]
@@ -87,12 +95,12 @@ pub(crate) fn balance(cx: _, [addr]: [Word]) -> Result<out> {
 
 #[instruction]
 pub(crate) fn origin(cx: _) -> out {
-    *out = address_to_word(cx.state.tx().origin);
+    *out = address_to_word(&cx.state.tx().origin);
 }
 
 #[instruction]
 pub(crate) fn caller(cx: _) -> out {
-    *out = address_to_word(cx.state.message().caller);
+    *out = address_to_word(&cx.state.message().caller);
 }
 
 #[instruction]
@@ -120,8 +128,9 @@ pub(crate) fn calldatasize(cx: _) -> out {
 #[instruction(dynamic_gas)]
 pub(crate) fn calldatacopy(cx: _, [memory_offset, data_offset, len]: [Word]) -> Result {
     let len = word_to_usize(*len)?;
-    let input = cx.state.message().input.clone();
-    copy_data(&mut cx, *memory_offset, *data_offset, len, &input)
+    let copy_cost = cx.state.gas_params().copy_cost(len);
+    let input = cx.state.message().input.as_ref();
+    copy_data(cx.gas, &mut cx.state.0.memory, copy_cost, *memory_offset, *data_offset, len, input)
 }
 
 #[instruction]
@@ -132,9 +141,16 @@ pub(crate) fn codesize(cx: _) -> out {
 #[instruction(dynamic_gas)]
 pub(crate) fn codecopy(cx: _, [memory_offset, code_offset, len]: [Word]) -> Result {
     let len = word_to_usize(*len)?;
-    let code = cx.state.bytecode().as_slice() as *const [u8];
-    // SAFETY: The interpreter owns bytecode for the duration of this instruction.
-    copy_data(&mut cx, *memory_offset, *code_offset, len, unsafe { &*code })
+    let copy_cost = cx.state.gas_params().copy_cost(len);
+    copy_data(
+        cx.gas,
+        &mut cx.state.0.memory,
+        copy_cost,
+        *memory_offset,
+        *code_offset,
+        len,
+        cx.state.0.bytecode.original_byte_slice(),
+    )
 }
 
 #[instruction]
@@ -157,10 +173,17 @@ pub(crate) fn extcodehash(cx: _, [addr]: [Word]) -> Result<out> {
 pub(crate) fn extcodecopy(cx: _, [addr, memory_offset, code_offset, len]: [Word]) -> Result {
     let len = word_to_usize(*len)?;
     cx.gas.spend(cx.state.gas_params().extcodecopy_cost(len))?;
-    let memory_offset = copy_memory_resize(&mut cx, *memory_offset, len)?.unwrap_or(0);
+    let memory_offset =
+        copy_memory_resize(cx.gas, &mut cx.state.0.memory, *memory_offset, len)?.unwrap_or(0);
 
     let code = load_account(&mut cx, *addr, true)?.code;
-    set_copy_data(&mut cx, memory_offset, *code_offset, len, code.original_byte_slice());
+    set_copy_data(
+        &mut cx.state.0.memory,
+        memory_offset,
+        *code_offset,
+        len,
+        code.original_byte_slice(),
+    );
 }
 
 #[instruction]
@@ -176,8 +199,16 @@ pub(crate) fn returndatacopy(cx: _, [memory_offset, data_offset, len]: [Word]) -
         return Err(InstrStop::OutOfOffset);
     }
 
-    let return_data = cx.state.return_data().clone();
-    copy_data(&mut cx, *memory_offset, Word::from(data_offset), len, &return_data)
+    let copy_cost = cx.state.gas_params().copy_cost(len);
+    copy_data(
+        cx.gas,
+        &mut cx.state.0.memory,
+        copy_cost,
+        *memory_offset,
+        Word::from(data_offset),
+        len,
+        &cx.state.0.return_data,
+    )
 }
 
 #[cfg(test)]
@@ -222,14 +253,14 @@ mod tests {
         let interpreter =
             run(RunConfig::new([op::ADDRESS, op::STOP]).host(&mut host).message(message));
         assert!(matches!(interpreter.err, InstrStop::Stop));
-        assert_eq!(interpreter.stack(), [address_to_word(address)]);
+        assert_eq!(interpreter.stack(), [address_to_word(&address)]);
     }
 
     #[test]
     fn balance_opcode() {
         assert_stack!(BALANCE(0xbeef), 0xbeef);
         assert_stack!(BALANCE(0), 0);
-        assert_stack!(BALANCE(neg(1)), address_to_word(Address::from([0xff; 20])));
+        assert_stack!(BALANCE(neg(1)), address_to_word(&Address::from([0xff; 20])));
     }
 
     #[test]
@@ -261,7 +292,7 @@ mod tests {
         let interpreter =
             run(RunConfig::new([op::ORIGIN, op::STOP]).host(&mut host).tx_env(tx_env));
         assert!(matches!(interpreter.err, InstrStop::Stop));
-        assert_eq!(interpreter.stack(), [address_to_word(origin)]);
+        assert_eq!(interpreter.stack(), [address_to_word(&origin)]);
     }
 
     #[test]
@@ -272,7 +303,7 @@ mod tests {
         let interpreter =
             run(RunConfig::new([op::CALLER, op::STOP]).host(&mut host).message(message));
         assert!(matches!(interpreter.err, InstrStop::Stop));
-        assert_eq!(interpreter.stack(), [address_to_word(caller)]);
+        assert_eq!(interpreter.stack(), [address_to_word(&caller)]);
     }
 
     #[test]

--- a/crates/evm2/src/interpreter/instructions/env.rs
+++ b/crates/evm2/src/interpreter/instructions/env.rs
@@ -127,15 +127,21 @@ pub(crate) fn extcodehash(cx: _, [addr]: [Word]) -> Result<out> {
 pub(crate) fn extcodecopy(cx: _, [addr, memory_offset, code_offset, len]: [Word]) -> Result {
     let len = word_to_usize(*len)?;
     cx.gas.spend(cx.state.gas_params().extcodecopy_cost(len))?;
+    let memory_offset = if len != 0 {
+        let memory_offset = word_to_usize(*memory_offset)?;
+        resize_memory(cx.gas, &mut cx.state.0.memory, memory_offset, len)?;
+        memory_offset
+    } else {
+        0
+    };
     let code = load_account(&mut cx, *addr, true)?.code;
-    copy_data(
-        cx.gas,
-        &mut cx.state.0.memory,
-        *memory_offset,
-        *code_offset,
+    cx.state.0.memory.set_data(
+        memory_offset,
+        word_to_usize_saturated(*code_offset),
         len,
         code.original_byte_slice(),
-    )
+    );
+    Ok(())
 }
 
 #[instruction]

--- a/crates/evm2/src/interpreter/instructions/env.rs
+++ b/crates/evm2/src/interpreter/instructions/env.rs
@@ -31,15 +31,15 @@ fn load_account<T: EvmTypes>(
 fn copy_data(
     gas: &mut Gas,
     memory: &mut Memory,
-    memory_offset: Word,
-    data_offset: Word,
+    memory_offset: &Word,
+    data_offset: &Word,
     len: usize,
     data: &[u8],
 ) -> Result {
     if len != 0 {
-        let memory_offset = word_to_usize(memory_offset)?;
+        let memory_offset = word_to_usize(*memory_offset)?;
         resize_memory(gas, memory, memory_offset, len)?;
-        memory.set_data(memory_offset, word_to_usize_saturated(data_offset), len, data);
+        memory.set_data(memory_offset, word_to_usize_saturated(*data_offset), len, data);
     }
     Ok(())
 }
@@ -91,7 +91,7 @@ pub(crate) fn calldatacopy(cx: _, [memory_offset, data_offset, len]: [Word]) -> 
     let len = word_to_usize(*len)?;
     cx.gas.spend(cx.state.gas_params().copy_cost(len))?;
     let input = cx.state.message().input.as_ref();
-    copy_data(cx.gas, &mut cx.state.0.memory, *memory_offset, *data_offset, len, input)
+    copy_data(cx.gas, &mut cx.state.0.memory, memory_offset, data_offset, len, input)
 }
 
 #[instruction]
@@ -104,7 +104,7 @@ pub(crate) fn codecopy(cx: _, [memory_offset, code_offset, len]: [Word]) -> Resu
     let len = word_to_usize(*len)?;
     cx.gas.spend(cx.state.gas_params().copy_cost(len))?;
     let data = cx.state.0.bytecode.original_byte_slice();
-    copy_data(cx.gas, &mut cx.state.0.memory, *memory_offset, *code_offset, len, data)
+    copy_data(cx.gas, &mut cx.state.0.memory, memory_offset, code_offset, len, data)
 }
 
 #[instruction]
@@ -159,7 +159,8 @@ pub(crate) fn returndatacopy(cx: _, [memory_offset, data_offset, len]: [Word]) -
 
     cx.gas.spend(cx.state.gas_params().copy_cost(len))?;
     let data = &cx.state.0.return_data;
-    copy_data(cx.gas, &mut cx.state.0.memory, *memory_offset, Word::from(data_offset), len, data)
+    let data_offset = Word::from(data_offset);
+    copy_data(cx.gas, &mut cx.state.0.memory, memory_offset, &data_offset, len, data)
 }
 
 #[cfg(test)]

--- a/crates/evm2/src/interpreter/instructions/env.rs
+++ b/crates/evm2/src/interpreter/instructions/env.rs
@@ -28,57 +28,18 @@ fn load_account<T: EvmTypes>(
 }
 
 #[inline]
-fn copy_memory_resize(
-    gas: &mut Gas,
-    memory: &mut Memory,
-    memory_offset: Word,
-    len: usize,
-) -> Result<Option<usize>> {
-    if len == 0 {
-        return Ok(None);
-    }
-    let memory_offset = word_to_usize(memory_offset)?;
-    resize_memory(gas, memory, memory_offset, len)?;
-    Ok(Some(memory_offset))
-}
-
-#[inline]
-fn copy_cost_and_memory_resize(
-    gas: &mut Gas,
-    memory: &mut Memory,
-    copy_cost: u64,
-    memory_offset: Word,
-    len: usize,
-) -> Result<Option<usize>> {
-    gas.spend(copy_cost)?;
-    copy_memory_resize(gas, memory, memory_offset, len)
-}
-
-#[inline]
-fn set_copy_data(
-    memory: &mut Memory,
-    memory_offset: usize,
-    data_offset: Word,
-    len: usize,
-    data: &[u8],
-) {
-    memory.set_data(memory_offset, word_to_usize_saturated(data_offset), len, data);
-}
-
-#[inline]
 fn copy_data(
     gas: &mut Gas,
     memory: &mut Memory,
-    copy_cost: u64,
     memory_offset: Word,
     data_offset: Word,
     len: usize,
     data: &[u8],
 ) -> Result {
-    if let Some(memory_offset) =
-        copy_cost_and_memory_resize(gas, memory, copy_cost, memory_offset, len)?
-    {
-        set_copy_data(memory, memory_offset, data_offset, len, data);
+    if len != 0 {
+        let memory_offset = word_to_usize(memory_offset)?;
+        resize_memory(gas, memory, memory_offset, len)?;
+        memory.set_data(memory_offset, word_to_usize_saturated(data_offset), len, data);
     }
     Ok(())
 }
@@ -128,9 +89,9 @@ pub(crate) fn calldatasize(cx: _) -> out {
 #[instruction(dynamic_gas)]
 pub(crate) fn calldatacopy(cx: _, [memory_offset, data_offset, len]: [Word]) -> Result {
     let len = word_to_usize(*len)?;
-    let copy_cost = cx.state.gas_params().copy_cost(len);
+    cx.gas.spend(cx.state.gas_params().copy_cost(len))?;
     let input = cx.state.message().input.as_ref();
-    copy_data(cx.gas, &mut cx.state.0.memory, copy_cost, *memory_offset, *data_offset, len, input)
+    copy_data(cx.gas, &mut cx.state.0.memory, *memory_offset, *data_offset, len, input)
 }
 
 #[instruction]
@@ -141,16 +102,9 @@ pub(crate) fn codesize(cx: _) -> out {
 #[instruction(dynamic_gas)]
 pub(crate) fn codecopy(cx: _, [memory_offset, code_offset, len]: [Word]) -> Result {
     let len = word_to_usize(*len)?;
-    let copy_cost = cx.state.gas_params().copy_cost(len);
-    copy_data(
-        cx.gas,
-        &mut cx.state.0.memory,
-        copy_cost,
-        *memory_offset,
-        *code_offset,
-        len,
-        cx.state.0.bytecode.original_byte_slice(),
-    )
+    cx.gas.spend(cx.state.gas_params().copy_cost(len))?;
+    let data = cx.state.0.bytecode.original_byte_slice();
+    copy_data(cx.gas, &mut cx.state.0.memory, *memory_offset, *code_offset, len, data)
 }
 
 #[instruction]
@@ -173,17 +127,15 @@ pub(crate) fn extcodehash(cx: _, [addr]: [Word]) -> Result<out> {
 pub(crate) fn extcodecopy(cx: _, [addr, memory_offset, code_offset, len]: [Word]) -> Result {
     let len = word_to_usize(*len)?;
     cx.gas.spend(cx.state.gas_params().extcodecopy_cost(len))?;
-    let memory_offset =
-        copy_memory_resize(cx.gas, &mut cx.state.0.memory, *memory_offset, len)?.unwrap_or(0);
-
     let code = load_account(&mut cx, *addr, true)?.code;
-    set_copy_data(
+    copy_data(
+        cx.gas,
         &mut cx.state.0.memory,
-        memory_offset,
+        *memory_offset,
         *code_offset,
         len,
         code.original_byte_slice(),
-    );
+    )
 }
 
 #[instruction]
@@ -199,16 +151,9 @@ pub(crate) fn returndatacopy(cx: _, [memory_offset, data_offset, len]: [Word]) -
         return Err(InstrStop::OutOfOffset);
     }
 
-    let copy_cost = cx.state.gas_params().copy_cost(len);
-    copy_data(
-        cx.gas,
-        &mut cx.state.0.memory,
-        copy_cost,
-        *memory_offset,
-        Word::from(data_offset),
-        len,
-        &cx.state.0.return_data,
-    )
+    cx.gas.spend(cx.state.gas_params().copy_cost(len))?;
+    let data = &cx.state.0.return_data;
+    copy_data(cx.gas, &mut cx.state.0.memory, *memory_offset, Word::from(data_offset), len, data)
 }
 
 #[cfg(test)]

--- a/crates/evm2/src/interpreter/instructions/host.rs
+++ b/crates/evm2/src/interpreter/instructions/host.rs
@@ -26,8 +26,8 @@ pub(crate) fn sload(cx: _, [key]: [Word]) -> Result<out> {
     let additional_cold_cost = cx.state.gas_params().get(GasId::ColdStorageAdditionalCost).into();
     let skip_cold_load =
         cx.state.spec().enables(SpecId::BERLIN) && cx.gas.remaining() < additional_cold_cost;
-    let destination = cx.state.message().destination;
-    let load = cx.state.host().sload(&destination, key, skip_cold_load)?;
+    let destination = &cx.state.message().destination;
+    let load = cx.state.host().sload(destination, key, skip_cold_load)?;
     if load.is_cold {
         cx.gas.spend(additional_cold_cost)?;
     }
@@ -55,8 +55,8 @@ pub(crate) fn sstore(cx: _, [key, value]: [Word]) -> Result {
     // original/present/new values for net metering.
     let skip_cold_load = cx.state.spec().enables(SpecId::BERLIN)
         && cx.gas.remaining() < cx.state.gas_params().get(GasId::ColdStorageAdditionalCost).into();
-    let destination = cx.state.message().destination;
-    let state_load = cx.state.host().sstore(&destination, key, value, skip_cold_load)?;
+    let destination = &cx.state.message().destination;
+    let state_load = cx.state.host().sstore(destination, key, value, skip_cold_load)?;
 
     // EIP-2200 net gas metering depends on original, present, and new slot values:
     // clean slots pay set/reset costs, dirty slots generally only pay the load cost,
@@ -78,15 +78,15 @@ pub(crate) fn sstore(cx: _, [key, value]: [Word]) -> Result {
 
 #[instruction]
 pub(crate) fn tload(cx: _, [key]: [Word]) -> out {
-    let destination = cx.state.message().destination;
-    *out = cx.state.host().tload(&destination, key);
+    let destination = &cx.state.message().destination;
+    *out = cx.state.host().tload(destination, key);
 }
 
 #[instruction]
 pub(crate) fn tstore(cx: _, [key, value]: [Word]) -> Result {
     require_non_staticcall(cx.state)?;
-    let destination = cx.state.message().destination;
-    cx.state.host().tstore(&destination, key, value);
+    let destination = &cx.state.message().destination;
+    cx.state.host().tstore(destination, key, value);
 }
 
 #[instruction(no_stack_preamble, dynamic_gas)]

--- a/crates/evm2/src/interpreter/instructions/system.rs
+++ b/crates/evm2/src/interpreter/instructions/system.rs
@@ -8,7 +8,6 @@ use crate::{
         Gas, GasTracker, Host, InstrStop, InterpreterState, Message, MessageKind, MessageResult,
         Result, StackMut, Word, memory::resize_memory,
     },
-    trustme,
     utils::{word_to_address, word_to_usize},
     version::GasId,
 };
@@ -251,7 +250,7 @@ fn call_inner<T: EvmTypes>(
     } else if message.depth > CALL_DEPTH_LIMIT {
         call_too_deep_result::<T>(message.gas_limit)
     } else {
-        let tx_env = unsafe { trustme::decouple_lt(state.tx()) };
+        let tx_env = state.tx();
         state.host().execute_message(tx_env, code, &mut message, caller_is_static)
     };
     state.inspect_call_end(&message, &mut result);
@@ -346,7 +345,7 @@ fn create_inner<T: EvmTypes>(
         call_too_deep_result::<T>(message.gas_limit)
     } else {
         let bytecode = crate::bytecode::Bytecode::new_legacy(message.input.clone());
-        let tx_env = unsafe { trustme::decouple_lt(state.tx()) };
+        let tx_env = state.tx();
         state.host().execute_message(tx_env, bytecode, &mut message, false)
     };
     state.inspect_create_end(&message, &mut result);
@@ -372,9 +371,9 @@ pub(crate) fn selfdestruct(cx: _, [target]: [Word]) -> Result {
     let target = word_to_address(*target);
     let cold_load_gas = cx.state.gas_params().selfdestruct_cold_cost();
     let skip_cold_load = cx.gas.remaining() < cold_load_gas;
-    let destination = cx.state.message().destination;
-    let res = cx.state.host().selfdestruct(&destination, &target, skip_cold_load)?;
-    cx.state.inspect_selfdestruct(&destination, &target, &res.value);
+    let destination = &cx.state.message().destination;
+    let res = cx.state.host().selfdestruct(destination, &target, skip_cold_load)?;
+    cx.state.inspect_selfdestruct(destination, &target, &res.value);
     let should_charge_topup =
         should_charge_new_account_gas(cx.state.spec(), res.had_value, res.target_is_empty);
     cx.gas.spend(cx.state.gas_params().selfdestruct_cost(should_charge_topup, res.is_cold))?;
@@ -419,7 +418,7 @@ mod tests {
                 Word::from(0),
                 Word::from(0),
                 Word::from(0),
-                address_to_word(target),
+                address_to_word(&target),
                 Word::from(1000),
             ],
         );
@@ -451,7 +450,7 @@ mod tests {
                 Word::from(0),
                 Word::from(0),
                 Word::ZERO,
-                address_to_word(target),
+                address_to_word(&target),
                 Word::from(1000),
             ],
         );
@@ -477,7 +476,7 @@ mod tests {
                 Word::ZERO,
                 Word::ZERO,
                 Word::from(1),
-                address_to_word(target),
+                address_to_word(&target),
                 Word::from(1000),
             ],
         );
@@ -540,7 +539,7 @@ mod tests {
                 Word::ZERO,
                 Word::ZERO,
                 Word::ZERO,
-                address_to_word(target),
+                address_to_word(&target),
                 Word::ZERO,
             ],
         );
@@ -571,7 +570,7 @@ mod tests {
                 Word::ZERO,
                 Word::ZERO,
                 Word::ZERO,
-                address_to_word(target),
+                address_to_word(&target),
                 Word::ZERO,
             ],
         );
@@ -601,7 +600,7 @@ mod tests {
                 Word::from(0),
                 Word::from(0),
                 Word::from(7),
-                address_to_word(code_address),
+                address_to_word(&code_address),
                 Word::from(1000),
             ],
         );
@@ -629,7 +628,7 @@ mod tests {
                 Word::from(0),
                 Word::from(0),
                 Word::from(7),
-                address_to_word(code_address),
+                address_to_word(&code_address),
                 Word::from(1000),
             ],
         );
@@ -660,7 +659,7 @@ mod tests {
                 Word::from(0),
                 Word::from(0),
                 Word::from(0),
-                address_to_word(code_address),
+                address_to_word(&code_address),
                 Word::from(1000),
             ],
         );
@@ -710,7 +709,7 @@ mod tests {
                 Word::from(0),
                 Word::from(0),
                 Word::from(0),
-                address_to_word(target),
+                address_to_word(&target),
                 Word::from(1000),
             ],
         );
@@ -758,7 +757,7 @@ mod tests {
 
         let interpreter = run(RunConfig::new(code).host(&mut host).gas_limit(50_000));
         assert!(matches!(interpreter.err, InstrStop::Stop));
-        assert_eq!(interpreter.stack(), [address_to_word(created)]);
+        assert_eq!(interpreter.stack(), [address_to_word(&created)]);
         assert_eq!(host.calls.len(), 1);
         assert_eq!(host.calls[0].kind, MessageKind::Create);
     }
@@ -781,7 +780,7 @@ mod tests {
 
         let interpreter = run(RunConfig::new(code).host(&mut host).gas_limit(50_000));
         assert!(matches!(interpreter.err, InstrStop::Stop));
-        assert_eq!(interpreter.stack(), [address_to_word(created), Word::ZERO]);
+        assert_eq!(interpreter.stack(), [address_to_word(&created), Word::ZERO]);
     }
 
     #[test]
@@ -851,7 +850,7 @@ mod tests {
 
         let interpreter = run(RunConfig::new(code).host(&mut host).gas_limit(50_000));
         assert!(matches!(interpreter.err, InstrStop::Stop));
-        assert_eq!(interpreter.stack(), [address_to_word(created)]);
+        assert_eq!(interpreter.stack(), [address_to_word(&created)]);
         assert_eq!(host.calls[0].kind, MessageKind::Create2);
 
         let interpreter = run(RunConfig::new([
@@ -875,7 +874,7 @@ mod tests {
         let target = Address::from([0x99; 20]);
         let mut host = TestHost::default();
         let mut code = Vec::new();
-        push(&mut code, address_to_word(target));
+        push(&mut code, address_to_word(&target));
         code.push(op::SELFDESTRUCT);
 
         let interpreter = run(RunConfig::new(code).host(&mut host).message(Message {

--- a/crates/evm2/src/interpreter/runtime.rs
+++ b/crates/evm2/src/interpreter/runtime.rs
@@ -19,9 +19,9 @@ use derive_where::derive_where;
 /// EVM interpreter.
 #[derive_where(Debug)]
 pub struct Interpreter<'frame, T: EvmTypes> {
-    pub(crate) bytecode: Bytecode,
-    pub(crate) memory: Memory,
-    pub(crate) return_data: Bytes,
+    pub(in crate::interpreter) bytecode: Bytecode,
+    pub(in crate::interpreter) memory: Memory,
+    pub(in crate::interpreter) return_data: Bytes,
 
     pub(in crate::interpreter) pc: *const u8,
     output: *const [u8],

--- a/crates/evm2/src/interpreter/runtime.rs
+++ b/crates/evm2/src/interpreter/runtime.rs
@@ -19,9 +19,9 @@ use derive_where::derive_where;
 /// EVM interpreter.
 #[derive_where(Debug)]
 pub struct Interpreter<'frame, T: EvmTypes> {
-    bytecode: Bytecode,
-    memory: Memory,
-    return_data: Bytes,
+    pub(crate) bytecode: Bytecode,
+    pub(crate) memory: Memory,
+    pub(crate) return_data: Bytes,
 
     pub(in crate::interpreter) pc: *const u8,
     output: *const [u8],
@@ -218,7 +218,7 @@ impl<'frame, T: EvmTypes> Interpreter<'frame, T> {
 
 /// Interpreter state exposed to instruction implementations.
 #[repr(transparent)]
-pub struct InterpreterState<'frame, T: EvmTypes>(Interpreter<'frame, T>);
+pub struct InterpreterState<'frame, T: EvmTypes>(pub(crate) Interpreter<'frame, T>);
 
 impl<T: EvmTypes> fmt::Debug for InterpreterState<'_, T> {
     #[inline]
@@ -269,7 +269,7 @@ impl<'frame, T: EvmTypes> InterpreterState<'frame, T> {
 
     /// Returns the cached transaction-global environment.
     #[inline]
-    pub const fn tx(&self) -> &TxEnv<T> {
+    pub const fn tx(&self) -> &'frame TxEnv<T> {
         // SAFETY: `tx_env` is initialized at the beginning of `run` and remains set for
         // instruction execution.
         unsafe { self.0.tx_env.unwrap_unchecked() }
@@ -300,7 +300,7 @@ impl<'frame, T: EvmTypes> InterpreterState<'frame, T> {
 
     /// Returns the active frame-local call/create message.
     #[inline]
-    pub const fn message(&self) -> &Message<T> {
+    pub const fn message(&self) -> &'frame Message<T> {
         // SAFETY: `message` is initialized at the beginning of `run` and remains set for
         // instruction execution.
         unsafe { self.0.message.unwrap_unchecked() }

--- a/crates/evm2/src/utils.rs
+++ b/crates/evm2/src/utils.rs
@@ -13,8 +13,8 @@ pub const fn num_words(len: usize) -> usize {
 
 /// Converts an address to an EVM word.
 #[inline]
-pub fn address_to_word(address: Address) -> Word {
-    address.into_word().into()
+pub fn address_to_word(address: &Address) -> Word {
+    Word::from_be_slice(address.as_slice())
 }
 
 /// Converts a 256-bit hash to an EVM word.


### PR DESCRIPTION
This makes the frame-local message and transaction getters return the frame lifetime so instruction implementations can keep borrowed frame data while mutably touching host or memory.

The storage, transient storage, self balance, self destruct, and copy opcodes now pass borrowed frame addresses or data through the existing instruction helpers instead of cloning or copying just to satisfy temporary borrow lifetimes. `address_to_word` now accepts an address reference so address-returning opcodes follow the same shape.
