### PR TITLE
chore: update corosensei

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,9 +48,7 @@ alloy-trie = { version = "0.9", default-features = false }
 derive-where = { version = "1.6", default-features = false }
 
 cfg-if = { version = "1.0", default-features = false }
-# Uses public `Coroutine::with_stack_unchecked`.
-# https://github.com/Amanieu/corosensei/pull/74
-corosensei = { version = "0.3.3", git = "https://github.com/Amanieu/corosensei", rev = "3a122508ab1d7c25e4dee8b2b4b4c47046c3c3d8", default-features = false, features = [
+corosensei = { version = "0.3.4", default-features = false, features = [
     "default-stack",
     "unwind",
 ] }


### PR DESCRIPTION
Updates corosensei to the latest crates.io release and removes the temporary git dependency now that the needed API is published.