### PR TITLE
feat: add async database support

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -3,9 +3,9 @@
     "rust-analyzer": {
       "initialization_options": {
         "cargo": {
-          "features": []
-        }
-      }
-    }
-  }
+          "features": ["std", "async"],
+        },
+      },
+    },
+  },
 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,10 @@ alloy-trie = { version = "0.9", default-features = false }
 derive-where = { version = "1.6", default-features = false }
 
 cfg-if = { version = "1.0", default-features = false }
+corosensei = { version = "0.3.3", default-features = false, features = [
+    "default-stack",
+    "unwind",
+] }
 libtest-mimic = "0.8"
 once_cell = { version = "1.21", default-features = false }
 rand = "0.10"
@@ -57,7 +61,6 @@ serde_json = { version = "1.0", default-features = false }
 thiserror = { version = "2.0", default-features = false }
 tokio = { version = "1", default-features = false }
 walkdir = { version = "2.5", default-features = false }
-wasmtime-fiber = { package = "wasmtime-internal-fiber", version = "44.0.1", default-features = false }
 
 # Precompiles
 ark-bls12-381 = { version = "0.6.0", default-features = false }
@@ -98,6 +101,9 @@ codegen-units = 1
 [patch.crates-io]
 # less memcpys, allocas etc.: https://github.com/tokio-rs/bytes/pull/826
 bytes = { git = "https://github.com/tokio-rs/bytes", branch = "master" }
+
+# Uses public `Coroutine::with_stack_unchecked`.
+corosensei = { git = "https://github.com/Amanieu/corosensei", branch = "master" }
 
 # faster compile times: https://github.com/arkworks-rs/algebra/issues/1104
 ark-ec = { git = "https://github.com/DaniPopes/algebra", rev = "a71d9795e2e527cd0c80e6831bd957134de30d22" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ rstest = "0.26.0"
 serde = { version = "1.0", default-features = false }
 serde_json = { version = "1.0", default-features = false }
 thiserror = { version = "2.0", default-features = false }
+tokio = { version = "1", default-features = false }
 walkdir = { version = "2.5", default-features = false }
 wasmtime-fiber = { package = "wasmtime-internal-fiber", version = "44.0.1", default-features = false }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ serde = { version = "1.0", default-features = false }
 serde_json = { version = "1.0", default-features = false }
 thiserror = { version = "2.0", default-features = false }
 walkdir = { version = "2.5", default-features = false }
+wasmtime-fiber = { package = "wasmtime-internal-fiber", version = "44.0.1", default-features = false }
 
 # Precompiles
 ark-bls12-381 = { version = "0.6.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,9 @@ alloy-trie = { version = "0.9", default-features = false }
 derive-where = { version = "1.6", default-features = false }
 
 cfg-if = { version = "1.0", default-features = false }
-corosensei = { version = "0.3.3", default-features = false, features = [
+# Uses public `Coroutine::with_stack_unchecked`.
+# https://github.com/Amanieu/corosensei/pull/74
+corosensei = { git = "https://github.com/Amanieu/corosensei", rev = "3a122508ab1d7c25e4dee8b2b4b4c47046c3c3d8", default-features = false, features = [
     "default-stack",
     "unwind",
 ] }
@@ -101,9 +103,6 @@ codegen-units = 1
 [patch.crates-io]
 # less memcpys, allocas etc.: https://github.com/tokio-rs/bytes/pull/826
 bytes = { git = "https://github.com/tokio-rs/bytes", branch = "master" }
-
-# Uses public `Coroutine::with_stack_unchecked`.
-corosensei = { git = "https://github.com/Amanieu/corosensei", branch = "master" }
 
 # faster compile times: https://github.com/arkworks-rs/algebra/issues/1104
 ark-ec = { git = "https://github.com/DaniPopes/algebra", rev = "a71d9795e2e527cd0c80e6831bd957134de30d22" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ derive-where = { version = "1.6", default-features = false }
 cfg-if = { version = "1.0", default-features = false }
 # Uses public `Coroutine::with_stack_unchecked`.
 # https://github.com/Amanieu/corosensei/pull/74
-corosensei = { git = "https://github.com/Amanieu/corosensei", rev = "3a122508ab1d7c25e4dee8b2b4b4c47046c3c3d8", default-features = false, features = [
+corosensei = { version = "0.3.3", git = "https://github.com/Amanieu/corosensei", rev = "3a122508ab1d7c25e4dee8b2b4b4c47046c3c3d8", default-features = false, features = [
     "default-stack",
     "unwind",
 ] }

--- a/crates/evm2/Cargo.toml
+++ b/crates/evm2/Cargo.toml
@@ -24,6 +24,7 @@ alloy-primitives.workspace = true
 derive-where.workspace = true
 thiserror.workspace = true
 cfg-if.workspace = true
+wasmtime-fiber = { workspace = true, features = ["std"], optional = true }
 
 # no_std
 once_cell = { workspace = true, features = ["alloc"] }
@@ -127,6 +128,8 @@ std = [
     "secp256k1?/std",
     "serde?/std",
 ]
+
+async = ["std", "dep:wasmtime-fiber"]
 
 serde = [
     "dep:serde",

--- a/crates/evm2/Cargo.toml
+++ b/crates/evm2/Cargo.toml
@@ -24,13 +24,16 @@ alloy-primitives.workspace = true
 derive-where.workspace = true
 thiserror.workspace = true
 cfg-if.workspace = true
-wasmtime-fiber = { workspace = true, features = ["std"], optional = true }
 
 # no_std
 once_cell = { workspace = true, features = ["alloc"] }
 
 # "serde"
 serde = { workspace = true, features = ["derive", "alloc"], optional = true }
+
+# "async"
+tokio = { workspace = true, features = ["rt-multi-thread"], optional = true }
+wasmtime-fiber = { workspace = true, features = ["std"], optional = true }
 
 # ecrecover
 k256 = { workspace = true, features = ["ecdsa"] }
@@ -83,6 +86,7 @@ serde_json = { workspace = true, features = ["std"] }
 rand = { workspace = true, features = ["std"] }
 ark-std = { workspace = true }
 rstest.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
 [target.'cfg(not(target_family = "wasm"))'.dev-dependencies]
 revm = { version = "38", default-features = true, features = ["test-types"] }
@@ -129,7 +133,7 @@ std = [
     "serde?/std",
 ]
 
-async = ["std", "dep:wasmtime-fiber"]
+async = ["std", "dep:tokio", "dep:wasmtime-fiber"]
 
 serde = [
     "dep:serde",

--- a/crates/evm2/Cargo.toml
+++ b/crates/evm2/Cargo.toml
@@ -33,7 +33,7 @@ serde = { workspace = true, features = ["derive", "alloc"], optional = true }
 
 # "async"
 tokio = { workspace = true, features = ["rt-multi-thread"], optional = true }
-wasmtime-fiber = { workspace = true, features = ["std"], optional = true }
+corosensei = { workspace = true, optional = true }
 
 # ecrecover
 k256 = { workspace = true, features = ["ecdsa"] }
@@ -133,7 +133,7 @@ std = [
     "serde?/std",
 ]
 
-async = ["std", "dep:tokio", "dep:wasmtime-fiber"]
+async = ["std", "dep:tokio", "dep:corosensei"]
 
 serde = [
     "dep:serde",

--- a/crates/evm2/examples/custom_evm/main.rs
+++ b/crates/evm2/examples/custom_evm/main.rs
@@ -118,9 +118,8 @@ fn inspector() -> HandlerResult<()> {
 
     let result = evm.transact(&tx)?;
     let inspector = evm.clear_inspector().expect("inspector should be set");
-    let inspector = (inspector.as_ref() as &dyn core::any::Any)
-        .downcast_ref::<ExampleInspector>()
-        .expect("inspector should have expected type");
+    let inspector =
+        inspector.downcast_ref::<ExampleInspector>().expect("inspector should have expected type");
     let inspector_state = &inspector.state;
     let expected_opcodes = [op::PUSH1, op::PUSH1, op::LOG0, opcode::CUSTOM_OPCODE, op::STOP];
 

--- a/crates/evm2/examples/custom_evm/main.rs
+++ b/crates/evm2/examples/custom_evm/main.rs
@@ -14,7 +14,6 @@ use evm2::{
     interpreter::{InstrStop, Interpreter, Message, MessageResult, op},
     registry::HandlerResult,
 };
-use std::sync::{Arc, Mutex};
 use tx::{CustomEnvelope, ExecuteCodeTx, custom_registry};
 
 pub mod config;
@@ -106,8 +105,7 @@ fn mainnet_fallback() -> HandlerResult<()> {
 
 fn inspector() -> HandlerResult<()> {
     let mut evm = custom_evm();
-    let inspector_state = Arc::new(Mutex::new(InspectorState::default()));
-    evm.set_inspector(ExampleInspector(Arc::clone(&inspector_state)));
+    evm.set_inspector(ExampleInspector::default());
     let tx = custom_opcode_tx(Bytes::from_static(&[
         op::PUSH1,
         0,
@@ -119,7 +117,11 @@ fn inspector() -> HandlerResult<()> {
     ]));
 
     let result = evm.transact(&tx)?;
-    let inspector_state = inspector_state.lock().unwrap();
+    let inspector = evm.clear_inspector().expect("inspector should be set");
+    let inspector = (inspector.as_ref() as &dyn core::any::Any)
+        .downcast_ref::<ExampleInspector>()
+        .expect("inspector should have expected type");
+    let inspector_state = &inspector.state;
     let expected_opcodes = [op::PUSH1, op::PUSH1, op::LOG0, opcode::CUSTOM_OPCODE, op::STOP];
 
     println!(
@@ -202,29 +204,31 @@ struct InspectorState {
     opcodes: Vec<u8>,
 }
 
-struct ExampleInspector(Arc<Mutex<InspectorState>>);
+#[derive(Default)]
+struct ExampleInspector {
+    state: InspectorState,
+}
 
 impl Inspector<CustomTypes> for ExampleInspector {
     fn initialize_interp(&mut self, _interp: &mut Interpreter<'_, CustomTypes>) {
-        self.0.lock().unwrap().initialized += 1;
+        self.state.initialized += 1;
     }
 
     fn step(&mut self, interp: &mut Interpreter<'_, CustomTypes>) {
-        let mut state = self.0.lock().unwrap();
-        state.steps += 1;
-        state.opcodes.push(interp.opcode());
+        self.state.steps += 1;
+        self.state.opcodes.push(interp.opcode());
     }
 
     fn step_end(&mut self, _interp: &mut Interpreter<'_, CustomTypes>) {
-        self.0.lock().unwrap().step_ends += 1;
+        self.state.step_ends += 1;
     }
 
     fn log(&mut self, _log: &alloy_primitives::Log) {
-        self.0.lock().unwrap().logs += 1;
+        self.state.logs += 1;
     }
 
     fn call(&mut self, _message: &mut Message<CustomTypes>) -> Option<MessageResult<CustomTypes>> {
-        self.0.lock().unwrap().calls += 1;
+        self.state.calls += 1;
         None
     }
 }

--- a/crates/evm2/examples/custom_evm/main.rs
+++ b/crates/evm2/examples/custom_evm/main.rs
@@ -14,7 +14,7 @@ use evm2::{
     interpreter::{InstrStop, Interpreter, Message, MessageResult, op},
     registry::HandlerResult,
 };
-use std::{cell::RefCell, rc::Rc};
+use std::sync::{Arc, Mutex};
 use tx::{CustomEnvelope, ExecuteCodeTx, custom_registry};
 
 pub mod config;
@@ -106,8 +106,8 @@ fn mainnet_fallback() -> HandlerResult<()> {
 
 fn inspector() -> HandlerResult<()> {
     let mut evm = custom_evm();
-    let inspector_state = Rc::new(RefCell::new(InspectorState::default()));
-    evm.set_inspector(ExampleInspector(Rc::clone(&inspector_state)));
+    let inspector_state = Arc::new(Mutex::new(InspectorState::default()));
+    evm.set_inspector(ExampleInspector(Arc::clone(&inspector_state)));
     let tx = custom_opcode_tx(Bytes::from_static(&[
         op::PUSH1,
         0,
@@ -119,7 +119,7 @@ fn inspector() -> HandlerResult<()> {
     ]));
 
     let result = evm.transact(&tx)?;
-    let inspector_state = inspector_state.borrow();
+    let inspector_state = inspector_state.lock().unwrap();
     let expected_opcodes = [op::PUSH1, op::PUSH1, op::LOG0, opcode::CUSTOM_OPCODE, op::STOP];
 
     println!(
@@ -202,29 +202,29 @@ struct InspectorState {
     opcodes: Vec<u8>,
 }
 
-struct ExampleInspector(Rc<RefCell<InspectorState>>);
+struct ExampleInspector(Arc<Mutex<InspectorState>>);
 
 impl Inspector<CustomTypes> for ExampleInspector {
     fn initialize_interp(&mut self, _interp: &mut Interpreter<'_, CustomTypes>) {
-        self.0.borrow_mut().initialized += 1;
+        self.0.lock().unwrap().initialized += 1;
     }
 
     fn step(&mut self, interp: &mut Interpreter<'_, CustomTypes>) {
-        let mut state = self.0.borrow_mut();
+        let mut state = self.0.lock().unwrap();
         state.steps += 1;
         state.opcodes.push(interp.opcode());
     }
 
     fn step_end(&mut self, _interp: &mut Interpreter<'_, CustomTypes>) {
-        self.0.borrow_mut().step_ends += 1;
+        self.0.lock().unwrap().step_ends += 1;
     }
 
     fn log(&mut self, _log: &alloy_primitives::Log) {
-        self.0.borrow_mut().logs += 1;
+        self.0.lock().unwrap().logs += 1;
     }
 
     fn call(&mut self, _message: &mut Message<CustomTypes>) -> Option<MessageResult<CustomTypes>> {
-        self.0.borrow_mut().calls += 1;
+        self.0.lock().unwrap().calls += 1;
         None
     }
 }

--- a/crates/evm2/src/async_.rs
+++ b/crates/evm2/src/async_.rs
@@ -31,6 +31,28 @@ type EvmFiber<R> = Coroutine<Resume, Yield, Complete<R>, DefaultStack>;
 
 const DEFAULT_STACK_SIZE: usize = 1024 * 1024;
 
+/// Reusable async EVM fiber stack storage.
+#[derive(Default)]
+pub(crate) struct FiberStack {
+    stack: Option<DefaultStack>,
+}
+
+impl FiberStack {
+    #[inline]
+    fn take_or_new(&mut self) -> AsyncResult<DefaultStack> {
+        match self.stack.take() {
+            Some(stack) => Ok(stack),
+            None => DefaultStack::new(DEFAULT_STACK_SIZE).map_err(AsyncError::Io),
+        }
+    }
+
+    #[inline]
+    fn put(&mut self, stack: DefaultStack) {
+        debug_assert!(self.stack.is_none());
+        self.stack = Some(stack);
+    }
+}
+
 thread_local! {
     static CURRENT: Cell<Option<NonNull<CurrentFiber>>> = const { Cell::new(None) };
 }
@@ -115,6 +137,7 @@ impl Drop for ResetCurrentFiber {
 ///
 /// Synchronous code running inside `func` may call [`block_on_current`] to wait for async host
 /// operations without blocking the executor thread.
+#[cfg(test)]
 pub(crate) fn on_fiber_result<'a, R, E>(
     func: impl FnOnce() -> Result<R, E> + 'a,
 ) -> impl Future<Output = AsyncResult<R, E>> + Send + 'a
@@ -125,6 +148,24 @@ where
     OnFiber::new(func)
 }
 
+/// Runs `func` on a native fiber backed by a reusable EVM stack slot.
+///
+/// # Safety
+///
+/// `stack` must point to valid stack storage for the lifetime of the returned future. That storage
+/// must not be accessed by anything else until the returned future is dropped.
+pub(crate) unsafe fn on_fiber_result_with_stack<'a, R, E>(
+    stack: NonNull<FiberStack>,
+    func: impl FnOnce() -> Result<R, E> + 'a,
+) -> impl Future<Output = AsyncResult<R, E>> + Send + 'a
+where
+    R: Send + 'a,
+    E: Send + 'a,
+{
+    OnFiber::with_stack(stack, func)
+}
+
+#[cfg(test)]
 pub(crate) fn on_fiber<'a, R>(
     func: impl FnOnce() -> R + 'a,
 ) -> impl Future<Output = AsyncResult<R>> + Send + 'a
@@ -134,6 +175,21 @@ where
     on_fiber_result(move || Ok::<_, core::convert::Infallible>(func()))
 }
 
+/// Runs `func` on a native fiber backed by a reusable EVM stack slot.
+///
+/// # Safety
+///
+/// See [`on_fiber_result_with_stack`].
+pub(crate) unsafe fn on_fiber_with_stack<'a, R>(
+    stack: NonNull<FiberStack>,
+    func: impl FnOnce() -> R + 'a,
+) -> impl Future<Output = AsyncResult<R>> + Send + 'a
+where
+    R: Send + 'a,
+{
+    unsafe { on_fiber_result_with_stack(stack, move || Ok::<_, core::convert::Infallible>(func())) }
+}
+
 enum OnFiber<'a, R, E> {
     Running(FiberFuture<'a, Result<R, E>>),
     Error(Option<AsyncError>),
@@ -141,8 +197,20 @@ enum OnFiber<'a, R, E> {
 }
 
 impl<'a, R, E> OnFiber<'a, R, E> {
+    #[cfg(test)]
     fn new(func: impl FnOnce() -> Result<R, E> + 'a) -> Self {
-        match FiberFuture::new(func) {
+        Self::new_inner(None, func)
+    }
+
+    fn with_stack(stack: NonNull<FiberStack>, func: impl FnOnce() -> Result<R, E> + 'a) -> Self {
+        Self::new_inner(Some(stack), func)
+    }
+
+    fn new_inner(
+        stack: Option<NonNull<FiberStack>>,
+        func: impl FnOnce() -> Result<R, E> + 'a,
+    ) -> Self {
+        match FiberFuture::new(stack, func) {
             Ok(fiber) => Self::Running(fiber),
             Err(error) => Self::Error(Some(error)),
         }
@@ -180,7 +248,8 @@ impl<R, E> Future for OnFiber<'_, R, E> {
 }
 
 struct FiberFuture<'a, R> {
-    fiber: EvmFiber<R>,
+    fiber: Option<EvmFiber<R>>,
+    stack: Option<NonNull<FiberStack>>,
     _marker: PhantomData<&'a ()>,
 }
 
@@ -190,8 +259,14 @@ struct FiberFuture<'a, R> {
 unsafe impl<R: Send> Send for FiberFuture<'_, R> {}
 
 impl<'a, R> FiberFuture<'a, R> {
-    fn new(func: impl FnOnce() -> R + 'a) -> AsyncResult<Self> {
-        let stack = DefaultStack::new(DEFAULT_STACK_SIZE).map_err(AsyncError::Io)?;
+    fn new(
+        mut stack: Option<NonNull<FiberStack>>,
+        func: impl FnOnce() -> R + 'a,
+    ) -> AsyncResult<Self> {
+        let fiber_stack = match &mut stack {
+            Some(stack) => unsafe { stack.as_mut() }.take_or_new()?,
+            None => DefaultStack::new(DEFAULT_STACK_SIZE).map_err(AsyncError::Io)?,
+        };
         let body = move |suspend: &Yielder<Resume, Yield>, resume| {
             let future_cx = resume?;
             let mut current =
@@ -203,8 +278,17 @@ impl<'a, R> FiberFuture<'a, R> {
         };
         // SAFETY: The coroutine is stored inside `FiberFuture<'a, R>`, which is tied to the
         // borrowed state lifetime and dropped before those borrows can expire.
-        let fiber = unsafe { Coroutine::with_stack_unchecked(stack, body) };
-        Ok(Self { fiber, _marker: PhantomData })
+        let fiber = unsafe { Coroutine::with_stack_unchecked(fiber_stack, body) };
+        Ok(Self { fiber: Some(fiber), stack, _marker: PhantomData })
+    }
+
+    fn recycle_stack(&mut self) {
+        let Some(fiber) = self.fiber.take() else { return };
+        debug_assert!(fiber.done());
+        let stack = fiber.into_stack();
+        if let Some(mut slot) = self.stack {
+            unsafe { slot.as_mut() }.put(stack);
+        }
     }
 }
 
@@ -214,8 +298,12 @@ impl<R> Future for FiberFuture<'_, R> {
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.get_mut();
         let cx = NonNull::from(unsafe { change_context_lifetime(cx) });
-        match this.fiber.resume(Ok(cx)) {
-            CoroutineResult::Return(result) => Poll::Ready(result),
+        let fiber = this.fiber.as_mut().expect("async EVM fiber polled after completion");
+        match fiber.resume(Ok(cx)) {
+            CoroutineResult::Return(result) => {
+                this.recycle_stack();
+                Poll::Ready(result)
+            }
             CoroutineResult::Yield(()) => Poll::Pending,
         }
     }
@@ -223,13 +311,17 @@ impl<R> Future for FiberFuture<'_, R> {
 
 impl<R> Drop for FiberFuture<'_, R> {
     fn drop(&mut self) {
-        if self.fiber.done() {
+        let Some(fiber) = self.fiber.as_mut() else {
             return;
-        }
-        if matches!(self.fiber.resume(Err(AsyncError::Cancelled)), CoroutineResult::Yield(())) {
+        };
+        if fiber.done() {
+            self.recycle_stack();
+        } else if matches!(fiber.resume(Err(AsyncError::Cancelled)), CoroutineResult::Yield(())) {
             // SAFETY: Cancellation already gave the coroutine a chance to return normally. If it
             // yields again, the stack is no longer useful to this future.
-            unsafe { self.fiber.force_reset() };
+            unsafe { fiber.force_reset() };
+        } else {
+            self.recycle_stack();
         }
     }
 }
@@ -535,7 +627,8 @@ mod tests {
     };
     use alloy_consensus::{TxLegacy, transaction::Recovered};
     use alloy_primitives::{Address, B256, Bytes};
-    use core::{convert::Infallible, fmt, future::Future, pin::Pin, task::Poll};
+    use core::{convert::Infallible, fmt, future::Future, pin::Pin, ptr::NonNull, task::Poll};
+    use corosensei::stack::Stack;
     use std::{
         error::Error,
         task::{Context, Waker},
@@ -558,6 +651,27 @@ mod tests {
 
         assert!(matches!(future.as_mut().poll(&mut cx), Poll::Pending));
         assert!(matches!(future.as_mut().poll(&mut cx), Poll::Ready(Ok(3))));
+    }
+
+    #[test]
+    fn fiber_reuses_stack_slot() {
+        let mut stack = super::FiberStack::default();
+        let stack_ptr = NonNull::from(&mut stack);
+
+        let first = poll_ready(unsafe {
+            super::on_fiber_result_with_stack(stack_ptr, || Ok::<_, Infallible>(1))
+        })
+        .unwrap();
+        let first_base = stack.stack.as_ref().unwrap().base();
+        let second = poll_ready(unsafe {
+            super::on_fiber_result_with_stack(stack_ptr, || Ok::<_, Infallible>(2))
+        })
+        .unwrap();
+        let second_base = stack.stack.as_ref().unwrap().base();
+
+        assert_eq!(first, 1);
+        assert_eq!(second, 2);
+        assert_eq!(first_base, second_base);
     }
 
     #[test]

--- a/crates/evm2/src/async_.rs
+++ b/crates/evm2/src/async_.rs
@@ -423,6 +423,11 @@ unsafe fn restore_context_lifetime<'a>(cx: &'a mut Context<'static>) -> &'a mut 
 }
 
 /// Asynchronous backing database implementation.
+///
+/// To take advantage of yielding host I/O, this must be wrapped in [`AsyncDb`] and used with
+/// async EVM entrypoints such as [`crate::Evm::transact_async`]. Calling synchronous EVM
+/// entrypoints with an [`AsyncDb`] can still execute the futures by blocking on Tokio, but it
+/// cannot suspend the EVM fiber and yield back to the caller.
 pub trait AsyncDatabase: Any + Send {
     /// Database error type.
     type Error: Error + Send + 'static;

--- a/crates/evm2/src/async_.rs
+++ b/crates/evm2/src/async_.rs
@@ -12,19 +12,20 @@ use crate::{
 };
 use alloc::boxed::Box;
 use alloy_primitives::{Address, B256};
-use core::{any::Any, fmt, future::Future, pin::Pin, ptr::NonNull, task::Poll};
+use core::{
+    any::Any, fmt, future::Future, marker::PhantomData, pin::Pin, ptr::NonNull, task::Poll,
+};
+use corosensei::{Coroutine, CoroutineResult, Yielder, stack::DefaultStack};
 use std::{cell::Cell, error::Error, task::Context};
 use tokio::{
     runtime::{Handle, Runtime},
     task,
 };
-use wasmtime_fiber::{Fiber, FiberStack, Suspend};
 
 type Resume = AsyncResult<NonNull<Context<'static>>>;
 type Yield = ();
 type Complete<R> = AsyncResult<R>;
-type EvmFiber<'a, R> = Fiber<'a, Resume, Yield, Complete<R>>;
-type EvmSuspend<R> = Suspend<Resume, Yield, Complete<R>>;
+type EvmFiber<R> = Coroutine<Resume, Yield, Complete<R>, DefaultStack>;
 
 thread_local! {
     static CURRENT: Cell<Option<NonNull<CurrentFiber<'static>>>> = const { Cell::new(None) };
@@ -62,19 +63,9 @@ impl AsyncError {
     }
 }
 
-trait FiberSuspend {
-    fn suspend(&mut self) -> Resume;
-}
-
-impl<R> FiberSuspend for EvmSuspend<R> {
-    #[inline]
-    fn suspend(&mut self) -> Resume {
-        self.suspend(())
-    }
-}
-
 struct CurrentFiber<'a> {
-    suspend: NonNull<dyn FiberSuspend + 'a>,
+    suspend: NonNull<Yielder<Resume, Yield>>,
+    _marker: PhantomData<&'a Yielder<Resume, Yield>>,
     future_cx: NonNull<Context<'static>>,
     cancelled: bool,
 }
@@ -87,7 +78,7 @@ impl CurrentFiber<'_> {
 
     #[inline]
     fn suspend(&mut self) -> AsyncResult<()> {
-        match unsafe { self.suspend.as_mut() }.suspend() {
+        match unsafe { self.suspend.as_ref() }.suspend(()) {
             Ok(cx) => {
                 self.future_cx = cx;
                 Ok(())
@@ -197,14 +188,15 @@ impl<R, E> Future for OnFiber<'_, R, E> {
 }
 
 struct FiberFuture<'a, R> {
-    fiber: Option<EvmFiber<'a, R>>,
+    fiber: Option<EvmFiber<R>>,
+    _marker: PhantomData<&'a mut R>,
 }
 
 impl<R> Unpin for FiberFuture<'_, R> {}
 
-// SAFETY: The future may move between polls, but the fiber stack itself is heap allocated by
-// `wasmtime-fiber` and is only resumed through `poll` with a fresh task context. Values that can
-// remain on the fiber stack across suspension are required to be `Send` by the blocking boundary.
+// SAFETY: The future may move between polls, but the coroutine stack itself is heap allocated and
+// is only resumed through `poll` with a fresh task context. Values that can remain on the coroutine
+// stack across suspension are required to be `Send` by the blocking boundary.
 unsafe impl<R: Send> Send for FiberFuture<'_, R> {}
 
 impl<'a, R> FiberFuture<'a, R> {
@@ -216,12 +208,13 @@ impl<'a, R> FiberFuture<'a, R> {
     where
         S: ?Sized,
     {
-        let stack = FiberStack::new(stack_size, false).map_err(fiber_error)?;
+        let stack = DefaultStack::new(stack_size).map_err(fiber_error)?;
         let state = core::ptr::from_mut(state);
-        let fiber = Fiber::new(stack, move |resume: Resume, suspend| {
+        let body = move |suspend: &Yielder<Resume, Yield>, resume| {
             let future_cx = resume?;
             let mut current = CurrentFiber {
-                suspend: NonNull::from(suspend as &mut dyn FiberSuspend),
+                suspend: NonNull::from(suspend),
+                _marker: PhantomData,
                 future_cx,
                 cancelled: false,
             };
@@ -230,9 +223,11 @@ impl<'a, R> FiberFuture<'a, R> {
             let previous = CURRENT.replace(Some(current));
             let _reset = ResetCurrentFiber(previous);
             Ok(func(unsafe { &mut *state }))
-        })
-        .map_err(fiber_error)?;
-        Ok(Self { fiber: Some(fiber) })
+        };
+        // SAFETY: The coroutine is stored inside `FiberFuture<'a, R>`, which is tied to the
+        // borrowed state lifetime and dropped before those borrows can expire.
+        let fiber = unsafe { Coroutine::with_stack_unchecked(stack, body) };
+        Ok(Self { fiber: Some(fiber), _marker: PhantomData })
     }
 }
 
@@ -242,24 +237,30 @@ impl<R> Future for FiberFuture<'_, R> {
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.get_mut();
         let cx = NonNull::from(unsafe { change_context_lifetime(cx) });
-        let fiber = this.fiber.as_ref().expect("async EVM fiber already completed");
+        let fiber = this.fiber.as_mut().expect("async EVM fiber already completed");
         match fiber.resume(Ok(cx)) {
-            Ok(result) => {
+            CoroutineResult::Return(result) => {
                 this.fiber = None;
                 Poll::Ready(result)
             }
-            Err(()) => Poll::Pending,
+            CoroutineResult::Yield(()) => Poll::Pending,
         }
     }
 }
 
 impl<R> Drop for FiberFuture<'_, R> {
     fn drop(&mut self) {
-        let Some(fiber) = self.fiber.take() else { return };
+        let Some(mut fiber) = self.fiber.take() else {
+            return;
+        };
         if fiber.done() {
             return;
         }
-        let _ = fiber.resume(Err(AsyncError::Cancelled));
+        if matches!(fiber.resume(Err(AsyncError::Cancelled)), CoroutineResult::Yield(())) {
+            // SAFETY: Cancellation already gave the coroutine a chance to return normally. If it
+            // yields again, the stack is no longer useful to this future.
+            unsafe { fiber.force_reset() };
+        }
     }
 }
 

--- a/crates/evm2/src/async_.rs
+++ b/crates/evm2/src/async_.rs
@@ -1,0 +1,659 @@
+//! Async execution support for synchronous EVM hosts.
+//!
+//! This module runs the synchronous EVM on a native fiber. Synchronous host methods can then use
+//! [`block_on_current`] to poll an async operation; if that operation is pending, the fiber is
+//! suspended and the outer async task returns `Poll::Pending`.
+
+use crate::{
+    bytecode::Bytecode,
+    evm::{AccountInfo, DatabaseCommit, DbErrorCode, DbResult, DynDatabase, StateChanges},
+    interpreter::Word,
+};
+use alloc::{
+    boxed::Box,
+    rc::Rc,
+    string::{String, ToString},
+};
+use alloy_primitives::{Address, B256};
+use core::{
+    any::Any, fmt, future::Future, marker::PhantomData, pin::Pin, ptr::NonNull, task::Poll,
+};
+use std::{cell::RefCell, error::Error, task::Context};
+use wasmtime_fiber::{Fiber, FiberStack, Suspend};
+
+/// Default stack size for async EVM execution.
+const DEFAULT_ASYNC_STACK_SIZE: usize = 2 * 1024 * 1024;
+
+type Resume = AsyncResult<NonNull<Context<'static>>>;
+type Yield = ();
+type Complete<R> = AsyncResult<R>;
+type EvmFiber<'a, R> = Fiber<'a, Resume, Yield, Complete<R>>;
+type EvmSuspend<R> = Suspend<Resume, Yield, Complete<R>>;
+
+thread_local! {
+    static CURRENT: RefCell<Option<NonNull<dyn CurrentFiber>>> = RefCell::new(None);
+}
+
+/// Result type used by async EVM execution helpers.
+pub type AsyncResult<T> = core::result::Result<T, AsyncError>;
+
+/// Error returned by async EVM execution helpers.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum AsyncError {
+    /// The async EVM fiber was cancelled before execution completed.
+    #[error("async EVM execution was cancelled")]
+    Cancelled,
+    /// A fiber stack or fiber could not be created.
+    #[error("failed to create EVM async fiber: {0}")]
+    Fiber(String),
+    /// An async host operation was called outside an async EVM fiber.
+    #[error("async host operation requires EVM async fiber execution")]
+    NotOnFiber,
+}
+
+trait CurrentFiber {
+    fn context(&mut self) -> &mut Context<'_>;
+
+    fn suspend(&mut self) -> AsyncResult<()>;
+
+    fn is_cancelled(&self) -> bool;
+}
+
+struct FiberContext<'a, R> {
+    suspend: &'a mut EvmSuspend<R>,
+    future_cx: Option<NonNull<Context<'static>>>,
+    cancelled: bool,
+}
+
+impl<R> CurrentFiber for FiberContext<'_, R> {
+    fn context(&mut self) -> &mut Context<'_> {
+        let cx = self.future_cx.as_mut().expect("future context is not available");
+        unsafe { restore_context_lifetime(cx.as_mut()) }
+    }
+
+    fn suspend(&mut self) -> AsyncResult<()> {
+        self.future_cx = None;
+        match self.suspend.suspend(()) {
+            Ok(cx) => {
+                self.future_cx = Some(cx);
+                Ok(())
+            }
+            Err(error) => {
+                self.cancelled = true;
+                Err(error)
+            }
+        }
+    }
+
+    fn is_cancelled(&self) -> bool {
+        self.cancelled
+    }
+}
+
+struct ResetCurrentFiber(Option<NonNull<dyn CurrentFiber>>);
+
+impl Drop for ResetCurrentFiber {
+    fn drop(&mut self) {
+        CURRENT.with(|current| *current.borrow_mut() = self.0);
+    }
+}
+
+/// Runs `func` on a native fiber and awaits its completion.
+///
+/// Synchronous code running inside `func` may call [`block_on_current`] to wait for async host
+/// operations without blocking the executor thread.
+pub(crate) async fn on_fiber<S, R>(state: &mut S, func: impl FnOnce(&mut S) -> R) -> AsyncResult<R>
+where
+    S: ?Sized,
+{
+    on_fiber_with_stack_size(state, DEFAULT_ASYNC_STACK_SIZE, func).await
+}
+
+/// Runs `func` on a native fiber with an explicit stack size.
+async fn on_fiber_with_stack_size<S, R>(
+    state: &mut S,
+    stack_size: usize,
+    func: impl FnOnce(&mut S) -> R,
+) -> AsyncResult<R>
+where
+    S: ?Sized,
+{
+    FiberFuture::new(state, stack_size, func)?.await
+}
+
+struct FiberFuture<'a, R> {
+    fiber: Option<EvmFiber<'a, R>>,
+    _not_send: PhantomData<Rc<()>>,
+}
+
+impl<R> Unpin for FiberFuture<'_, R> {}
+
+impl<'a, R> FiberFuture<'a, R> {
+    fn new<S>(
+        state: &'a mut S,
+        stack_size: usize,
+        func: impl FnOnce(&mut S) -> R + 'a,
+    ) -> AsyncResult<Self>
+    where
+        S: ?Sized,
+    {
+        let stack = FiberStack::new(stack_size, false).map_err(fiber_error)?;
+        let state = core::ptr::from_mut(state);
+        let fiber = Fiber::new(stack, move |resume: Resume, suspend| {
+            let future_cx = resume?;
+            let mut fiber_context =
+                FiberContext { suspend, future_cx: Some(future_cx), cancelled: false };
+            let current = NonNull::from(&mut fiber_context as &mut dyn CurrentFiber);
+            let current = unsafe { erase_current_fiber_lifetime(current) };
+            let previous = CURRENT.with(|slot| slot.borrow_mut().replace(current));
+            let _reset = ResetCurrentFiber(previous);
+            Ok(func(unsafe { &mut *state }))
+        })
+        .map_err(fiber_error)?;
+        Ok(Self { fiber: Some(fiber), _not_send: PhantomData })
+    }
+}
+
+impl<R> Future for FiberFuture<'_, R> {
+    type Output = AsyncResult<R>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.get_mut();
+        let cx = NonNull::from(unsafe { change_context_lifetime(cx) });
+        let fiber = this.fiber.as_ref().expect("async EVM fiber already completed");
+        match fiber.resume(Ok(cx)) {
+            Ok(result) => {
+                this.fiber = None;
+                Poll::Ready(result)
+            }
+            Err(()) => Poll::Pending,
+        }
+    }
+}
+
+impl<R> Drop for FiberFuture<'_, R> {
+    fn drop(&mut self) {
+        let Some(fiber) = self.fiber.take() else { return };
+        if fiber.done() {
+            return;
+        }
+        let _ = fiber.resume(Err(AsyncError::Cancelled));
+    }
+}
+
+/// Polls `future` to completion from inside an async EVM fiber.
+///
+/// If `future` returns `Poll::Pending`, the current EVM fiber is suspended and the outer
+/// [`on_fiber`] future returns `Poll::Pending`. When the executor wakes and polls the outer future
+/// again, the EVM fiber resumes and continues polling `future`.
+///
+/// # Errors
+///
+/// Returns [`AsyncError::NotOnFiber`] if called outside [`on_fiber`], or
+/// [`AsyncError::Cancelled`] if the outer async EVM execution was dropped.
+pub(crate) fn block_on_current<F>(future: F) -> AsyncResult<F::Output>
+where
+    F: Future,
+{
+    let mut future = core::pin::pin!(future);
+    loop {
+        if with_current(|current| current.is_cancelled())? {
+            return Err(AsyncError::Cancelled);
+        }
+        match with_current(|current| future.as_mut().poll(current.context()))? {
+            Poll::Ready(value) => return Ok(value),
+            Poll::Pending => with_current(|current| current.suspend())??,
+        }
+    }
+}
+
+fn with_current<R>(f: impl FnOnce(&mut dyn CurrentFiber) -> R) -> AsyncResult<R> {
+    let mut current =
+        CURRENT.with(|slot| slot.borrow().as_ref().copied()).ok_or(AsyncError::NotOnFiber)?;
+    Ok(f(unsafe { current.as_mut() }))
+}
+
+unsafe fn change_context_lifetime<'a>(cx: &'a mut Context<'_>) -> &'a mut Context<'static> {
+    unsafe { core::mem::transmute::<&'a mut Context<'_>, &'a mut Context<'static>>(cx) }
+}
+
+unsafe fn restore_context_lifetime<'a>(cx: &'a mut Context<'static>) -> &'a mut Context<'a> {
+    unsafe { core::mem::transmute::<&'a mut Context<'static>, &'a mut Context<'a>>(cx) }
+}
+
+unsafe fn erase_current_fiber_lifetime<'a>(
+    fiber: NonNull<dyn CurrentFiber + 'a>,
+) -> NonNull<dyn CurrentFiber + 'static> {
+    unsafe {
+        core::mem::transmute::<NonNull<dyn CurrentFiber + 'a>, NonNull<dyn CurrentFiber + 'static>>(
+            fiber,
+        )
+    }
+}
+
+fn fiber_error(error: impl fmt::Display) -> AsyncError {
+    AsyncError::Fiber(error.to_string())
+}
+
+/// Asynchronous backing database implementation.
+pub trait AsyncDatabase: Any {
+    /// Database error type.
+    type Error: Error + 'static;
+
+    /// Loads account information.
+    fn get_account(
+        &mut self,
+        address: Address,
+    ) -> impl Future<Output = core::result::Result<Option<AccountInfo>, Self::Error>> + '_;
+
+    /// Loads bytecode by code hash.
+    fn get_code_by_hash(
+        &mut self,
+        code_hash: B256,
+    ) -> impl Future<Output = core::result::Result<Bytecode, Self::Error>> + '_;
+
+    /// Loads a persistent storage slot.
+    fn get_storage(
+        &mut self,
+        address: Address,
+        key: Word,
+    ) -> impl Future<Output = core::result::Result<Word, Self::Error>> + '_;
+
+    /// Loads a historical block hash.
+    fn get_block_hash(
+        &mut self,
+        number: Word,
+    ) -> impl Future<Output = core::result::Result<Option<B256>, Self::Error>> + '_;
+}
+
+/// Adapter that exposes an [`AsyncDatabase`] through the synchronous [`DynDatabase`] interface.
+pub struct AsyncDb<D: AsyncDatabase> {
+    db: D,
+    error: Option<Box<dyn Error>>,
+}
+
+impl<D: AsyncDatabase> AsyncDb<D> {
+    /// Creates a new async database adapter.
+    #[inline]
+    pub const fn new(db: D) -> Self {
+        Self { db, error: None }
+    }
+
+    /// Returns the wrapped database.
+    #[inline]
+    pub const fn inner(&self) -> &D {
+        &self.db
+    }
+
+    /// Returns the wrapped database mutably.
+    #[inline]
+    pub const fn inner_mut(&mut self) -> &mut D {
+        &mut self.db
+    }
+
+    /// Consumes the adapter and returns the wrapped database.
+    #[inline]
+    pub fn into_inner(self) -> D {
+        self.db
+    }
+
+    /// Takes the stored database or async execution error.
+    #[inline]
+    pub fn take_error(&mut self) -> Option<Box<dyn Error>> {
+        self.error.take()
+    }
+
+    #[inline]
+    fn store_error(&mut self, error: impl Error + 'static) -> DbErrorCode {
+        self.error = Some(Box::new(error));
+        stored_error_code()
+    }
+}
+
+impl<D: AsyncDatabase + DatabaseCommit> DatabaseCommit for AsyncDb<D> {
+    #[inline]
+    fn commit(&mut self, changes: &StateChanges) {
+        self.db.commit(changes);
+    }
+}
+
+impl<D: AsyncDatabase> DynDatabase for AsyncDb<D> {
+    #[inline]
+    fn get_account(&mut self, address: &Address) -> DbResult<Option<AccountInfo>> {
+        match block_on_current(self.db.get_account(*address)) {
+            Ok(Ok(account)) => Ok(account),
+            Ok(Err(error)) => Err(self.store_error(error)),
+            Err(error) => Err(self.store_error(error)),
+        }
+    }
+
+    #[inline]
+    fn get_code_by_hash(&mut self, code_hash: &B256) -> DbResult<Bytecode> {
+        match block_on_current(self.db.get_code_by_hash(*code_hash)) {
+            Ok(Ok(bytecode)) => Ok(bytecode),
+            Ok(Err(error)) => Err(self.store_error(error)),
+            Err(error) => Err(self.store_error(error)),
+        }
+    }
+
+    #[inline]
+    fn get_storage(&mut self, address: &Address, key: &Word) -> DbResult<Word> {
+        match block_on_current(self.db.get_storage(*address, *key)) {
+            Ok(Ok(value)) => Ok(value),
+            Ok(Err(error)) => Err(self.store_error(error)),
+            Err(error) => Err(self.store_error(error)),
+        }
+    }
+
+    #[inline]
+    fn get_block_hash(&mut self, number: &Word) -> DbResult<Option<B256>> {
+        match block_on_current(self.db.get_block_hash(*number)) {
+            Ok(Ok(hash)) => Ok(hash),
+            Ok(Err(error)) => Err(self.store_error(error)),
+            Err(error) => Err(self.store_error(error)),
+        }
+    }
+
+    #[inline]
+    fn error(&mut self, code: DbErrorCode) -> Box<dyn Error> {
+        if code == stored_error_code()
+            && let Some(error) = self.error.take()
+        {
+            return error;
+        }
+        Box::new(AsyncDbErrorUnavailable(code))
+    }
+}
+
+impl<D: AsyncDatabase + fmt::Debug> fmt::Debug for AsyncDb<D> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("AsyncDb").field("db", &self.db).finish_non_exhaustive()
+    }
+}
+
+#[inline]
+fn stored_error_code() -> DbErrorCode {
+    match DbErrorCode::new(1) {
+        Some(code) => code,
+        None => unreachable!("stored database error code is non-zero"),
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct AsyncDbErrorUnavailable(DbErrorCode);
+
+impl fmt::Display for AsyncDbErrorUnavailable {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "async database error {:?} is unavailable", self.0)
+    }
+}
+
+impl Error for AsyncDbErrorUnavailable {}
+
+#[cfg(test)]
+mod tests {
+    use super::{AsyncDatabase, AsyncDb, AsyncError, block_on_current, on_fiber};
+    use crate::{bytecode::Bytecode, evm::DynDatabase, interpreter::Word};
+    use alloc::boxed::Box;
+    use alloy_primitives::{Address, B256};
+    use core::{convert::Infallible, fmt, future::Future, pin::Pin, task::Poll};
+    use std::{
+        error::Error,
+        task::{Context, Waker},
+    };
+
+    #[test]
+    fn block_on_requires_fiber() {
+        assert!(matches!(block_on_current(core::future::ready(())), Err(AsyncError::NotOnFiber)));
+    }
+
+    #[test]
+    fn fiber_suspends_and_resumes_pending_future() {
+        let mut state = 1;
+        let mut future = Box::pin(on_fiber(&mut state, |state| {
+            *state += block_on_current(PendingOnce { pending: true }).unwrap();
+            *state
+        }));
+        let waker = Waker::noop();
+        let mut cx = Context::from_waker(waker);
+
+        assert!(matches!(future.as_mut().poll(&mut cx), Poll::Pending));
+        assert!(matches!(future.as_mut().poll(&mut cx), Poll::Ready(Ok(3))));
+    }
+
+    #[test]
+    fn async_database_adapts_to_dyn_database() {
+        let mut db = AsyncDb::new(TestDb);
+        let address = Address::ZERO;
+        let key = Word::from(7);
+        let mut future =
+            Box::pin(on_fiber(&mut db, |db| DynDatabase::get_storage(db, &address, &key).unwrap()));
+        let waker = Waker::noop();
+        let mut cx = Context::from_waker(waker);
+
+        assert!(
+            matches!(future.as_mut().poll(&mut cx), Poll::Ready(Ok(value)) if value == Word::from(9))
+        );
+    }
+
+    #[test]
+    fn async_database_suspends_until_ready() {
+        let mut db = AsyncDb::new(PendingDb { pending: true });
+        let address = Address::ZERO;
+        let key = Word::from(7);
+        let mut future =
+            Box::pin(on_fiber(&mut db, |db| DynDatabase::get_storage(db, &address, &key).unwrap()));
+        let waker = Waker::noop();
+        let mut cx = Context::from_waker(waker);
+
+        assert!(matches!(future.as_mut().poll(&mut cx), Poll::Pending));
+        assert!(
+            matches!(future.as_mut().poll(&mut cx), Poll::Ready(Ok(value)) if value == Word::from(9))
+        );
+    }
+
+    #[test]
+    fn async_database_stores_database_error() {
+        let mut db = AsyncDb::new(FailingDb);
+        let address = Address::ZERO;
+        let key = Word::from(7);
+        let code =
+            on_fiber(&mut db, |db| DynDatabase::get_storage(db, &address, &key).unwrap_err());
+        let code = poll_ready(code).unwrap();
+
+        assert_eq!(db.error(code).to_string(), "storage read failed");
+    }
+
+    #[test]
+    fn dropping_fiber_cancels_blocked_future() {
+        let mut saw_cancel = false;
+        let mut future = Box::pin(on_fiber(&mut saw_cancel, |saw_cancel| {
+            *saw_cancel = matches!(block_on_current(PendingForever), Err(AsyncError::Cancelled));
+        }));
+        let waker = Waker::noop();
+        let mut cx = Context::from_waker(waker);
+
+        assert!(matches!(future.as_mut().poll(&mut cx), Poll::Pending));
+        drop(future);
+        assert!(saw_cancel);
+    }
+
+    fn poll_ready<F: Future>(future: F) -> F::Output {
+        let mut future = Box::pin(future);
+        let waker = Waker::noop();
+        let mut cx = Context::from_waker(waker);
+
+        match future.as_mut().poll(&mut cx) {
+            Poll::Ready(value) => value,
+            Poll::Pending => panic!("future unexpectedly pending"),
+        }
+    }
+
+    struct PendingOnce {
+        pending: bool,
+    }
+
+    impl Future for PendingOnce {
+        type Output = i32;
+
+        fn poll(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
+            if self.pending {
+                self.pending = false;
+                Poll::Pending
+            } else {
+                Poll::Ready(2)
+            }
+        }
+    }
+
+    struct PendingForever;
+
+    impl Future for PendingForever {
+        type Output = ();
+
+        fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
+            Poll::Pending
+        }
+    }
+
+    struct TestDb;
+
+    impl AsyncDatabase for TestDb {
+        type Error = Infallible;
+
+        fn get_account(
+            &mut self,
+            _address: Address,
+        ) -> impl Future<Output = Result<Option<crate::evm::AccountInfo>, Self::Error>> + '_
+        {
+            core::future::ready(Ok(None))
+        }
+
+        fn get_code_by_hash(
+            &mut self,
+            _code_hash: B256,
+        ) -> impl Future<Output = Result<Bytecode, Self::Error>> + '_ {
+            core::future::ready(Ok(Bytecode::default()))
+        }
+
+        fn get_storage(
+            &mut self,
+            _address: Address,
+            _key: Word,
+        ) -> impl Future<Output = Result<Word, Self::Error>> + '_ {
+            core::future::ready(Ok(Word::from(9)))
+        }
+
+        fn get_block_hash(
+            &mut self,
+            _number: Word,
+        ) -> impl Future<Output = Result<Option<B256>, Self::Error>> + '_ {
+            core::future::ready(Ok(None))
+        }
+    }
+
+    struct PendingDb {
+        pending: bool,
+    }
+
+    impl AsyncDatabase for PendingDb {
+        type Error = Infallible;
+
+        fn get_account(
+            &mut self,
+            _address: Address,
+        ) -> impl Future<Output = Result<Option<crate::evm::AccountInfo>, Self::Error>> + '_
+        {
+            core::future::ready(Ok(None))
+        }
+
+        fn get_code_by_hash(
+            &mut self,
+            _code_hash: B256,
+        ) -> impl Future<Output = Result<Bytecode, Self::Error>> + '_ {
+            core::future::ready(Ok(Bytecode::default()))
+        }
+
+        fn get_storage(
+            &mut self,
+            _address: Address,
+            _key: Word,
+        ) -> impl Future<Output = Result<Word, Self::Error>> + '_ {
+            PendingStorage { db: self }
+        }
+
+        fn get_block_hash(
+            &mut self,
+            _number: Word,
+        ) -> impl Future<Output = Result<Option<B256>, Self::Error>> + '_ {
+            core::future::ready(Ok(None))
+        }
+    }
+
+    struct PendingStorage<'a> {
+        db: &'a mut PendingDb,
+    }
+
+    impl Future for PendingStorage<'_> {
+        type Output = Result<Word, Infallible>;
+
+        fn poll(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
+            if self.db.pending {
+                self.db.pending = false;
+                Poll::Pending
+            } else {
+                Poll::Ready(Ok(Word::from(9)))
+            }
+        }
+    }
+
+    struct FailingDb;
+
+    impl AsyncDatabase for FailingDb {
+        type Error = TestError;
+
+        fn get_account(
+            &mut self,
+            _address: Address,
+        ) -> impl Future<Output = Result<Option<crate::evm::AccountInfo>, Self::Error>> + '_
+        {
+            core::future::ready(Ok(None))
+        }
+
+        fn get_code_by_hash(
+            &mut self,
+            _code_hash: B256,
+        ) -> impl Future<Output = Result<Bytecode, Self::Error>> + '_ {
+            core::future::ready(Ok(Bytecode::default()))
+        }
+
+        fn get_storage(
+            &mut self,
+            _address: Address,
+            _key: Word,
+        ) -> impl Future<Output = Result<Word, Self::Error>> + '_ {
+            core::future::ready(Err(TestError))
+        }
+
+        fn get_block_hash(
+            &mut self,
+            _number: Word,
+        ) -> impl Future<Output = Result<Option<B256>, Self::Error>> + '_ {
+            core::future::ready(Ok(None))
+        }
+    }
+
+    #[derive(Clone, Copy, Debug)]
+    struct TestError;
+
+    impl fmt::Display for TestError {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.write_str("storage read failed")
+        }
+    }
+
+    impl Error for TestError {}
+}

--- a/crates/evm2/src/async_.rs
+++ b/crates/evm2/src/async_.rs
@@ -30,7 +30,7 @@ type EvmFiber<'a, R> = Fiber<'a, Resume, Yield, Complete<R>>;
 type EvmSuspend<R> = Suspend<Resume, Yield, Complete<R>>;
 
 thread_local! {
-    static CURRENT: Cell<Option<NonNull<dyn CurrentFiber>>> = const { Cell::new(None) };
+    static CURRENT: Cell<Option<NonNull<CurrentFiber<'static>>>> = const { Cell::new(None) };
 }
 
 /// Result type used by async EVM execution helpers.
@@ -54,29 +54,34 @@ pub enum AsyncError {
     Runtime(String),
 }
 
-trait CurrentFiber {
-    fn context(&mut self) -> &mut Context<'_>;
-
-    fn suspend(&mut self) -> AsyncResult<()>;
-
-    fn is_cancelled(&self) -> bool;
+trait FiberSuspend {
+    fn suspend(&mut self) -> Resume;
 }
 
-struct FiberContext<'a, R> {
-    suspend: &'a mut EvmSuspend<R>,
+impl<R> FiberSuspend for EvmSuspend<R> {
+    #[inline]
+    fn suspend(&mut self) -> Resume {
+        self.suspend(())
+    }
+}
+
+struct CurrentFiber<'a> {
+    suspend: NonNull<dyn FiberSuspend + 'a>,
     future_cx: Option<NonNull<Context<'static>>>,
     cancelled: bool,
 }
 
-impl<R> CurrentFiber for FiberContext<'_, R> {
+impl CurrentFiber<'_> {
+    #[inline]
     fn context(&mut self) -> &mut Context<'_> {
         let cx = self.future_cx.as_mut().expect("future context is not available");
         unsafe { restore_context_lifetime(cx.as_mut()) }
     }
 
+    #[inline]
     fn suspend(&mut self) -> AsyncResult<()> {
         self.future_cx = None;
-        match self.suspend.suspend(()) {
+        match unsafe { self.suspend.as_mut() }.suspend() {
             Ok(cx) => {
                 self.future_cx = Some(cx);
                 Ok(())
@@ -88,12 +93,13 @@ impl<R> CurrentFiber for FiberContext<'_, R> {
         }
     }
 
-    fn is_cancelled(&self) -> bool {
+    #[inline]
+    const fn is_cancelled(&self) -> bool {
         self.cancelled
     }
 }
 
-struct ResetCurrentFiber(Option<NonNull<dyn CurrentFiber>>);
+struct ResetCurrentFiber(Option<NonNull<CurrentFiber<'static>>>);
 
 impl Drop for ResetCurrentFiber {
     fn drop(&mut self) {
@@ -182,9 +188,12 @@ impl<'a, R> FiberFuture<'a, R> {
         let state = core::ptr::from_mut(state);
         let fiber = Fiber::new(stack, move |resume: Resume, suspend| {
             let future_cx = resume?;
-            let mut fiber_context =
-                FiberContext { suspend, future_cx: Some(future_cx), cancelled: false };
-            let current = NonNull::from(&mut fiber_context as &mut dyn CurrentFiber);
+            let mut current = CurrentFiber {
+                suspend: NonNull::from(suspend as &mut dyn FiberSuspend),
+                future_cx: Some(future_cx),
+                cancelled: false,
+            };
+            let current = NonNull::from(&mut current);
             let current = unsafe { erase_current_fiber_lifetime(current) };
             let previous = CURRENT.replace(Some(current));
             let _reset = ResetCurrentFiber(previous);
@@ -325,7 +334,7 @@ where
     }
 }
 
-fn with_current<R>(f: impl FnOnce(&mut dyn CurrentFiber) -> R) -> AsyncResult<R> {
+fn with_current<R>(f: impl FnOnce(&mut CurrentFiber<'_>) -> R) -> AsyncResult<R> {
     let mut current = CURRENT.get().ok_or(AsyncError::NotOnFiber)?;
     Ok(f(unsafe { current.as_mut() }))
 }
@@ -339,12 +348,10 @@ unsafe fn restore_context_lifetime<'a>(cx: &'a mut Context<'static>) -> &'a mut 
 }
 
 unsafe fn erase_current_fiber_lifetime<'a>(
-    fiber: NonNull<dyn CurrentFiber + 'a>,
-) -> NonNull<dyn CurrentFiber + 'static> {
+    fiber: NonNull<CurrentFiber<'a>>,
+) -> NonNull<CurrentFiber<'static>> {
     unsafe {
-        core::mem::transmute::<NonNull<dyn CurrentFiber + 'a>, NonNull<dyn CurrentFiber + 'static>>(
-            fiber,
-        )
+        core::mem::transmute::<NonNull<CurrentFiber<'a>>, NonNull<CurrentFiber<'static>>>(fiber)
     }
 }
 

--- a/crates/evm2/src/async_.rs
+++ b/crates/evm2/src/async_.rs
@@ -34,12 +34,12 @@ thread_local! {
 }
 
 /// Result type used by async EVM execution helpers.
-pub type AsyncResult<T> = core::result::Result<T, AsyncError>;
+pub type AsyncResult<T, E = core::convert::Infallible> = core::result::Result<T, AsyncError<E>>;
 
 /// Error returned by async EVM execution helpers.
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
-pub enum AsyncError {
+pub enum AsyncError<E = core::convert::Infallible> {
     /// The async EVM fiber was cancelled before execution completed.
     #[error("async EVM execution was cancelled")]
     Cancelled,
@@ -52,6 +52,21 @@ pub enum AsyncError {
     /// Blocking async I/O was requested outside a supported Tokio runtime.
     #[error("async host operation requires a Tokio multi-thread runtime: {0}")]
     Runtime(String),
+    /// EVM execution returned an error.
+    #[error(transparent)]
+    Evm(#[from] E),
+}
+
+impl AsyncError {
+    fn with_evm_error<E>(self) -> AsyncError<E> {
+        match self {
+            Self::Cancelled => AsyncError::Cancelled,
+            Self::Fiber(error) => AsyncError::Fiber(error),
+            Self::NotOnFiber => AsyncError::NotOnFiber,
+            Self::Runtime(error) => AsyncError::Runtime(error),
+            Self::Evm(error) => match error {},
+        }
+    }
 }
 
 trait FiberSuspend {
@@ -121,6 +136,19 @@ where
     OnFiber::new(state, stack_size, func)
 }
 
+pub(crate) fn on_fiber_result<'a, S, R, E>(
+    state: &'a mut S,
+    stack_size: usize,
+    func: impl FnOnce(&mut S) -> core::result::Result<R, E> + 'a,
+) -> impl Future<Output = AsyncResult<R, E>> + Send + 'a
+where
+    S: ?Sized,
+    R: Send + 'a,
+    E: Send + 'a,
+{
+    FlattenFiber { inner: OnFiber::new(state, stack_size, func) }
+}
+
 enum OnFiber<'a, R> {
     Running(FiberFuture<'a, R>),
     Error(Option<AsyncError>),
@@ -158,6 +186,25 @@ impl<R> Future for OnFiber<'_, R> {
                 Poll::Ready(Err(error.take().expect("async EVM fiber error already returned")))
             }
             Self::Done => panic!("async EVM fiber polled after completion"),
+        }
+    }
+}
+
+struct FlattenFiber<'a, R, E> {
+    inner: OnFiber<'a, core::result::Result<R, E>>,
+}
+
+impl<R, E> Unpin for FlattenFiber<'_, R, E> {}
+
+impl<R, E> Future for FlattenFiber<'_, R, E> {
+    type Output = AsyncResult<R, E>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        match Pin::new(&mut self.get_mut().inner).poll(cx) {
+            Poll::Ready(Ok(Ok(value))) => Poll::Ready(Ok(value)),
+            Poll::Ready(Ok(Err(error))) => Poll::Ready(Err(AsyncError::Evm(error))),
+            Poll::Ready(Err(error)) => Poll::Ready(Err(error.with_evm_error())),
+            Poll::Pending => Poll::Pending,
         }
     }
 }
@@ -591,7 +638,7 @@ mod tests {
         env::BlockEnv,
         evm::{DynDatabase, InMemoryDB},
         interpreter::Word,
-        registry::{HandlerResult, TxRegistry, TxRequest},
+        registry::{HandlerError, HandlerResult, TxRegistry, TxRequest},
     };
     use alloy_consensus::{TxLegacy, transaction::Recovered};
     use alloy_primitives::{Address, B256, Bytes};
@@ -682,9 +729,28 @@ mod tests {
         );
         let tx = test_tx(41);
 
-        let result = poll_ready(evm.transact_async(&tx)).unwrap().unwrap();
+        let result = poll_ready(evm.transact_async(&tx)).unwrap();
 
         assert_eq!(result.gas_used, 42);
+    }
+
+    #[test]
+    fn transaction_async_flattens_handler_error() {
+        let mut evm = Evm::<BaseEvmTypes>::new(
+            SpecId::OSAKA,
+            BlockEnv::default(),
+            TxRegistry::new(),
+            InMemoryDB::default(),
+            Precompiles::base(SpecId::OSAKA),
+        );
+        let tx = test_tx(41);
+
+        let result = poll_ready(evm.transact_async(&tx));
+
+        assert!(matches!(
+            result,
+            Err(AsyncError::Evm(HandlerError::UnsupportedTransactionType(TEST_TX_TYPE)))
+        ));
     }
 
     #[test]

--- a/crates/evm2/src/async_.rs
+++ b/crates/evm2/src/async_.rs
@@ -188,7 +188,7 @@ impl<R, E> Future for OnFiber<'_, R, E> {
 }
 
 struct FiberFuture<'a, R> {
-    fiber: Option<EvmFiber<R>>,
+    fiber: EvmFiber<R>,
     _marker: PhantomData<&'a mut R>,
 }
 
@@ -227,7 +227,7 @@ impl<'a, R> FiberFuture<'a, R> {
         // SAFETY: The coroutine is stored inside `FiberFuture<'a, R>`, which is tied to the
         // borrowed state lifetime and dropped before those borrows can expire.
         let fiber = unsafe { Coroutine::with_stack_unchecked(stack, body) };
-        Ok(Self { fiber: Some(fiber), _marker: PhantomData })
+        Ok(Self { fiber, _marker: PhantomData })
     }
 }
 
@@ -237,12 +237,8 @@ impl<R> Future for FiberFuture<'_, R> {
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.get_mut();
         let cx = NonNull::from(unsafe { change_context_lifetime(cx) });
-        let fiber = this.fiber.as_mut().expect("async EVM fiber already completed");
-        match fiber.resume(Ok(cx)) {
-            CoroutineResult::Return(result) => {
-                this.fiber = None;
-                Poll::Ready(result)
-            }
+        match this.fiber.resume(Ok(cx)) {
+            CoroutineResult::Return(result) => Poll::Ready(result),
             CoroutineResult::Yield(()) => Poll::Pending,
         }
     }
@@ -250,16 +246,13 @@ impl<R> Future for FiberFuture<'_, R> {
 
 impl<R> Drop for FiberFuture<'_, R> {
     fn drop(&mut self) {
-        let Some(mut fiber) = self.fiber.take() else {
-            return;
-        };
-        if fiber.done() {
+        if self.fiber.done() {
             return;
         }
-        if matches!(fiber.resume(Err(AsyncError::Cancelled)), CoroutineResult::Yield(())) {
+        if matches!(self.fiber.resume(Err(AsyncError::Cancelled)), CoroutineResult::Yield(())) {
             // SAFETY: Cancellation already gave the coroutine a chance to return normally. If it
             // yields again, the stack is no longer useful to this future.
-            unsafe { fiber.force_reset() };
+            unsafe { self.fiber.force_reset() };
         }
     }
 }

--- a/crates/evm2/src/async_.rs
+++ b/crates/evm2/src/async_.rs
@@ -139,8 +139,6 @@ enum OnFiber<'a, R, E> {
     Done,
 }
 
-impl<R, E> Unpin for OnFiber<'_, R, E> {}
-
 impl<'a, R, E> OnFiber<'a, R, E> {
     fn new<S>(
         state: &'a mut S,
@@ -191,8 +189,6 @@ struct FiberFuture<'a, R> {
     fiber: EvmFiber<R>,
     _marker: PhantomData<&'a mut R>,
 }
-
-impl<R> Unpin for FiberFuture<'_, R> {}
 
 // SAFETY: The future may move between polls, but the coroutine stack itself is heap allocated and
 // is only resumed through `poll` with a fresh task context. Values that can remain on the coroutine

--- a/crates/evm2/src/async_.rs
+++ b/crates/evm2/src/async_.rs
@@ -16,7 +16,7 @@ use alloc::{
 };
 use alloy_primitives::{Address, B256};
 use core::{any::Any, fmt, future::Future, pin::Pin, ptr::NonNull, task::Poll};
-use std::{cell::RefCell, error::Error, task::Context};
+use std::{cell::Cell, error::Error, task::Context};
 use tokio::{
     runtime::{Handle, Runtime},
     task,
@@ -30,7 +30,7 @@ type EvmFiber<'a, R> = Fiber<'a, Resume, Yield, Complete<R>>;
 type EvmSuspend<R> = Suspend<Resume, Yield, Complete<R>>;
 
 thread_local! {
-    static CURRENT: RefCell<Option<NonNull<dyn CurrentFiber>>> = RefCell::new(None);
+    static CURRENT: Cell<Option<NonNull<dyn CurrentFiber>>> = const { Cell::new(None) };
 }
 
 /// Result type used by async EVM execution helpers.
@@ -97,7 +97,7 @@ struct ResetCurrentFiber(Option<NonNull<dyn CurrentFiber>>);
 
 impl Drop for ResetCurrentFiber {
     fn drop(&mut self) {
-        CURRENT.with_borrow_mut(|current| *current = self.0);
+        CURRENT.set(self.0);
     }
 }
 
@@ -186,7 +186,7 @@ impl<'a, R> FiberFuture<'a, R> {
                 FiberContext { suspend, future_cx: Some(future_cx), cancelled: false };
             let current = NonNull::from(&mut fiber_context as &mut dyn CurrentFiber);
             let current = unsafe { erase_current_fiber_lifetime(current) };
-            let previous = CURRENT.with_borrow_mut(|slot| slot.replace(current));
+            let previous = CURRENT.replace(Some(current));
             let _reset = ResetCurrentFiber(previous);
             Ok(func(unsafe { &mut *state }))
         })
@@ -318,8 +318,7 @@ where
 }
 
 fn with_current<R>(f: impl FnOnce(&mut dyn CurrentFiber) -> R) -> AsyncResult<R> {
-    let mut current =
-        CURRENT.with_borrow(|slot| slot.as_ref().copied()).ok_or(AsyncError::NotOnFiber)?;
+    let mut current = CURRENT.get().ok_or(AsyncError::NotOnFiber)?;
     Ok(f(unsafe { current.as_mut() }))
 }
 

--- a/crates/evm2/src/async_.rs
+++ b/crates/evm2/src/async_.rs
@@ -19,10 +19,7 @@ use core::{
 };
 use corosensei::{Coroutine, CoroutineResult, Yielder, stack::DefaultStack};
 use std::{cell::Cell, error::Error, io, task::Context};
-use tokio::{
-    runtime::{Handle, Runtime},
-    task,
-};
+use tokio::{runtime::Handle, task};
 
 type Resume = AsyncResult<NonNull<Context<'static>>>;
 type Yield = ();
@@ -355,54 +352,36 @@ pub(crate) fn block_on_current<F: Future>(future: F) -> AsyncResult<F::Output> {
     }
 }
 
-#[derive(Debug)]
-enum HandleOrRuntime {
-    Handle(Handle),
-    Runtime(Runtime),
-}
-
-impl HandleOrRuntime {
-    #[inline]
-    fn current() -> Option<Self> {
-        match Handle::try_current() {
-            Ok(handle) => match handle.runtime_flavor() {
-                tokio::runtime::RuntimeFlavor::CurrentThread => None,
-                _ => Some(Self::Handle(handle)),
-            },
-            Err(_) => None,
-        }
-    }
-
-    #[inline]
-    fn block_on<F>(&self, future: F) -> F::Output
-    where
-        F: Future + Send,
-        F::Output: Send,
-    {
-        match self {
-            Self::Handle(handle) => {
-                let should_use_block_in_place = Handle::try_current()
-                    .ok()
-                    .map(|current| {
-                        !matches!(
-                            current.runtime_flavor(),
-                            tokio::runtime::RuntimeFlavor::CurrentThread
-                        )
-                    })
-                    .unwrap_or(false);
-
-                if should_use_block_in_place {
-                    task::block_in_place(move || handle.block_on(future))
-                } else {
-                    handle.block_on(future)
-                }
-            }
-            Self::Runtime(runtime) => runtime.block_on(future),
-        }
+fn current_tokio_handle() -> Option<Handle> {
+    match Handle::try_current() {
+        Ok(handle) => match handle.runtime_flavor() {
+            tokio::runtime::RuntimeFlavor::CurrentThread => None,
+            _ => Some(handle),
+        },
+        Err(_) => None,
     }
 }
 
-fn block_on_runtime<F>(runtime: Option<&HandleOrRuntime>, future: F) -> AsyncResult<F::Output>
+fn block_on_handle<F>(handle: &Handle, future: F) -> F::Output
+where
+    F: Future + Send,
+    F::Output: Send,
+{
+    let should_use_block_in_place = Handle::try_current()
+        .ok()
+        .map(|current| {
+            !matches!(current.runtime_flavor(), tokio::runtime::RuntimeFlavor::CurrentThread)
+        })
+        .unwrap_or(false);
+
+    if should_use_block_in_place {
+        task::block_in_place(move || handle.block_on(future))
+    } else {
+        handle.block_on(future)
+    }
+}
+
+fn block_on_runtime<F>(runtime: Option<&Handle>, future: F) -> AsyncResult<F::Output>
 where
     F: Future + Send,
     F::Output: Send,
@@ -412,16 +391,13 @@ where
     }
 
     if let Some(runtime) = runtime {
-        return Ok(runtime.block_on(future));
+        return Ok(block_on_handle(runtime, future));
     }
 
     Err(AsyncError::Runtime)
 }
 
-fn block_on_runtime_result<F, T, E>(
-    runtime: Option<&HandleOrRuntime>,
-    future: F,
-) -> AsyncResult<T, E>
+fn block_on_runtime_result<F, T, E>(runtime: Option<&Handle>, future: F) -> AsyncResult<T, E>
 where
     F: Future<Output = Result<T, E>> + Send,
     T: Send,
@@ -481,7 +457,7 @@ pub trait AsyncDatabase: Any + Send {
 pub struct AsyncDb<D: AsyncDatabase> {
     db: D,
     error: Option<Box<dyn Error + Send>>,
-    runtime: Option<HandleOrRuntime>,
+    runtime: Option<Handle>,
 }
 
 impl<D: AsyncDatabase> AsyncDb<D> {
@@ -490,7 +466,7 @@ impl<D: AsyncDatabase> AsyncDb<D> {
     /// This captures the current Tokio runtime handle when one is available.
     #[inline]
     pub fn new(db: D) -> Self {
-        Self { db, error: None, runtime: HandleOrRuntime::current() }
+        Self { db, error: None, runtime: current_tokio_handle() }
     }
 
     /// Creates a new async database adapter using the current Tokio runtime handle.
@@ -498,19 +474,13 @@ impl<D: AsyncDatabase> AsyncDb<D> {
     /// Returns `None` if no Tokio runtime is available or the current runtime is current-threaded.
     #[inline]
     pub fn blocking(db: D) -> Option<Self> {
-        Some(Self { db, error: None, runtime: Some(HandleOrRuntime::current()?) })
-    }
-
-    /// Creates a new async database adapter with a Tokio runtime.
-    #[inline]
-    pub fn with_tokio_runtime(db: D, runtime: Runtime) -> Self {
-        Self { db, error: None, runtime: Some(HandleOrRuntime::Runtime(runtime)) }
+        Some(Self { db, error: None, runtime: Some(current_tokio_handle()?) })
     }
 
     /// Creates a new async database adapter with a Tokio runtime handle.
     #[inline]
     pub fn with_tokio_handle(db: D, handle: Handle) -> Self {
-        Self { db, error: None, runtime: Some(HandleOrRuntime::Handle(handle)) }
+        Self { db, error: None, runtime: Some(handle) }
     }
 
     /// Returns the wrapped database.
@@ -785,9 +755,9 @@ mod tests {
     }
 
     #[test]
-    fn synchronous_database_blocks_with_stored_tokio_runtime() {
+    fn synchronous_database_blocks_with_stored_tokio_handle() {
         let runtime = tokio::runtime::Runtime::new().unwrap();
-        let mut db = AsyncDb::with_tokio_runtime(TokioDb, runtime);
+        let mut db = AsyncDb::with_tokio_handle(TokioDb, runtime.handle().clone());
         let address = Address::ZERO;
         let key = Word::from(7);
 

--- a/crates/evm2/src/async_.rs
+++ b/crates/evm2/src/async_.rs
@@ -412,13 +412,13 @@ impl<D: AsyncDatabase> AsyncDb<D> {
 
     /// Creates a new async database adapter with a Tokio runtime.
     #[inline]
-    pub const fn with_runtime(db: D, runtime: Runtime) -> Self {
+    pub fn with_tokio_runtime(db: D, runtime: Runtime) -> Self {
         Self { db, error: None, runtime: Some(HandleOrRuntime::Runtime(runtime)) }
     }
 
     /// Creates a new async database adapter with a Tokio runtime handle.
     #[inline]
-    pub const fn with_handle(db: D, handle: Handle) -> Self {
+    pub fn with_tokio_handle(db: D, handle: Handle) -> Self {
         Self { db, error: None, runtime: Some(HandleOrRuntime::Handle(handle)) }
     }
 
@@ -676,7 +676,7 @@ mod tests {
     #[test]
     fn synchronous_database_blocks_with_stored_tokio_runtime() {
         let runtime = tokio::runtime::Runtime::new().unwrap();
-        let mut db = AsyncDb::with_runtime(TokioDb, runtime);
+        let mut db = AsyncDb::with_tokio_runtime(TokioDb, runtime);
         let address = Address::ZERO;
         let key = Word::from(7);
 

--- a/crates/evm2/src/async_.rs
+++ b/crates/evm2/src/async_.rs
@@ -67,23 +67,21 @@ impl<R> FiberSuspend for EvmSuspend<R> {
 
 struct CurrentFiber<'a> {
     suspend: NonNull<dyn FiberSuspend + 'a>,
-    future_cx: Option<NonNull<Context<'static>>>,
+    future_cx: NonNull<Context<'static>>,
     cancelled: bool,
 }
 
 impl CurrentFiber<'_> {
     #[inline]
     fn context(&mut self) -> &mut Context<'_> {
-        let cx = self.future_cx.as_mut().expect("future context is not available");
-        unsafe { restore_context_lifetime(cx.as_mut()) }
+        unsafe { restore_context_lifetime(self.future_cx.as_mut()) }
     }
 
     #[inline]
     fn suspend(&mut self) -> AsyncResult<()> {
-        self.future_cx = None;
         match unsafe { self.suspend.as_mut() }.suspend() {
             Ok(cx) => {
-                self.future_cx = Some(cx);
+                self.future_cx = cx;
                 Ok(())
             }
             Err(error) => {
@@ -190,7 +188,7 @@ impl<'a, R> FiberFuture<'a, R> {
             let future_cx = resume?;
             let mut current = CurrentFiber {
                 suspend: NonNull::from(suspend as &mut dyn FiberSuspend),
-                future_cx: Some(future_cx),
+                future_cx,
                 cancelled: false,
             };
             let current = NonNull::from(&mut current);

--- a/crates/evm2/src/async_.rs
+++ b/crates/evm2/src/async_.rs
@@ -242,10 +242,7 @@ impl<R> Drop for FiberFuture<'_, R> {
 ///
 /// Returns [`AsyncError::NotOnFiber`] if called outside async EVM execution, or
 /// [`AsyncError::Cancelled`] if the outer async EVM execution was dropped.
-pub(crate) fn block_on_current<F>(future: F) -> AsyncResult<F::Output>
-where
-    F: Future + Send,
-{
+pub(crate) fn block_on_current<F: Future>(future: F) -> AsyncResult<F::Output> {
     let mut future = core::pin::pin!(future);
     loop {
         match with_current(|current| {
@@ -257,7 +254,7 @@ where
                 current.suspend()?;
             }
             Ok(poll)
-        })?? {
+        })? {
             Poll::Ready(value) => return Ok(value),
             Poll::Pending => {}
         }
@@ -347,9 +344,9 @@ where
     }
 }
 
-fn with_current<R>(f: impl FnOnce(&mut CurrentFiber) -> R) -> AsyncResult<R> {
+fn with_current<R>(f: impl FnOnce(&mut CurrentFiber) -> AsyncResult<R>) -> AsyncResult<R> {
     let mut current = CURRENT.get().ok_or(AsyncError::NotOnFiber)?;
-    Ok(f(unsafe { current.as_mut() }))
+    f(unsafe { current.as_mut() })
 }
 
 unsafe fn change_context_lifetime<'a>(cx: &'a mut Context<'_>) -> &'a mut Context<'static> {

--- a/crates/evm2/src/async_.rs
+++ b/crates/evm2/src/async_.rs
@@ -323,10 +323,7 @@ where
         return Ok(runtime.block_on(future));
     }
 
-    let Some(runtime) = HandleOrRuntime::current() else {
-        return Err(AsyncError::Runtime);
-    };
-    Ok(runtime.block_on(future))
+    Err(AsyncError::Runtime)
 }
 
 fn block_on_runtime_result<F, T, E>(
@@ -397,9 +394,11 @@ pub struct AsyncDb<D: AsyncDatabase> {
 
 impl<D: AsyncDatabase> AsyncDb<D> {
     /// Creates a new async database adapter.
+    ///
+    /// This captures the current Tokio runtime handle when one is available.
     #[inline]
-    pub const fn new(db: D) -> Self {
-        Self { db, error: None, runtime: None }
+    pub fn new(db: D) -> Self {
+        Self { db, error: None, runtime: HandleOrRuntime::current() }
     }
 
     /// Creates a new async database adapter using the current Tokio runtime handle.

--- a/crates/evm2/src/async_.rs
+++ b/crates/evm2/src/async_.rs
@@ -28,7 +28,7 @@ type Complete<R> = AsyncResult<R>;
 type EvmFiber<R> = Coroutine<Resume, Yield, Complete<R>, DefaultStack>;
 
 thread_local! {
-    static CURRENT: Cell<Option<NonNull<CurrentFiber<'static>>>> = const { Cell::new(None) };
+    static CURRENT: Cell<Option<NonNull<CurrentFiber>>> = const { Cell::new(None) };
 }
 
 /// Result type used by async EVM execution helpers.
@@ -67,14 +67,13 @@ impl AsyncError {
     }
 }
 
-struct CurrentFiber<'a> {
+struct CurrentFiber {
     suspend: NonNull<Yielder<Resume, Yield>>,
-    _marker: PhantomData<&'a Yielder<Resume, Yield>>,
     future_cx: NonNull<Context<'static>>,
     cancelled: bool,
 }
 
-impl CurrentFiber<'_> {
+impl CurrentFiber {
     #[inline]
     fn context(&mut self) -> &mut Context<'_> {
         unsafe { restore_context_lifetime(self.future_cx.as_mut()) }
@@ -100,7 +99,7 @@ impl CurrentFiber<'_> {
     }
 }
 
-struct ResetCurrentFiber(Option<NonNull<CurrentFiber<'static>>>);
+struct ResetCurrentFiber(Option<NonNull<CurrentFiber>>);
 
 impl Drop for ResetCurrentFiber {
     fn drop(&mut self) {
@@ -193,14 +192,9 @@ impl<'a, R> FiberFuture<'a, R> {
         let stack = DefaultStack::new(stack_size).map_err(AsyncError::Io)?;
         let body = move |suspend: &Yielder<Resume, Yield>, resume| {
             let future_cx = resume?;
-            let mut current = CurrentFiber {
-                suspend: NonNull::from(suspend),
-                _marker: PhantomData,
-                future_cx,
-                cancelled: false,
-            };
+            let mut current =
+                CurrentFiber { suspend: NonNull::from(suspend), future_cx, cancelled: false };
             let current = NonNull::from(&mut current);
-            let current = unsafe { erase_current_fiber_lifetime(current) };
             let previous = CURRENT.replace(Some(current));
             let _reset = ResetCurrentFiber(previous);
             Ok(func())
@@ -353,7 +347,7 @@ where
     }
 }
 
-fn with_current<R>(f: impl FnOnce(&mut CurrentFiber<'_>) -> R) -> AsyncResult<R> {
+fn with_current<R>(f: impl FnOnce(&mut CurrentFiber) -> R) -> AsyncResult<R> {
     let mut current = CURRENT.get().ok_or(AsyncError::NotOnFiber)?;
     Ok(f(unsafe { current.as_mut() }))
 }
@@ -364,14 +358,6 @@ unsafe fn change_context_lifetime<'a>(cx: &'a mut Context<'_>) -> &'a mut Contex
 
 unsafe fn restore_context_lifetime<'a>(cx: &'a mut Context<'static>) -> &'a mut Context<'a> {
     unsafe { core::mem::transmute::<&'a mut Context<'static>, &'a mut Context<'a>>(cx) }
-}
-
-unsafe fn erase_current_fiber_lifetime<'a>(
-    fiber: NonNull<CurrentFiber<'a>>,
-) -> NonNull<CurrentFiber<'static>> {
-    unsafe {
-        core::mem::transmute::<NonNull<CurrentFiber<'a>>, NonNull<CurrentFiber<'static>>>(fiber)
-    }
 }
 
 /// Asynchronous backing database implementation.

--- a/crates/evm2/src/async_.rs
+++ b/crates/evm2/src/async_.rs
@@ -7,7 +7,10 @@
 use crate::{
     IoMode,
     bytecode::Bytecode,
-    evm::{AccountInfo, DatabaseCommit, DbErrorCode, DbResult, DynDatabase, StateChanges},
+    evm::{
+        AccountInfo, DatabaseCommit, DbErrorCode, DbResult, DynDatabase, StateChanges,
+        db_error_unavailable, stored_error_code,
+    },
     interpreter::Word,
 };
 use alloc::boxed::Box;
@@ -528,7 +531,7 @@ impl<D: AsyncDatabase> DynDatabase for AsyncDb<D> {
         {
             return error;
         }
-        Box::new(AsyncDbErrorUnavailable(code))
+        db_error_unavailable(code)
     }
 
     #[inline]
@@ -553,26 +556,6 @@ impl<D: AsyncDatabase + fmt::Debug> fmt::Debug for AsyncDb<D> {
         f.debug_struct("AsyncDb").field("db", &self.db).finish_non_exhaustive()
     }
 }
-
-#[inline]
-fn stored_error_code() -> DbErrorCode {
-    match DbErrorCode::new(1) {
-        Some(code) => code,
-        None => unreachable!("stored database error code is non-zero"),
-    }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-struct AsyncDbErrorUnavailable(DbErrorCode);
-
-impl fmt::Display for AsyncDbErrorUnavailable {
-    #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "async database error {:?} is unavailable", self.0)
-    }
-}
-
-impl Error for AsyncDbErrorUnavailable {}
 
 #[cfg(test)]
 mod tests {

--- a/crates/evm2/src/async_.rs
+++ b/crates/evm2/src/async_.rs
@@ -5,6 +5,7 @@
 //! suspended and the outer async task returns `Poll::Pending`.
 
 use crate::{
+    IoMode,
     bytecode::Bytecode,
     evm::{AccountInfo, DatabaseCommit, DbErrorCode, DbResult, DynDatabase, StateChanges},
     interpreter::Word,
@@ -18,9 +19,6 @@ use core::{any::Any, fmt, future::Future, pin::Pin, ptr::NonNull, task::Poll};
 use std::{cell::RefCell, error::Error, task::Context};
 use tokio::{runtime::Handle, task};
 use wasmtime_fiber::{Fiber, FiberStack, Suspend};
-
-/// Default stack size for async EVM execution.
-const DEFAULT_ASYNC_STACK_SIZE: usize = 2 * 1024 * 1024;
 
 type Resume = AsyncResult<NonNull<Context<'static>>>;
 type Yield = ();
@@ -51,16 +49,6 @@ pub enum AsyncError {
     /// Blocking async I/O was requested outside a supported Tokio runtime.
     #[error("async host operation requires a Tokio multi-thread runtime: {0}")]
     Runtime(String),
-}
-
-/// How async database I/O should be driven from synchronous EVM host calls.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
-pub enum IoMode {
-    /// Block the current Tokio worker with `block_in_place`.
-    Blocking,
-    /// Suspend the EVM fiber while database I/O is pending.
-    #[default]
-    Async,
 }
 
 trait CurrentFiber {
@@ -114,15 +102,7 @@ impl Drop for ResetCurrentFiber {
 ///
 /// Synchronous code running inside `func` may call [`block_on_current`] to wait for async host
 /// operations without blocking the executor thread.
-pub(crate) async fn on_fiber<S, R>(state: &mut S, func: impl FnOnce(&mut S) -> R) -> AsyncResult<R>
-where
-    S: ?Sized,
-{
-    on_fiber_with_stack_size(state, DEFAULT_ASYNC_STACK_SIZE, func).await
-}
-
-/// Runs `func` on a native fiber with an explicit stack size.
-async fn on_fiber_with_stack_size<S, R>(
+pub(crate) async fn on_fiber<S, R>(
     state: &mut S,
     stack_size: usize,
     func: impl FnOnce(&mut S) -> R,
@@ -209,7 +189,7 @@ impl<R> Drop for FiberFuture<'_, R> {
 /// [`AsyncError::Cancelled`] if the outer async EVM execution was dropped.
 pub(crate) fn block_on_current<F>(future: F) -> AsyncResult<F::Output>
 where
-    F: Future,
+    F: Future + Send,
 {
     let mut future = core::pin::pin!(future);
     loop {
@@ -321,8 +301,8 @@ pub struct AsyncDb<D: AsyncDatabase> {
 impl<D: AsyncDatabase> AsyncDb<D> {
     /// Creates a new async database adapter.
     #[inline]
-    pub const fn new(db: D, io_mode: IoMode) -> Self {
-        Self { db, error: None, io_mode }
+    pub const fn new(db: D) -> Self {
+        Self { db, error: None, io_mode: IoMode::Async }
     }
 
     /// Returns the wrapped database.
@@ -446,9 +426,9 @@ impl Error for AsyncDbErrorUnavailable {}
 
 #[cfg(test)]
 mod tests {
-    use super::{AsyncDatabase, AsyncDb, AsyncError, IoMode, block_on_current, on_fiber};
+    use super::{AsyncDatabase, AsyncDb, AsyncError, block_on_current, on_fiber};
     use crate::{
-        BaseEvmTypes, Evm, Precompiles, SpecId,
+        BaseEvmTypes, Evm, ExecutionConfig, IoMode, Precompiles, SpecId, Version,
         bytecode::Bytecode,
         env::BlockEnv,
         evm::{DynDatabase, InMemoryDB},
@@ -470,7 +450,7 @@ mod tests {
     #[test]
     fn fiber_suspends_and_resumes_pending_future() {
         let mut state = 1;
-        let mut future = core::pin::pin!(on_fiber(&mut state, |state| {
+        let mut future = core::pin::pin!(on_fiber(&mut state, stack_size(), |state| {
             *state += block_on_current(PendingOnce { pending: true }).unwrap();
             *state
         }));
@@ -483,10 +463,10 @@ mod tests {
 
     #[test]
     fn async_database_adapts_to_dyn_database() {
-        let mut db = AsyncDb::new(TestDb, IoMode::Async);
+        let mut db = AsyncDb::new(TestDb);
         let address = Address::ZERO;
         let key = Word::from(7);
-        let mut future = core::pin::pin!(on_fiber(&mut db, |db| {
+        let mut future = core::pin::pin!(on_fiber(&mut db, stack_size(), |db| {
             DynDatabase::get_storage(db, &address, &key).unwrap()
         }));
         let waker = Waker::noop();
@@ -499,10 +479,10 @@ mod tests {
 
     #[test]
     fn async_database_suspends_until_ready() {
-        let mut db = AsyncDb::new(PendingDb { pending: true }, IoMode::Async);
+        let mut db = AsyncDb::new(PendingDb { pending: true });
         let address = Address::ZERO;
         let key = Word::from(7);
-        let mut future = core::pin::pin!(on_fiber(&mut db, |db| {
+        let mut future = core::pin::pin!(on_fiber(&mut db, stack_size(), |db| {
             DynDatabase::get_storage(db, &address, &key).unwrap()
         }));
         let waker = Waker::noop();
@@ -516,11 +496,12 @@ mod tests {
 
     #[test]
     fn async_database_stores_database_error() {
-        let mut db = AsyncDb::new(FailingDb, IoMode::Async);
+        let mut db = AsyncDb::new(FailingDb);
         let address = Address::ZERO;
         let key = Word::from(7);
-        let code =
-            on_fiber(&mut db, |db| DynDatabase::get_storage(db, &address, &key).unwrap_err());
+        let code = on_fiber(&mut db, stack_size(), |db| {
+            DynDatabase::get_storage(db, &address, &key).unwrap_err()
+        });
         let code = poll_ready(code).unwrap();
 
         assert_eq!(db.error(code).to_string(), "storage read failed");
@@ -528,10 +509,11 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn blocking_io_mode_blocks_with_tokio_when_not_on_fiber() {
-        let mut db = AsyncDb::new(TokioDb, IoMode::Blocking);
+        let mut db = AsyncDb::new(TokioDb);
         let address = Address::ZERO;
         let key = Word::from(7);
 
+        assert!(DynDatabase::set_io_mode(&mut db, IoMode::Blocking));
         let value = DynDatabase::get_storage(&mut db, &address, &key).unwrap();
 
         assert_eq!(value, Word::from(9));
@@ -543,13 +525,33 @@ mod tests {
             SpecId::OSAKA,
             BlockEnv::default(),
             TxRegistry::new(),
-            AsyncDb::new(TokioDb, IoMode::Async),
+            AsyncDb::new(TokioDb),
             Precompiles::base(SpecId::OSAKA),
         );
         let address = Address::ZERO;
         let key = Word::from(7);
 
-        assert!(evm.set_io_mode(IoMode::Blocking));
+        evm.set_io_mode(IoMode::Blocking);
+        let value = evm.database_mut().get_storage(&address, &key).unwrap();
+
+        assert_eq!(value, Word::from(9));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn evm_applies_version_io_mode_to_async_database() {
+        let mut version = Version::new(SpecId::OSAKA);
+        version.io_mode = IoMode::Blocking;
+        let mut evm = Evm::<BaseEvmTypes>::new_with_execution_config(
+            ExecutionConfig::for_spec_and_version(SpecId::OSAKA, version),
+            SpecId::OSAKA,
+            BlockEnv::default(),
+            TxRegistry::new(),
+            AsyncDb::new(TokioDb),
+            Precompiles::base(SpecId::OSAKA),
+        );
+        let address = Address::ZERO;
+        let key = Word::from(7);
+
         let value = evm.database_mut().get_storage(&address, &key).unwrap();
 
         assert_eq!(value, Word::from(9));
@@ -575,7 +577,7 @@ mod tests {
 
     #[test]
     fn async_io_mode_requires_fiber() {
-        let mut db = AsyncDb::new(TestDb, IoMode::Async);
+        let mut db = AsyncDb::new(TestDb);
         let address = Address::ZERO;
         let key = Word::from(7);
         let code = DynDatabase::get_storage(&mut db, &address, &key).unwrap_err();
@@ -590,16 +592,29 @@ mod tests {
     fn dropping_fiber_cancels_blocked_future() {
         let mut saw_cancel = false;
         {
-            let mut future = core::pin::pin!(on_fiber(&mut saw_cancel, |saw_cancel| {
-                *saw_cancel =
-                    matches!(block_on_current(PendingForever), Err(AsyncError::Cancelled));
-            }));
+            let mut future =
+                core::pin::pin!(on_fiber(&mut saw_cancel, stack_size(), |saw_cancel| {
+                    *saw_cancel =
+                        matches!(block_on_current(PendingForever), Err(AsyncError::Cancelled));
+                }));
             let waker = Waker::noop();
             let mut cx = Context::from_waker(waker);
 
             assert!(matches!(future.as_mut().poll(&mut cx), Poll::Pending));
         }
         assert!(saw_cancel);
+    }
+
+    #[test]
+    fn version_defaults_async_io_mode_and_stack_size() {
+        let version = Version::new(SpecId::OSAKA);
+
+        assert_eq!(version.io_mode, IoMode::Async);
+        assert_eq!(version.min_stack_size, 1024 * 1024);
+    }
+
+    fn stack_size() -> usize {
+        Version::new(SpecId::OSAKA).min_stack_size
     }
 
     fn poll_ready<F: Future + Send>(future: F) -> F::Output {

--- a/crates/evm2/src/async_.rs
+++ b/crates/evm2/src/async_.rs
@@ -108,29 +108,25 @@ impl Drop for ResetCurrentFiber {
 ///
 /// Synchronous code running inside `func` may call [`block_on_current`] to wait for async host
 /// operations without blocking the executor thread.
-pub(crate) fn on_fiber_result<'a, S, R, E>(
-    state: &'a mut S,
+pub(crate) fn on_fiber_result<'a, R, E>(
     stack_size: usize,
-    func: impl FnOnce(&mut S) -> core::result::Result<R, E> + 'a,
+    func: impl FnOnce() -> core::result::Result<R, E> + 'a,
 ) -> impl Future<Output = AsyncResult<R, E>> + Send + 'a
 where
-    S: ?Sized,
     R: Send + 'a,
     E: Send + 'a,
 {
-    OnFiber::new(state, stack_size, func)
+    OnFiber::new(stack_size, func)
 }
 
-pub(crate) fn on_fiber<'a, S, R>(
-    state: &'a mut S,
+pub(crate) fn on_fiber<'a, R>(
     stack_size: usize,
-    func: impl FnOnce(&mut S) -> R + 'a,
+    func: impl FnOnce() -> R + 'a,
 ) -> impl Future<Output = AsyncResult<R>> + Send + 'a
 where
-    S: ?Sized,
     R: Send + 'a,
 {
-    on_fiber_result(state, stack_size, move |state| Ok::<_, core::convert::Infallible>(func(state)))
+    on_fiber_result(stack_size, move || Ok::<_, core::convert::Infallible>(func()))
 }
 
 enum OnFiber<'a, R, E> {
@@ -140,15 +136,8 @@ enum OnFiber<'a, R, E> {
 }
 
 impl<'a, R, E> OnFiber<'a, R, E> {
-    fn new<S>(
-        state: &'a mut S,
-        stack_size: usize,
-        func: impl FnOnce(&mut S) -> core::result::Result<R, E> + 'a,
-    ) -> Self
-    where
-        S: ?Sized,
-    {
-        match FiberFuture::new(state, stack_size, func) {
+    fn new(stack_size: usize, func: impl FnOnce() -> core::result::Result<R, E> + 'a) -> Self {
+        match FiberFuture::new(stack_size, func) {
             Ok(fiber) => Self::Running(fiber),
             Err(error) => Self::Error(Some(error)),
         }
@@ -196,16 +185,8 @@ struct FiberFuture<'a, R> {
 unsafe impl<R: Send> Send for FiberFuture<'_, R> {}
 
 impl<'a, R> FiberFuture<'a, R> {
-    fn new<S>(
-        state: &'a mut S,
-        stack_size: usize,
-        func: impl FnOnce(&mut S) -> R + 'a,
-    ) -> AsyncResult<Self>
-    where
-        S: ?Sized,
-    {
+    fn new(stack_size: usize, func: impl FnOnce() -> R + 'a) -> AsyncResult<Self> {
         let stack = DefaultStack::new(stack_size).map_err(fiber_error)?;
-        let state = core::ptr::from_mut(state);
         let body = move |suspend: &Yielder<Resume, Yield>, resume| {
             let future_cx = resume?;
             let mut current = CurrentFiber {
@@ -218,7 +199,7 @@ impl<'a, R> FiberFuture<'a, R> {
             let current = unsafe { erase_current_fiber_lifetime(current) };
             let previous = CURRENT.replace(Some(current));
             let _reset = ResetCurrentFiber(previous);
-            Ok(func(unsafe { &mut *state }))
+            Ok(func())
         };
         // SAFETY: The coroutine is stored inside `FiberFuture<'a, R>`, which is tied to the
         // borrowed state lifetime and dropped before those borrows can expire.
@@ -637,9 +618,9 @@ mod tests {
     #[test]
     fn fiber_suspends_and_resumes_pending_future() {
         let mut state = 1;
-        let mut future = core::pin::pin!(on_fiber(&mut state, stack_size(), |state| {
-            *state += block_on_current(PendingOnce { pending: true }).unwrap();
-            *state
+        let mut future = core::pin::pin!(on_fiber(stack_size(), || {
+            state += block_on_current(PendingOnce { pending: true }).unwrap();
+            state
         }));
         let waker = Waker::noop();
         let mut cx = Context::from_waker(waker);
@@ -653,8 +634,8 @@ mod tests {
         let mut db = AsyncDb::new(TestDb);
         let address = Address::ZERO;
         let key = Word::from(7);
-        let mut future = core::pin::pin!(on_fiber(&mut db, stack_size(), |db| {
-            DynDatabase::get_storage(db, &address, &key).unwrap()
+        let mut future = core::pin::pin!(on_fiber(stack_size(), || {
+            DynDatabase::get_storage(&mut db, &address, &key).unwrap()
         }));
         let waker = Waker::noop();
         let mut cx = Context::from_waker(waker);
@@ -669,8 +650,8 @@ mod tests {
         let mut db = AsyncDb::new(PendingDb { pending: true });
         let address = Address::ZERO;
         let key = Word::from(7);
-        let mut future = core::pin::pin!(on_fiber(&mut db, stack_size(), |db| {
-            DynDatabase::get_storage(db, &address, &key).unwrap()
+        let mut future = core::pin::pin!(on_fiber(stack_size(), || {
+            DynDatabase::get_storage(&mut db, &address, &key).unwrap()
         }));
         let waker = Waker::noop();
         let mut cx = Context::from_waker(waker);
@@ -686,8 +667,8 @@ mod tests {
         let mut db = AsyncDb::new(FailingDb);
         let address = Address::ZERO;
         let key = Word::from(7);
-        let code = on_fiber(&mut db, stack_size(), |db| {
-            DynDatabase::get_storage(db, &address, &key).unwrap_err()
+        let code = on_fiber(stack_size(), || {
+            DynDatabase::get_storage(&mut db, &address, &key).unwrap_err()
         });
         let code = poll_ready(code).unwrap();
 
@@ -857,11 +838,9 @@ mod tests {
     fn dropping_fiber_cancels_blocked_future() {
         let mut saw_cancel = false;
         {
-            let mut future =
-                core::pin::pin!(on_fiber(&mut saw_cancel, stack_size(), |saw_cancel| {
-                    *saw_cancel =
-                        matches!(block_on_current(PendingForever), Err(AsyncError::Cancelled));
-                }));
+            let mut future = core::pin::pin!(on_fiber(stack_size(), || {
+                saw_cancel = matches!(block_on_current(PendingForever), Err(AsyncError::Cancelled));
+            }));
             let waker = Waker::noop();
             let mut cx = Context::from_waker(waker);
 

--- a/crates/evm2/src/async_.rs
+++ b/crates/evm2/src/async_.rs
@@ -17,7 +17,10 @@ use alloc::{
 use alloy_primitives::{Address, B256};
 use core::{any::Any, fmt, future::Future, pin::Pin, ptr::NonNull, task::Poll};
 use std::{cell::RefCell, error::Error, task::Context};
-use tokio::{runtime::Handle, task};
+use tokio::{
+    runtime::{Handle, Runtime},
+    task,
+};
 use wasmtime_fiber::{Fiber, FiberStack, Suspend};
 
 type Resume = AsyncResult<NonNull<Context<'static>>>;
@@ -203,28 +206,72 @@ where
     }
 }
 
-fn block_on_io<F>(mode: IoMode, future: F) -> AsyncResult<F::Output>
-where
-    F: Future + Send,
-{
-    match mode {
-        IoMode::Blocking => block_on_tokio(future),
-        IoMode::Async => block_on_current(future),
+#[derive(Debug)]
+enum HandleOrRuntime {
+    Handle(Handle),
+    Runtime(Runtime),
+}
+
+impl HandleOrRuntime {
+    #[inline]
+    fn current() -> Option<Self> {
+        match Handle::try_current() {
+            Ok(handle) => match handle.runtime_flavor() {
+                tokio::runtime::RuntimeFlavor::CurrentThread => None,
+                _ => Some(Self::Handle(handle)),
+            },
+            Err(_) => None,
+        }
+    }
+
+    #[inline]
+    fn block_on<F>(&self, future: F) -> F::Output
+    where
+        F: Future + Send,
+        F::Output: Send,
+    {
+        match self {
+            Self::Handle(handle) => {
+                let should_use_block_in_place = Handle::try_current()
+                    .ok()
+                    .map(|current| {
+                        !matches!(
+                            current.runtime_flavor(),
+                            tokio::runtime::RuntimeFlavor::CurrentThread
+                        )
+                    })
+                    .unwrap_or(false);
+
+                if should_use_block_in_place {
+                    task::block_in_place(move || handle.block_on(future))
+                } else {
+                    handle.block_on(future)
+                }
+            }
+            Self::Runtime(runtime) => runtime.block_on(future),
+        }
     }
 }
 
-fn block_on_tokio<F>(future: F) -> AsyncResult<F::Output>
+fn block_on_runtime<F>(
+    mode: IoMode,
+    runtime: Option<&HandleOrRuntime>,
+    future: F,
+) -> AsyncResult<F::Output>
 where
     F: Future + Send,
+    F::Output: Send,
 {
-    let handle = Handle::try_current().map_err(runtime_error)?;
-    match handle.runtime_flavor() {
-        tokio::runtime::RuntimeFlavor::MultiThread => {
-            Ok(task::block_in_place(|| handle.block_on(future)))
+    match mode {
+        IoMode::Blocking => {
+            let Some(runtime) = runtime else {
+                return Err(AsyncError::Runtime(
+                    "blocking async host operation requires a Tokio runtime handle".to_string(),
+                ));
+            };
+            Ok(runtime.block_on(future))
         }
-        flavor => {
-            Err(AsyncError::Runtime(format!("block_in_place is not available on {flavor:?}")))
-        }
+        IoMode::Async => block_on_current(future),
     }
 }
 
@@ -254,10 +301,6 @@ unsafe fn erase_current_fiber_lifetime<'a>(
 
 fn fiber_error(error: impl fmt::Display) -> AsyncError {
     AsyncError::Fiber(error.to_string())
-}
-
-fn runtime_error(error: impl fmt::Display) -> AsyncError {
-    AsyncError::Runtime(error.to_string())
 }
 
 /// Asynchronous backing database implementation.
@@ -296,13 +339,49 @@ pub struct AsyncDb<D: AsyncDatabase> {
     db: D,
     error: Option<Box<dyn Error + Send>>,
     io_mode: IoMode,
+    runtime: Option<HandleOrRuntime>,
 }
 
 impl<D: AsyncDatabase> AsyncDb<D> {
     /// Creates a new async database adapter.
     #[inline]
     pub const fn new(db: D) -> Self {
-        Self { db, error: None, io_mode: IoMode::Async }
+        Self { db, error: None, io_mode: IoMode::Async, runtime: None }
+    }
+
+    /// Creates a new blocking async database adapter using the current Tokio runtime handle.
+    ///
+    /// Returns `None` if no Tokio runtime is available or the current runtime is current-threaded.
+    #[inline]
+    pub fn blocking(db: D) -> Option<Self> {
+        Some(Self {
+            db,
+            error: None,
+            io_mode: IoMode::Blocking,
+            runtime: Some(HandleOrRuntime::current()?),
+        })
+    }
+
+    /// Creates a new blocking async database adapter with a Tokio runtime.
+    #[inline]
+    pub const fn with_runtime(db: D, runtime: Runtime) -> Self {
+        Self {
+            db,
+            error: None,
+            io_mode: IoMode::Blocking,
+            runtime: Some(HandleOrRuntime::Runtime(runtime)),
+        }
+    }
+
+    /// Creates a new blocking async database adapter with a Tokio runtime handle.
+    #[inline]
+    pub const fn with_handle(db: D, handle: Handle) -> Self {
+        Self {
+            db,
+            error: None,
+            io_mode: IoMode::Blocking,
+            runtime: Some(HandleOrRuntime::Handle(handle)),
+        }
     }
 
     /// Returns the wrapped database.
@@ -346,7 +425,11 @@ impl<D: AsyncDatabase + DatabaseCommit> DatabaseCommit for AsyncDb<D> {
 impl<D: AsyncDatabase> DynDatabase for AsyncDb<D> {
     #[inline]
     fn get_account(&mut self, address: &Address) -> DbResult<Option<AccountInfo>> {
-        match block_on_io(self.io_mode, self.db.get_account(*address)) {
+        let result = {
+            let Self { db, io_mode, runtime, .. } = self;
+            block_on_runtime(*io_mode, runtime.as_ref(), db.get_account(*address))
+        };
+        match result {
             Ok(Ok(account)) => Ok(account),
             Ok(Err(error)) => Err(self.store_error(error)),
             Err(error) => Err(self.store_error(error)),
@@ -355,7 +438,11 @@ impl<D: AsyncDatabase> DynDatabase for AsyncDb<D> {
 
     #[inline]
     fn get_code_by_hash(&mut self, code_hash: &B256) -> DbResult<Bytecode> {
-        match block_on_io(self.io_mode, self.db.get_code_by_hash(*code_hash)) {
+        let result = {
+            let Self { db, io_mode, runtime, .. } = self;
+            block_on_runtime(*io_mode, runtime.as_ref(), db.get_code_by_hash(*code_hash))
+        };
+        match result {
             Ok(Ok(bytecode)) => Ok(bytecode),
             Ok(Err(error)) => Err(self.store_error(error)),
             Err(error) => Err(self.store_error(error)),
@@ -364,7 +451,11 @@ impl<D: AsyncDatabase> DynDatabase for AsyncDb<D> {
 
     #[inline]
     fn get_storage(&mut self, address: &Address, key: &Word) -> DbResult<Word> {
-        match block_on_io(self.io_mode, self.db.get_storage(*address, *key)) {
+        let result = {
+            let Self { db, io_mode, runtime, .. } = self;
+            block_on_runtime(*io_mode, runtime.as_ref(), db.get_storage(*address, *key))
+        };
+        match result {
             Ok(Ok(value)) => Ok(value),
             Ok(Err(error)) => Err(self.store_error(error)),
             Err(error) => Err(self.store_error(error)),
@@ -373,7 +464,11 @@ impl<D: AsyncDatabase> DynDatabase for AsyncDb<D> {
 
     #[inline]
     fn get_block_hash(&mut self, number: &Word) -> DbResult<Option<B256>> {
-        match block_on_io(self.io_mode, self.db.get_block_hash(*number)) {
+        let result = {
+            let Self { db, io_mode, runtime, .. } = self;
+            block_on_runtime(*io_mode, runtime.as_ref(), db.get_block_hash(*number))
+        };
+        match result {
             Ok(Ok(hash)) => Ok(hash),
             Ok(Err(error)) => Err(self.store_error(error)),
             Err(error) => Err(self.store_error(error)),
@@ -392,6 +487,15 @@ impl<D: AsyncDatabase> DynDatabase for AsyncDb<D> {
 
     #[inline]
     fn set_io_mode(&mut self, io_mode: IoMode) -> bool {
+        if matches!(io_mode, IoMode::Blocking)
+            && self.runtime.is_none()
+            && let Some(runtime) = HandleOrRuntime::current()
+        {
+            self.runtime = Some(runtime);
+        }
+        if matches!(io_mode, IoMode::Blocking) && self.runtime.is_none() {
+            return false;
+        }
         self.io_mode = io_mode;
         true
     }
@@ -520,6 +624,36 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    async fn blocking_constructor_uses_current_tokio_runtime() {
+        let mut db = AsyncDb::blocking(TokioDb).unwrap();
+        let address = Address::ZERO;
+        let key = Word::from(7);
+
+        let value = DynDatabase::get_storage(&mut db, &address, &key).unwrap();
+
+        assert_eq!(value, Word::from(9));
+    }
+
+    #[test]
+    fn blocking_io_mode_blocks_with_stored_tokio_runtime() {
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let mut db = AsyncDb::with_runtime(TokioDb, runtime);
+        let address = Address::ZERO;
+        let key = Word::from(7);
+
+        let value = DynDatabase::get_storage(&mut db, &address, &key).unwrap();
+
+        assert_eq!(value, Word::from(9));
+    }
+
+    #[test]
+    fn blocking_io_mode_requires_runtime_handle() {
+        let mut db = AsyncDb::new(TestDb);
+
+        assert!(!DynDatabase::set_io_mode(&mut db, IoMode::Blocking));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
     async fn evm_sets_async_database_io_mode() {
         let mut evm = Evm::<BaseEvmTypes>::new(
             SpecId::OSAKA,
@@ -531,7 +665,7 @@ mod tests {
         let address = Address::ZERO;
         let key = Word::from(7);
 
-        evm.set_io_mode(IoMode::Blocking);
+        assert!(evm.set_io_mode(IoMode::Blocking));
         let value = evm.database_mut().get_storage(&address, &key).unwrap();
 
         assert_eq!(value, Word::from(9));

--- a/crates/evm2/src/async_.rs
+++ b/crates/evm2/src/async_.rs
@@ -105,15 +105,57 @@ impl Drop for ResetCurrentFiber {
 ///
 /// Synchronous code running inside `func` may call [`block_on_current`] to wait for async host
 /// operations without blocking the executor thread.
-pub(crate) async fn on_fiber<S, R>(
-    state: &mut S,
+pub(crate) fn on_fiber<'a, S, R>(
+    state: &'a mut S,
     stack_size: usize,
-    func: impl FnOnce(&mut S) -> R,
-) -> AsyncResult<R>
+    func: impl FnOnce(&mut S) -> R + 'a,
+) -> impl Future<Output = AsyncResult<R>> + Send + 'a
 where
     S: ?Sized,
+    R: Send + 'a,
 {
-    FiberFuture::new(state, stack_size, func)?.await
+    OnFiber::new(state, stack_size, func)
+}
+
+enum OnFiber<'a, R> {
+    Running(FiberFuture<'a, R>),
+    Error(Option<AsyncError>),
+    Done,
+}
+
+impl<R> Unpin for OnFiber<'_, R> {}
+
+impl<'a, R> OnFiber<'a, R> {
+    fn new<S>(state: &'a mut S, stack_size: usize, func: impl FnOnce(&mut S) -> R + 'a) -> Self
+    where
+        S: ?Sized,
+    {
+        match FiberFuture::new(state, stack_size, func) {
+            Ok(fiber) => Self::Running(fiber),
+            Err(error) => Self::Error(Some(error)),
+        }
+    }
+}
+
+impl<R> Future for OnFiber<'_, R> {
+    type Output = AsyncResult<R>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.get_mut();
+        match this {
+            Self::Running(fiber) => match Pin::new(fiber).poll(cx) {
+                Poll::Ready(result) => {
+                    *this = Self::Done;
+                    Poll::Ready(result)
+                }
+                Poll::Pending => Poll::Pending,
+            },
+            Self::Error(error) => {
+                Poll::Ready(Err(error.take().expect("async EVM fiber error already returned")))
+            }
+            Self::Done => panic!("async EVM fiber polled after completion"),
+        }
+    }
 }
 
 struct FiberFuture<'a, R> {
@@ -633,8 +675,10 @@ mod tests {
         assert_eq!(result.gas_used, 42);
     }
 
-    #[tokio::test(flavor = "multi_thread")]
-    async fn blocking_io_mode_blocks_with_tokio_when_not_on_fiber() {
+    #[test]
+    fn blocking_io_mode_blocks_with_tokio_when_not_on_fiber() {
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let _guard = runtime.enter();
         let mut db = AsyncDb::new(TokioDb);
         let address = Address::ZERO;
         let key = Word::from(7);
@@ -645,8 +689,10 @@ mod tests {
         assert_eq!(value, Word::from(9));
     }
 
-    #[tokio::test(flavor = "multi_thread")]
-    async fn blocking_constructor_uses_current_tokio_runtime() {
+    #[test]
+    fn blocking_constructor_uses_current_tokio_runtime() {
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let _guard = runtime.enter();
         let mut db = AsyncDb::blocking(TokioDb).unwrap();
         let address = Address::ZERO;
         let key = Word::from(7);
@@ -675,8 +721,10 @@ mod tests {
         assert!(!DynDatabase::set_io_mode(&mut db, IoMode::Blocking));
     }
 
-    #[tokio::test(flavor = "multi_thread")]
-    async fn evm_sets_async_database_io_mode() {
+    #[test]
+    fn evm_sets_async_database_io_mode() {
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let _guard = runtime.enter();
         let mut evm = Evm::<BaseEvmTypes>::new(
             SpecId::OSAKA,
             BlockEnv::default(),
@@ -693,8 +741,10 @@ mod tests {
         assert_eq!(value, Word::from(9));
     }
 
-    #[tokio::test(flavor = "multi_thread")]
-    async fn evm_applies_version_io_mode_to_async_database() {
+    #[test]
+    fn evm_applies_version_io_mode_to_async_database() {
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let _guard = runtime.enter();
         let mut version = Version::new(SpecId::OSAKA);
         version.io_mode = IoMode::Blocking;
         let mut evm = Evm::<BaseEvmTypes>::new_with_execution_config(
@@ -832,27 +882,34 @@ mod tests {
     impl AsyncDatabase for TestDb {
         type Error = Infallible;
 
-        async fn get_account(
+        fn get_account(
             &mut self,
             _address: Address,
-        ) -> Result<Option<crate::evm::AccountInfo>, Self::Error> {
-            Ok(None)
+        ) -> impl Future<Output = Result<Option<crate::evm::AccountInfo>, Self::Error>> + Send + '_
+        {
+            core::future::ready(Ok(None))
         }
 
-        async fn get_code_by_hash(&mut self, _code_hash: B256) -> Result<Bytecode, Self::Error> {
-            Ok(Bytecode::default())
+        fn get_code_by_hash(
+            &mut self,
+            _code_hash: B256,
+        ) -> impl Future<Output = Result<Bytecode, Self::Error>> + Send + '_ {
+            core::future::ready(Ok(Bytecode::default()))
         }
 
-        async fn get_storage(
+        fn get_storage(
             &mut self,
             _address: Address,
             _key: Word,
-        ) -> Result<Word, Self::Error> {
-            Ok(Word::from(9))
+        ) -> impl Future<Output = Result<Word, Self::Error>> + Send + '_ {
+            core::future::ready(Ok(Word::from(9)))
         }
 
-        async fn get_block_hash(&mut self, _number: Word) -> Result<Option<B256>, Self::Error> {
-            Ok(None)
+        fn get_block_hash(
+            &mut self,
+            _number: Word,
+        ) -> impl Future<Output = Result<Option<B256>, Self::Error>> + Send + '_ {
+            core::future::ready(Ok(None))
         }
     }
 
@@ -863,28 +920,34 @@ mod tests {
     impl AsyncDatabase for PendingDb {
         type Error = Infallible;
 
-        async fn get_account(
+        fn get_account(
             &mut self,
             _address: Address,
-        ) -> Result<Option<crate::evm::AccountInfo>, Self::Error> {
-            Ok(None)
+        ) -> impl Future<Output = Result<Option<crate::evm::AccountInfo>, Self::Error>> + Send + '_
+        {
+            core::future::ready(Ok(None))
         }
 
-        async fn get_code_by_hash(&mut self, _code_hash: B256) -> Result<Bytecode, Self::Error> {
-            Ok(Bytecode::default())
+        fn get_code_by_hash(
+            &mut self,
+            _code_hash: B256,
+        ) -> impl Future<Output = Result<Bytecode, Self::Error>> + Send + '_ {
+            core::future::ready(Ok(Bytecode::default()))
         }
 
-        async fn get_storage(
+        fn get_storage(
             &mut self,
             _address: Address,
             _key: Word,
-        ) -> Result<Word, Self::Error> {
-            PendingStorage { pending: &mut self.pending }.await;
-            Ok(Word::from(9))
+        ) -> impl Future<Output = Result<Word, Self::Error>> + Send + '_ {
+            PendingStorage { pending: &mut self.pending }
         }
 
-        async fn get_block_hash(&mut self, _number: Word) -> Result<Option<B256>, Self::Error> {
-            Ok(None)
+        fn get_block_hash(
+            &mut self,
+            _number: Word,
+        ) -> impl Future<Output = Result<Option<B256>, Self::Error>> + Send + '_ {
+            core::future::ready(Ok(None))
         }
     }
 
@@ -893,14 +956,14 @@ mod tests {
     }
 
     impl Future for PendingStorage<'_> {
-        type Output = ();
+        type Output = Result<Word, Infallible>;
 
         fn poll(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
             if *self.pending {
                 *self.pending = false;
                 Poll::Pending
             } else {
-                Poll::Ready(())
+                Poll::Ready(Ok(Word::from(9)))
             }
         }
     }
@@ -910,27 +973,59 @@ mod tests {
     impl AsyncDatabase for FailingDb {
         type Error = TestError;
 
-        async fn get_account(
+        fn get_account(
             &mut self,
             _address: Address,
-        ) -> Result<Option<crate::evm::AccountInfo>, Self::Error> {
-            Ok(None)
+        ) -> impl Future<Output = Result<Option<crate::evm::AccountInfo>, Self::Error>> + Send + '_
+        {
+            core::future::ready(Ok(None))
         }
 
-        async fn get_code_by_hash(&mut self, _code_hash: B256) -> Result<Bytecode, Self::Error> {
-            Ok(Bytecode::default())
+        fn get_code_by_hash(
+            &mut self,
+            _code_hash: B256,
+        ) -> impl Future<Output = Result<Bytecode, Self::Error>> + Send + '_ {
+            core::future::ready(Ok(Bytecode::default()))
         }
 
-        async fn get_storage(
+        fn get_storage(
             &mut self,
             _address: Address,
             _key: Word,
-        ) -> Result<Word, Self::Error> {
-            Err(TestError)
+        ) -> impl Future<Output = Result<Word, Self::Error>> + Send + '_ {
+            core::future::ready(Err(TestError))
         }
 
-        async fn get_block_hash(&mut self, _number: Word) -> Result<Option<B256>, Self::Error> {
-            Ok(None)
+        fn get_block_hash(
+            &mut self,
+            _number: Word,
+        ) -> impl Future<Output = Result<Option<B256>, Self::Error>> + Send + '_ {
+            core::future::ready(Ok(None))
+        }
+    }
+
+    struct YieldOnce<T> {
+        value: Option<T>,
+        pending: bool,
+    }
+
+    impl<T> YieldOnce<T> {
+        fn new(value: T) -> Self {
+            Self { value: Some(value), pending: true }
+        }
+    }
+
+    impl<T: Unpin> Future for YieldOnce<T> {
+        type Output = T;
+
+        fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+            if self.pending {
+                self.pending = false;
+                cx.waker().wake_by_ref();
+                Poll::Pending
+            } else {
+                Poll::Ready(self.value.take().expect("yield future polled after completion"))
+            }
         }
     }
 
@@ -939,31 +1034,34 @@ mod tests {
     impl AsyncDatabase for TokioDb {
         type Error = Infallible;
 
-        async fn get_account(
+        fn get_account(
             &mut self,
             _address: Address,
-        ) -> Result<Option<crate::evm::AccountInfo>, Self::Error> {
-            tokio::task::yield_now().await;
-            Ok(None)
+        ) -> impl Future<Output = Result<Option<crate::evm::AccountInfo>, Self::Error>> + Send + '_
+        {
+            YieldOnce::new(Ok(None))
         }
 
-        async fn get_code_by_hash(&mut self, _code_hash: B256) -> Result<Bytecode, Self::Error> {
-            tokio::task::yield_now().await;
-            Ok(Bytecode::default())
+        fn get_code_by_hash(
+            &mut self,
+            _code_hash: B256,
+        ) -> impl Future<Output = Result<Bytecode, Self::Error>> + Send + '_ {
+            YieldOnce::new(Ok(Bytecode::default()))
         }
 
-        async fn get_storage(
+        fn get_storage(
             &mut self,
             _address: Address,
             _key: Word,
-        ) -> Result<Word, Self::Error> {
-            tokio::task::yield_now().await;
-            Ok(Word::from(9))
+        ) -> impl Future<Output = Result<Word, Self::Error>> + Send + '_ {
+            YieldOnce::new(Ok(Word::from(9)))
         }
 
-        async fn get_block_hash(&mut self, _number: Word) -> Result<Option<B256>, Self::Error> {
-            tokio::task::yield_now().await;
-            Ok(None)
+        fn get_block_hash(
+            &mut self,
+            _number: Word,
+        ) -> impl Future<Output = Result<Option<B256>, Self::Error>> + Send + '_ {
+            YieldOnce::new(Ok(None))
         }
     }
 

--- a/crates/evm2/src/async_.rs
+++ b/crates/evm2/src/async_.rs
@@ -52,19 +52,19 @@ pub enum AsyncError<E = core::convert::Infallible> {
     /// Blocking async I/O was requested outside a supported Tokio runtime.
     #[error("async host operation requires a Tokio multi-thread runtime: {0}")]
     Runtime(String),
-    /// EVM execution returned an error.
+    /// The wrapped operation returned an error.
     #[error(transparent)]
-    Evm(#[from] E),
+    Inner(#[from] E),
 }
 
 impl AsyncError {
-    fn with_evm_error<E>(self) -> AsyncError<E> {
+    fn with_inner_error<E>(self) -> AsyncError<E> {
         match self {
             Self::Cancelled => AsyncError::Cancelled,
             Self::Fiber(error) => AsyncError::Fiber(error),
             Self::NotOnFiber => AsyncError::NotOnFiber,
             Self::Runtime(error) => AsyncError::Runtime(error),
-            Self::Evm(error) => match error {},
+            Self::Inner(error) => match error {},
         }
     }
 }
@@ -202,8 +202,8 @@ impl<R, E> Future for FlattenFiber<'_, R, E> {
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         match Pin::new(&mut self.get_mut().inner).poll(cx) {
             Poll::Ready(Ok(Ok(value))) => Poll::Ready(Ok(value)),
-            Poll::Ready(Ok(Err(error))) => Poll::Ready(Err(AsyncError::Evm(error))),
-            Poll::Ready(Err(error)) => Poll::Ready(Err(error.with_evm_error())),
+            Poll::Ready(Ok(Err(error))) => Poll::Ready(Err(AsyncError::Inner(error))),
+            Poll::Ready(Err(error)) => Poll::Ready(Err(error.with_inner_error())),
             Poll::Pending => Poll::Pending,
         }
     }
@@ -296,13 +296,11 @@ where
             if current.is_cancelled() {
                 return Err(AsyncError::Cancelled);
             }
-            match future.as_mut().poll(current.context()) {
-                Poll::Ready(value) => Ok(Poll::Ready(value)),
-                Poll::Pending => {
-                    current.suspend()?;
-                    Ok(Poll::Pending)
-                }
+            let poll = future.as_mut().poll(current.context());
+            if poll.is_pending() {
+                current.suspend()?;
             }
+            Ok(poll)
         })?? {
             Poll::Ready(value) => return Ok(value),
             Poll::Pending => {}
@@ -376,6 +374,22 @@ where
             Ok(runtime.block_on(future))
         }
         IoMode::Async => block_on_current(future),
+    }
+}
+
+fn block_on_runtime_result<F, T, E>(
+    mode: IoMode,
+    runtime: Option<&HandleOrRuntime>,
+    future: F,
+) -> AsyncResult<T, E>
+where
+    F: Future<Output = core::result::Result<T, E>> + Send,
+    T: Send,
+    E: Send,
+{
+    match block_on_runtime(mode, runtime, future).map_err(AsyncError::with_inner_error)? {
+        Ok(value) => Ok(value),
+        Err(error) => Err(AsyncError::Inner(error)),
     }
 }
 
@@ -514,6 +528,14 @@ impl<D: AsyncDatabase> AsyncDb<D> {
         self.error = Some(Box::new(error));
         stored_error_code()
     }
+
+    #[inline]
+    fn database_result<T>(&mut self, result: AsyncResult<T, D::Error>) -> DbResult<T> {
+        result.map_err(|error| match error {
+            AsyncError::Inner(error) => self.store_error(error),
+            error => self.store_error(error),
+        })
+    }
 }
 
 impl<D: AsyncDatabase + DatabaseCommit> DatabaseCommit for AsyncDb<D> {
@@ -528,52 +550,36 @@ impl<D: AsyncDatabase> DynDatabase for AsyncDb<D> {
     fn get_account(&mut self, address: &Address) -> DbResult<Option<AccountInfo>> {
         let result = {
             let Self { db, io_mode, runtime, .. } = self;
-            block_on_runtime(*io_mode, runtime.as_ref(), db.get_account(*address))
+            block_on_runtime_result(*io_mode, runtime.as_ref(), db.get_account(*address))
         };
-        match result {
-            Ok(Ok(account)) => Ok(account),
-            Ok(Err(error)) => Err(self.store_error(error)),
-            Err(error) => Err(self.store_error(error)),
-        }
+        self.database_result(result)
     }
 
     #[inline]
     fn get_code_by_hash(&mut self, code_hash: &B256) -> DbResult<Bytecode> {
         let result = {
             let Self { db, io_mode, runtime, .. } = self;
-            block_on_runtime(*io_mode, runtime.as_ref(), db.get_code_by_hash(*code_hash))
+            block_on_runtime_result(*io_mode, runtime.as_ref(), db.get_code_by_hash(*code_hash))
         };
-        match result {
-            Ok(Ok(bytecode)) => Ok(bytecode),
-            Ok(Err(error)) => Err(self.store_error(error)),
-            Err(error) => Err(self.store_error(error)),
-        }
+        self.database_result(result)
     }
 
     #[inline]
     fn get_storage(&mut self, address: &Address, key: &Word) -> DbResult<Word> {
         let result = {
             let Self { db, io_mode, runtime, .. } = self;
-            block_on_runtime(*io_mode, runtime.as_ref(), db.get_storage(*address, *key))
+            block_on_runtime_result(*io_mode, runtime.as_ref(), db.get_storage(*address, *key))
         };
-        match result {
-            Ok(Ok(value)) => Ok(value),
-            Ok(Err(error)) => Err(self.store_error(error)),
-            Err(error) => Err(self.store_error(error)),
-        }
+        self.database_result(result)
     }
 
     #[inline]
     fn get_block_hash(&mut self, number: &Word) -> DbResult<Option<B256>> {
         let result = {
             let Self { db, io_mode, runtime, .. } = self;
-            block_on_runtime(*io_mode, runtime.as_ref(), db.get_block_hash(*number))
+            block_on_runtime_result(*io_mode, runtime.as_ref(), db.get_block_hash(*number))
         };
-        match result {
-            Ok(Ok(hash)) => Ok(hash),
-            Ok(Err(error)) => Err(self.store_error(error)),
-            Err(error) => Err(self.store_error(error)),
-        }
+        self.database_result(result)
     }
 
     #[inline]
@@ -749,7 +755,7 @@ mod tests {
 
         assert!(matches!(
             result,
-            Err(AsyncError::Evm(HandlerError::UnsupportedTransactionType(TEST_TX_TYPE)))
+            Err(AsyncError::Inner(HandlerError::UnsupportedTransactionType(TEST_TX_TYPE)))
         ));
     }
 

--- a/crates/evm2/src/async_.rs
+++ b/crates/evm2/src/async_.rs
@@ -29,6 +29,8 @@ type Yield = ();
 type Complete<R> = AsyncResult<R>;
 type EvmFiber<R> = Coroutine<Resume, Yield, Complete<R>, DefaultStack>;
 
+const DEFAULT_STACK_SIZE: usize = 1024 * 1024;
+
 thread_local! {
     static CURRENT: Cell<Option<NonNull<CurrentFiber>>> = const { Cell::new(None) };
 }
@@ -114,24 +116,22 @@ impl Drop for ResetCurrentFiber {
 /// Synchronous code running inside `func` may call [`block_on_current`] to wait for async host
 /// operations without blocking the executor thread.
 pub(crate) fn on_fiber_result<'a, R, E>(
-    stack_size: usize,
     func: impl FnOnce() -> Result<R, E> + 'a,
 ) -> impl Future<Output = AsyncResult<R, E>> + Send + 'a
 where
     R: Send + 'a,
     E: Send + 'a,
 {
-    OnFiber::new(stack_size, func)
+    OnFiber::new(func)
 }
 
 pub(crate) fn on_fiber<'a, R>(
-    stack_size: usize,
     func: impl FnOnce() -> R + 'a,
 ) -> impl Future<Output = AsyncResult<R>> + Send + 'a
 where
     R: Send + 'a,
 {
-    on_fiber_result(stack_size, move || Ok::<_, core::convert::Infallible>(func()))
+    on_fiber_result(move || Ok::<_, core::convert::Infallible>(func()))
 }
 
 enum OnFiber<'a, R, E> {
@@ -141,8 +141,8 @@ enum OnFiber<'a, R, E> {
 }
 
 impl<'a, R, E> OnFiber<'a, R, E> {
-    fn new(stack_size: usize, func: impl FnOnce() -> Result<R, E> + 'a) -> Self {
-        match FiberFuture::new(stack_size, func) {
+    fn new(func: impl FnOnce() -> Result<R, E> + 'a) -> Self {
+        match FiberFuture::new(func) {
             Ok(fiber) => Self::Running(fiber),
             Err(error) => Self::Error(Some(error)),
         }
@@ -190,8 +190,8 @@ struct FiberFuture<'a, R> {
 unsafe impl<R: Send> Send for FiberFuture<'_, R> {}
 
 impl<'a, R> FiberFuture<'a, R> {
-    fn new(stack_size: usize, func: impl FnOnce() -> R + 'a) -> AsyncResult<Self> {
-        let stack = DefaultStack::new(stack_size).map_err(AsyncError::Io)?;
+    fn new(func: impl FnOnce() -> R + 'a) -> AsyncResult<Self> {
+        let stack = DefaultStack::new(DEFAULT_STACK_SIZE).map_err(AsyncError::Io)?;
         let body = move |suspend: &Yielder<Resume, Yield>, resume| {
             let future_cx = resume?;
             let mut current =
@@ -526,7 +526,7 @@ impl<D: AsyncDatabase + fmt::Debug> fmt::Debug for AsyncDb<D> {
 mod tests {
     use super::{AsyncDatabase, AsyncDb, AsyncError, block_on_current, on_fiber};
     use crate::{
-        BaseEvmTypes, Evm, Precompiles, SpecId, TxResult, Version,
+        BaseEvmTypes, Evm, Precompiles, SpecId, TxResult,
         bytecode::Bytecode,
         env::BlockEnv,
         evm::{DynDatabase, InMemoryDB},
@@ -549,7 +549,7 @@ mod tests {
     #[test]
     fn fiber_suspends_and_resumes_pending_future() {
         let mut state = 1;
-        let mut future = core::pin::pin!(on_fiber(stack_size(), || {
+        let mut future = core::pin::pin!(on_fiber(|| {
             state += block_on_current(PendingOnce { pending: true }).unwrap();
             state
         }));
@@ -565,7 +565,7 @@ mod tests {
         let mut db = AsyncDb::new(TestDb);
         let address = Address::ZERO;
         let key = Word::from(7);
-        let mut future = core::pin::pin!(on_fiber(stack_size(), || {
+        let mut future = core::pin::pin!(on_fiber(|| {
             DynDatabase::get_storage(&mut db, &address, &key).unwrap()
         }));
         let waker = Waker::noop();
@@ -581,7 +581,7 @@ mod tests {
         let mut db = AsyncDb::new(PendingDb { pending: true });
         let address = Address::ZERO;
         let key = Word::from(7);
-        let mut future = core::pin::pin!(on_fiber(stack_size(), || {
+        let mut future = core::pin::pin!(on_fiber(|| {
             DynDatabase::get_storage(&mut db, &address, &key).unwrap()
         }));
         let waker = Waker::noop();
@@ -598,9 +598,7 @@ mod tests {
         let mut db = AsyncDb::new(FailingDb);
         let address = Address::ZERO;
         let key = Word::from(7);
-        let code = on_fiber(stack_size(), || {
-            DynDatabase::get_storage(&mut db, &address, &key).unwrap_err()
-        });
+        let code = on_fiber(|| DynDatabase::get_storage(&mut db, &address, &key).unwrap_err());
         let code = poll_ready(code).unwrap();
 
         assert_eq!(db.error(code).to_string(), "storage read failed");
@@ -738,7 +736,7 @@ mod tests {
     fn dropping_fiber_cancels_blocked_future() {
         let mut saw_cancel = false;
         {
-            let mut future = core::pin::pin!(on_fiber(stack_size(), || {
+            let mut future = core::pin::pin!(on_fiber(|| {
                 saw_cancel = matches!(block_on_current(PendingForever), Err(AsyncError::Cancelled));
             }));
             let waker = Waker::noop();
@@ -747,17 +745,6 @@ mod tests {
             assert!(matches!(future.as_mut().poll(&mut cx), Poll::Pending));
         }
         assert!(saw_cancel);
-    }
-
-    #[test]
-    fn version_defaults_async_stack_size() {
-        let version = Version::new(SpecId::OSAKA);
-
-        assert_eq!(version.min_stack_size, 1024 * 1024);
-    }
-
-    fn stack_size() -> usize {
-        Version::new(SpecId::OSAKA).min_stack_size
     }
 
     const TEST_TX_TYPE: u8 = 0x00;

--- a/crates/evm2/src/async_.rs
+++ b/crates/evm2/src/async_.rs
@@ -124,18 +124,6 @@ impl Drop for ResetCurrentFiber {
 ///
 /// Synchronous code running inside `func` may call [`block_on_current`] to wait for async host
 /// operations without blocking the executor thread.
-pub(crate) fn on_fiber<'a, S, R>(
-    state: &'a mut S,
-    stack_size: usize,
-    func: impl FnOnce(&mut S) -> R + 'a,
-) -> impl Future<Output = AsyncResult<R>> + Send + 'a
-where
-    S: ?Sized,
-    R: Send + 'a,
-{
-    OnFiber::new(state, stack_size, func)
-}
-
 pub(crate) fn on_fiber_result<'a, S, R, E>(
     state: &'a mut S,
     stack_size: usize,
@@ -637,7 +625,7 @@ impl Error for AsyncDbErrorUnavailable {}
 
 #[cfg(test)]
 mod tests {
-    use super::{AsyncDatabase, AsyncDb, AsyncError, block_on_current, on_fiber};
+    use super::{AsyncDatabase, AsyncDb, AsyncError, block_on_current, on_fiber_result};
     use crate::{
         BaseEvmTypes, Evm, ExecutionConfig, IoMode, Precompiles, SpecId, TxResult, Version,
         bytecode::Bytecode,
@@ -662,9 +650,9 @@ mod tests {
     #[test]
     fn fiber_suspends_and_resumes_pending_future() {
         let mut state = 1;
-        let mut future = core::pin::pin!(on_fiber(&mut state, stack_size(), |state| {
+        let mut future = core::pin::pin!(on_fiber_result(&mut state, stack_size(), |state| {
             *state += block_on_current(PendingOnce { pending: true }).unwrap();
-            *state
+            Ok::<_, Infallible>(*state)
         }));
         let waker = Waker::noop();
         let mut cx = Context::from_waker(waker);
@@ -678,8 +666,8 @@ mod tests {
         let mut db = AsyncDb::new(TestDb);
         let address = Address::ZERO;
         let key = Word::from(7);
-        let mut future = core::pin::pin!(on_fiber(&mut db, stack_size(), |db| {
-            DynDatabase::get_storage(db, &address, &key).unwrap()
+        let mut future = core::pin::pin!(on_fiber_result(&mut db, stack_size(), |db| {
+            Ok::<_, Infallible>(DynDatabase::get_storage(db, &address, &key).unwrap())
         }));
         let waker = Waker::noop();
         let mut cx = Context::from_waker(waker);
@@ -694,8 +682,8 @@ mod tests {
         let mut db = AsyncDb::new(PendingDb { pending: true });
         let address = Address::ZERO;
         let key = Word::from(7);
-        let mut future = core::pin::pin!(on_fiber(&mut db, stack_size(), |db| {
-            DynDatabase::get_storage(db, &address, &key).unwrap()
+        let mut future = core::pin::pin!(on_fiber_result(&mut db, stack_size(), |db| {
+            Ok::<_, Infallible>(DynDatabase::get_storage(db, &address, &key).unwrap())
         }));
         let waker = Waker::noop();
         let mut cx = Context::from_waker(waker);
@@ -711,8 +699,8 @@ mod tests {
         let mut db = AsyncDb::new(FailingDb);
         let address = Address::ZERO;
         let key = Word::from(7);
-        let code = on_fiber(&mut db, stack_size(), |db| {
-            DynDatabase::get_storage(db, &address, &key).unwrap_err()
+        let code = on_fiber_result(&mut db, stack_size(), |db| {
+            Ok::<_, Infallible>(DynDatabase::get_storage(db, &address, &key).unwrap_err())
         });
         let code = poll_ready(code).unwrap();
 
@@ -883,9 +871,10 @@ mod tests {
         let mut saw_cancel = false;
         {
             let mut future =
-                core::pin::pin!(on_fiber(&mut saw_cancel, stack_size(), |saw_cancel| {
+                core::pin::pin!(on_fiber_result(&mut saw_cancel, stack_size(), |saw_cancel| {
                     *saw_cancel =
                         matches!(block_on_current(PendingForever), Err(AsyncError::Cancelled));
+                    Ok::<_, Infallible>(())
                 }));
             let waker = Waker::noop();
             let mut cx = Context::from_waker(waker);

--- a/crates/evm2/src/async_.rs
+++ b/crates/evm2/src/async_.rs
@@ -5,7 +5,6 @@
 //! suspended and the outer async task returns `Poll::Pending`.
 
 use crate::{
-    IoMode,
     bytecode::Bytecode,
     evm::{
         AccountInfo, DatabaseCommit, DbErrorCode, DbResult, DynDatabase, StateChanges,
@@ -35,7 +34,7 @@ thread_local! {
 }
 
 /// Result type used by async EVM execution helpers.
-pub type AsyncResult<T, E = core::convert::Infallible> = core::result::Result<T, AsyncError<E>>;
+pub type AsyncResult<T, E = core::convert::Infallible> = Result<T, AsyncError<E>>;
 
 /// Error returned by async EVM execution helpers.
 #[derive(Debug, thiserror::Error)]
@@ -116,7 +115,7 @@ impl Drop for ResetCurrentFiber {
 /// operations without blocking the executor thread.
 pub(crate) fn on_fiber_result<'a, R, E>(
     stack_size: usize,
-    func: impl FnOnce() -> core::result::Result<R, E> + 'a,
+    func: impl FnOnce() -> Result<R, E> + 'a,
 ) -> impl Future<Output = AsyncResult<R, E>> + Send + 'a
 where
     R: Send + 'a,
@@ -136,13 +135,13 @@ where
 }
 
 enum OnFiber<'a, R, E> {
-    Running(FiberFuture<'a, core::result::Result<R, E>>),
+    Running(FiberFuture<'a, Result<R, E>>),
     Error(Option<AsyncError>),
     Done,
 }
 
 impl<'a, R, E> OnFiber<'a, R, E> {
-    fn new(stack_size: usize, func: impl FnOnce() -> core::result::Result<R, E> + 'a) -> Self {
+    fn new(stack_size: usize, func: impl FnOnce() -> Result<R, E> + 'a) -> Self {
         match FiberFuture::new(stack_size, func) {
             Ok(fiber) => Self::Running(fiber),
             Err(error) => Self::Error(Some(error)),
@@ -311,37 +310,35 @@ impl HandleOrRuntime {
     }
 }
 
-fn block_on_runtime<F>(
-    mode: IoMode,
-    runtime: Option<&HandleOrRuntime>,
-    future: F,
-) -> AsyncResult<F::Output>
+fn block_on_runtime<F>(runtime: Option<&HandleOrRuntime>, future: F) -> AsyncResult<F::Output>
 where
     F: Future + Send,
     F::Output: Send,
 {
-    match mode {
-        IoMode::Blocking => {
-            let Some(runtime) = runtime else {
-                return Err(AsyncError::Runtime);
-            };
-            Ok(runtime.block_on(future))
-        }
-        IoMode::Async => block_on_current(future),
+    if CURRENT.get().is_some() {
+        return block_on_current(future);
     }
+
+    if let Some(runtime) = runtime {
+        return Ok(runtime.block_on(future));
+    }
+
+    let Some(runtime) = HandleOrRuntime::current() else {
+        return Err(AsyncError::Runtime);
+    };
+    Ok(runtime.block_on(future))
 }
 
 fn block_on_runtime_result<F, T, E>(
-    mode: IoMode,
     runtime: Option<&HandleOrRuntime>,
     future: F,
 ) -> AsyncResult<T, E>
 where
-    F: Future<Output = core::result::Result<T, E>> + Send,
+    F: Future<Output = Result<T, E>> + Send,
     T: Send,
     E: Send,
 {
-    match block_on_runtime(mode, runtime, future).map_err(AsyncError::with_inner_error)? {
+    match block_on_runtime(runtime, future).map_err(AsyncError::with_inner_error)? {
         Ok(value) => Ok(value),
         Err(error) => Err(AsyncError::Inner(error)),
     }
@@ -369,33 +366,32 @@ pub trait AsyncDatabase: Any + Send {
     fn get_account(
         &mut self,
         address: Address,
-    ) -> impl Future<Output = core::result::Result<Option<AccountInfo>, Self::Error>> + Send + '_;
+    ) -> impl Future<Output = Result<Option<AccountInfo>, Self::Error>> + Send + '_;
 
     /// Loads bytecode by code hash.
     fn get_code_by_hash(
         &mut self,
         code_hash: B256,
-    ) -> impl Future<Output = core::result::Result<Bytecode, Self::Error>> + Send + '_;
+    ) -> impl Future<Output = Result<Bytecode, Self::Error>> + Send + '_;
 
     /// Loads a persistent storage slot.
     fn get_storage(
         &mut self,
         address: Address,
         key: Word,
-    ) -> impl Future<Output = core::result::Result<Word, Self::Error>> + Send + '_;
+    ) -> impl Future<Output = Result<Word, Self::Error>> + Send + '_;
 
     /// Loads a historical block hash.
     fn get_block_hash(
         &mut self,
         number: Word,
-    ) -> impl Future<Output = core::result::Result<Option<B256>, Self::Error>> + Send + '_;
+    ) -> impl Future<Output = Result<Option<B256>, Self::Error>> + Send + '_;
 }
 
 /// Adapter that exposes an [`AsyncDatabase`] through the synchronous [`DynDatabase`] interface.
 pub struct AsyncDb<D: AsyncDatabase> {
     db: D,
     error: Option<Box<dyn Error + Send>>,
-    io_mode: IoMode,
     runtime: Option<HandleOrRuntime>,
 }
 
@@ -403,42 +399,27 @@ impl<D: AsyncDatabase> AsyncDb<D> {
     /// Creates a new async database adapter.
     #[inline]
     pub const fn new(db: D) -> Self {
-        Self { db, error: None, io_mode: IoMode::Async, runtime: None }
+        Self { db, error: None, runtime: None }
     }
 
-    /// Creates a new blocking async database adapter using the current Tokio runtime handle.
+    /// Creates a new async database adapter using the current Tokio runtime handle.
     ///
     /// Returns `None` if no Tokio runtime is available or the current runtime is current-threaded.
     #[inline]
     pub fn blocking(db: D) -> Option<Self> {
-        Some(Self {
-            db,
-            error: None,
-            io_mode: IoMode::Blocking,
-            runtime: Some(HandleOrRuntime::current()?),
-        })
+        Some(Self { db, error: None, runtime: Some(HandleOrRuntime::current()?) })
     }
 
-    /// Creates a new blocking async database adapter with a Tokio runtime.
+    /// Creates a new async database adapter with a Tokio runtime.
     #[inline]
     pub const fn with_runtime(db: D, runtime: Runtime) -> Self {
-        Self {
-            db,
-            error: None,
-            io_mode: IoMode::Blocking,
-            runtime: Some(HandleOrRuntime::Runtime(runtime)),
-        }
+        Self { db, error: None, runtime: Some(HandleOrRuntime::Runtime(runtime)) }
     }
 
-    /// Creates a new blocking async database adapter with a Tokio runtime handle.
+    /// Creates a new async database adapter with a Tokio runtime handle.
     #[inline]
     pub const fn with_handle(db: D, handle: Handle) -> Self {
-        Self {
-            db,
-            error: None,
-            io_mode: IoMode::Blocking,
-            runtime: Some(HandleOrRuntime::Handle(handle)),
-        }
+        Self { db, error: None, runtime: Some(HandleOrRuntime::Handle(handle)) }
     }
 
     /// Returns the wrapped database.
@@ -491,8 +472,8 @@ impl<D: AsyncDatabase> DynDatabase for AsyncDb<D> {
     #[inline]
     fn get_account(&mut self, address: &Address) -> DbResult<Option<AccountInfo>> {
         let result = {
-            let Self { db, io_mode, runtime, .. } = self;
-            block_on_runtime_result(*io_mode, runtime.as_ref(), db.get_account(*address))
+            let Self { db, runtime, .. } = self;
+            block_on_runtime_result(runtime.as_ref(), db.get_account(*address))
         };
         self.database_result(result)
     }
@@ -500,8 +481,8 @@ impl<D: AsyncDatabase> DynDatabase for AsyncDb<D> {
     #[inline]
     fn get_code_by_hash(&mut self, code_hash: &B256) -> DbResult<Bytecode> {
         let result = {
-            let Self { db, io_mode, runtime, .. } = self;
-            block_on_runtime_result(*io_mode, runtime.as_ref(), db.get_code_by_hash(*code_hash))
+            let Self { db, runtime, .. } = self;
+            block_on_runtime_result(runtime.as_ref(), db.get_code_by_hash(*code_hash))
         };
         self.database_result(result)
     }
@@ -509,8 +490,8 @@ impl<D: AsyncDatabase> DynDatabase for AsyncDb<D> {
     #[inline]
     fn get_storage(&mut self, address: &Address, key: &Word) -> DbResult<Word> {
         let result = {
-            let Self { db, io_mode, runtime, .. } = self;
-            block_on_runtime_result(*io_mode, runtime.as_ref(), db.get_storage(*address, *key))
+            let Self { db, runtime, .. } = self;
+            block_on_runtime_result(runtime.as_ref(), db.get_storage(*address, *key))
         };
         self.database_result(result)
     }
@@ -518,8 +499,8 @@ impl<D: AsyncDatabase> DynDatabase for AsyncDb<D> {
     #[inline]
     fn get_block_hash(&mut self, number: &Word) -> DbResult<Option<B256>> {
         let result = {
-            let Self { db, io_mode, runtime, .. } = self;
-            block_on_runtime_result(*io_mode, runtime.as_ref(), db.get_block_hash(*number))
+            let Self { db, runtime, .. } = self;
+            block_on_runtime_result(runtime.as_ref(), db.get_block_hash(*number))
         };
         self.database_result(result)
     }
@@ -532,21 +513,6 @@ impl<D: AsyncDatabase> DynDatabase for AsyncDb<D> {
             return error;
         }
         db_error_unavailable(code)
-    }
-
-    #[inline]
-    fn set_io_mode(&mut self, io_mode: IoMode) -> bool {
-        if matches!(io_mode, IoMode::Blocking)
-            && self.runtime.is_none()
-            && let Some(runtime) = HandleOrRuntime::current()
-        {
-            self.runtime = Some(runtime);
-        }
-        if matches!(io_mode, IoMode::Blocking) && self.runtime.is_none() {
-            return false;
-        }
-        self.io_mode = io_mode;
-        true
     }
 }
 
@@ -561,7 +527,7 @@ impl<D: AsyncDatabase + fmt::Debug> fmt::Debug for AsyncDb<D> {
 mod tests {
     use super::{AsyncDatabase, AsyncDb, AsyncError, block_on_current, on_fiber};
     use crate::{
-        BaseEvmTypes, Evm, ExecutionConfig, IoMode, Precompiles, SpecId, TxResult, Version,
+        BaseEvmTypes, Evm, Precompiles, SpecId, TxResult, Version,
         bytecode::Bytecode,
         env::BlockEnv,
         evm::{DynDatabase, InMemoryDB},
@@ -682,14 +648,13 @@ mod tests {
     }
 
     #[test]
-    fn blocking_io_mode_blocks_with_tokio_when_not_on_fiber() {
+    fn synchronous_database_blocks_with_current_tokio_runtime() {
         let runtime = tokio::runtime::Runtime::new().unwrap();
         let _guard = runtime.enter();
         let mut db = AsyncDb::new(TokioDb);
         let address = Address::ZERO;
         let key = Word::from(7);
 
-        assert!(DynDatabase::set_io_mode(&mut db, IoMode::Blocking));
         let value = DynDatabase::get_storage(&mut db, &address, &key).unwrap();
 
         assert_eq!(value, Word::from(9));
@@ -709,7 +674,7 @@ mod tests {
     }
 
     #[test]
-    fn blocking_io_mode_blocks_with_stored_tokio_runtime() {
+    fn synchronous_database_blocks_with_stored_tokio_runtime() {
         let runtime = tokio::runtime::Runtime::new().unwrap();
         let mut db = AsyncDb::with_runtime(TokioDb, runtime);
         let address = Address::ZERO;
@@ -721,40 +686,23 @@ mod tests {
     }
 
     #[test]
-    fn blocking_io_mode_requires_runtime_handle() {
+    fn synchronous_database_requires_runtime_handle() {
         let mut db = AsyncDb::new(TestDb);
+        let address = Address::ZERO;
+        let key = Word::from(7);
+        let code = DynDatabase::get_storage(&mut db, &address, &key).unwrap_err();
 
-        assert!(!DynDatabase::set_io_mode(&mut db, IoMode::Blocking));
+        assert_eq!(
+            db.error(code).to_string(),
+            "async host operation requires a Tokio multi-thread runtime"
+        );
     }
 
     #[test]
-    fn evm_sets_async_database_io_mode() {
+    fn synchronous_evm_database_blocks_with_current_tokio_runtime() {
         let runtime = tokio::runtime::Runtime::new().unwrap();
         let _guard = runtime.enter();
         let mut evm = Evm::<BaseEvmTypes>::new(
-            SpecId::OSAKA,
-            BlockEnv::default(),
-            TxRegistry::new(),
-            AsyncDb::new(TokioDb),
-            Precompiles::base(SpecId::OSAKA),
-        );
-        let address = Address::ZERO;
-        let key = Word::from(7);
-
-        assert!(evm.set_io_mode(IoMode::Blocking));
-        let value = evm.database_mut().get_storage(&address, &key).unwrap();
-
-        assert_eq!(value, Word::from(9));
-    }
-
-    #[test]
-    fn evm_applies_version_io_mode_to_async_database() {
-        let runtime = tokio::runtime::Runtime::new().unwrap();
-        let _guard = runtime.enter();
-        let mut version = Version::new(SpecId::OSAKA);
-        version.io_mode = IoMode::Blocking;
-        let mut evm = Evm::<BaseEvmTypes>::new_with_execution_config(
-            ExecutionConfig::for_spec_and_version(SpecId::OSAKA, version),
             SpecId::OSAKA,
             BlockEnv::default(),
             TxRegistry::new(),
@@ -788,19 +736,6 @@ mod tests {
     }
 
     #[test]
-    fn async_io_mode_requires_fiber() {
-        let mut db = AsyncDb::new(TestDb);
-        let address = Address::ZERO;
-        let key = Word::from(7);
-        let code = DynDatabase::get_storage(&mut db, &address, &key).unwrap_err();
-
-        assert_eq!(
-            db.error(code).to_string(),
-            "async host operation requires EVM async fiber execution"
-        );
-    }
-
-    #[test]
     fn dropping_fiber_cancels_blocked_future() {
         let mut saw_cancel = false;
         {
@@ -816,10 +751,9 @@ mod tests {
     }
 
     #[test]
-    fn version_defaults_async_io_mode_and_stack_size() {
+    fn version_defaults_async_stack_size() {
         let version = Version::new(SpecId::OSAKA);
 
-        assert_eq!(version.io_mode, IoMode::Async);
         assert_eq!(version.min_stack_size, 1024 * 1024);
     }
 

--- a/crates/evm2/src/async_.rs
+++ b/crates/evm2/src/async_.rs
@@ -176,7 +176,7 @@ impl<R, E> Future for OnFiber<'_, R, E> {
 
 struct FiberFuture<'a, R> {
     fiber: EvmFiber<R>,
-    _marker: PhantomData<&'a mut R>,
+    _marker: PhantomData<&'a ()>,
 }
 
 // SAFETY: The future may move between polls, but the coroutine stack itself is heap allocated and

--- a/crates/evm2/src/async_.rs
+++ b/crates/evm2/src/async_.rs
@@ -127,19 +127,35 @@ where
     R: Send + 'a,
     E: Send + 'a,
 {
-    FlattenFiber { inner: OnFiber::new(state, stack_size, func) }
+    OnFiber::new(state, stack_size, func)
 }
 
-enum OnFiber<'a, R> {
-    Running(FiberFuture<'a, R>),
+pub(crate) fn on_fiber<'a, S, R>(
+    state: &'a mut S,
+    stack_size: usize,
+    func: impl FnOnce(&mut S) -> R + 'a,
+) -> impl Future<Output = AsyncResult<R>> + Send + 'a
+where
+    S: ?Sized,
+    R: Send + 'a,
+{
+    on_fiber_result(state, stack_size, move |state| Ok::<_, core::convert::Infallible>(func(state)))
+}
+
+enum OnFiber<'a, R, E> {
+    Running(FiberFuture<'a, core::result::Result<R, E>>),
     Error(Option<AsyncError>),
     Done,
 }
 
-impl<R> Unpin for OnFiber<'_, R> {}
+impl<R, E> Unpin for OnFiber<'_, R, E> {}
 
-impl<'a, R> OnFiber<'a, R> {
-    fn new<S>(state: &'a mut S, stack_size: usize, func: impl FnOnce(&mut S) -> R + 'a) -> Self
+impl<'a, R, E> OnFiber<'a, R, E> {
+    fn new<S>(
+        state: &'a mut S,
+        stack_size: usize,
+        func: impl FnOnce(&mut S) -> core::result::Result<R, E> + 'a,
+    ) -> Self
     where
         S: ?Sized,
     {
@@ -150,42 +166,32 @@ impl<'a, R> OnFiber<'a, R> {
     }
 }
 
-impl<R> Future for OnFiber<'_, R> {
-    type Output = AsyncResult<R>;
+impl<R, E> Future for OnFiber<'_, R, E> {
+    type Output = AsyncResult<R, E>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.get_mut();
         match this {
             Self::Running(fiber) => match Pin::new(fiber).poll(cx) {
-                Poll::Ready(result) => {
+                Poll::Ready(Ok(Ok(value))) => {
                     *this = Self::Done;
-                    Poll::Ready(result)
+                    Poll::Ready(Ok(value))
+                }
+                Poll::Ready(Ok(Err(error))) => {
+                    *this = Self::Done;
+                    Poll::Ready(Err(AsyncError::Inner(error)))
+                }
+                Poll::Ready(Err(error)) => {
+                    *this = Self::Done;
+                    Poll::Ready(Err(error.with_inner_error()))
                 }
                 Poll::Pending => Poll::Pending,
             },
             Self::Error(error) => {
-                Poll::Ready(Err(error.take().expect("async EVM fiber error already returned")))
+                let error = error.take().expect("async EVM fiber error already returned");
+                Poll::Ready(Err(error.with_inner_error()))
             }
             Self::Done => panic!("async EVM fiber polled after completion"),
-        }
-    }
-}
-
-struct FlattenFiber<'a, R, E> {
-    inner: OnFiber<'a, core::result::Result<R, E>>,
-}
-
-impl<R, E> Unpin for FlattenFiber<'_, R, E> {}
-
-impl<R, E> Future for FlattenFiber<'_, R, E> {
-    type Output = AsyncResult<R, E>;
-
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        match Pin::new(&mut self.get_mut().inner).poll(cx) {
-            Poll::Ready(Ok(Ok(value))) => Poll::Ready(Ok(value)),
-            Poll::Ready(Ok(Err(error))) => Poll::Ready(Err(AsyncError::Inner(error))),
-            Poll::Ready(Err(error)) => Poll::Ready(Err(error.with_inner_error())),
-            Poll::Pending => Poll::Pending,
         }
     }
 }
@@ -616,7 +622,7 @@ impl Error for AsyncDbErrorUnavailable {}
 
 #[cfg(test)]
 mod tests {
-    use super::{AsyncDatabase, AsyncDb, AsyncError, block_on_current, on_fiber_result};
+    use super::{AsyncDatabase, AsyncDb, AsyncError, block_on_current, on_fiber};
     use crate::{
         BaseEvmTypes, Evm, ExecutionConfig, IoMode, Precompiles, SpecId, TxResult, Version,
         bytecode::Bytecode,
@@ -641,9 +647,9 @@ mod tests {
     #[test]
     fn fiber_suspends_and_resumes_pending_future() {
         let mut state = 1;
-        let mut future = core::pin::pin!(on_fiber_result(&mut state, stack_size(), |state| {
+        let mut future = core::pin::pin!(on_fiber(&mut state, stack_size(), |state| {
             *state += block_on_current(PendingOnce { pending: true }).unwrap();
-            Ok::<_, Infallible>(*state)
+            *state
         }));
         let waker = Waker::noop();
         let mut cx = Context::from_waker(waker);
@@ -657,8 +663,8 @@ mod tests {
         let mut db = AsyncDb::new(TestDb);
         let address = Address::ZERO;
         let key = Word::from(7);
-        let mut future = core::pin::pin!(on_fiber_result(&mut db, stack_size(), |db| {
-            Ok::<_, Infallible>(DynDatabase::get_storage(db, &address, &key).unwrap())
+        let mut future = core::pin::pin!(on_fiber(&mut db, stack_size(), |db| {
+            DynDatabase::get_storage(db, &address, &key).unwrap()
         }));
         let waker = Waker::noop();
         let mut cx = Context::from_waker(waker);
@@ -673,8 +679,8 @@ mod tests {
         let mut db = AsyncDb::new(PendingDb { pending: true });
         let address = Address::ZERO;
         let key = Word::from(7);
-        let mut future = core::pin::pin!(on_fiber_result(&mut db, stack_size(), |db| {
-            Ok::<_, Infallible>(DynDatabase::get_storage(db, &address, &key).unwrap())
+        let mut future = core::pin::pin!(on_fiber(&mut db, stack_size(), |db| {
+            DynDatabase::get_storage(db, &address, &key).unwrap()
         }));
         let waker = Waker::noop();
         let mut cx = Context::from_waker(waker);
@@ -690,8 +696,8 @@ mod tests {
         let mut db = AsyncDb::new(FailingDb);
         let address = Address::ZERO;
         let key = Word::from(7);
-        let code = on_fiber_result(&mut db, stack_size(), |db| {
-            Ok::<_, Infallible>(DynDatabase::get_storage(db, &address, &key).unwrap_err())
+        let code = on_fiber(&mut db, stack_size(), |db| {
+            DynDatabase::get_storage(db, &address, &key).unwrap_err()
         });
         let code = poll_ready(code).unwrap();
 
@@ -862,10 +868,9 @@ mod tests {
         let mut saw_cancel = false;
         {
             let mut future =
-                core::pin::pin!(on_fiber_result(&mut saw_cancel, stack_size(), |saw_cancel| {
+                core::pin::pin!(on_fiber(&mut saw_cancel, stack_size(), |saw_cancel| {
                     *saw_cancel =
                         matches!(block_on_current(PendingForever), Err(AsyncError::Cancelled));
-                    Ok::<_, Infallible>(())
                 }));
             let waker = Waker::noop();
             let mut cx = Context::from_waker(waker);

--- a/crates/evm2/src/async_.rs
+++ b/crates/evm2/src/async_.rs
@@ -44,9 +44,12 @@ pub enum AsyncError<E = core::convert::Infallible> {
     /// An async host operation was called outside an async EVM fiber.
     #[error("async host operation requires EVM async fiber execution")]
     NotOnFiber,
-    /// Async fiber runtime setup failed.
+    /// Blocking async I/O was requested outside a supported Tokio runtime.
+    #[error("async host operation requires a Tokio multi-thread runtime")]
+    Runtime,
+    /// Async fiber stack setup failed.
     #[error(transparent)]
-    Runtime(io::Error),
+    Io(io::Error),
     /// The wrapped operation returned an error.
     #[error(transparent)]
     Inner(#[from] E),
@@ -57,7 +60,8 @@ impl AsyncError {
         match self {
             Self::Cancelled => AsyncError::Cancelled,
             Self::NotOnFiber => AsyncError::NotOnFiber,
-            Self::Runtime(error) => AsyncError::Runtime(error),
+            Self::Runtime => AsyncError::Runtime,
+            Self::Io(error) => AsyncError::Io(error),
             Self::Inner(error) => match error {},
         }
     }
@@ -186,7 +190,7 @@ unsafe impl<R: Send> Send for FiberFuture<'_, R> {}
 
 impl<'a, R> FiberFuture<'a, R> {
     fn new(stack_size: usize, func: impl FnOnce() -> R + 'a) -> AsyncResult<Self> {
-        let stack = DefaultStack::new(stack_size).map_err(AsyncError::Runtime)?;
+        let stack = DefaultStack::new(stack_size).map_err(AsyncError::Io)?;
         let body = move |suspend: &Yielder<Resume, Yield>, resume| {
             let future_cx = resume?;
             let mut current = CurrentFiber {
@@ -325,9 +329,7 @@ where
     match mode {
         IoMode::Blocking => {
             let Some(runtime) = runtime else {
-                return Err(AsyncError::Runtime(io::Error::other(
-                    "async host operation requires a Tokio multi-thread runtime",
-                )));
+                return Err(AsyncError::Runtime);
             };
             Ok(runtime.block_on(future))
         }

--- a/crates/evm2/src/async_.rs
+++ b/crates/evm2/src/async_.rs
@@ -532,13 +532,14 @@ impl Error for AsyncDbErrorUnavailable {}
 mod tests {
     use super::{AsyncDatabase, AsyncDb, AsyncError, block_on_current, on_fiber};
     use crate::{
-        BaseEvmTypes, Evm, ExecutionConfig, IoMode, Precompiles, SpecId, Version,
+        BaseEvmTypes, Evm, ExecutionConfig, IoMode, Precompiles, SpecId, TxResult, Version,
         bytecode::Bytecode,
         env::BlockEnv,
         evm::{DynDatabase, InMemoryDB},
         interpreter::Word,
-        registry::TxRegistry,
+        registry::{HandlerResult, TxRegistry, TxRequest},
     };
+    use alloy_consensus::{TxLegacy, transaction::Recovered};
     use alloy_primitives::{Address, B256, Bytes};
     use core::{convert::Infallible, fmt, future::Future, pin::Pin, task::Poll};
     use std::{
@@ -609,6 +610,27 @@ mod tests {
         let code = poll_ready(code).unwrap();
 
         assert_eq!(db.error(code).to_string(), "storage read failed");
+    }
+
+    #[test]
+    fn dispatches_transaction_async_by_typed_2718_type() {
+        let registry = TxRegistry::new().with_handler(
+            TEST_TX_TYPE,
+            crate::ethereum::RecoveredTxEnvelope::as_legacy,
+            handle_test_tx,
+        );
+        let mut evm = Evm::<BaseEvmTypes>::new(
+            SpecId::OSAKA,
+            BlockEnv::default(),
+            registry,
+            InMemoryDB::default(),
+            Precompiles::base(SpecId::OSAKA),
+        );
+        let tx = test_tx(41);
+
+        let result = poll_ready(evm.transact_async(&tx)).unwrap().unwrap();
+
+        assert_eq!(result.gas_used, 42);
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -749,6 +771,22 @@ mod tests {
 
     fn stack_size() -> usize {
         Version::new(SpecId::OSAKA).min_stack_size
+    }
+
+    const TEST_TX_TYPE: u8 = 0x00;
+
+    fn test_tx(value: u64) -> crate::ethereum::RecoveredTxEnvelope {
+        crate::ethereum::RecoveredTxEnvelope::Legacy(Recovered::new_unchecked(
+            TxLegacy { nonce: value, ..TxLegacy::default() },
+            Address::ZERO,
+        ))
+    }
+
+    fn handle_test_tx(
+        req: TxRequest<'_, Recovered<TxLegacy>, Evm<BaseEvmTypes>>,
+    ) -> HandlerResult<TxResult> {
+        let _ = req.host.spec_id();
+        Ok(TxResult { status: true, gas_used: req.tx.nonce + 1, ..TxResult::default() })
     }
 
     fn poll_ready<F: Future + Send>(future: F) -> F::Output {

--- a/crates/evm2/src/async_.rs
+++ b/crates/evm2/src/async_.rs
@@ -11,14 +11,12 @@ use crate::{
 };
 use alloc::{
     boxed::Box,
-    rc::Rc,
     string::{String, ToString},
 };
 use alloy_primitives::{Address, B256};
-use core::{
-    any::Any, fmt, future::Future, marker::PhantomData, pin::Pin, ptr::NonNull, task::Poll,
-};
+use core::{any::Any, fmt, future::Future, pin::Pin, ptr::NonNull, task::Poll};
 use std::{cell::RefCell, error::Error, task::Context};
+use tokio::{runtime::Handle, task};
 use wasmtime_fiber::{Fiber, FiberStack, Suspend};
 
 /// Default stack size for async EVM execution.
@@ -50,6 +48,19 @@ pub enum AsyncError {
     /// An async host operation was called outside an async EVM fiber.
     #[error("async host operation requires EVM async fiber execution")]
     NotOnFiber,
+    /// Blocking async I/O was requested outside a supported Tokio runtime.
+    #[error("async host operation requires a Tokio multi-thread runtime: {0}")]
+    Runtime(String),
+}
+
+/// How async database I/O should be driven from synchronous EVM host calls.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub enum IoMode {
+    /// Block the current Tokio worker with `block_in_place`.
+    Blocking,
+    /// Suspend the EVM fiber while database I/O is pending.
+    #[default]
+    Async,
 }
 
 trait CurrentFiber {
@@ -95,7 +106,7 @@ struct ResetCurrentFiber(Option<NonNull<dyn CurrentFiber>>);
 
 impl Drop for ResetCurrentFiber {
     fn drop(&mut self) {
-        CURRENT.with(|current| *current.borrow_mut() = self.0);
+        CURRENT.with_borrow_mut(|current| *current = self.0);
     }
 }
 
@@ -124,10 +135,14 @@ where
 
 struct FiberFuture<'a, R> {
     fiber: Option<EvmFiber<'a, R>>,
-    _not_send: PhantomData<Rc<()>>,
 }
 
 impl<R> Unpin for FiberFuture<'_, R> {}
+
+// SAFETY: The future may move between polls, but the fiber stack itself is heap allocated by
+// `wasmtime-fiber` and is only resumed through `poll` with a fresh task context. Values that can
+// remain on the fiber stack across suspension are required to be `Send` by the blocking boundary.
+unsafe impl<R: Send> Send for FiberFuture<'_, R> {}
 
 impl<'a, R> FiberFuture<'a, R> {
     fn new<S>(
@@ -146,12 +161,12 @@ impl<'a, R> FiberFuture<'a, R> {
                 FiberContext { suspend, future_cx: Some(future_cx), cancelled: false };
             let current = NonNull::from(&mut fiber_context as &mut dyn CurrentFiber);
             let current = unsafe { erase_current_fiber_lifetime(current) };
-            let previous = CURRENT.with(|slot| slot.borrow_mut().replace(current));
+            let previous = CURRENT.with_borrow_mut(|slot| slot.replace(current));
             let _reset = ResetCurrentFiber(previous);
             Ok(func(unsafe { &mut *state }))
         })
         .map_err(fiber_error)?;
-        Ok(Self { fiber: Some(fiber), _not_send: PhantomData })
+        Ok(Self { fiber: Some(fiber) })
     }
 }
 
@@ -208,9 +223,34 @@ where
     }
 }
 
+fn block_on_io<F>(mode: IoMode, future: F) -> AsyncResult<F::Output>
+where
+    F: Future + Send,
+{
+    match mode {
+        IoMode::Blocking => block_on_tokio(future),
+        IoMode::Async => block_on_current(future),
+    }
+}
+
+fn block_on_tokio<F>(future: F) -> AsyncResult<F::Output>
+where
+    F: Future + Send,
+{
+    let handle = Handle::try_current().map_err(runtime_error)?;
+    match handle.runtime_flavor() {
+        tokio::runtime::RuntimeFlavor::MultiThread => {
+            Ok(task::block_in_place(|| handle.block_on(future)))
+        }
+        flavor => {
+            Err(AsyncError::Runtime(format!("block_in_place is not available on {flavor:?}")))
+        }
+    }
+}
+
 fn with_current<R>(f: impl FnOnce(&mut dyn CurrentFiber) -> R) -> AsyncResult<R> {
     let mut current =
-        CURRENT.with(|slot| slot.borrow().as_ref().copied()).ok_or(AsyncError::NotOnFiber)?;
+        CURRENT.with_borrow(|slot| slot.as_ref().copied()).ok_or(AsyncError::NotOnFiber)?;
     Ok(f(unsafe { current.as_mut() }))
 }
 
@@ -236,48 +276,53 @@ fn fiber_error(error: impl fmt::Display) -> AsyncError {
     AsyncError::Fiber(error.to_string())
 }
 
+fn runtime_error(error: impl fmt::Display) -> AsyncError {
+    AsyncError::Runtime(error.to_string())
+}
+
 /// Asynchronous backing database implementation.
-pub trait AsyncDatabase: Any {
+pub trait AsyncDatabase: Any + Send {
     /// Database error type.
-    type Error: Error + 'static;
+    type Error: Error + Send + 'static;
 
     /// Loads account information.
     fn get_account(
         &mut self,
         address: Address,
-    ) -> impl Future<Output = core::result::Result<Option<AccountInfo>, Self::Error>> + '_;
+    ) -> impl Future<Output = core::result::Result<Option<AccountInfo>, Self::Error>> + Send + '_;
 
     /// Loads bytecode by code hash.
     fn get_code_by_hash(
         &mut self,
         code_hash: B256,
-    ) -> impl Future<Output = core::result::Result<Bytecode, Self::Error>> + '_;
+    ) -> impl Future<Output = core::result::Result<Bytecode, Self::Error>> + Send + '_;
 
     /// Loads a persistent storage slot.
     fn get_storage(
         &mut self,
         address: Address,
         key: Word,
-    ) -> impl Future<Output = core::result::Result<Word, Self::Error>> + '_;
+    ) -> impl Future<Output = core::result::Result<Word, Self::Error>> + Send + '_;
 
     /// Loads a historical block hash.
     fn get_block_hash(
         &mut self,
         number: Word,
-    ) -> impl Future<Output = core::result::Result<Option<B256>, Self::Error>> + '_;
+    ) -> impl Future<Output = core::result::Result<Option<B256>, Self::Error>> + Send + '_;
 }
 
 /// Adapter that exposes an [`AsyncDatabase`] through the synchronous [`DynDatabase`] interface.
 pub struct AsyncDb<D: AsyncDatabase> {
     db: D,
-    error: Option<Box<dyn Error>>,
+    error: Option<Box<dyn Error + Send>>,
+    io_mode: IoMode,
 }
 
 impl<D: AsyncDatabase> AsyncDb<D> {
     /// Creates a new async database adapter.
     #[inline]
-    pub const fn new(db: D) -> Self {
-        Self { db, error: None }
+    pub const fn new(db: D, io_mode: IoMode) -> Self {
+        Self { db, error: None, io_mode }
     }
 
     /// Returns the wrapped database.
@@ -300,12 +345,12 @@ impl<D: AsyncDatabase> AsyncDb<D> {
 
     /// Takes the stored database or async execution error.
     #[inline]
-    pub fn take_error(&mut self) -> Option<Box<dyn Error>> {
+    pub fn take_error(&mut self) -> Option<Box<dyn Error + Send>> {
         self.error.take()
     }
 
     #[inline]
-    fn store_error(&mut self, error: impl Error + 'static) -> DbErrorCode {
+    fn store_error(&mut self, error: impl Error + Send + 'static) -> DbErrorCode {
         self.error = Some(Box::new(error));
         stored_error_code()
     }
@@ -321,7 +366,7 @@ impl<D: AsyncDatabase + DatabaseCommit> DatabaseCommit for AsyncDb<D> {
 impl<D: AsyncDatabase> DynDatabase for AsyncDb<D> {
     #[inline]
     fn get_account(&mut self, address: &Address) -> DbResult<Option<AccountInfo>> {
-        match block_on_current(self.db.get_account(*address)) {
+        match block_on_io(self.io_mode, self.db.get_account(*address)) {
             Ok(Ok(account)) => Ok(account),
             Ok(Err(error)) => Err(self.store_error(error)),
             Err(error) => Err(self.store_error(error)),
@@ -330,7 +375,7 @@ impl<D: AsyncDatabase> DynDatabase for AsyncDb<D> {
 
     #[inline]
     fn get_code_by_hash(&mut self, code_hash: &B256) -> DbResult<Bytecode> {
-        match block_on_current(self.db.get_code_by_hash(*code_hash)) {
+        match block_on_io(self.io_mode, self.db.get_code_by_hash(*code_hash)) {
             Ok(Ok(bytecode)) => Ok(bytecode),
             Ok(Err(error)) => Err(self.store_error(error)),
             Err(error) => Err(self.store_error(error)),
@@ -339,7 +384,7 @@ impl<D: AsyncDatabase> DynDatabase for AsyncDb<D> {
 
     #[inline]
     fn get_storage(&mut self, address: &Address, key: &Word) -> DbResult<Word> {
-        match block_on_current(self.db.get_storage(*address, *key)) {
+        match block_on_io(self.io_mode, self.db.get_storage(*address, *key)) {
             Ok(Ok(value)) => Ok(value),
             Ok(Err(error)) => Err(self.store_error(error)),
             Err(error) => Err(self.store_error(error)),
@@ -348,7 +393,7 @@ impl<D: AsyncDatabase> DynDatabase for AsyncDb<D> {
 
     #[inline]
     fn get_block_hash(&mut self, number: &Word) -> DbResult<Option<B256>> {
-        match block_on_current(self.db.get_block_hash(*number)) {
+        match block_on_io(self.io_mode, self.db.get_block_hash(*number)) {
             Ok(Ok(hash)) => Ok(hash),
             Ok(Err(error)) => Err(self.store_error(error)),
             Err(error) => Err(self.store_error(error)),
@@ -356,13 +401,19 @@ impl<D: AsyncDatabase> DynDatabase for AsyncDb<D> {
     }
 
     #[inline]
-    fn error(&mut self, code: DbErrorCode) -> Box<dyn Error> {
+    fn error(&mut self, code: DbErrorCode) -> Box<dyn Error + Send> {
         if code == stored_error_code()
             && let Some(error) = self.error.take()
         {
             return error;
         }
         Box::new(AsyncDbErrorUnavailable(code))
+    }
+
+    #[inline]
+    fn set_io_mode(&mut self, io_mode: IoMode) -> bool {
+        self.io_mode = io_mode;
+        true
     }
 }
 
@@ -395,10 +446,16 @@ impl Error for AsyncDbErrorUnavailable {}
 
 #[cfg(test)]
 mod tests {
-    use super::{AsyncDatabase, AsyncDb, AsyncError, block_on_current, on_fiber};
-    use crate::{bytecode::Bytecode, evm::DynDatabase, interpreter::Word};
-    use alloc::boxed::Box;
-    use alloy_primitives::{Address, B256};
+    use super::{AsyncDatabase, AsyncDb, AsyncError, IoMode, block_on_current, on_fiber};
+    use crate::{
+        BaseEvmTypes, Evm, Precompiles, SpecId,
+        bytecode::Bytecode,
+        env::BlockEnv,
+        evm::{DynDatabase, InMemoryDB},
+        interpreter::Word,
+        registry::TxRegistry,
+    };
+    use alloy_primitives::{Address, B256, Bytes};
     use core::{convert::Infallible, fmt, future::Future, pin::Pin, task::Poll};
     use std::{
         error::Error,
@@ -413,7 +470,7 @@ mod tests {
     #[test]
     fn fiber_suspends_and_resumes_pending_future() {
         let mut state = 1;
-        let mut future = Box::pin(on_fiber(&mut state, |state| {
+        let mut future = core::pin::pin!(on_fiber(&mut state, |state| {
             *state += block_on_current(PendingOnce { pending: true }).unwrap();
             *state
         }));
@@ -426,11 +483,12 @@ mod tests {
 
     #[test]
     fn async_database_adapts_to_dyn_database() {
-        let mut db = AsyncDb::new(TestDb);
+        let mut db = AsyncDb::new(TestDb, IoMode::Async);
         let address = Address::ZERO;
         let key = Word::from(7);
-        let mut future =
-            Box::pin(on_fiber(&mut db, |db| DynDatabase::get_storage(db, &address, &key).unwrap()));
+        let mut future = core::pin::pin!(on_fiber(&mut db, |db| {
+            DynDatabase::get_storage(db, &address, &key).unwrap()
+        }));
         let waker = Waker::noop();
         let mut cx = Context::from_waker(waker);
 
@@ -441,11 +499,12 @@ mod tests {
 
     #[test]
     fn async_database_suspends_until_ready() {
-        let mut db = AsyncDb::new(PendingDb { pending: true });
+        let mut db = AsyncDb::new(PendingDb { pending: true }, IoMode::Async);
         let address = Address::ZERO;
         let key = Word::from(7);
-        let mut future =
-            Box::pin(on_fiber(&mut db, |db| DynDatabase::get_storage(db, &address, &key).unwrap()));
+        let mut future = core::pin::pin!(on_fiber(&mut db, |db| {
+            DynDatabase::get_storage(db, &address, &key).unwrap()
+        }));
         let waker = Waker::noop();
         let mut cx = Context::from_waker(waker);
 
@@ -457,7 +516,7 @@ mod tests {
 
     #[test]
     fn async_database_stores_database_error() {
-        let mut db = AsyncDb::new(FailingDb);
+        let mut db = AsyncDb::new(FailingDb, IoMode::Async);
         let address = Address::ZERO;
         let key = Word::from(7);
         let code =
@@ -467,22 +526,84 @@ mod tests {
         assert_eq!(db.error(code).to_string(), "storage read failed");
     }
 
+    #[tokio::test(flavor = "multi_thread")]
+    async fn blocking_io_mode_blocks_with_tokio_when_not_on_fiber() {
+        let mut db = AsyncDb::new(TokioDb, IoMode::Blocking);
+        let address = Address::ZERO;
+        let key = Word::from(7);
+
+        let value = DynDatabase::get_storage(&mut db, &address, &key).unwrap();
+
+        assert_eq!(value, Word::from(9));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn evm_sets_async_database_io_mode() {
+        let mut evm = Evm::<BaseEvmTypes>::new(
+            SpecId::OSAKA,
+            BlockEnv::default(),
+            TxRegistry::new(),
+            AsyncDb::new(TokioDb, IoMode::Async),
+            Precompiles::base(SpecId::OSAKA),
+        );
+        let address = Address::ZERO;
+        let key = Word::from(7);
+
+        assert!(evm.set_io_mode(IoMode::Blocking));
+        let value = evm.database_mut().get_storage(&address, &key).unwrap();
+
+        assert_eq!(value, Word::from(9));
+    }
+
+    #[test]
+    fn system_call_async_to_missing_code_is_noop() {
+        let contract = Address::from([0x42; 20]);
+        let mut evm = Evm::<BaseEvmTypes>::new(
+            SpecId::OSAKA,
+            BlockEnv::default(),
+            TxRegistry::new(),
+            InMemoryDB::default(),
+            Precompiles::base(SpecId::OSAKA),
+        );
+
+        let result = poll_ready(evm.system_call_async(contract, Bytes::new())).unwrap();
+
+        assert!(result.status);
+        assert_eq!(result.gas_used, 0);
+        assert!(result.state_changes.is_empty());
+    }
+
+    #[test]
+    fn async_io_mode_requires_fiber() {
+        let mut db = AsyncDb::new(TestDb, IoMode::Async);
+        let address = Address::ZERO;
+        let key = Word::from(7);
+        let code = DynDatabase::get_storage(&mut db, &address, &key).unwrap_err();
+
+        assert_eq!(
+            db.error(code).to_string(),
+            "async host operation requires EVM async fiber execution"
+        );
+    }
+
     #[test]
     fn dropping_fiber_cancels_blocked_future() {
         let mut saw_cancel = false;
-        let mut future = Box::pin(on_fiber(&mut saw_cancel, |saw_cancel| {
-            *saw_cancel = matches!(block_on_current(PendingForever), Err(AsyncError::Cancelled));
-        }));
-        let waker = Waker::noop();
-        let mut cx = Context::from_waker(waker);
+        {
+            let mut future = core::pin::pin!(on_fiber(&mut saw_cancel, |saw_cancel| {
+                *saw_cancel =
+                    matches!(block_on_current(PendingForever), Err(AsyncError::Cancelled));
+            }));
+            let waker = Waker::noop();
+            let mut cx = Context::from_waker(waker);
 
-        assert!(matches!(future.as_mut().poll(&mut cx), Poll::Pending));
-        drop(future);
+            assert!(matches!(future.as_mut().poll(&mut cx), Poll::Pending));
+        }
         assert!(saw_cancel);
     }
 
-    fn poll_ready<F: Future>(future: F) -> F::Output {
-        let mut future = Box::pin(future);
+    fn poll_ready<F: Future + Send>(future: F) -> F::Output {
+        let mut future = core::pin::pin!(future);
         let waker = Waker::noop();
         let mut cx = Context::from_waker(waker);
 
@@ -524,34 +645,27 @@ mod tests {
     impl AsyncDatabase for TestDb {
         type Error = Infallible;
 
-        fn get_account(
+        async fn get_account(
             &mut self,
             _address: Address,
-        ) -> impl Future<Output = Result<Option<crate::evm::AccountInfo>, Self::Error>> + '_
-        {
-            core::future::ready(Ok(None))
+        ) -> Result<Option<crate::evm::AccountInfo>, Self::Error> {
+            Ok(None)
         }
 
-        fn get_code_by_hash(
-            &mut self,
-            _code_hash: B256,
-        ) -> impl Future<Output = Result<Bytecode, Self::Error>> + '_ {
-            core::future::ready(Ok(Bytecode::default()))
+        async fn get_code_by_hash(&mut self, _code_hash: B256) -> Result<Bytecode, Self::Error> {
+            Ok(Bytecode::default())
         }
 
-        fn get_storage(
+        async fn get_storage(
             &mut self,
             _address: Address,
             _key: Word,
-        ) -> impl Future<Output = Result<Word, Self::Error>> + '_ {
-            core::future::ready(Ok(Word::from(9)))
+        ) -> Result<Word, Self::Error> {
+            Ok(Word::from(9))
         }
 
-        fn get_block_hash(
-            &mut self,
-            _number: Word,
-        ) -> impl Future<Output = Result<Option<B256>, Self::Error>> + '_ {
-            core::future::ready(Ok(None))
+        async fn get_block_hash(&mut self, _number: Word) -> Result<Option<B256>, Self::Error> {
+            Ok(None)
         }
     }
 
@@ -562,50 +676,44 @@ mod tests {
     impl AsyncDatabase for PendingDb {
         type Error = Infallible;
 
-        fn get_account(
+        async fn get_account(
             &mut self,
             _address: Address,
-        ) -> impl Future<Output = Result<Option<crate::evm::AccountInfo>, Self::Error>> + '_
-        {
-            core::future::ready(Ok(None))
+        ) -> Result<Option<crate::evm::AccountInfo>, Self::Error> {
+            Ok(None)
         }
 
-        fn get_code_by_hash(
-            &mut self,
-            _code_hash: B256,
-        ) -> impl Future<Output = Result<Bytecode, Self::Error>> + '_ {
-            core::future::ready(Ok(Bytecode::default()))
+        async fn get_code_by_hash(&mut self, _code_hash: B256) -> Result<Bytecode, Self::Error> {
+            Ok(Bytecode::default())
         }
 
-        fn get_storage(
+        async fn get_storage(
             &mut self,
             _address: Address,
             _key: Word,
-        ) -> impl Future<Output = Result<Word, Self::Error>> + '_ {
-            PendingStorage { db: self }
+        ) -> Result<Word, Self::Error> {
+            PendingStorage { pending: &mut self.pending }.await;
+            Ok(Word::from(9))
         }
 
-        fn get_block_hash(
-            &mut self,
-            _number: Word,
-        ) -> impl Future<Output = Result<Option<B256>, Self::Error>> + '_ {
-            core::future::ready(Ok(None))
+        async fn get_block_hash(&mut self, _number: Word) -> Result<Option<B256>, Self::Error> {
+            Ok(None)
         }
     }
 
     struct PendingStorage<'a> {
-        db: &'a mut PendingDb,
+        pending: &'a mut bool,
     }
 
     impl Future for PendingStorage<'_> {
-        type Output = Result<Word, Infallible>;
+        type Output = ();
 
         fn poll(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
-            if self.db.pending {
-                self.db.pending = false;
+            if *self.pending {
+                *self.pending = false;
                 Poll::Pending
             } else {
-                Poll::Ready(Ok(Word::from(9)))
+                Poll::Ready(())
             }
         }
     }
@@ -615,34 +723,60 @@ mod tests {
     impl AsyncDatabase for FailingDb {
         type Error = TestError;
 
-        fn get_account(
+        async fn get_account(
             &mut self,
             _address: Address,
-        ) -> impl Future<Output = Result<Option<crate::evm::AccountInfo>, Self::Error>> + '_
-        {
-            core::future::ready(Ok(None))
+        ) -> Result<Option<crate::evm::AccountInfo>, Self::Error> {
+            Ok(None)
         }
 
-        fn get_code_by_hash(
-            &mut self,
-            _code_hash: B256,
-        ) -> impl Future<Output = Result<Bytecode, Self::Error>> + '_ {
-            core::future::ready(Ok(Bytecode::default()))
+        async fn get_code_by_hash(&mut self, _code_hash: B256) -> Result<Bytecode, Self::Error> {
+            Ok(Bytecode::default())
         }
 
-        fn get_storage(
+        async fn get_storage(
             &mut self,
             _address: Address,
             _key: Word,
-        ) -> impl Future<Output = Result<Word, Self::Error>> + '_ {
-            core::future::ready(Err(TestError))
+        ) -> Result<Word, Self::Error> {
+            Err(TestError)
         }
 
-        fn get_block_hash(
+        async fn get_block_hash(&mut self, _number: Word) -> Result<Option<B256>, Self::Error> {
+            Ok(None)
+        }
+    }
+
+    struct TokioDb;
+
+    impl AsyncDatabase for TokioDb {
+        type Error = Infallible;
+
+        async fn get_account(
             &mut self,
-            _number: Word,
-        ) -> impl Future<Output = Result<Option<B256>, Self::Error>> + '_ {
-            core::future::ready(Ok(None))
+            _address: Address,
+        ) -> Result<Option<crate::evm::AccountInfo>, Self::Error> {
+            tokio::task::yield_now().await;
+            Ok(None)
+        }
+
+        async fn get_code_by_hash(&mut self, _code_hash: B256) -> Result<Bytecode, Self::Error> {
+            tokio::task::yield_now().await;
+            Ok(Bytecode::default())
+        }
+
+        async fn get_storage(
+            &mut self,
+            _address: Address,
+            _key: Word,
+        ) -> Result<Word, Self::Error> {
+            tokio::task::yield_now().await;
+            Ok(Word::from(9))
+        }
+
+        async fn get_block_hash(&mut self, _number: Word) -> Result<Option<B256>, Self::Error> {
+            tokio::task::yield_now().await;
+            Ok(None)
         }
     }
 

--- a/crates/evm2/src/async_.rs
+++ b/crates/evm2/src/async_.rs
@@ -238,12 +238,20 @@ where
 {
     let mut future = core::pin::pin!(future);
     loop {
-        if with_current(|current| current.is_cancelled())? {
-            return Err(AsyncError::Cancelled);
-        }
-        match with_current(|current| future.as_mut().poll(current.context()))? {
+        match with_current(|current| {
+            if current.is_cancelled() {
+                return Err(AsyncError::Cancelled);
+            }
+            match future.as_mut().poll(current.context()) {
+                Poll::Ready(value) => Ok(Poll::Ready(value)),
+                Poll::Pending => {
+                    current.suspend()?;
+                    Ok(Poll::Pending)
+                }
+            }
+        })?? {
             Poll::Ready(value) => return Ok(value),
-            Poll::Pending => with_current(|current| current.suspend())??,
+            Poll::Pending => {}
         }
     }
 }

--- a/crates/evm2/src/async_.rs
+++ b/crates/evm2/src/async_.rs
@@ -16,7 +16,7 @@ use core::{
     any::Any, fmt, future::Future, marker::PhantomData, pin::Pin, ptr::NonNull, task::Poll,
 };
 use corosensei::{Coroutine, CoroutineResult, Yielder, stack::DefaultStack};
-use std::{cell::Cell, error::Error, task::Context};
+use std::{cell::Cell, error::Error, io, task::Context};
 use tokio::{
     runtime::{Handle, Runtime},
     task,
@@ -44,20 +44,20 @@ pub enum AsyncError<E = core::convert::Infallible> {
     /// An async host operation was called outside an async EVM fiber.
     #[error("async host operation requires EVM async fiber execution")]
     NotOnFiber,
-    /// Blocking async I/O was requested outside a supported Tokio runtime.
-    #[error("async host operation requires a Tokio multi-thread runtime")]
-    Runtime,
+    /// Async fiber runtime setup failed.
+    #[error(transparent)]
+    Runtime(io::Error),
     /// The wrapped operation returned an error.
     #[error(transparent)]
     Inner(#[from] E),
 }
 
 impl AsyncError {
-    const fn with_inner_error<E>(self) -> AsyncError<E> {
+    fn with_inner_error<E>(self) -> AsyncError<E> {
         match self {
             Self::Cancelled => AsyncError::Cancelled,
             Self::NotOnFiber => AsyncError::NotOnFiber,
-            Self::Runtime => AsyncError::Runtime,
+            Self::Runtime(error) => AsyncError::Runtime(error),
             Self::Inner(error) => match error {},
         }
     }
@@ -186,7 +186,7 @@ unsafe impl<R: Send> Send for FiberFuture<'_, R> {}
 
 impl<'a, R> FiberFuture<'a, R> {
     fn new(stack_size: usize, func: impl FnOnce() -> R + 'a) -> AsyncResult<Self> {
-        let stack = DefaultStack::new(stack_size).map_err(fiber_error)?;
+        let stack = DefaultStack::new(stack_size).map_err(AsyncError::Runtime)?;
         let body = move |suspend: &Yielder<Resume, Yield>, resume| {
             let future_cx = resume?;
             let mut current = CurrentFiber {
@@ -325,7 +325,9 @@ where
     match mode {
         IoMode::Blocking => {
             let Some(runtime) = runtime else {
-                return Err(AsyncError::Runtime);
+                return Err(AsyncError::Runtime(io::Error::other(
+                    "async host operation requires a Tokio multi-thread runtime",
+                )));
             };
             Ok(runtime.block_on(future))
         }
@@ -368,10 +370,6 @@ unsafe fn erase_current_fiber_lifetime<'a>(
     unsafe {
         core::mem::transmute::<NonNull<CurrentFiber<'a>>, NonNull<CurrentFiber<'static>>>(fiber)
     }
-}
-
-fn fiber_error(_error: impl fmt::Display) -> AsyncError {
-    AsyncError::Runtime
 }
 
 /// Asynchronous backing database implementation.

--- a/crates/evm2/src/async_.rs
+++ b/crates/evm2/src/async_.rs
@@ -10,10 +10,7 @@ use crate::{
     evm::{AccountInfo, DatabaseCommit, DbErrorCode, DbResult, DynDatabase, StateChanges},
     interpreter::Word,
 };
-use alloc::{
-    boxed::Box,
-    string::{String, ToString},
-};
+use alloc::boxed::Box;
 use alloy_primitives::{Address, B256};
 use core::{any::Any, fmt, future::Future, pin::Pin, ptr::NonNull, task::Poll};
 use std::{cell::Cell, error::Error, task::Context};
@@ -43,27 +40,23 @@ pub enum AsyncError<E = core::convert::Infallible> {
     /// The async EVM fiber was cancelled before execution completed.
     #[error("async EVM execution was cancelled")]
     Cancelled,
-    /// A fiber stack or fiber could not be created.
-    #[error("failed to create EVM async fiber: {0}")]
-    Fiber(String),
     /// An async host operation was called outside an async EVM fiber.
     #[error("async host operation requires EVM async fiber execution")]
     NotOnFiber,
     /// Blocking async I/O was requested outside a supported Tokio runtime.
-    #[error("async host operation requires a Tokio multi-thread runtime: {0}")]
-    Runtime(String),
+    #[error("async host operation requires a Tokio multi-thread runtime")]
+    Runtime,
     /// The wrapped operation returned an error.
     #[error(transparent)]
     Inner(#[from] E),
 }
 
 impl AsyncError {
-    fn with_inner_error<E>(self) -> AsyncError<E> {
+    const fn with_inner_error<E>(self) -> AsyncError<E> {
         match self {
             Self::Cancelled => AsyncError::Cancelled,
-            Self::Fiber(error) => AsyncError::Fiber(error),
             Self::NotOnFiber => AsyncError::NotOnFiber,
-            Self::Runtime(error) => AsyncError::Runtime(error),
+            Self::Runtime => AsyncError::Runtime,
             Self::Inner(error) => match error {},
         }
     }
@@ -267,12 +260,12 @@ impl<R> Drop for FiberFuture<'_, R> {
 /// Polls `future` to completion from inside an async EVM fiber.
 ///
 /// If `future` returns `Poll::Pending`, the current EVM fiber is suspended and the outer
-/// [`on_fiber`] future returns `Poll::Pending`. When the executor wakes and polls the outer future
+/// async EVM future returns `Poll::Pending`. When the executor wakes and polls the outer future
 /// again, the EVM fiber resumes and continues polling `future`.
 ///
 /// # Errors
 ///
-/// Returns [`AsyncError::NotOnFiber`] if called outside [`on_fiber`], or
+/// Returns [`AsyncError::NotOnFiber`] if called outside async EVM execution, or
 /// [`AsyncError::Cancelled`] if the outer async EVM execution was dropped.
 pub(crate) fn block_on_current<F>(future: F) -> AsyncResult<F::Output>
 where
@@ -355,9 +348,7 @@ where
     match mode {
         IoMode::Blocking => {
             let Some(runtime) = runtime else {
-                return Err(AsyncError::Runtime(
-                    "blocking async host operation requires a Tokio runtime handle".to_string(),
-                ));
+                return Err(AsyncError::Runtime);
             };
             Ok(runtime.block_on(future))
         }
@@ -402,8 +393,8 @@ unsafe fn erase_current_fiber_lifetime<'a>(
     }
 }
 
-fn fiber_error(error: impl fmt::Display) -> AsyncError {
-    AsyncError::Fiber(error.to_string())
+fn fiber_error(_error: impl fmt::Display) -> AsyncError {
+    AsyncError::Runtime
 }
 
 /// Asynchronous backing database implementation.

--- a/crates/evm2/src/async_.rs
+++ b/crates/evm2/src/async_.rs
@@ -882,34 +882,27 @@ mod tests {
     impl AsyncDatabase for TestDb {
         type Error = Infallible;
 
-        fn get_account(
+        async fn get_account(
             &mut self,
             _address: Address,
-        ) -> impl Future<Output = Result<Option<crate::evm::AccountInfo>, Self::Error>> + Send + '_
-        {
-            core::future::ready(Ok(None))
+        ) -> Result<Option<crate::evm::AccountInfo>, Self::Error> {
+            Ok(None)
         }
 
-        fn get_code_by_hash(
-            &mut self,
-            _code_hash: B256,
-        ) -> impl Future<Output = Result<Bytecode, Self::Error>> + Send + '_ {
-            core::future::ready(Ok(Bytecode::default()))
+        async fn get_code_by_hash(&mut self, _code_hash: B256) -> Result<Bytecode, Self::Error> {
+            Ok(Bytecode::default())
         }
 
-        fn get_storage(
+        async fn get_storage(
             &mut self,
             _address: Address,
             _key: Word,
-        ) -> impl Future<Output = Result<Word, Self::Error>> + Send + '_ {
-            core::future::ready(Ok(Word::from(9)))
+        ) -> Result<Word, Self::Error> {
+            Ok(Word::from(9))
         }
 
-        fn get_block_hash(
-            &mut self,
-            _number: Word,
-        ) -> impl Future<Output = Result<Option<B256>, Self::Error>> + Send + '_ {
-            core::future::ready(Ok(None))
+        async fn get_block_hash(&mut self, _number: Word) -> Result<Option<B256>, Self::Error> {
+            Ok(None)
         }
     }
 
@@ -920,34 +913,28 @@ mod tests {
     impl AsyncDatabase for PendingDb {
         type Error = Infallible;
 
-        fn get_account(
+        async fn get_account(
             &mut self,
             _address: Address,
-        ) -> impl Future<Output = Result<Option<crate::evm::AccountInfo>, Self::Error>> + Send + '_
-        {
-            core::future::ready(Ok(None))
+        ) -> Result<Option<crate::evm::AccountInfo>, Self::Error> {
+            Ok(None)
         }
 
-        fn get_code_by_hash(
-            &mut self,
-            _code_hash: B256,
-        ) -> impl Future<Output = Result<Bytecode, Self::Error>> + Send + '_ {
-            core::future::ready(Ok(Bytecode::default()))
+        async fn get_code_by_hash(&mut self, _code_hash: B256) -> Result<Bytecode, Self::Error> {
+            Ok(Bytecode::default())
         }
 
-        fn get_storage(
+        async fn get_storage(
             &mut self,
             _address: Address,
             _key: Word,
-        ) -> impl Future<Output = Result<Word, Self::Error>> + Send + '_ {
-            PendingStorage { pending: &mut self.pending }
+        ) -> Result<Word, Self::Error> {
+            PendingStorage { pending: &mut self.pending }.await;
+            Ok(Word::from(9))
         }
 
-        fn get_block_hash(
-            &mut self,
-            _number: Word,
-        ) -> impl Future<Output = Result<Option<B256>, Self::Error>> + Send + '_ {
-            core::future::ready(Ok(None))
+        async fn get_block_hash(&mut self, _number: Word) -> Result<Option<B256>, Self::Error> {
+            Ok(None)
         }
     }
 
@@ -956,14 +943,14 @@ mod tests {
     }
 
     impl Future for PendingStorage<'_> {
-        type Output = Result<Word, Infallible>;
+        type Output = ();
 
         fn poll(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
             if *self.pending {
                 *self.pending = false;
                 Poll::Pending
             } else {
-                Poll::Ready(Ok(Word::from(9)))
+                Poll::Ready(())
             }
         }
     }
@@ -973,59 +960,27 @@ mod tests {
     impl AsyncDatabase for FailingDb {
         type Error = TestError;
 
-        fn get_account(
+        async fn get_account(
             &mut self,
             _address: Address,
-        ) -> impl Future<Output = Result<Option<crate::evm::AccountInfo>, Self::Error>> + Send + '_
-        {
-            core::future::ready(Ok(None))
+        ) -> Result<Option<crate::evm::AccountInfo>, Self::Error> {
+            Ok(None)
         }
 
-        fn get_code_by_hash(
-            &mut self,
-            _code_hash: B256,
-        ) -> impl Future<Output = Result<Bytecode, Self::Error>> + Send + '_ {
-            core::future::ready(Ok(Bytecode::default()))
+        async fn get_code_by_hash(&mut self, _code_hash: B256) -> Result<Bytecode, Self::Error> {
+            Ok(Bytecode::default())
         }
 
-        fn get_storage(
+        async fn get_storage(
             &mut self,
             _address: Address,
             _key: Word,
-        ) -> impl Future<Output = Result<Word, Self::Error>> + Send + '_ {
-            core::future::ready(Err(TestError))
+        ) -> Result<Word, Self::Error> {
+            Err(TestError)
         }
 
-        fn get_block_hash(
-            &mut self,
-            _number: Word,
-        ) -> impl Future<Output = Result<Option<B256>, Self::Error>> + Send + '_ {
-            core::future::ready(Ok(None))
-        }
-    }
-
-    struct YieldOnce<T> {
-        value: Option<T>,
-        pending: bool,
-    }
-
-    impl<T> YieldOnce<T> {
-        fn new(value: T) -> Self {
-            Self { value: Some(value), pending: true }
-        }
-    }
-
-    impl<T: Unpin> Future for YieldOnce<T> {
-        type Output = T;
-
-        fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-            if self.pending {
-                self.pending = false;
-                cx.waker().wake_by_ref();
-                Poll::Pending
-            } else {
-                Poll::Ready(self.value.take().expect("yield future polled after completion"))
-            }
+        async fn get_block_hash(&mut self, _number: Word) -> Result<Option<B256>, Self::Error> {
+            Ok(None)
         }
     }
 
@@ -1034,34 +989,31 @@ mod tests {
     impl AsyncDatabase for TokioDb {
         type Error = Infallible;
 
-        fn get_account(
+        async fn get_account(
             &mut self,
             _address: Address,
-        ) -> impl Future<Output = Result<Option<crate::evm::AccountInfo>, Self::Error>> + Send + '_
-        {
-            YieldOnce::new(Ok(None))
+        ) -> Result<Option<crate::evm::AccountInfo>, Self::Error> {
+            tokio::task::yield_now().await;
+            Ok(None)
         }
 
-        fn get_code_by_hash(
-            &mut self,
-            _code_hash: B256,
-        ) -> impl Future<Output = Result<Bytecode, Self::Error>> + Send + '_ {
-            YieldOnce::new(Ok(Bytecode::default()))
+        async fn get_code_by_hash(&mut self, _code_hash: B256) -> Result<Bytecode, Self::Error> {
+            tokio::task::yield_now().await;
+            Ok(Bytecode::default())
         }
 
-        fn get_storage(
+        async fn get_storage(
             &mut self,
             _address: Address,
             _key: Word,
-        ) -> impl Future<Output = Result<Word, Self::Error>> + Send + '_ {
-            YieldOnce::new(Ok(Word::from(9)))
+        ) -> Result<Word, Self::Error> {
+            tokio::task::yield_now().await;
+            Ok(Word::from(9))
         }
 
-        fn get_block_hash(
-            &mut self,
-            _number: Word,
-        ) -> impl Future<Output = Result<Option<B256>, Self::Error>> + Send + '_ {
-            YieldOnce::new(Ok(None))
+        async fn get_block_hash(&mut self, _number: Word) -> Result<Option<B256>, Self::Error> {
+            tokio::task::yield_now().await;
+            Ok(None)
         }
     }
 

--- a/crates/evm2/src/evm/db.rs
+++ b/crates/evm2/src/evm/db.rs
@@ -124,7 +124,7 @@ impl<T: Database + DatabaseCommit> DatabaseCommit for Db<T> {
 }
 
 #[inline]
-fn stored_error_code() -> DbErrorCode {
+pub(crate) fn stored_error_code() -> DbErrorCode {
     match DbErrorCode::new(1) {
         Some(code) => code,
         None => unreachable!("stored database error code is non-zero"),
@@ -141,6 +141,11 @@ impl fmt::Display for DbErrorUnavailable {
 }
 
 impl Error for DbErrorUnavailable {}
+
+#[inline]
+pub(crate) fn db_error_unavailable(code: DbErrorCode) -> Box<dyn Error + Send> {
+    Box::new(DbErrorUnavailable(code))
+}
 
 impl<T: Database> DynDatabase for Db<T> {
     #[inline]
@@ -170,7 +175,7 @@ impl<T: Database> DynDatabase for Db<T> {
         {
             return Box::new(err);
         }
-        Box::new(DbErrorUnavailable(code))
+        db_error_unavailable(code)
     }
 }
 
@@ -190,7 +195,7 @@ pub trait DynDatabase: Any + Send {
 
     /// Retrieves the full error for a previously returned error code.
     fn error(&mut self, code: DbErrorCode) -> Box<dyn Error + Send> {
-        Box::new(DbErrorUnavailable(code))
+        db_error_unavailable(code)
     }
 
     /// Sets the asynchronous database I/O mode, if supported by this database.

--- a/crates/evm2/src/evm/db.rs
+++ b/crates/evm2/src/evm/db.rs
@@ -197,13 +197,6 @@ pub trait DynDatabase: Any + Send {
     fn error(&mut self, code: DbErrorCode) -> Box<dyn Error + Send> {
         db_error_unavailable(code)
     }
-
-    /// Sets the asynchronous database I/O mode, if supported by this database.
-    ///
-    /// Currently unused unless the `"async"` feature is enabled.
-    fn set_io_mode(&mut self, _io_mode: crate::IoMode) -> bool {
-        false
-    }
 }
 
 impl DynDatabase for Box<dyn DynDatabase> {
@@ -230,11 +223,6 @@ impl DynDatabase for Box<dyn DynDatabase> {
     #[inline]
     fn error(&mut self, code: DbErrorCode) -> Box<dyn Error + Send> {
         self.as_mut().error(code)
-    }
-
-    #[inline]
-    fn set_io_mode(&mut self, io_mode: crate::IoMode) -> bool {
-        self.as_mut().set_io_mode(io_mode)
     }
 }
 

--- a/crates/evm2/src/evm/db.rs
+++ b/crates/evm2/src/evm/db.rs
@@ -199,6 +199,22 @@ pub trait DynDatabase: Any + Send {
     }
 }
 
+impl core::ops::Deref for dyn DynDatabase + '_ {
+    type Target = dyn Any;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        self
+    }
+}
+
+impl core::ops::DerefMut for dyn DynDatabase + '_ {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self
+    }
+}
+
 impl DynDatabase for Box<dyn DynDatabase> {
     #[inline]
     fn get_account(&mut self, address: &Address) -> DbResult<Option<AccountInfo>> {

--- a/crates/evm2/src/evm/db.rs
+++ b/crates/evm2/src/evm/db.rs
@@ -48,9 +48,9 @@ impl DbErrorCode {
 pub type DbResult<T> = Result<T, DbErrorCode>;
 
 /// Backing database implementation with a concrete error type.
-pub trait Database: Any {
+pub trait Database: Any + Send {
     /// Database error type.
-    type Error: Error + 'static;
+    type Error: Error + Send + 'static;
 
     /// Loads account information.
     fn get_account(&mut self, address: &Address) -> Result<Option<AccountInfo>, Self::Error>;
@@ -164,7 +164,7 @@ impl<T: Database> DynDatabase for Db<T> {
     }
 
     #[inline]
-    fn error(&mut self, code: DbErrorCode) -> Box<dyn Error> {
+    fn error(&mut self, code: DbErrorCode) -> Box<dyn Error + Send> {
         if code == stored_error_code()
             && let Some(err) = self.result.take()
         {
@@ -175,7 +175,7 @@ impl<T: Database> DynDatabase for Db<T> {
 }
 
 /// Backing database view used to initialize mutable [`super::State`].
-pub trait DynDatabase: Any {
+pub trait DynDatabase: Any + Send {
     /// Loads account information.
     fn get_account(&mut self, address: &Address) -> DbResult<Option<AccountInfo>>;
 
@@ -189,8 +189,14 @@ pub trait DynDatabase: Any {
     fn get_block_hash(&mut self, number: &Word) -> DbResult<Option<B256>>;
 
     /// Retrieves the full error for a previously returned error code.
-    fn error(&mut self, code: DbErrorCode) -> Box<dyn Error> {
+    fn error(&mut self, code: DbErrorCode) -> Box<dyn Error + Send> {
         Box::new(DbErrorUnavailable(code))
+    }
+
+    /// Sets the asynchronous database I/O mode, if supported by this database.
+    #[cfg(feature = "async")]
+    fn set_io_mode(&mut self, _io_mode: crate::IoMode) -> bool {
+        false
     }
 }
 
@@ -216,8 +222,14 @@ impl DynDatabase for Box<dyn DynDatabase> {
     }
 
     #[inline]
-    fn error(&mut self, code: DbErrorCode) -> Box<dyn Error> {
+    fn error(&mut self, code: DbErrorCode) -> Box<dyn Error + Send> {
         self.as_mut().error(code)
+    }
+
+    #[cfg(feature = "async")]
+    #[inline]
+    fn set_io_mode(&mut self, io_mode: crate::IoMode) -> bool {
+        self.as_mut().set_io_mode(io_mode)
     }
 }
 

--- a/crates/evm2/src/evm/db.rs
+++ b/crates/evm2/src/evm/db.rs
@@ -194,7 +194,8 @@ pub trait DynDatabase: Any + Send {
     }
 
     /// Sets the asynchronous database I/O mode, if supported by this database.
-    #[cfg(feature = "async")]
+    ///
+    /// Currently unused unless the `"async"` feature is enabled.
     fn set_io_mode(&mut self, _io_mode: crate::IoMode) -> bool {
         false
     }
@@ -226,7 +227,6 @@ impl DynDatabase for Box<dyn DynDatabase> {
         self.as_mut().error(code)
     }
 
-    #[cfg(feature = "async")]
     #[inline]
     fn set_io_mode(&mut self, io_mode: crate::IoMode) -> bool {
         self.as_mut().set_io_mode(io_mode)

--- a/crates/evm2/src/evm/db/cache.rs
+++ b/crates/evm2/src/evm/db/cache.rs
@@ -205,11 +205,6 @@ impl<ExtDB: DynDatabase> DynDatabase for CacheDB<ExtDB> {
     fn error(&mut self, code: DbErrorCode) -> alloc::boxed::Box<dyn core::error::Error + Send> {
         self.db.error(code)
     }
-
-    #[inline]
-    fn set_io_mode(&mut self, io_mode: crate::IoMode) -> bool {
-        self.db.set_io_mode(io_mode)
-    }
 }
 
 #[cfg(test)]

--- a/crates/evm2/src/evm/db/cache.rs
+++ b/crates/evm2/src/evm/db/cache.rs
@@ -206,7 +206,6 @@ impl<ExtDB: DynDatabase> DynDatabase for CacheDB<ExtDB> {
         self.db.error(code)
     }
 
-    #[cfg(feature = "async")]
     #[inline]
     fn set_io_mode(&mut self, io_mode: crate::IoMode) -> bool {
         self.db.set_io_mode(io_mode)

--- a/crates/evm2/src/evm/db/cache.rs
+++ b/crates/evm2/src/evm/db/cache.rs
@@ -202,8 +202,14 @@ impl<ExtDB: DynDatabase> DynDatabase for CacheDB<ExtDB> {
     }
 
     #[inline]
-    fn error(&mut self, code: DbErrorCode) -> alloc::boxed::Box<dyn core::error::Error> {
+    fn error(&mut self, code: DbErrorCode) -> alloc::boxed::Box<dyn core::error::Error + Send> {
         self.db.error(code)
+    }
+
+    #[cfg(feature = "async")]
+    #[inline]
+    fn set_io_mode(&mut self, io_mode: crate::IoMode) -> bool {
+        self.db.set_io_mode(io_mode)
     }
 }
 

--- a/crates/evm2/src/evm/inspector.rs
+++ b/crates/evm2/src/evm/inspector.rs
@@ -74,11 +74,13 @@ pub trait Inspector<T: EvmTypes>: Any + Send {
 mod tests {
     use super::Inspector;
     use crate::{
-        BaseEvmConfigSelector, ExecutionConfig, SpecId,
+        BaseEvmConfigSelector, BaseEvmTypes, Evm, ExecutionConfig, Precompiles, SYSTEM_ADDRESS,
+        SpecId,
         bytecode::Bytecode,
         constants::CALL_DEPTH_LIMIT,
-        env::TxEnv,
-        evm::SelfDestructResult,
+        env::{BlockEnv, TxEnv},
+        ethereum::{RecoveredTxEnvelope, ethereum_tx_registry},
+        evm::{AccountInfo, InMemoryDB, SelfDestructResult},
         interpreter::{
             GasTracker, InstrStop, Interpreter, Message, MessageResult, Word,
             instructions::tests::{TestHost, TestTypes, push},
@@ -86,23 +88,9 @@ mod tests {
         },
         utils::address_to_word,
     };
-    #[cfg(feature = "std")]
-    use crate::{
-        BaseEvmTypes, Evm, Precompiles, SYSTEM_ADDRESS,
-        env::BlockEnv,
-        ethereum::{RecoveredTxEnvelope, ethereum_tx_registry},
-        evm::{AccountInfo, InMemoryDB},
-    };
-    #[cfg(feature = "std")]
-    use alloc::sync::Arc;
-    use alloc::vec::Vec;
-    #[cfg(feature = "std")]
+    use alloc::{sync::Arc, vec::Vec};
     use alloy_consensus::{TxLegacy, transaction::Recovered};
-    use alloy_primitives::{Address, Bytes, Log};
-    #[cfg(feature = "std")]
-    use alloy_primitives::{TxKind, U256};
-    #[cfg(feature = "std")]
-    use std::sync::Mutex;
+    use alloy_primitives::{Address, Bytes, Log, TxKind, U256};
 
     #[derive(Default)]
     struct StepInspector {
@@ -334,7 +322,6 @@ mod tests {
     }
 
     #[derive(Default)]
-    #[cfg(feature = "std")]
     struct E2eState {
         initialized: usize,
         steps: usize,
@@ -344,32 +331,33 @@ mod tests {
         creates: usize,
     }
 
-    #[cfg(feature = "std")]
-    struct SharedE2eInspector(Arc<Mutex<E2eState>>);
+    #[derive(Default)]
+    struct SharedE2eInspector {
+        state: Arc<E2eState>,
+    }
 
-    #[cfg(feature = "std")]
     impl Inspector<BaseEvmTypes> for SharedE2eInspector {
         fn initialize_interp(&mut self, _interp: &mut Interpreter<'_, BaseEvmTypes>) {
-            self.0.lock().unwrap().initialized += 1;
+            Arc::get_mut(&mut self.state).unwrap().initialized += 1;
         }
 
         fn step(&mut self, _interp: &mut Interpreter<'_, BaseEvmTypes>) {
-            self.0.lock().unwrap().steps += 1;
+            Arc::get_mut(&mut self.state).unwrap().steps += 1;
         }
 
         fn step_end(&mut self, _interp: &mut Interpreter<'_, BaseEvmTypes>) {
-            self.0.lock().unwrap().step_ends += 1;
+            Arc::get_mut(&mut self.state).unwrap().step_ends += 1;
         }
 
         fn log(&mut self, log: &Log) {
-            self.0.lock().unwrap().logs.push(log.clone());
+            Arc::get_mut(&mut self.state).unwrap().logs.push(log.clone());
         }
 
         fn call(
             &mut self,
             _message: &mut Message<BaseEvmTypes>,
         ) -> Option<MessageResult<BaseEvmTypes>> {
-            self.0.lock().unwrap().calls += 1;
+            Arc::get_mut(&mut self.state).unwrap().calls += 1;
             None
         }
 
@@ -377,7 +365,7 @@ mod tests {
             &mut self,
             _message: &mut Message<BaseEvmTypes>,
         ) -> Option<MessageResult<BaseEvmTypes>> {
-            self.0.lock().unwrap().creates += 1;
+            Arc::get_mut(&mut self.state).unwrap().creates += 1;
             None
         }
     }
@@ -776,7 +764,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "std")]
     fn evm_transaction_inspects_interpreter_steps_and_logs() {
         let caller = Address::from([0xaa; 20]);
         let contract = Address::from([0xbb; 20]);
@@ -801,15 +788,17 @@ mod tests {
             database,
             Precompiles::base(SpecId::OSAKA),
         );
-        let state = Arc::new(Mutex::new(E2eState::default()));
-        evm.set_inspector(SharedE2eInspector(Arc::clone(&state)));
+        evm.set_inspector(SharedE2eInspector::default());
         let tx = RecoveredTxEnvelope::Legacy(Recovered::new_unchecked(
             TxLegacy { to: TxKind::Call(contract), gas_limit: 100_000, ..Default::default() },
             caller,
         ));
 
         let result = evm.transact(&tx).unwrap();
-        let state = state.lock().unwrap();
+        let inspector = (evm.inspector().unwrap() as &dyn core::any::Any)
+            .downcast_ref::<SharedE2eInspector>()
+            .unwrap();
+        let state = &inspector.state;
 
         assert!(result.status);
         assert_eq!(state.initialized, 1);
@@ -822,7 +811,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "std")]
     fn evm_transaction_inspects_eip7708_transfer_log() {
         let caller = Address::from([0xaa; 20]);
         let target = Address::from([0xbb; 20]);
@@ -838,8 +826,7 @@ mod tests {
             database,
             Precompiles::base(SpecId::AMSTERDAM),
         );
-        let state = Arc::new(Mutex::new(E2eState::default()));
-        evm.set_inspector(SharedE2eInspector(Arc::clone(&state)));
+        evm.set_inspector(SharedE2eInspector::default());
         let tx = RecoveredTxEnvelope::Legacy(Recovered::new_unchecked(
             TxLegacy {
                 to: TxKind::Call(target),
@@ -851,7 +838,10 @@ mod tests {
         ));
 
         let result = evm.transact(&tx).unwrap();
-        let state = state.lock().unwrap();
+        let inspector = (evm.inspector().unwrap() as &dyn core::any::Any)
+            .downcast_ref::<SharedE2eInspector>()
+            .unwrap();
+        let state = &inspector.state;
 
         assert!(result.status);
         assert_eq!(result.state_changes.logs.len(), 1);
@@ -860,7 +850,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "std")]
     fn evm_create_transaction_initializes_interpreter_without_create_hook() {
         let caller = Address::from([0xaa; 20]);
         let mut database = InMemoryDB::default();
@@ -875,8 +864,7 @@ mod tests {
             database,
             Precompiles::base(SpecId::OSAKA),
         );
-        let state = Arc::new(Mutex::new(E2eState::default()));
-        evm.set_inspector(SharedE2eInspector(Arc::clone(&state)));
+        evm.set_inspector(SharedE2eInspector::default());
         let tx = RecoveredTxEnvelope::Legacy(Recovered::new_unchecked(
             TxLegacy {
                 to: TxKind::Create,
@@ -888,7 +876,10 @@ mod tests {
         ));
 
         let result = evm.transact(&tx).unwrap();
-        let state = state.lock().unwrap();
+        let inspector = (evm.inspector().unwrap() as &dyn core::any::Any)
+            .downcast_ref::<SharedE2eInspector>()
+            .unwrap();
+        let state = &inspector.state;
 
         assert!(result.status);
         assert_eq!(state.initialized, 1);

--- a/crates/evm2/src/evm/inspector.rs
+++ b/crates/evm2/src/evm/inspector.rs
@@ -8,7 +8,7 @@ use alloy_primitives::{Address, Log, U256};
 use core::any::Any;
 
 /// EVM execution inspector.
-pub trait Inspector<T: EvmTypes>: Any {
+pub trait Inspector<T: EvmTypes>: Any + Send {
     /// Called after a frame interpreter has been initialized.
     #[inline]
     fn initialize_interp(&mut self, interp: &mut Interpreter<'_, T>) {
@@ -88,10 +88,10 @@ mod tests {
         },
         utils::address_to_word,
     };
-    use alloc::{rc::Rc, vec::Vec};
+    use alloc::{sync::Arc, vec::Vec};
     use alloy_consensus::{TxLegacy, transaction::Recovered};
     use alloy_primitives::{Address, Bytes, Log, TxKind, U256};
-    use core::cell::RefCell;
+    use std::sync::Mutex;
 
     #[derive(Default)]
     struct StepInspector {
@@ -332,30 +332,30 @@ mod tests {
         creates: usize,
     }
 
-    struct SharedE2eInspector(Rc<RefCell<E2eState>>);
+    struct SharedE2eInspector(Arc<Mutex<E2eState>>);
 
     impl Inspector<BaseEvmTypes> for SharedE2eInspector {
         fn initialize_interp(&mut self, _interp: &mut Interpreter<'_, BaseEvmTypes>) {
-            self.0.borrow_mut().initialized += 1;
+            self.0.lock().unwrap().initialized += 1;
         }
 
         fn step(&mut self, _interp: &mut Interpreter<'_, BaseEvmTypes>) {
-            self.0.borrow_mut().steps += 1;
+            self.0.lock().unwrap().steps += 1;
         }
 
         fn step_end(&mut self, _interp: &mut Interpreter<'_, BaseEvmTypes>) {
-            self.0.borrow_mut().step_ends += 1;
+            self.0.lock().unwrap().step_ends += 1;
         }
 
         fn log(&mut self, log: &Log) {
-            self.0.borrow_mut().logs.push(log.clone());
+            self.0.lock().unwrap().logs.push(log.clone());
         }
 
         fn call(
             &mut self,
             _message: &mut Message<BaseEvmTypes>,
         ) -> Option<MessageResult<BaseEvmTypes>> {
-            self.0.borrow_mut().calls += 1;
+            self.0.lock().unwrap().calls += 1;
             None
         }
 
@@ -363,7 +363,7 @@ mod tests {
             &mut self,
             _message: &mut Message<BaseEvmTypes>,
         ) -> Option<MessageResult<BaseEvmTypes>> {
-            self.0.borrow_mut().creates += 1;
+            self.0.lock().unwrap().creates += 1;
             None
         }
     }
@@ -786,15 +786,15 @@ mod tests {
             database,
             Precompiles::base(SpecId::OSAKA),
         );
-        let state = Rc::new(RefCell::new(E2eState::default()));
-        evm.set_inspector(SharedE2eInspector(Rc::clone(&state)));
+        let state = Arc::new(Mutex::new(E2eState::default()));
+        evm.set_inspector(SharedE2eInspector(Arc::clone(&state)));
         let tx = RecoveredTxEnvelope::Legacy(Recovered::new_unchecked(
             TxLegacy { to: TxKind::Call(contract), gas_limit: 100_000, ..Default::default() },
             caller,
         ));
 
         let result = evm.transact(&tx).unwrap();
-        let state = state.borrow();
+        let state = state.lock().unwrap();
 
         assert!(result.status);
         assert_eq!(state.initialized, 1);
@@ -822,8 +822,8 @@ mod tests {
             database,
             Precompiles::base(SpecId::AMSTERDAM),
         );
-        let state = Rc::new(RefCell::new(E2eState::default()));
-        evm.set_inspector(SharedE2eInspector(Rc::clone(&state)));
+        let state = Arc::new(Mutex::new(E2eState::default()));
+        evm.set_inspector(SharedE2eInspector(Arc::clone(&state)));
         let tx = RecoveredTxEnvelope::Legacy(Recovered::new_unchecked(
             TxLegacy {
                 to: TxKind::Call(target),
@@ -835,7 +835,7 @@ mod tests {
         ));
 
         let result = evm.transact(&tx).unwrap();
-        let state = state.borrow();
+        let state = state.lock().unwrap();
 
         assert!(result.status);
         assert_eq!(result.state_changes.logs.len(), 1);
@@ -858,8 +858,8 @@ mod tests {
             database,
             Precompiles::base(SpecId::OSAKA),
         );
-        let state = Rc::new(RefCell::new(E2eState::default()));
-        evm.set_inspector(SharedE2eInspector(Rc::clone(&state)));
+        let state = Arc::new(Mutex::new(E2eState::default()));
+        evm.set_inspector(SharedE2eInspector(Arc::clone(&state)));
         let tx = RecoveredTxEnvelope::Legacy(Recovered::new_unchecked(
             TxLegacy {
                 to: TxKind::Create,
@@ -871,7 +871,7 @@ mod tests {
         ));
 
         let result = evm.transact(&tx).unwrap();
-        let state = state.borrow();
+        let state = state.lock().unwrap();
 
         assert!(result.status);
         assert_eq!(state.initialized, 1);

--- a/crates/evm2/src/evm/inspector.rs
+++ b/crates/evm2/src/evm/inspector.rs
@@ -70,6 +70,22 @@ pub trait Inspector<T: EvmTypes>: Any + Send {
     }
 }
 
+impl<T: EvmTypes> core::ops::Deref for dyn Inspector<T> + '_ {
+    type Target = dyn Any;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        self
+    }
+}
+
+impl<T: EvmTypes> core::ops::DerefMut for dyn Inspector<T> + '_ {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::Inspector;
@@ -795,9 +811,7 @@ mod tests {
         ));
 
         let result = evm.transact(&tx).unwrap();
-        let inspector = (evm.inspector().unwrap() as &dyn core::any::Any)
-            .downcast_ref::<SharedE2eInspector>()
-            .unwrap();
+        let inspector = evm.inspector().unwrap().downcast_ref::<SharedE2eInspector>().unwrap();
         let state = &inspector.state;
 
         assert!(result.status);
@@ -838,9 +852,7 @@ mod tests {
         ));
 
         let result = evm.transact(&tx).unwrap();
-        let inspector = (evm.inspector().unwrap() as &dyn core::any::Any)
-            .downcast_ref::<SharedE2eInspector>()
-            .unwrap();
+        let inspector = evm.inspector().unwrap().downcast_ref::<SharedE2eInspector>().unwrap();
         let state = &inspector.state;
 
         assert!(result.status);
@@ -876,9 +888,7 @@ mod tests {
         ));
 
         let result = evm.transact(&tx).unwrap();
-        let inspector = (evm.inspector().unwrap() as &dyn core::any::Any)
-            .downcast_ref::<SharedE2eInspector>()
-            .unwrap();
+        let inspector = evm.inspector().unwrap().downcast_ref::<SharedE2eInspector>().unwrap();
         let state = &inspector.state;
 
         assert!(result.status);

--- a/crates/evm2/src/evm/inspector.rs
+++ b/crates/evm2/src/evm/inspector.rs
@@ -74,13 +74,11 @@ pub trait Inspector<T: EvmTypes>: Any + Send {
 mod tests {
     use super::Inspector;
     use crate::{
-        BaseEvmConfigSelector, BaseEvmTypes, Evm, ExecutionConfig, Precompiles, SYSTEM_ADDRESS,
-        SpecId,
+        BaseEvmConfigSelector, ExecutionConfig, SpecId,
         bytecode::Bytecode,
         constants::CALL_DEPTH_LIMIT,
-        env::{BlockEnv, TxEnv},
-        ethereum::{RecoveredTxEnvelope, ethereum_tx_registry},
-        evm::{AccountInfo, InMemoryDB, SelfDestructResult},
+        env::TxEnv,
+        evm::SelfDestructResult,
         interpreter::{
             GasTracker, InstrStop, Interpreter, Message, MessageResult, Word,
             instructions::tests::{TestHost, TestTypes, push},
@@ -88,9 +86,22 @@ mod tests {
         },
         utils::address_to_word,
     };
-    use alloc::{sync::Arc, vec::Vec};
+    #[cfg(feature = "std")]
+    use crate::{
+        BaseEvmTypes, Evm, Precompiles, SYSTEM_ADDRESS,
+        env::BlockEnv,
+        ethereum::{RecoveredTxEnvelope, ethereum_tx_registry},
+        evm::{AccountInfo, InMemoryDB},
+    };
+    #[cfg(feature = "std")]
+    use alloc::sync::Arc;
+    use alloc::vec::Vec;
+    #[cfg(feature = "std")]
     use alloy_consensus::{TxLegacy, transaction::Recovered};
-    use alloy_primitives::{Address, Bytes, Log, TxKind, U256};
+    use alloy_primitives::{Address, Bytes, Log};
+    #[cfg(feature = "std")]
+    use alloy_primitives::{TxKind, U256};
+    #[cfg(feature = "std")]
     use std::sync::Mutex;
 
     #[derive(Default)]
@@ -323,6 +334,7 @@ mod tests {
     }
 
     #[derive(Default)]
+    #[cfg(feature = "std")]
     struct E2eState {
         initialized: usize,
         steps: usize,
@@ -332,8 +344,10 @@ mod tests {
         creates: usize,
     }
 
+    #[cfg(feature = "std")]
     struct SharedE2eInspector(Arc<Mutex<E2eState>>);
 
+    #[cfg(feature = "std")]
     impl Inspector<BaseEvmTypes> for SharedE2eInspector {
         fn initialize_interp(&mut self, _interp: &mut Interpreter<'_, BaseEvmTypes>) {
             self.0.lock().unwrap().initialized += 1;
@@ -762,6 +776,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "std")]
     fn evm_transaction_inspects_interpreter_steps_and_logs() {
         let caller = Address::from([0xaa; 20]);
         let contract = Address::from([0xbb; 20]);
@@ -807,6 +822,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "std")]
     fn evm_transaction_inspects_eip7708_transfer_log() {
         let caller = Address::from([0xaa; 20]);
         let target = Address::from([0xbb; 20]);
@@ -844,6 +860,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "std")]
     fn evm_create_transaction_initializes_interpreter_without_create_hook() {
         let caller = Address::from([0xaa; 20]);
         let mut database = InMemoryDB::default();

--- a/crates/evm2/src/evm/inspector.rs
+++ b/crates/evm2/src/evm/inspector.rs
@@ -88,7 +88,7 @@ mod tests {
         },
         utils::address_to_word,
     };
-    use alloc::{sync::Arc, vec::Vec};
+    use alloc::vec::Vec;
     use alloy_consensus::{TxLegacy, transaction::Recovered};
     use alloy_primitives::{Address, Bytes, Log, TxKind, U256};
 
@@ -333,31 +333,31 @@ mod tests {
 
     #[derive(Default)]
     struct SharedE2eInspector {
-        state: Arc<E2eState>,
+        state: E2eState,
     }
 
     impl Inspector<BaseEvmTypes> for SharedE2eInspector {
         fn initialize_interp(&mut self, _interp: &mut Interpreter<'_, BaseEvmTypes>) {
-            Arc::get_mut(&mut self.state).unwrap().initialized += 1;
+            self.state.initialized += 1;
         }
 
         fn step(&mut self, _interp: &mut Interpreter<'_, BaseEvmTypes>) {
-            Arc::get_mut(&mut self.state).unwrap().steps += 1;
+            self.state.steps += 1;
         }
 
         fn step_end(&mut self, _interp: &mut Interpreter<'_, BaseEvmTypes>) {
-            Arc::get_mut(&mut self.state).unwrap().step_ends += 1;
+            self.state.step_ends += 1;
         }
 
         fn log(&mut self, log: &Log) {
-            Arc::get_mut(&mut self.state).unwrap().logs.push(log.clone());
+            self.state.logs.push(log.clone());
         }
 
         fn call(
             &mut self,
             _message: &mut Message<BaseEvmTypes>,
         ) -> Option<MessageResult<BaseEvmTypes>> {
-            Arc::get_mut(&mut self.state).unwrap().calls += 1;
+            self.state.calls += 1;
             None
         }
 
@@ -365,7 +365,7 @@ mod tests {
             &mut self,
             _message: &mut Message<BaseEvmTypes>,
         ) -> Option<MessageResult<BaseEvmTypes>> {
-            Arc::get_mut(&mut self.state).unwrap().creates += 1;
+            self.state.creates += 1;
             None
         }
     }

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -390,12 +390,14 @@ impl<T: EvmTypes<Tx: Typed2718>> Evm<T> {
     pub fn transact_async<'a>(
         &'a mut self,
         tx: &'a T::Tx,
-    ) -> impl core::future::Future<Output = crate::AsyncResult<HandlerResult<TxResult<T>>>> + Send + 'a
+    ) -> impl core::future::Future<Output = crate::AsyncResult<TxResult<T>, registry::HandlerError>>
+    + Send
+    + 'a
     where
         T::TxResultExt: Send,
     {
         let stack_size = self.version().min_stack_size;
-        crate::async_::on_fiber(self, stack_size, move |evm| evm.transact(tx))
+        crate::async_::on_fiber_result(self, stack_size, move |evm| evm.transact(tx))
     }
 
     /// Dispatches each transaction to its registered EIP-2718 handler.

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -199,13 +199,13 @@ impl<T: EvmTypes> Evm<T> {
     /// Returns the backing database as `D` if it has that concrete type.
     #[inline]
     pub fn database_as<D: DynDatabase>(&self) -> Option<&D> {
-        <dyn core::any::Any>::downcast_ref(self.database())
+        self.database().downcast_ref()
     }
 
     /// Returns the backing database mutably as `D` if it has that concrete type.
     #[inline]
     pub fn database_as_mut<D: DynDatabase>(&mut self) -> Option<&mut D> {
-        <dyn core::any::Any>::downcast_mut(self.database_mut())
+        self.database_mut().downcast_mut()
     }
 
     /// Returns the mutable EVM state.
@@ -259,7 +259,7 @@ impl<T: EvmTypes> Evm<T> {
     /// Returns the active execution inspector mutably.
     #[inline]
     pub fn inspector_mut(&mut self) -> Option<&mut dyn Inspector<T>> {
-        self.inspector.as_mut().map(|inspector| inspector.as_mut() as &mut dyn Inspector<T>)
+        self.inspector.as_deref_mut()
     }
 
     #[inline]

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -358,6 +358,16 @@ impl<T: EvmTypes<Tx: Typed2718>> Evm<T> {
         result
     }
 
+    /// Dispatches the transaction to the handler registered for its EIP-2718 type byte on an async
+    /// fiber.
+    #[cfg(feature = "async")]
+    pub async fn transact_async(
+        &mut self,
+        tx: &T::Tx,
+    ) -> crate::AsyncResult<HandlerResult<TxResult<T>>> {
+        crate::async_::on_fiber(self, |evm| evm.transact(tx)).await
+    }
+
     /// Dispatches each transaction to its registered EIP-2718 handler.
     pub fn transact_iter<'a, I>(
         &'a mut self,
@@ -1082,6 +1092,28 @@ mod tests {
         assert_eq!(evm.transact(&tx).map(|result| result.gas_used), Ok(42));
     }
 
+    #[cfg(feature = "async")]
+    #[test]
+    fn dispatches_transaction_async_by_typed_2718_type() {
+        let registry = TxRegistry::new().with_handler(
+            TEST_TX_TYPE,
+            RecoveredTxEnvelope::as_legacy,
+            handle_test_tx,
+        );
+        let mut evm = Evm::<BaseEvmTypes>::new(
+            SpecId::OSAKA,
+            BlockEnv::default(),
+            registry,
+            InMemoryDB::default(),
+            Precompiles::base(SpecId::OSAKA),
+        );
+        let tx = test_tx(41);
+
+        let result = poll_ready(evm.transact_async(&tx)).unwrap().unwrap();
+
+        assert_eq!(result.gas_used, 42);
+    }
+
     #[test]
     fn dispatches_transaction_without_evm_config() {
         let registry = TxRegistry::new().with_handler(
@@ -1473,5 +1505,20 @@ mod tests {
             ]
         );
         assert_eq!(log.data.data, Bytes::copy_from_slice(&U256::from(7).to_be_bytes::<32>()));
+    }
+
+    #[cfg(feature = "async")]
+    fn poll_ready<F: core::future::Future>(future: F) -> F::Output {
+        use core::task::Poll;
+        use std::task::{Context, Waker};
+
+        let mut future = Box::pin(future);
+        let waker = Waker::noop();
+        let mut cx = Context::from_waker(waker);
+
+        match future.as_mut().poll(&mut cx) {
+            Poll::Ready(value) => value,
+            Poll::Pending => panic!("future unexpectedly pending"),
+        }
     }
 }

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -121,6 +121,18 @@ impl<T: EvmTypes> Evm<T> {
             execution_config.version().spec_id,
             "execution config version spec mismatch"
         );
+        let database = {
+            #[cfg(feature = "async")]
+            {
+                let mut database = database;
+                database.set_io_mode(execution_config.version().io_mode);
+                database
+            }
+            #[cfg(not(feature = "async"))]
+            {
+                database
+            }
+        };
         Self {
             spec_id,
             features: execution_config.version().features,
@@ -181,13 +193,30 @@ impl<T: EvmTypes> Evm<T> {
     #[inline]
     pub fn set_database(&mut self, database: impl DynDatabase) {
         self.state.set_initial(database);
+        #[cfg(feature = "async")]
+        self.apply_io_mode_to_database();
     }
 
-    /// Sets the asynchronous database I/O mode, if supported by the backing database.
+    /// Sets the asynchronous database I/O mode.
     #[cfg(feature = "async")]
     #[inline]
-    pub fn set_io_mode(&mut self, io_mode: crate::IoMode) -> bool {
-        self.database_mut().set_io_mode(io_mode)
+    pub fn set_io_mode(&mut self, io_mode: crate::IoMode) {
+        self.execution_config.version.io_mode = io_mode;
+        self.apply_io_mode_to_database();
+    }
+
+    /// Sets the minimum async EVM fiber stack size in bytes.
+    #[cfg(feature = "async")]
+    #[inline]
+    pub const fn set_min_stack_size(&mut self, min_stack_size: usize) {
+        self.execution_config.version.min_stack_size = min_stack_size;
+    }
+
+    #[cfg(feature = "async")]
+    #[inline]
+    fn apply_io_mode_to_database(&mut self) {
+        let io_mode = self.execution_config.version.io_mode;
+        self.database_mut().set_io_mode(io_mode);
     }
 
     /// Returns the backing database as `D` if it has that concrete type.
@@ -372,7 +401,8 @@ impl<T: EvmTypes<Tx: Typed2718>> Evm<T> {
         &mut self,
         tx: &T::Tx,
     ) -> crate::AsyncResult<HandlerResult<TxResult<T>>> {
-        crate::async_::on_fiber(self, |evm| evm.transact(tx)).await
+        let stack_size = self.version().min_stack_size;
+        crate::async_::on_fiber(self, stack_size, |evm| evm.transact(tx)).await
     }
 
     /// Dispatches each transaction to its registered EIP-2718 handler.

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -185,14 +185,6 @@ impl<T: EvmTypes> Evm<T> {
         self.state.set_initial(database);
     }
 
-    /// Sets the minimum async EVM fiber stack size in bytes.
-    ///
-    /// Currently unused unless the `"async"` feature is enabled.
-    #[inline]
-    pub const fn set_min_stack_size(&mut self, min_stack_size: usize) {
-        self.execution_config.version.min_stack_size = min_stack_size;
-    }
-
     /// Returns the backing database as `D` if it has that concrete type.
     #[inline]
     pub fn database_as<D: DynDatabase>(&self) -> Option<&D> {
@@ -380,8 +372,7 @@ impl<T: EvmTypes<Tx: Typed2718>> Evm<T> {
     where
         T::TxResultExt: Send,
     {
-        let stack_size = self.version().min_stack_size;
-        crate::async_::on_fiber_result(stack_size, move || self.transact(tx))
+        crate::async_::on_fiber_result(move || self.transact(tx))
     }
 
     /// Dispatches each transaction to its registered EIP-2718 handler.

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -183,6 +183,13 @@ impl<T: EvmTypes> Evm<T> {
         self.state.set_initial(database);
     }
 
+    /// Sets the asynchronous database I/O mode, if supported by the backing database.
+    #[cfg(feature = "async")]
+    #[inline]
+    pub fn set_io_mode(&mut self, io_mode: crate::IoMode) -> bool {
+        self.database_mut().set_io_mode(io_mode)
+    }
+
     /// Returns the backing database as `D` if it has that concrete type.
     #[inline]
     pub fn database_as<D: DynDatabase>(&self) -> Option<&D> {
@@ -1508,11 +1515,11 @@ mod tests {
     }
 
     #[cfg(feature = "async")]
-    fn poll_ready<F: core::future::Future>(future: F) -> F::Output {
+    fn poll_ready<F: core::future::Future + Send>(future: F) -> F::Output {
         use core::task::Poll;
         use std::task::{Context, Waker};
 
-        let mut future = Box::pin(future);
+        let mut future = core::pin::pin!(future);
         let waker = Waker::noop();
         let mut cx = Context::from_waker(waker);
 

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -387,12 +387,15 @@ impl<T: EvmTypes<Tx: Typed2718>> Evm<T> {
     /// Dispatches the transaction to the handler registered for its EIP-2718 type byte on an async
     /// fiber.
     #[cfg(feature = "async")]
-    pub async fn transact_async(
-        &mut self,
-        tx: &T::Tx,
-    ) -> crate::AsyncResult<HandlerResult<TxResult<T>>> {
+    pub fn transact_async<'a>(
+        &'a mut self,
+        tx: &'a T::Tx,
+    ) -> impl core::future::Future<Output = crate::AsyncResult<HandlerResult<TxResult<T>>>> + Send + 'a
+    where
+        T::TxResultExt: Send,
+    {
         let stack_size = self.version().min_stack_size;
-        crate::async_::on_fiber(self, stack_size, |evm| evm.transact(tx)).await
+        crate::async_::on_fiber(self, stack_size, move |evm| evm.transact(tx))
     }
 
     /// Dispatches each transaction to its registered EIP-2718 handler.

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -1119,28 +1119,6 @@ mod tests {
         assert_eq!(evm.transact(&tx).map(|result| result.gas_used), Ok(42));
     }
 
-    #[cfg(feature = "async")]
-    #[test]
-    fn dispatches_transaction_async_by_typed_2718_type() {
-        let registry = TxRegistry::new().with_handler(
-            TEST_TX_TYPE,
-            RecoveredTxEnvelope::as_legacy,
-            handle_test_tx,
-        );
-        let mut evm = Evm::<BaseEvmTypes>::new(
-            SpecId::OSAKA,
-            BlockEnv::default(),
-            registry,
-            InMemoryDB::default(),
-            Precompiles::base(SpecId::OSAKA),
-        );
-        let tx = test_tx(41);
-
-        let result = poll_ready(evm.transact_async(&tx)).unwrap().unwrap();
-
-        assert_eq!(result.gas_used, 42);
-    }
-
     #[test]
     fn dispatches_transaction_without_evm_config() {
         let registry = TxRegistry::new().with_handler(
@@ -1532,20 +1510,5 @@ mod tests {
             ]
         );
         assert_eq!(log.data.data, Bytes::copy_from_slice(&U256::from(7).to_be_bytes::<32>()));
-    }
-
-    #[cfg(feature = "async")]
-    fn poll_ready<F: core::future::Future + Send>(future: F) -> F::Output {
-        use core::task::Poll;
-        use std::task::{Context, Waker};
-
-        let mut future = core::pin::pin!(future);
-        let waker = Waker::noop();
-        let mut cx = Context::from_waker(waker);
-
-        match future.as_mut().poll(&mut cx) {
-            Poll::Ready(value) => value,
-            Poll::Pending => panic!("future unexpectedly pending"),
-        }
     }
 }

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -200,9 +200,9 @@ impl<T: EvmTypes> Evm<T> {
     /// Sets the asynchronous database I/O mode.
     #[cfg(feature = "async")]
     #[inline]
-    pub fn set_io_mode(&mut self, io_mode: crate::IoMode) {
+    pub fn set_io_mode(&mut self, io_mode: crate::IoMode) -> bool {
         self.execution_config.version.io_mode = io_mode;
-        self.apply_io_mode_to_database();
+        self.apply_io_mode_to_database()
     }
 
     /// Sets the minimum async EVM fiber stack size in bytes.
@@ -214,9 +214,9 @@ impl<T: EvmTypes> Evm<T> {
 
     #[cfg(feature = "async")]
     #[inline]
-    fn apply_io_mode_to_database(&mut self) {
+    fn apply_io_mode_to_database(&mut self) -> bool {
         let io_mode = self.execution_config.version.io_mode;
-        self.database_mut().set_io_mode(io_mode);
+        self.database_mut().set_io_mode(io_mode)
     }
 
     /// Returns the backing database as `D` if it has that concrete type.

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -65,6 +65,9 @@ pub struct Evm<T: EvmTypes> {
     interpreter_pool: InterpreterPool<T>,
     #[derive_where(skip)]
     inspector: Option<Box<dyn Inspector<T>>>,
+    #[cfg(feature = "async")]
+    #[derive_where(skip)]
+    async_stack: crate::async_::FiberStack,
     db_error_code: Option<DbErrorCode>,
 }
 
@@ -133,6 +136,8 @@ impl<T: EvmTypes> Evm<T> {
             precompiles,
             interpreter_pool: InterpreterPool::new(),
             inspector: None,
+            #[cfg(feature = "async")]
+            async_stack: crate::async_::FiberStack::default(),
             db_error_code: None,
         }
     }
@@ -183,6 +188,12 @@ impl<T: EvmTypes> Evm<T> {
     #[inline]
     pub fn set_database(&mut self, database: impl DynDatabase) {
         self.state.set_initial(database);
+    }
+
+    #[cfg(feature = "async")]
+    #[inline]
+    fn async_stack(&mut self) -> core::ptr::NonNull<crate::async_::FiberStack> {
+        core::ptr::NonNull::from(&mut self.async_stack)
     }
 
     /// Returns the backing database as `D` if it has that concrete type.
@@ -372,7 +383,10 @@ impl<T: EvmTypes<Tx: Typed2718>> Evm<T> {
     where
         T::TxResultExt: Send,
     {
-        crate::async_::on_fiber_result(move || self.transact(tx))
+        let stack = self.async_stack();
+        // SAFETY: The returned future owns the exclusive `&mut self` borrow, so nothing else can
+        // access the EVM stack slot until that future is dropped.
+        unsafe { crate::async_::on_fiber_result_with_stack(stack, move || self.transact(tx)) }
     }
 
     /// Dispatches each transaction to its registered EIP-2718 handler.

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -123,8 +123,6 @@ impl<T: EvmTypes> Evm<T> {
             execution_config.version().spec_id,
             "execution config version spec mismatch"
         );
-        let mut database = database;
-        database.set_io_mode(execution_config.version().io_mode);
         Self {
             spec_id,
             features: execution_config.version().features,
@@ -185,16 +183,6 @@ impl<T: EvmTypes> Evm<T> {
     #[inline]
     pub fn set_database(&mut self, database: impl DynDatabase) {
         self.state.set_initial(database);
-        self.apply_io_mode_to_database();
-    }
-
-    /// Sets the asynchronous database I/O mode.
-    ///
-    /// Currently unused unless the `"async"` feature is enabled.
-    #[inline]
-    pub fn set_io_mode(&mut self, io_mode: crate::IoMode) -> bool {
-        self.execution_config.version.io_mode = io_mode;
-        self.apply_io_mode_to_database()
     }
 
     /// Sets the minimum async EVM fiber stack size in bytes.
@@ -203,12 +191,6 @@ impl<T: EvmTypes> Evm<T> {
     #[inline]
     pub const fn set_min_stack_size(&mut self, min_stack_size: usize) {
         self.execution_config.version.min_stack_size = min_stack_size;
-    }
-
-    #[inline]
-    fn apply_io_mode_to_database(&mut self) -> bool {
-        let io_mode = self.execution_config.version.io_mode;
-        self.database_mut().set_io_mode(io_mode)
     }
 
     /// Returns the backing database as `D` if it has that concrete type.

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -38,6 +38,7 @@ pub use db::{
     Cache, CacheDB, Database, DatabaseCommit, Db, DbErrorCode, DbResult, DynDatabase, EmptyDB,
     InMemoryDB,
 };
+#[cfg(feature = "async")]
 pub(crate) use db::{db_error_unavailable, stored_error_code};
 
 mod state;

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -397,7 +397,7 @@ impl<T: EvmTypes<Tx: Typed2718>> Evm<T> {
         T::TxResultExt: Send,
     {
         let stack_size = self.version().min_stack_size;
-        crate::async_::on_fiber_result(self, stack_size, move |evm| evm.transact(tx))
+        crate::async_::on_fiber_result(stack_size, move || self.transact(tx))
     }
 
     /// Dispatches each transaction to its registered EIP-2718 handler.

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -38,6 +38,7 @@ pub use db::{
     Cache, CacheDB, Database, DatabaseCommit, Db, DbErrorCode, DbResult, DynDatabase, EmptyDB,
     InMemoryDB,
 };
+pub(crate) use db::{db_error_unavailable, stored_error_code};
 
 mod state;
 pub use state::{

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -121,18 +121,8 @@ impl<T: EvmTypes> Evm<T> {
             execution_config.version().spec_id,
             "execution config version spec mismatch"
         );
-        let database = {
-            #[cfg(feature = "async")]
-            {
-                let mut database = database;
-                database.set_io_mode(execution_config.version().io_mode);
-                database
-            }
-            #[cfg(not(feature = "async"))]
-            {
-                database
-            }
-        };
+        let mut database = database;
+        database.set_io_mode(execution_config.version().io_mode);
         Self {
             spec_id,
             features: execution_config.version().features,
@@ -193,12 +183,12 @@ impl<T: EvmTypes> Evm<T> {
     #[inline]
     pub fn set_database(&mut self, database: impl DynDatabase) {
         self.state.set_initial(database);
-        #[cfg(feature = "async")]
         self.apply_io_mode_to_database();
     }
 
     /// Sets the asynchronous database I/O mode.
-    #[cfg(feature = "async")]
+    ///
+    /// Currently unused unless the `"async"` feature is enabled.
     #[inline]
     pub fn set_io_mode(&mut self, io_mode: crate::IoMode) -> bool {
         self.execution_config.version.io_mode = io_mode;
@@ -206,13 +196,13 @@ impl<T: EvmTypes> Evm<T> {
     }
 
     /// Sets the minimum async EVM fiber stack size in bytes.
-    #[cfg(feature = "async")]
+    ///
+    /// Currently unused unless the `"async"` feature is enabled.
     #[inline]
     pub const fn set_min_stack_size(&mut self, min_stack_size: usize) {
         self.execution_config.version.min_stack_size = min_stack_size;
     }
 
-    #[cfg(feature = "async")]
     #[inline]
     fn apply_io_mode_to_database(&mut self) -> bool {
         let io_mode = self.execution_config.version.io_mode;

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -373,6 +373,10 @@ impl<T: EvmTypes<Tx: Typed2718>> Evm<T> {
 
     /// Dispatches the transaction to the handler registered for its EIP-2718 type byte on an async
     /// fiber.
+    ///
+    /// This must be used with an async database adapter such as [`crate::AsyncDb`] to take
+    /// advantage of yielding database I/O. With a synchronous database this is mostly equivalent to
+    /// running the synchronous transaction on a fiber.
     #[cfg(feature = "async")]
     pub fn transact_async<'a>(
         &'a mut self,

--- a/crates/evm2/src/evm/precompile.rs
+++ b/crates/evm2/src/evm/precompile.rs
@@ -33,7 +33,7 @@ impl PrecompileOutput {
 }
 
 /// Precompile execution hook.
-pub trait PrecompileProvider: Any {
+pub trait PrecompileProvider: Any + Send {
     /// Returns precompile addresses that should be warm at transaction start.
     fn warm_addresses(&self) -> Vec<Address> {
         Vec::new()

--- a/crates/evm2/src/evm/registry.rs
+++ b/crates/evm2/src/evm/registry.rs
@@ -52,7 +52,7 @@
 //! # Ok::<(), HandlerError>(())
 //! ```
 
-use alloc::rc::Rc;
+use alloc::sync::Arc;
 use alloy_primitives::{Address, U256, map::HashMap};
 use core::{fmt, marker::PhantomData};
 use thiserror::Error;
@@ -216,7 +216,7 @@ where
 /// An erased transaction handler returned by [`TxRegistry`].
 #[derive(Clone)]
 pub struct AnyTxHandler<Env, Output, Host = ()> {
-    inner: Rc<dyn ErasedTxHandler<Env, Output, Host>>,
+    inner: Arc<dyn ErasedTxHandler<Env, Output, Host>>,
 }
 
 impl<Env, Output, Host> fmt::Debug for AnyTxHandler<Env, Output, Host> {
@@ -232,7 +232,7 @@ impl<Env, Output, Host> AnyTxHandler<Env, Output, Host> {
     }
 }
 
-trait ErasedTxHandler<Env, Output, Host> {
+trait ErasedTxHandler<Env, Output, Host>: Send + Sync {
     fn call(&self, env: &Env, host: &mut Host) -> HandlerResult<Output>;
 }
 
@@ -251,8 +251,8 @@ impl<Tx, H, F> HandlerAdapter<Tx, H, F> {
 
 impl<Env, Tx, Output, Host, H, F> ErasedTxHandler<Env, Output, Host> for HandlerAdapter<Tx, H, F>
 where
-    H: TxHandler<Tx, Output, Host>,
-    F: for<'a> Fn(&'a Env) -> Option<&'a Tx>,
+    H: TxHandler<Tx, Output, Host> + Send + Sync,
+    F: for<'a> Fn(&'a Env) -> Option<&'a Tx> + Send + Sync,
 {
     fn call(&self, env: &Env, host: &mut Host) -> HandlerResult<Output> {
         let tx = (self.extract)(env)
@@ -263,7 +263,7 @@ where
 
 /// A type-erased transaction handler registry keyed by transaction type byte.
 pub struct TxRegistry<Env, Output = (), Host = ()> {
-    handlers: HashMap<u8, Rc<dyn ErasedTxHandler<Env, Output, Host>>>,
+    handlers: HashMap<u8, Arc<dyn ErasedTxHandler<Env, Output, Host>>>,
 }
 
 impl<Env, Output, Host> fmt::Debug for TxRegistry<Env, Output, Host> {
@@ -291,10 +291,10 @@ impl<Env, Output, Host> TxRegistry<Env, Output, Host> {
     pub fn register<Tx, H, F>(&mut self, type_id: u8, extract: F, handler: H) -> &mut Self
     where
         Tx: 'static,
-        H: TxHandler<Tx, Output, Host> + 'static,
-        F: for<'a> Fn(&'a Env) -> Option<&'a Tx> + 'static,
+        H: TxHandler<Tx, Output, Host> + Send + Sync + 'static,
+        F: for<'a> Fn(&'a Env) -> Option<&'a Tx> + Send + Sync + 'static,
     {
-        self.handlers.insert(type_id, Rc::new(HandlerAdapter::new(type_id, extract, handler)));
+        self.handlers.insert(type_id, Arc::new(HandlerAdapter::new(type_id, extract, handler)));
         self
     }
 
@@ -303,8 +303,8 @@ impl<Env, Output, Host> TxRegistry<Env, Output, Host> {
     pub fn with_handler<Tx, H, F>(mut self, type_id: u8, extract: F, handler: H) -> Self
     where
         Tx: 'static,
-        H: TxHandler<Tx, Output, Host> + 'static,
-        F: for<'a> Fn(&'a Env) -> Option<&'a Tx> + 'static,
+        H: TxHandler<Tx, Output, Host> + Send + Sync + 'static,
+        F: for<'a> Fn(&'a Env) -> Option<&'a Tx> + Send + Sync + 'static,
     {
         self.register(type_id, extract, handler);
         self
@@ -317,7 +317,7 @@ impl<Env, Output, Host> TxRegistry<Env, Output, Host> {
 
     /// Returns the erased handler registered for `type_id`, if any.
     pub fn get_by_type(&self, type_id: u8) -> Option<AnyTxHandler<Env, Output, Host>> {
-        self.handlers.get(&type_id).map(|inner| AnyTxHandler { inner: Rc::clone(inner) })
+        self.handlers.get(&type_id).map(|inner| AnyTxHandler { inner: Arc::clone(inner) })
     }
 
     /// Returns the erased handler registered for `type_id`.

--- a/crates/evm2/src/evm/system.rs
+++ b/crates/evm2/src/evm/system.rs
@@ -59,9 +59,7 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
         T::TxResultExt: Send,
     {
         let stack_size = self.version().min_stack_size;
-        crate::async_::on_fiber(self, stack_size, move |evm| {
-            evm.system_call(system_contract_address, data)
-        })
+        crate::async_::on_fiber(stack_size, move || self.system_call(system_contract_address, data))
     }
 
     /// Executes a system call from `caller` to `system_contract_address`.
@@ -144,8 +142,8 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
         T::TxResultExt: Send,
     {
         let stack_size = self.version().min_stack_size;
-        crate::async_::on_fiber(self, stack_size, move |evm| {
-            evm.system_call_with_caller(caller, system_contract_address, data)
+        crate::async_::on_fiber(stack_size, move || {
+            self.system_call_with_caller(caller, system_contract_address, data)
         })
     }
 }

--- a/crates/evm2/src/evm/system.rs
+++ b/crates/evm2/src/evm/system.rs
@@ -47,16 +47,18 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
     /// fiber.
     #[cfg(feature = "async")]
     #[inline]
-    pub async fn system_call_async(
+    pub fn system_call_async(
         &mut self,
         system_contract_address: Address,
         data: Bytes,
-    ) -> crate::AsyncResult<TxResult<T>> {
+    ) -> impl core::future::Future<Output = crate::AsyncResult<TxResult<T>>> + Send + '_
+    where
+        T::TxResultExt: Send,
+    {
         let stack_size = self.version().min_stack_size;
-        crate::async_::on_fiber(self, stack_size, |evm| {
+        crate::async_::on_fiber(self, stack_size, move |evm| {
             evm.system_call(system_contract_address, data)
         })
-        .await
     }
 
     /// Executes a system call from `caller` to `system_contract_address`.
@@ -126,17 +128,19 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
     /// Executes a system call from `caller` to `system_contract_address` on an async fiber.
     #[cfg(feature = "async")]
     #[inline]
-    pub async fn system_call_with_caller_async(
+    pub fn system_call_with_caller_async(
         &mut self,
         caller: Address,
         system_contract_address: Address,
         data: Bytes,
-    ) -> crate::AsyncResult<TxResult<T>> {
+    ) -> impl core::future::Future<Output = crate::AsyncResult<TxResult<T>>> + Send + '_
+    where
+        T::TxResultExt: Send,
+    {
         let stack_size = self.version().min_stack_size;
-        crate::async_::on_fiber(self, stack_size, |evm| {
+        crate::async_::on_fiber(self, stack_size, move |evm| {
             evm.system_call_with_caller(caller, system_contract_address, data)
         })
-        .await
     }
 }
 

--- a/crates/evm2/src/evm/system.rs
+++ b/crates/evm2/src/evm/system.rs
@@ -58,8 +58,7 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
     where
         T::TxResultExt: Send,
     {
-        let stack_size = self.version().min_stack_size;
-        crate::async_::on_fiber(stack_size, move || self.system_call(system_contract_address, data))
+        crate::async_::on_fiber(move || self.system_call(system_contract_address, data))
     }
 
     /// Executes a system call from `caller` to `system_contract_address`.
@@ -141,8 +140,7 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
     where
         T::TxResultExt: Send,
     {
-        let stack_size = self.version().min_stack_size;
-        crate::async_::on_fiber(stack_size, move || {
+        crate::async_::on_fiber(move || {
             self.system_call_with_caller(caller, system_contract_address, data)
         })
     }

--- a/crates/evm2/src/evm/system.rs
+++ b/crates/evm2/src/evm/system.rs
@@ -59,8 +59,8 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
         T::TxResultExt: Send,
     {
         let stack_size = self.version().min_stack_size;
-        crate::async_::on_fiber_result(self, stack_size, move |evm| {
-            Ok::<_, core::convert::Infallible>(evm.system_call(system_contract_address, data))
+        crate::async_::on_fiber(self, stack_size, move |evm| {
+            evm.system_call(system_contract_address, data)
         })
     }
 
@@ -144,12 +144,8 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
         T::TxResultExt: Send,
     {
         let stack_size = self.version().min_stack_size;
-        crate::async_::on_fiber_result(self, stack_size, move |evm| {
-            Ok::<_, core::convert::Infallible>(evm.system_call_with_caller(
-                caller,
-                system_contract_address,
-                data,
-            ))
+        crate::async_::on_fiber(self, stack_size, move |evm| {
+            evm.system_call_with_caller(caller, system_contract_address, data)
         })
     }
 }

--- a/crates/evm2/src/evm/system.rs
+++ b/crates/evm2/src/evm/system.rs
@@ -58,7 +58,14 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
     where
         T::TxResultExt: Send,
     {
-        crate::async_::on_fiber(move || self.system_call(system_contract_address, data))
+        let stack = self.async_stack();
+        // SAFETY: The returned future owns the exclusive `&mut self` borrow, so nothing else can
+        // access the EVM stack slot until that future is dropped.
+        unsafe {
+            crate::async_::on_fiber_with_stack(stack, move || {
+                self.system_call(system_contract_address, data)
+            })
+        }
     }
 
     /// Executes a system call from `caller` to `system_contract_address`.
@@ -140,9 +147,14 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
     where
         T::TxResultExt: Send,
     {
-        crate::async_::on_fiber(move || {
-            self.system_call_with_caller(caller, system_contract_address, data)
-        })
+        let stack = self.async_stack();
+        // SAFETY: The returned future owns the exclusive `&mut self` borrow, so nothing else can
+        // access the EVM stack slot until that future is dropped.
+        unsafe {
+            crate::async_::on_fiber_with_stack(stack, move || {
+                self.system_call_with_caller(caller, system_contract_address, data)
+            })
+        }
     }
 }
 

--- a/crates/evm2/src/evm/system.rs
+++ b/crates/evm2/src/evm/system.rs
@@ -230,25 +230,6 @@ mod tests {
         assert!(result.state_changes.is_empty());
     }
 
-    #[cfg(feature = "async")]
-    #[test]
-    fn system_call_async_to_missing_code_is_noop() {
-        let contract = Address::from([0x42; 20]);
-        let mut evm = TestEvm::new(
-            SpecId::OSAKA,
-            BlockEnv::default(),
-            TxRegistry::new(),
-            InMemoryDB::default(),
-            Precompiles::base(SpecId::OSAKA),
-        );
-
-        let result = poll_ready(evm.system_call_async(contract, Bytes::new())).unwrap();
-
-        assert!(result.status);
-        assert_eq!(result.gas_used, 0);
-        assert!(result.state_changes.is_empty());
-    }
-
     #[test]
     fn system_call_reverts_state_changes() {
         let contract = Address::from([0x42; 20]);
@@ -279,21 +260,5 @@ mod tests {
         assert!(!result.status);
         assert_eq!(result.stop, InstrStop::Revert);
         assert!(result.state_changes.is_empty());
-    }
-
-    #[cfg(feature = "async")]
-    fn poll_ready<F: core::future::Future>(future: F) -> F::Output {
-        use alloc::boxed::Box;
-        use core::task::Poll;
-        use std::task::{Context, Waker};
-
-        let mut future = Box::pin(future);
-        let waker = Waker::noop();
-        let mut cx = Context::from_waker(waker);
-
-        match future.as_mut().poll(&mut cx) {
-            Poll::Ready(value) => value,
-            Poll::Pending => panic!("future unexpectedly pending"),
-        }
     }
 }

--- a/crates/evm2/src/evm/system.rs
+++ b/crates/evm2/src/evm/system.rs
@@ -52,7 +52,11 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
         system_contract_address: Address,
         data: Bytes,
     ) -> crate::AsyncResult<TxResult<T>> {
-        crate::async_::on_fiber(self, |evm| evm.system_call(system_contract_address, data)).await
+        let stack_size = self.version().min_stack_size;
+        crate::async_::on_fiber(self, stack_size, |evm| {
+            evm.system_call(system_contract_address, data)
+        })
+        .await
     }
 
     /// Executes a system call from `caller` to `system_contract_address`.
@@ -128,7 +132,8 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
         system_contract_address: Address,
         data: Bytes,
     ) -> crate::AsyncResult<TxResult<T>> {
-        crate::async_::on_fiber(self, |evm| {
+        let stack_size = self.version().min_stack_size;
+        crate::async_::on_fiber(self, stack_size, |evm| {
             evm.system_call_with_caller(caller, system_contract_address, data)
         })
         .await

--- a/crates/evm2/src/evm/system.rs
+++ b/crates/evm2/src/evm/system.rs
@@ -43,6 +43,18 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
         self.system_call_with_caller(SYSTEM_ADDRESS, system_contract_address, data)
     }
 
+    /// Executes a system call from [`SYSTEM_ADDRESS`] to `system_contract_address` on an async
+    /// fiber.
+    #[cfg(feature = "async")]
+    #[inline]
+    pub async fn system_call_async(
+        &mut self,
+        system_contract_address: Address,
+        data: Bytes,
+    ) -> crate::AsyncResult<TxResult<T>> {
+        crate::async_::on_fiber(self, |evm| evm.system_call(system_contract_address, data)).await
+    }
+
     /// Executes a system call from `caller` to `system_contract_address`.
     ///
     /// System calls bypass normal transaction validation, nonce updates, fee charging, gas refunds,
@@ -105,6 +117,21 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
         result.db_error_code = self.db_error_code();
         self.state.clear_transaction_state();
         result
+    }
+
+    /// Executes a system call from `caller` to `system_contract_address` on an async fiber.
+    #[cfg(feature = "async")]
+    #[inline]
+    pub async fn system_call_with_caller_async(
+        &mut self,
+        caller: Address,
+        system_contract_address: Address,
+        data: Bytes,
+    ) -> crate::AsyncResult<TxResult<T>> {
+        crate::async_::on_fiber(self, |evm| {
+            evm.system_call_with_caller(caller, system_contract_address, data)
+        })
+        .await
     }
 }
 
@@ -203,6 +230,25 @@ mod tests {
         assert!(result.state_changes.is_empty());
     }
 
+    #[cfg(feature = "async")]
+    #[test]
+    fn system_call_async_to_missing_code_is_noop() {
+        let contract = Address::from([0x42; 20]);
+        let mut evm = TestEvm::new(
+            SpecId::OSAKA,
+            BlockEnv::default(),
+            TxRegistry::new(),
+            InMemoryDB::default(),
+            Precompiles::base(SpecId::OSAKA),
+        );
+
+        let result = poll_ready(evm.system_call_async(contract, Bytes::new())).unwrap();
+
+        assert!(result.status);
+        assert_eq!(result.gas_used, 0);
+        assert!(result.state_changes.is_empty());
+    }
+
     #[test]
     fn system_call_reverts_state_changes() {
         let contract = Address::from([0x42; 20]);
@@ -233,5 +279,21 @@ mod tests {
         assert!(!result.status);
         assert_eq!(result.stop, InstrStop::Revert);
         assert!(result.state_changes.is_empty());
+    }
+
+    #[cfg(feature = "async")]
+    fn poll_ready<F: core::future::Future>(future: F) -> F::Output {
+        use alloc::boxed::Box;
+        use core::task::Poll;
+        use std::task::{Context, Waker};
+
+        let mut future = Box::pin(future);
+        let waker = Waker::noop();
+        let mut cx = Context::from_waker(waker);
+
+        match future.as_mut().poll(&mut cx) {
+            Poll::Ready(value) => value,
+            Poll::Pending => panic!("future unexpectedly pending"),
+        }
     }
 }

--- a/crates/evm2/src/evm/system.rs
+++ b/crates/evm2/src/evm/system.rs
@@ -51,13 +51,16 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
         &mut self,
         system_contract_address: Address,
         data: Bytes,
-    ) -> impl core::future::Future<Output = crate::AsyncResult<TxResult<T>>> + Send + '_
+    ) -> impl core::future::Future<
+        Output = crate::AsyncResult<TxResult<T>, core::convert::Infallible>,
+    > + Send
+    + '_
     where
         T::TxResultExt: Send,
     {
         let stack_size = self.version().min_stack_size;
-        crate::async_::on_fiber(self, stack_size, move |evm| {
-            evm.system_call(system_contract_address, data)
+        crate::async_::on_fiber_result(self, stack_size, move |evm| {
+            Ok::<_, core::convert::Infallible>(evm.system_call(system_contract_address, data))
         })
     }
 
@@ -133,13 +136,20 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
         caller: Address,
         system_contract_address: Address,
         data: Bytes,
-    ) -> impl core::future::Future<Output = crate::AsyncResult<TxResult<T>>> + Send + '_
+    ) -> impl core::future::Future<
+        Output = crate::AsyncResult<TxResult<T>, core::convert::Infallible>,
+    > + Send
+    + '_
     where
         T::TxResultExt: Send,
     {
         let stack_size = self.version().min_stack_size;
-        crate::async_::on_fiber(self, stack_size, move |evm| {
-            evm.system_call_with_caller(caller, system_contract_address, data)
+        crate::async_::on_fiber_result(self, stack_size, move |evm| {
+            Ok::<_, core::convert::Infallible>(evm.system_call_with_caller(
+                caller,
+                system_contract_address,
+                data,
+            ))
         })
     }
 }

--- a/crates/evm2/src/evm/system.rs
+++ b/crates/evm2/src/evm/system.rs
@@ -45,6 +45,10 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
 
     /// Executes a system call from [`SYSTEM_ADDRESS`] to `system_contract_address` on an async
     /// fiber.
+    ///
+    /// This must be used with an async database adapter such as [`crate::AsyncDb`] to take
+    /// advantage of yielding database I/O. With a synchronous database this is mostly equivalent to
+    /// running the synchronous system call on a fiber.
     #[cfg(feature = "async")]
     #[inline]
     pub fn system_call_async(
@@ -133,6 +137,10 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
     }
 
     /// Executes a system call from `caller` to `system_contract_address` on an async fiber.
+    ///
+    /// This must be used with an async database adapter such as [`crate::AsyncDb`] to take
+    /// advantage of yielding database I/O. With a synchronous database this is mostly equivalent to
+    /// running the synchronous system call on a fiber.
     #[cfg(feature = "async")]
     #[inline]
     pub fn system_call_with_caller_async(

--- a/crates/evm2/src/interpreter/instructions/control.rs
+++ b/crates/evm2/src/interpreter/instructions/control.rs
@@ -72,14 +72,19 @@ fn return_inner<T: EvmTypes>(
     result: InstrStop,
 ) -> Result {
     let len = word_to_usize(*len)?;
-    let offset = if len != 0 {
+    let output = if len != 0 {
         let offset = word_to_usize(*offset)?;
+        let Some(end) = offset.checked_add(len) else {
+            return Err(InstrStop::MemoryOOG);
+        };
+        if end > u32::MAX as usize {
+            return Err(InstrStop::MemoryLimitOOG);
+        }
         resize_memory(cx.gas, cx.state.memory(), offset, len)?;
-        offset
+        offset as u32..end as u32
     } else {
-        0
+        0..0
     };
-    let output = cx.state.memory().slice(offset, len) as *const [u8];
     cx.state.set_output(output);
     Err(result)
 }
@@ -232,6 +237,9 @@ mod tests {
 
         let interpreter = run_stack([Word::from(0), Word::MAX], op::RETURN);
         assert!(matches!(interpreter.err, InstrStop::InvalidOperandOOG));
+
+        let interpreter = run_stack([Word::from(u32::MAX), Word::from(1)], op::RETURN);
+        assert!(matches!(interpreter.err, InstrStop::MemoryLimitOOG));
     }
 
     #[test]
@@ -259,5 +267,8 @@ mod tests {
 
         let interpreter = run_stack([Word::from(0), Word::MAX], op::REVERT);
         assert!(matches!(interpreter.err, InstrStop::InvalidOperandOOG));
+
+        let interpreter = run_stack([Word::from(u32::MAX), Word::from(1)], op::REVERT);
+        assert!(matches!(interpreter.err, InstrStop::MemoryLimitOOG));
     }
 }

--- a/crates/evm2/src/interpreter/instructions/tests.rs
+++ b/crates/evm2/src/interpreter/instructions/tests.rs
@@ -11,6 +11,7 @@ use crate::{
 };
 use alloc::{boxed::Box, vec::Vec};
 use alloy_primitives::{Address, B256, Bytes, Log};
+use core::ops::Range;
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub(crate) struct TestTypes;
@@ -208,7 +209,7 @@ pub(super) struct TestInterpreter {
     pub(super) stack_len: usize,
     pub(super) gas: Gas,
     pub(super) memory: Memory,
-    pub(super) output: *const [u8],
+    pub(super) output: Range<u32>,
     pub(super) err: InstrStop,
 }
 
@@ -234,9 +235,7 @@ impl TestInterpreter {
     }
 
     pub(super) fn output(&self) -> &[u8] {
-        // SAFETY: The output pointer is created from memory owned by this test interpreter, or is
-        // the shared empty slice pointer.
-        unsafe { &*self.output }
+        self.memory.slice(self.output.start as usize, self.output.len())
     }
 }
 

--- a/crates/evm2/src/interpreter/runtime.rs
+++ b/crates/evm2/src/interpreter/runtime.rs
@@ -43,6 +43,12 @@ pub struct Interpreter<'frame, T: EvmTypes> {
     is_static: bool,
 }
 
+// SAFETY: The interpreter's internal pointers are always valid. `pc` points into owned bytecode,
+// `output` points into owned memory or byte slices, frame-local references are cleared before
+// pooling, and host/inspector/version pointers are installed for execution and not used after the
+// owning execution context is gone.
+unsafe impl<T: EvmTypes> Send for Interpreter<'_, T> {}
+
 impl<T: EvmTypes> Default for Interpreter<'_, T> {
     fn default() -> Self {
         let bytecode = Bytecode::new();
@@ -433,11 +439,6 @@ impl<'frame, T: EvmTypes> InterpreterState<'frame, T> {
 pub(crate) struct InterpreterPool<T: EvmTypes> {
     frames: Vec<Box<Interpreter<'static, T>>>,
 }
-
-// SAFETY: Pooled interpreters have their frame-local references cleared before storage. The raw
-// pointers that remain either point into owned bytecode/output buffers or are reset on the next
-// initialization before use.
-unsafe impl<T: EvmTypes> Send for InterpreterPool<T> {}
 
 impl<T: EvmTypes> InterpreterPool<T> {
     pub(crate) const fn new() -> Self {

--- a/crates/evm2/src/interpreter/runtime.rs
+++ b/crates/evm2/src/interpreter/runtime.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 use alloc::{boxed::Box, vec::Vec};
 use alloy_primitives::{Address, Bytes, Log};
-use core::{fmt, ptr::NonNull};
+use core::{fmt, ops::Range, ptr::NonNull};
 use derive_where::derive_where;
 
 /// EVM interpreter.
@@ -24,7 +24,7 @@ pub struct Interpreter<'frame, T: EvmTypes> {
     pub(in crate::interpreter) return_data: Bytes,
 
     pub(in crate::interpreter) pc: *const u8,
-    output: *const [u8],
+    output: Range<u32>,
     #[derive_where(skip)]
     tx_env: Option<&'frame TxEnv<T>>,
     #[derive_where(skip)]
@@ -44,9 +44,8 @@ pub struct Interpreter<'frame, T: EvmTypes> {
 }
 
 // SAFETY: The interpreter's internal pointers are always valid. `pc` points into owned bytecode,
-// `output` points into owned memory or byte slices, frame-local references are cleared before
-// pooling, and host/inspector/version pointers are installed for execution and not used after the
-// owning execution context is gone.
+// frame-local references are cleared before pooling, and host/inspector/version pointers are
+// installed for execution and not used after the owning execution context is gone.
 unsafe impl<T: EvmTypes> Send for Interpreter<'_, T> {}
 
 impl<T: EvmTypes> Default for Interpreter<'_, T> {
@@ -59,7 +58,7 @@ impl<T: EvmTypes> Default for Interpreter<'_, T> {
             gas: Gas::new(0),
             memory: Memory::new(),
             result: Ok(()),
-            output: &[],
+            output: 0..0,
             tx_env: None,
             message: None,
             is_static: false,
@@ -105,7 +104,7 @@ impl<'frame, T: EvmTypes> Interpreter<'frame, T> {
         self.gas = Gas::new(gas_limit);
         self.memory.clear();
         self.result = Ok(());
-        self.output = &[];
+        self.output = 0..0;
         self.tx_env = Some(tx_env);
         self.message = Some(message);
         self.is_static = is_static;
@@ -128,14 +127,15 @@ impl<'frame, T: EvmTypes> Interpreter<'frame, T> {
     }
 
     #[cfg(test)]
-    pub(crate) fn into_parts(self) -> (Box<StackBacking>, usize, Gas, Memory, *const [u8]) {
+    pub(crate) fn into_parts(self) -> (Box<StackBacking>, usize, Gas, Memory, Range<u32>) {
         (self.stack, self.stack_len, self.gas, self.memory, self.output)
     }
 
     /// Returns output produced by `RETURN` or `REVERT`.
     #[inline]
-    pub const fn output(&self) -> &[u8] {
-        unsafe { &*self.output }
+    pub fn output(&self) -> &[u8] {
+        let start = self.output.start as usize;
+        self.memory.slice(start, self.output.len())
     }
 
     /// Returns the current bytecode-relative program counter.
@@ -362,7 +362,7 @@ impl<'frame, T: EvmTypes> InterpreterState<'frame, T> {
 
     /// Sets the current frame output.
     #[inline]
-    pub const fn set_output(&mut self, output: *const [u8]) {
+    pub const fn set_output(&mut self, output: Range<u32>) {
         self.0.output = output;
     }
 

--- a/crates/evm2/src/interpreter/runtime.rs
+++ b/crates/evm2/src/interpreter/runtime.rs
@@ -434,6 +434,11 @@ pub(crate) struct InterpreterPool<T: EvmTypes> {
     frames: Vec<Box<Interpreter<'static, T>>>,
 }
 
+// SAFETY: Pooled interpreters have their frame-local references cleared before storage. The raw
+// pointers that remain either point into owned bytecode/output buffers or are reset on the next
+// initialization before use.
+unsafe impl<T: EvmTypes> Send for InterpreterPool<T> {}
+
 impl<T: EvmTypes> InterpreterPool<T> {
     pub(crate) const fn new() -> Self {
         Self { frames: Vec::new() }

--- a/crates/evm2/src/lib.rs
+++ b/crates/evm2/src/lib.rs
@@ -13,6 +13,9 @@ pub mod ethereum;
 pub mod interpreter;
 pub mod utils;
 
+#[cfg(feature = "async")]
+mod async_;
+
 pub mod evm;
 pub use evm::{
     BEACON_ROOTS_ADDRESS, CONSOLIDATION_REQUEST_ADDRESS, Evm, HISTORY_STORAGE_ADDRESS,
@@ -28,6 +31,9 @@ pub mod precompiles;
 pub use precompiles::{
     Crypto, PrecompileError, PrecompileHalt, Precompiles, crypto, install_crypto,
 };
+
+#[cfg(feature = "async")]
+pub use async_::{AsyncDatabase, AsyncDb, AsyncError, AsyncResult};
 
 pub(crate) mod trustme;
 

--- a/crates/evm2/src/lib.rs
+++ b/crates/evm2/src/lib.rs
@@ -15,6 +15,8 @@ pub mod utils;
 
 #[cfg(feature = "async")]
 mod async_;
+#[cfg(feature = "async")]
+pub use async_::{AsyncDatabase, AsyncDb, AsyncError, AsyncResult};
 
 pub mod evm;
 pub use evm::{
@@ -31,9 +33,6 @@ pub mod precompiles;
 pub use precompiles::{
     Crypto, PrecompileError, PrecompileHalt, Precompiles, crypto, install_crypto,
 };
-
-#[cfg(feature = "async")]
-pub use async_::{AsyncDatabase, AsyncDb, AsyncError, AsyncResult};
 
 pub(crate) mod trustme;
 

--- a/crates/evm2/src/lib.rs
+++ b/crates/evm2/src/lib.rs
@@ -33,7 +33,7 @@ pub use precompiles::{
 };
 
 #[cfg(feature = "async")]
-pub use async_::{AsyncDatabase, AsyncDb, AsyncError, AsyncResult};
+pub use async_::{AsyncDatabase, AsyncDb, AsyncError, AsyncResult, IoMode};
 
 pub(crate) mod trustme;
 

--- a/crates/evm2/src/lib.rs
+++ b/crates/evm2/src/lib.rs
@@ -33,12 +33,12 @@ pub use precompiles::{
 };
 
 #[cfg(feature = "async")]
-pub use async_::{AsyncDatabase, AsyncDb, AsyncError, AsyncResult, IoMode};
+pub use async_::{AsyncDatabase, AsyncDb, AsyncError, AsyncResult};
 
 pub(crate) mod trustme;
 
 pub mod version;
-pub use version::{EvmFeatures, OpcodeConfig, Version};
+pub use version::{EvmFeatures, IoMode, OpcodeConfig, Version};
 
 mod spec_id;
 pub use spec_id::SpecId;

--- a/crates/evm2/src/lib.rs
+++ b/crates/evm2/src/lib.rs
@@ -38,7 +38,7 @@ pub use async_::{AsyncDatabase, AsyncDb, AsyncError, AsyncResult};
 pub(crate) mod trustme;
 
 pub mod version;
-pub use version::{EvmFeatures, IoMode, OpcodeConfig, Version};
+pub use version::{EvmFeatures, OpcodeConfig, Version};
 
 mod spec_id;
 pub use spec_id::SpecId;

--- a/crates/evm2/src/version/mod.rs
+++ b/crates/evm2/src/version/mod.rs
@@ -19,6 +19,16 @@ pub use features::EvmFeatures;
 mod opcode_config;
 pub use opcode_config::OpcodeConfig;
 
+/// How async database I/O should be driven from synchronous EVM host calls.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub enum IoMode {
+    /// Block the current Tokio worker with `block_in_place`.
+    Blocking,
+    /// Suspend the EVM fiber while database I/O is pending.
+    #[default]
+    Async,
+}
+
 /// Runtime configuration data.
 ///
 /// The name is a bit misleading: this is a catch-all runtime configuration object. It stores fork
@@ -50,6 +60,10 @@ pub struct Version {
     pub max_blobs_per_tx: usize,
     /// Blob base fee update fraction.
     pub blob_base_fee_update_fraction: u64,
+    /// Async database I/O mode.
+    pub io_mode: IoMode,
+    /// Minimum async EVM fiber stack size in bytes.
+    pub min_stack_size: usize,
     #[doc(hidden)] // Not public API. Please use an existing constructor.
     pub _non_exhaustive: (),
 }
@@ -106,6 +120,7 @@ const fn base_blob_base_fee_update_fraction(spec_id: SpecId) -> u64 {
 
 const DEFAULT_MEMORY_LIMIT: u64 = (1 << 32) - 1;
 const DEFAULT_CHAIN_ID: u64 = 1;
+const DEFAULT_MIN_STACK_SIZE: usize = 1024 * 1024;
 
 static BASE_VERSIONS: [Version; SpecId::COUNT] = {
     let mut versions = [const {
@@ -120,6 +135,8 @@ static BASE_VERSIONS: [Version; SpecId::COUNT] = {
             max_initcode_size: MAX_INITCODE_SIZE,
             max_blobs_per_tx: MAX_BLOBS_PER_BLOCK_DENCUN,
             blob_base_fee_update_fraction: BLOB_BASE_FEE_UPDATE_FRACTION_CANCUN,
+            io_mode: IoMode::Async,
+            min_stack_size: DEFAULT_MIN_STACK_SIZE,
             _non_exhaustive: (),
         }
     }; SpecId::COUNT];
@@ -137,6 +154,8 @@ static BASE_VERSIONS: [Version; SpecId::COUNT] = {
             max_initcode_size: base_max_initcode_size(spec_id),
             max_blobs_per_tx: base_max_blobs_per_tx(spec_id),
             blob_base_fee_update_fraction: base_blob_base_fee_update_fraction(spec_id),
+            io_mode: IoMode::Async,
+            min_stack_size: DEFAULT_MIN_STACK_SIZE,
             _non_exhaustive: (),
         };
         i += 1;

--- a/crates/evm2/src/version/mod.rs
+++ b/crates/evm2/src/version/mod.rs
@@ -20,6 +20,8 @@ mod opcode_config;
 pub use opcode_config::OpcodeConfig;
 
 /// How async database I/O should be driven from synchronous EVM host calls.
+///
+/// Currently unused unless the `"async"` feature is enabled.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
 pub enum IoMode {
     /// Block the current Tokio worker with `block_in_place`.
@@ -61,8 +63,12 @@ pub struct Version {
     /// Blob base fee update fraction.
     pub blob_base_fee_update_fraction: u64,
     /// Async database I/O mode.
+    ///
+    /// Currently unused unless the `"async"` feature is enabled.
     pub io_mode: IoMode,
     /// Minimum async EVM fiber stack size in bytes.
+    ///
+    /// Currently unused unless the `"async"` feature is enabled.
     pub min_stack_size: usize,
     #[doc(hidden)] // Not public API. Please use an existing constructor.
     pub _non_exhaustive: (),

--- a/crates/evm2/src/version/mod.rs
+++ b/crates/evm2/src/version/mod.rs
@@ -51,12 +51,6 @@ pub struct Version {
     /// Blob base fee update fraction.
     pub blob_base_fee_update_fraction: u64,
 
-    // Implementation config.
-    /// Minimum async EVM fiber stack size in bytes.
-    ///
-    /// Currently unused unless the `"async"` feature is enabled.
-    pub min_stack_size: usize,
-
     #[doc(hidden)] // Not public API. Please use an existing constructor.
     pub _non_exhaustive: (),
 }
@@ -113,7 +107,6 @@ const fn base_blob_base_fee_update_fraction(spec_id: SpecId) -> u64 {
 
 const DEFAULT_MEMORY_LIMIT: u64 = (1 << 32) - 1;
 const DEFAULT_CHAIN_ID: u64 = 1;
-const DEFAULT_MIN_STACK_SIZE: usize = 1024 * 1024;
 
 static BASE_VERSIONS: [Version; SpecId::COUNT] = {
     let mut versions = [const {
@@ -128,7 +121,6 @@ static BASE_VERSIONS: [Version; SpecId::COUNT] = {
             max_initcode_size: MAX_INITCODE_SIZE,
             max_blobs_per_tx: MAX_BLOBS_PER_BLOCK_DENCUN,
             blob_base_fee_update_fraction: BLOB_BASE_FEE_UPDATE_FRACTION_CANCUN,
-            min_stack_size: DEFAULT_MIN_STACK_SIZE,
             _non_exhaustive: (),
         }
     }; SpecId::COUNT];
@@ -146,7 +138,6 @@ static BASE_VERSIONS: [Version; SpecId::COUNT] = {
             max_initcode_size: base_max_initcode_size(spec_id),
             max_blobs_per_tx: base_max_blobs_per_tx(spec_id),
             blob_base_fee_update_fraction: base_blob_base_fee_update_fraction(spec_id),
-            min_stack_size: DEFAULT_MIN_STACK_SIZE,
             _non_exhaustive: (),
         };
         i += 1;

--- a/crates/evm2/src/version/mod.rs
+++ b/crates/evm2/src/version/mod.rs
@@ -62,6 +62,8 @@ pub struct Version {
     pub max_blobs_per_tx: usize,
     /// Blob base fee update fraction.
     pub blob_base_fee_update_fraction: u64,
+
+    // Implementation config.
     /// Async database I/O mode.
     ///
     /// Currently unused unless the `"async"` feature is enabled.
@@ -70,6 +72,7 @@ pub struct Version {
     ///
     /// Currently unused unless the `"async"` feature is enabled.
     pub min_stack_size: usize,
+
     #[doc(hidden)] // Not public API. Please use an existing constructor.
     pub _non_exhaustive: (),
 }

--- a/crates/evm2/src/version/mod.rs
+++ b/crates/evm2/src/version/mod.rs
@@ -19,18 +19,6 @@ pub use features::EvmFeatures;
 mod opcode_config;
 pub use opcode_config::OpcodeConfig;
 
-/// How async database I/O should be driven from synchronous EVM host calls.
-///
-/// Currently unused unless the `"async"` feature is enabled.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
-pub enum IoMode {
-    /// Block the current Tokio worker with `block_in_place`.
-    Blocking,
-    /// Suspend the EVM fiber while database I/O is pending.
-    #[default]
-    Async,
-}
-
 /// Runtime configuration data.
 ///
 /// The name is a bit misleading: this is a catch-all runtime configuration object. It stores fork
@@ -64,10 +52,6 @@ pub struct Version {
     pub blob_base_fee_update_fraction: u64,
 
     // Implementation config.
-    /// Async database I/O mode.
-    ///
-    /// Currently unused unless the `"async"` feature is enabled.
-    pub io_mode: IoMode,
     /// Minimum async EVM fiber stack size in bytes.
     ///
     /// Currently unused unless the `"async"` feature is enabled.
@@ -144,7 +128,6 @@ static BASE_VERSIONS: [Version; SpecId::COUNT] = {
             max_initcode_size: MAX_INITCODE_SIZE,
             max_blobs_per_tx: MAX_BLOBS_PER_BLOCK_DENCUN,
             blob_base_fee_update_fraction: BLOB_BASE_FEE_UPDATE_FRACTION_CANCUN,
-            io_mode: IoMode::Async,
             min_stack_size: DEFAULT_MIN_STACK_SIZE,
             _non_exhaustive: (),
         }
@@ -163,7 +146,6 @@ static BASE_VERSIONS: [Version; SpecId::COUNT] = {
             max_initcode_size: base_max_initcode_size(spec_id),
             max_blobs_per_tx: base_max_blobs_per_tx(spec_id),
             blob_base_fee_update_fraction: base_blob_base_fee_update_fraction(spec_id),
-            io_mode: IoMode::Async,
             min_stack_size: DEFAULT_MIN_STACK_SIZE,
             _non_exhaustive: (),
         };


### PR DESCRIPTION
Adds an async database adapter that lets the synchronous EVM execute against async host I/O by running the EVM on a coroutine-backed fiber. Async entrypoints suspend the fiber when database futures are pending, while synchronous entrypoints block on a stored or current Tokio runtime.

This keeps the core execution path synchronous and hides the coroutine implementation behind the async feature. The implementation currently patches corosensei from upstream master for public `Coroutine::with_stack_unchecked`.
