### PR TITLE
chore: bump msrv to 1.96

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "3"
 [workspace.package]
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.95"
+rust-version = "1.96"
 authors = ["DaniPopes <57450786+DaniPopes@users.noreply.github.com>"]
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/danipopes/evm2"

--- a/crates/evm2/src/async_.rs
+++ b/crates/evm2/src/async_.rs
@@ -602,7 +602,10 @@ mod tests {
     };
     use alloy_consensus::{TxLegacy, transaction::Recovered};
     use alloy_primitives::{Address, B256, Bytes};
-    use core::{convert::Infallible, fmt, future::Future, pin::Pin, ptr::NonNull, task::Poll};
+    use core::{
+        assert_matches, convert::Infallible, fmt, future::Future, pin::Pin, ptr::NonNull,
+        task::Poll,
+    };
     use corosensei::stack::Stack;
     use std::{
         error::Error,
@@ -611,7 +614,7 @@ mod tests {
 
     #[test]
     fn block_on_requires_fiber() {
-        assert!(matches!(block_on_current(core::future::ready(())), Err(AsyncError::NotOnFiber)));
+        assert_matches!(block_on_current(core::future::ready(())), Err(AsyncError::NotOnFiber));
     }
 
     #[test]
@@ -624,8 +627,8 @@ mod tests {
         let waker = Waker::noop();
         let mut cx = Context::from_waker(waker);
 
-        assert!(matches!(future.as_mut().poll(&mut cx), Poll::Pending));
-        assert!(matches!(future.as_mut().poll(&mut cx), Poll::Ready(Ok(3))));
+        assert_matches!(future.as_mut().poll(&mut cx), Poll::Pending);
+        assert_matches!(future.as_mut().poll(&mut cx), Poll::Ready(Ok(3)));
     }
 
     #[test]
@@ -660,8 +663,9 @@ mod tests {
         let waker = Waker::noop();
         let mut cx = Context::from_waker(waker);
 
-        assert!(
-            matches!(future.as_mut().poll(&mut cx), Poll::Ready(Ok(value)) if value == Word::from(9))
+        assert_matches!(
+            future.as_mut().poll(&mut cx),
+            Poll::Ready(Ok(value)) if value == Word::from(9),
         );
     }
 
@@ -676,9 +680,10 @@ mod tests {
         let waker = Waker::noop();
         let mut cx = Context::from_waker(waker);
 
-        assert!(matches!(future.as_mut().poll(&mut cx), Poll::Pending));
-        assert!(
-            matches!(future.as_mut().poll(&mut cx), Poll::Ready(Ok(value)) if value == Word::from(9))
+        assert_matches!(future.as_mut().poll(&mut cx), Poll::Pending);
+        assert_matches!(
+            future.as_mut().poll(&mut cx),
+            Poll::Ready(Ok(value)) if value == Word::from(9),
         );
     }
 
@@ -727,10 +732,10 @@ mod tests {
 
         let result = poll_ready(evm.transact_async(&tx));
 
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(AsyncError::Inner(HandlerError::UnsupportedTransactionType(TEST_TX_TYPE)))
-        ));
+        );
     }
 
     #[test]
@@ -831,7 +836,7 @@ mod tests {
             let waker = Waker::noop();
             let mut cx = Context::from_waker(waker);
 
-            assert!(matches!(future.as_mut().poll(&mut cx), Poll::Pending));
+            assert_matches!(future.as_mut().poll(&mut cx), Poll::Pending);
         }
         assert!(saw_cancel);
     }

--- a/crates/evm2/src/evm/inspector.rs
+++ b/crates/evm2/src/evm/inspector.rs
@@ -106,6 +106,7 @@ mod tests {
     use alloc::vec::Vec;
     use alloy_consensus::{TxLegacy, transaction::Recovered};
     use alloy_primitives::{Address, Bytes, Log, TxKind, U256};
+    use core::assert_matches;
 
     #[derive(Default)]
     struct StepInspector {
@@ -505,7 +506,7 @@ mod tests {
             &mut inspector,
         );
 
-        assert!(matches!(stop, InstrStop::Stop));
+        assert_matches!(stop, InstrStop::Stop);
         assert_eq!(stack, [Word::ZERO]);
         assert_eq!(inspector.call_depth, Some(CALL_DEPTH_LIMIT + 1));
         assert_eq!(inspector.call_end_stop, Some(InstrStop::CallTooDeep));
@@ -531,7 +532,7 @@ mod tests {
         let (stop, stack) =
             run_with_inspector(code, &mut host, &Message::default(), 50_000, &mut inspector);
 
-        assert!(matches!(stop, InstrStop::Stop));
+        assert_matches!(stop, InstrStop::Stop);
         assert_eq!(stack, [Word::from(1), Word::from(3)]);
         assert_eq!(inspector.call_depth, Some(1));
         assert_eq!(inspector.call_end_stop, Some(InstrStop::Return));
@@ -558,7 +559,7 @@ mod tests {
             &mut inspector,
         );
 
-        assert!(matches!(stop, InstrStop::Stop));
+        assert_matches!(stop, InstrStop::Stop);
         assert_eq!(stack, [Word::from(1)]);
         assert_eq!(inspector.call_end_stop, Some(InstrStop::Return));
         assert!(host.calls.is_empty());
@@ -576,7 +577,7 @@ mod tests {
         let (stop, stack) =
             run_with_inspector(code, &mut host, &Message::default(), 50_000, &mut inspector);
 
-        assert!(matches!(stop, InstrStop::Stop));
+        assert_matches!(stop, InstrStop::Stop);
         assert_eq!(stack, [Word::from(1)]);
         assert_eq!(host.calls.len(), 1);
         assert_eq!(host.calls[0].destination, replacement);
@@ -593,7 +594,7 @@ mod tests {
         let (stop, stack) =
             run_with_inspector(code, &mut host, &Message::default(), 50_000, &mut inspector);
 
-        assert!(matches!(stop, InstrStop::Stop));
+        assert_matches!(stop, InstrStop::Stop);
         assert_eq!(stack, [Word::from(1), Word::from(2)]);
         assert!(host.calls.is_empty());
     }
@@ -613,7 +614,7 @@ mod tests {
             &mut inspector,
         );
 
-        assert!(matches!(stop, InstrStop::Stop));
+        assert_matches!(stop, InstrStop::Stop);
         assert_eq!(stack, [Word::ZERO]);
         assert_eq!(inspector.create_depth, Some(CALL_DEPTH_LIMIT + 1));
         assert_eq!(inspector.create_end_stop, Some(InstrStop::CallTooDeep));
@@ -632,7 +633,7 @@ mod tests {
         let (stop, stack) =
             run_with_inspector(code, &mut host, &Message::default(), 50_000, &mut inspector);
 
-        assert!(matches!(stop, InstrStop::Stop));
+        assert_matches!(stop, InstrStop::Stop);
         assert_eq!(stack, [address_to_word(&created)]);
         assert_eq!(inspector.create_depth, Some(1));
         assert_eq!(inspector.create_end_stop, Some(InstrStop::Return));
@@ -656,7 +657,7 @@ mod tests {
             &mut inspector,
         );
 
-        assert!(matches!(stop, InstrStop::Stop));
+        assert_matches!(stop, InstrStop::Stop);
         assert_eq!(stack, [address_to_word(&created)]);
         assert_eq!(inspector.create_depth, Some(CALL_DEPTH_LIMIT + 1));
         assert_eq!(inspector.create_end_stop, Some(InstrStop::Return));
@@ -674,7 +675,7 @@ mod tests {
         let (stop, stack) =
             run_with_inspector(code, &mut host, &Message::default(), 50_000, &mut inspector);
 
-        assert!(matches!(stop, InstrStop::Stop));
+        assert_matches!(stop, InstrStop::Stop);
         assert_eq!(stack, [address_to_word(&created)]);
         assert!(host.calls.is_empty());
     }
@@ -694,7 +695,7 @@ mod tests {
             &mut inspector,
         );
 
-        assert!(matches!(stop, InstrStop::Stop));
+        assert_matches!(stop, InstrStop::Stop);
         assert_eq!(inspector.logs.len(), 1);
         assert_eq!(inspector.logs[0].address, contract);
         assert_eq!(host.logs, inspector.logs);
@@ -752,7 +753,7 @@ mod tests {
             &mut inspector,
         );
 
-        assert!(matches!(stop, InstrStop::SelfDestruct));
+        assert_matches!(stop, InstrStop::SelfDestruct);
         assert_eq!(inspector.selfdestruct, Some((contract, target, value)));
     }
 

--- a/crates/evm2/src/interpreter/gas.rs
+++ b/crates/evm2/src/interpreter/gas.rs
@@ -470,6 +470,7 @@ impl MemoryGas {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use core::assert_matches;
 
     #[test]
     fn test_spend_state() {
@@ -494,7 +495,7 @@ mod tests {
         assert_eq!((gas.reservoir(), gas.remaining(), gas.state_gas_spent()), (50, 100, 0));
 
         let mut gas = Gas::new_with_regular_gas_and_reservoir(100, 50);
-        assert!(matches!(gas.spend_state(200), Err(InstrStop::OutOfGas)));
+        assert_matches!(gas.spend_state(200), Err(InstrStop::OutOfGas));
 
         let mut gas = Gas::new_with_regular_gas_and_reservoir(2000, 1000);
         assert!(gas.spend_state(100).is_ok());
@@ -514,11 +515,11 @@ mod tests {
     #[test]
     fn test_spend_state_oog_does_not_inflate_state_gas_spent() {
         let mut gas = Gas::new(30);
-        assert!(matches!(gas.spend_state(100), Err(InstrStop::OutOfGas)));
+        assert_matches!(gas.spend_state(100), Err(InstrStop::OutOfGas));
         assert_eq!(gas.state_gas_spent(), 0);
 
         let mut gas = Gas::new_with_regular_gas_and_reservoir(30, 20);
-        assert!(matches!(gas.spend_state(100), Err(InstrStop::OutOfGas)));
+        assert_matches!(gas.spend_state(100), Err(InstrStop::OutOfGas));
         assert_eq!(gas.state_gas_spent(), 0);
         assert_eq!(gas.reservoir(), 20);
     }
@@ -532,6 +533,6 @@ mod tests {
         assert!(gas.spend_state(300).is_ok());
         assert_eq!((gas.reservoir(), gas.remaining(), gas.state_gas_spent()), (0, 0, 500));
 
-        assert!(matches!(gas.spend_state(1), Err(InstrStop::OutOfGas)));
+        assert_matches!(gas.spend_state(1), Err(InstrStop::OutOfGas));
     }
 }

--- a/crates/evm2/src/interpreter/instructions/arithmetic.rs
+++ b/crates/evm2/src/interpreter/instructions/arithmetic.rs
@@ -65,6 +65,7 @@ pub(crate) fn signextend([ext, value]: [Word]) -> out {
 #[cfg(test)]
 mod tests {
     use alloc::vec::Vec;
+    use core::assert_matches;
 
     use crate::{
         SpecId,
@@ -158,7 +159,7 @@ mod tests {
 
         let interpreter = run(RunConfig::new(code).spec(SpecId::FRONTIER).gas_limit(25));
 
-        assert!(matches!(interpreter.err, InstrStop::OutOfGas));
+        assert_matches!(interpreter.err, InstrStop::OutOfGas);
     }
 
     #[test]
@@ -172,7 +173,7 @@ mod tests {
         let spurious_dragon = run(RunConfig::new(code).spec(SpecId::SPURIOUS_DRAGON).gas_limit(65));
 
         assert_eq!(frontier.err, InstrStop::Stop);
-        assert!(matches!(spurious_dragon.err, InstrStop::OutOfGas));
+        assert_matches!(spurious_dragon.err, InstrStop::OutOfGas);
     }
 
     #[test]

--- a/crates/evm2/src/interpreter/instructions/block.rs
+++ b/crates/evm2/src/interpreter/instructions/block.rs
@@ -98,6 +98,7 @@ mod tests {
     };
     use alloc::vec::Vec;
     use alloy_primitives::{Address, B256};
+    use core::assert_matches;
 
     fn test_host(block: BlockEnv<TestTypes>) -> TestHost {
         TestHost { block, ..TestHost::default() }
@@ -112,7 +113,7 @@ mod tests {
         code.push(op::STOP);
 
         let interpreter = run(RunConfig::new(code).host(&mut host));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [b256_to_word(B256::with_last_byte(9))]);
 
         let mut code = Vec::new();
@@ -120,7 +121,7 @@ mod tests {
         code.push(op::BLOCKHASH);
         code.push(op::STOP);
         let interpreter = run(RunConfig::new(code).host(&mut host));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [0]);
     }
 
@@ -129,7 +130,7 @@ mod tests {
         let beneficiary = Address::from([0x44; 20]);
         let mut host = test_host(BlockEnv { beneficiary, ..BlockEnv::default() });
         let interpreter = run(RunConfig::new([op::COINBASE, op::STOP]).host(&mut host));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [address_to_word(&beneficiary)]);
     }
 
@@ -137,7 +138,7 @@ mod tests {
     fn timestamp_opcode() {
         let mut host = test_host(BlockEnv { timestamp: Word::from(12), ..BlockEnv::default() });
         let interpreter = run(RunConfig::new([op::TIMESTAMP, op::STOP]).host(&mut host));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [Word::from(12)]);
     }
 
@@ -145,7 +146,7 @@ mod tests {
     fn number_opcode() {
         let mut host = test_host(BlockEnv { number: Word::from(13), ..BlockEnv::default() });
         let interpreter = run(RunConfig::new([op::NUMBER, op::STOP]).host(&mut host));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [Word::from(13)]);
     }
 
@@ -159,12 +160,12 @@ mod tests {
         });
         let interpreter =
             run(RunConfig::new([op::DIFFICULTY, op::STOP]).host(&mut host).spec(SpecId::FRONTIER));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [Word::from(14)]);
 
         let interpreter =
             run(RunConfig::new([op::DIFFICULTY, op::STOP]).host(&mut host).spec(SpecId::MERGE));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [b256_to_word(randao)]);
     }
 
@@ -172,7 +173,7 @@ mod tests {
     fn gaslimit_opcode() {
         let mut host = test_host(BlockEnv { gas_limit: Word::from(15), ..BlockEnv::default() });
         let interpreter = run(RunConfig::new([op::GASLIMIT, op::STOP]).host(&mut host));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [Word::from(15)]);
     }
 
@@ -184,7 +185,7 @@ mod tests {
             .host(&mut host)
             .tx_env(tx_env)
             .spec(SpecId::ISTANBUL));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [Word::from(1)]);
     }
 
@@ -195,7 +196,7 @@ mod tests {
         let message = Message { destination: address, gas_limit: 10_000, ..Default::default() };
         let interpreter =
             run(RunConfig::new([op::SELFBALANCE, op::STOP]).host(&mut host).message(message));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [address_to_word(&address)]);
     }
 
@@ -204,7 +205,7 @@ mod tests {
         let mut host = test_host(BlockEnv { basefee: Word::from(16), ..BlockEnv::default() });
         let interpreter =
             run(RunConfig::new([op::BASEFEE, op::STOP]).host(&mut host).spec(SpecId::LONDON));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [Word::from(16)]);
     }
 
@@ -218,14 +219,14 @@ mod tests {
             .host(&mut host)
             .tx_env(tx_env.clone())
             .spec(SpecId::CANCUN));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [b256_to_word(hash)]);
 
         let interpreter = run(RunConfig::new([op::PUSH1, 0x01, op::BLOBHASH, op::STOP])
             .host(&mut host)
             .tx_env(tx_env)
             .spec(SpecId::CANCUN));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [0]);
     }
 
@@ -234,7 +235,7 @@ mod tests {
         let mut host = test_host(BlockEnv { blob_basefee: Word::from(17), ..BlockEnv::default() });
         let interpreter =
             run(RunConfig::new([op::BLOBBASEFEE, op::STOP]).host(&mut host).spec(SpecId::CANCUN));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [Word::from(17)]);
     }
 
@@ -243,7 +244,7 @@ mod tests {
         let mut host = test_host(BlockEnv { slot_num: Word::from(18), ..BlockEnv::default() });
         let interpreter =
             run(RunConfig::new([op::SLOTNUM, op::STOP]).host(&mut host).spec(SpecId::AMSTERDAM));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [Word::from(18)]);
     }
 }

--- a/crates/evm2/src/interpreter/instructions/control.rs
+++ b/crates/evm2/src/interpreter/instructions/control.rs
@@ -103,42 +103,43 @@ mod tests {
         op,
     };
     use alloc::vec::Vec;
+    use core::assert_matches;
 
     #[test]
     fn stop_opcode() {
         let interpreter = run(RunConfig::new([op::STOP]));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
 
         let interpreter = run(RunConfig::new([op::STOP, op::INVALID]));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
     }
 
     #[test]
     fn invalid_opcode() {
         let interpreter = run(RunConfig::new([op::INVALID]));
-        assert!(matches!(interpreter.err, InstrStop::InvalidOpcode));
+        assert_matches!(interpreter.err, InstrStop::InvalidOpcode);
 
         let interpreter = run(RunConfig::new([0x0c]));
-        assert!(matches!(interpreter.err, InstrStop::InvalidOpcode));
+        assert_matches!(interpreter.err, InstrStop::InvalidOpcode);
     }
 
     #[test]
     fn jump_opcode() {
         let interpreter = run(RunConfig::new([op::PUSH1, 0x03, op::JUMP, op::JUMPDEST, op::STOP]));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
 
         let interpreter = run(RunConfig::new([op::PUSH1, 0x00, op::JUMP, op::JUMPDEST, op::STOP]));
-        assert!(matches!(interpreter.err, InstrStop::InvalidJump));
+        assert_matches!(interpreter.err, InstrStop::InvalidJump);
 
         let mut code = Vec::new();
         push(&mut code, Word::MAX);
         code.push(op::JUMP);
         let interpreter = run(RunConfig::new(code));
-        assert!(matches!(interpreter.err, InstrStop::InvalidJump));
+        assert_matches!(interpreter.err, InstrStop::InvalidJump);
 
         let interpreter =
             run(RunConfig::new([op::PUSH1, 0x04, op::JUMP, op::STOP, op::JUMPDEST, op::STOP]));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
     }
 
     #[test]
@@ -153,7 +154,7 @@ mod tests {
             op::JUMPDEST,
             op::STOP,
         ]));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
 
         let interpreter = run(RunConfig::new([
             op::PUSH1,
@@ -164,40 +165,40 @@ mod tests {
             op::JUMPDEST,
             op::STOP,
         ]));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
 
         let interpreter =
             run(RunConfig::new([op::PUSH1, 0x01, op::PUSH1, 0x05, op::JUMPI, op::STOP, op::STOP]));
-        assert!(matches!(interpreter.err, InstrStop::InvalidJump));
+        assert_matches!(interpreter.err, InstrStop::InvalidJump);
 
         let mut code = Vec::new();
         push(&mut code, 1);
         push(&mut code, Word::MAX);
         code.push(op::JUMPI);
         let interpreter = run(RunConfig::new(code));
-        assert!(matches!(interpreter.err, InstrStop::InvalidJump));
+        assert_matches!(interpreter.err, InstrStop::InvalidJump);
     }
 
     #[test]
     fn pc_opcode() {
         let interpreter = run(RunConfig::new([op::PC, op::JUMPDEST, op::STOP]));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [0]);
 
         let interpreter = run(RunConfig::new([op::JUMPDEST, op::PC, op::STOP]));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [Word::from(1)]);
     }
 
     #[test]
     fn gas_opcode() {
         let interpreter = run(RunConfig::new([op::GAS, op::STOP]));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack().len(), 1);
         assert!(interpreter.stack()[0] < Word::from(10_000));
 
         let interpreter = run(RunConfig::new([op::GAS, op::GAS, op::STOP]));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack().len(), 2);
         assert!(interpreter.stack()[1] < interpreter.stack()[0]);
     }
@@ -205,22 +206,22 @@ mod tests {
     #[test]
     fn jumpdest_opcode() {
         let interpreter = run(RunConfig::new([op::JUMPDEST, op::STOP]));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert!(interpreter.stack().is_empty());
 
         let interpreter = run(RunConfig::new([op::JUMPDEST, op::JUMPDEST, op::STOP]));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
     }
 
     #[test]
     fn return_opcode() {
         let mut interpreter = run_stack([0, 0], op::RETURN);
-        assert!(matches!(interpreter.err, InstrStop::Return));
+        assert_matches!(interpreter.err, InstrStop::Return);
         assert!(interpreter.memory(0, 0).is_empty());
         assert!(interpreter.output().is_empty());
 
         let mut interpreter = run_stack([0, 1], op::RETURN);
-        assert!(matches!(interpreter.err, InstrStop::Return));
+        assert_matches!(interpreter.err, InstrStop::Return);
         assert_eq!(interpreter.memory(0, 1), [0]);
         assert_eq!(interpreter.output(), [0]);
 
@@ -232,25 +233,25 @@ mod tests {
         push(&mut code, Word::from(2));
         code.push(op::RETURN);
         let interpreter = run(RunConfig::new(code));
-        assert!(matches!(interpreter.err, InstrStop::Return));
+        assert_matches!(interpreter.err, InstrStop::Return);
         assert_eq!(interpreter.output(), [0xab, 0, 0]);
 
         let interpreter = run_stack([Word::from(0), Word::MAX], op::RETURN);
-        assert!(matches!(interpreter.err, InstrStop::InvalidOperandOOG));
+        assert_matches!(interpreter.err, InstrStop::InvalidOperandOOG);
 
         let interpreter = run_stack([Word::from(u32::MAX), Word::from(1)], op::RETURN);
-        assert!(matches!(interpreter.err, InstrStop::MemoryLimitOOG));
+        assert_matches!(interpreter.err, InstrStop::MemoryLimitOOG);
     }
 
     #[test]
     fn revert_opcode() {
         let mut interpreter = run_stack([0, 0], op::REVERT);
-        assert!(matches!(interpreter.err, InstrStop::Revert));
+        assert_matches!(interpreter.err, InstrStop::Revert);
         assert!(interpreter.memory(0, 0).is_empty());
         assert!(interpreter.output().is_empty());
 
         let mut interpreter = run_stack([2, 3], op::REVERT);
-        assert!(matches!(interpreter.err, InstrStop::Revert));
+        assert_matches!(interpreter.err, InstrStop::Revert);
         assert_eq!(interpreter.memory(2, 3), [0, 0, 0]);
         assert_eq!(interpreter.output(), [0, 0, 0]);
 
@@ -262,13 +263,13 @@ mod tests {
         push(&mut code, Word::from(4));
         code.push(op::REVERT);
         let interpreter = run(RunConfig::new(code));
-        assert!(matches!(interpreter.err, InstrStop::Revert));
+        assert_matches!(interpreter.err, InstrStop::Revert);
         assert_eq!(interpreter.output(), [0xcd, 0]);
 
         let interpreter = run_stack([Word::from(0), Word::MAX], op::REVERT);
-        assert!(matches!(interpreter.err, InstrStop::InvalidOperandOOG));
+        assert_matches!(interpreter.err, InstrStop::InvalidOperandOOG);
 
         let interpreter = run_stack([Word::from(u32::MAX), Word::from(1)], op::REVERT);
-        assert!(matches!(interpreter.err, InstrStop::MemoryLimitOOG));
+        assert_matches!(interpreter.err, InstrStop::MemoryLimitOOG);
     }
 }

--- a/crates/evm2/src/interpreter/instructions/crypto.rs
+++ b/crates/evm2/src/interpreter/instructions/crypto.rs
@@ -31,6 +31,7 @@ mod tests {
     };
     use alloc::vec::Vec;
     use alloy_primitives::keccak256;
+    use core::assert_matches;
 
     #[test]
     fn keccak256_opcode() {
@@ -40,7 +41,7 @@ mod tests {
         code.push(op::KECCAK256);
         code.push(op::STOP);
         let interpreter = run(RunConfig::new(code));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [b256_to_word(keccak256([]))]);
 
         let mut code = Vec::new();
@@ -52,14 +53,14 @@ mod tests {
         code.push(op::KECCAK256);
         code.push(op::STOP);
         let interpreter = run(RunConfig::new(code));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [b256_to_word(keccak256([0x80]))]);
 
         let interpreter = run_stack([Word::MAX, Word::from(0)], op::KECCAK256);
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [b256_to_word(keccak256([]))]);
 
         let interpreter = run_stack([Word::MAX, Word::from(1)], op::KECCAK256);
-        assert!(matches!(interpreter.err, InstrStop::InvalidOperandOOG));
+        assert_matches!(interpreter.err, InstrStop::InvalidOperandOOG);
     }
 }

--- a/crates/evm2/src/interpreter/instructions/env.rs
+++ b/crates/evm2/src/interpreter/instructions/env.rs
@@ -179,6 +179,7 @@ mod tests {
     };
     use alloc::{vec, vec::Vec};
     use alloy_primitives::{Address, B256, Bytes};
+    use core::assert_matches;
 
     fn neg(value: u64) -> Word {
         Word::from(0).wrapping_sub(Word::from(value))
@@ -204,7 +205,7 @@ mod tests {
         let message = Message { destination: address, ..test_message() };
         let interpreter =
             run(RunConfig::new([op::ADDRESS, op::STOP]).host(&mut host).message(message));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [address_to_word(&address)]);
     }
 
@@ -221,7 +222,7 @@ mod tests {
         let interpreter = run(RunConfig::new([op::PUSH1, 0xbe, op::BALANCE, op::STOP])
             .host(&mut host)
             .spec(SpecId::BERLIN));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [Word::from(0xbe)]);
         assert_eq!(interpreter.gas_remaining(), 7_397);
     }
@@ -233,7 +234,7 @@ mod tests {
             .host(&mut host)
             .spec(SpecId::BERLIN)
             .gas_limit(103));
-        assert!(matches!(interpreter.err, InstrStop::OutOfGas));
+        assert_matches!(interpreter.err, InstrStop::OutOfGas);
     }
 
     #[test]
@@ -243,7 +244,7 @@ mod tests {
         let tx_env = TxEnv { origin, ..TxEnv::default() };
         let interpreter =
             run(RunConfig::new([op::ORIGIN, op::STOP]).host(&mut host).tx_env(tx_env));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [address_to_word(&origin)]);
     }
 
@@ -254,7 +255,7 @@ mod tests {
         let message = Message { caller, ..test_message() };
         let interpreter =
             run(RunConfig::new([op::CALLER, op::STOP]).host(&mut host).message(message));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [address_to_word(&caller)]);
     }
 
@@ -264,7 +265,7 @@ mod tests {
         let message = Message { value: Word::from(0xbeef), ..test_message() };
         let interpreter =
             run(RunConfig::new([op::CALLVALUE, op::STOP]).host(&mut host).message(message));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [Word::from(0xbeef)]);
     }
 
@@ -279,13 +280,13 @@ mod tests {
             .message(message.clone()));
         let mut expected = [0_u8; 32];
         expected[..3].copy_from_slice(&[1, 2, 3]);
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [Word::from_be_bytes(expected)]);
 
         let interpreter = run(RunConfig::new([op::PUSH1, 0x20, op::CALLDATALOAD, op::STOP])
             .host(&mut host)
             .message(message));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [0]);
     }
 
@@ -296,7 +297,7 @@ mod tests {
         let message = Message { input, ..test_message() };
         let interpreter =
             run(RunConfig::new([op::CALLDATASIZE, op::STOP]).host(&mut host).message(message));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [Word::from(4)]);
     }
 
@@ -317,7 +318,7 @@ mod tests {
         let interpreter = run(RunConfig::new(code).host(&mut host).message(message.clone()));
         let mut expected = [0_u8; 32];
         expected[..2].copy_from_slice(&[0xbb, 0xcc]);
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [Word::from_be_bytes(expected)]);
 
         let interpreter = run(RunConfig::new(stack_code(
@@ -326,17 +327,17 @@ mod tests {
         ))
         .host(&mut host)
         .message(message));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
     }
 
     #[test]
     fn codesize_opcode() {
         let interpreter = run(RunConfig::new([op::CODESIZE, op::STOP]));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [Word::from(2)]);
 
         let interpreter = run(RunConfig::new([op::PUSH1, 0x00, op::CODESIZE, op::STOP]));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [Word::from(0), Word::from(4)]);
     }
 
@@ -354,7 +355,7 @@ mod tests {
         let interpreter = run(RunConfig::new(code));
         let mut expected = [0u8; 32];
         expected[..2].copy_from_slice(&[0, op::CODECOPY]);
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [Word::from_be_bytes(expected)]);
 
         let mut code = Vec::new();
@@ -366,14 +367,14 @@ mod tests {
         code.push(op::MLOAD);
         code.push(op::STOP);
         let interpreter = run(RunConfig::new(code));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [0]);
 
         let interpreter = run_stack([Word::MAX, Word::MAX, Word::from(0)], op::CODECOPY);
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
 
         let interpreter = run_stack([Word::MAX, Word::from(0), Word::from(1)], op::CODECOPY);
-        assert!(matches!(interpreter.err, InstrStop::InvalidOperandOOG));
+        assert_matches!(interpreter.err, InstrStop::InvalidOperandOOG);
     }
 
     #[test]
@@ -382,7 +383,7 @@ mod tests {
         let tx_env = TxEnv { gas_price: Word::from(0x1234), ..TxEnv::default() };
         let interpreter =
             run(RunConfig::new([op::GASPRICE, op::STOP]).host(&mut host).tx_env(tx_env));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [Word::from(0x1234)]);
     }
 
@@ -391,7 +392,7 @@ mod tests {
         let mut host = TestHost { code: Bytes::from(vec![0; 0x42]), ..TestHost::default() };
         let interpreter =
             run(RunConfig::new([op::PUSH1, 0xbe, op::EXTCODESIZE, op::STOP]).host(&mut host));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [Word::from(0x42)]);
     }
 
@@ -412,7 +413,7 @@ mod tests {
         let interpreter = run(RunConfig::new(code).host(&mut host));
         let mut expected = [0_u8; 32];
         expected[..2].copy_from_slice(&[0xbb, 0xcc]);
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [Word::from_be_bytes(expected)]);
 
         let mut code = Vec::new();
@@ -427,7 +428,7 @@ mod tests {
         let interpreter = run(RunConfig::new(code).host(&mut host));
         let mut expected = [0_u8; 32];
         expected[..1].copy_from_slice(&[0xcc]);
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [Word::from_be_bytes(expected)]);
 
         let interpreter = run(RunConfig::new(stack_code(
@@ -435,14 +436,14 @@ mod tests {
             op::EXTCODECOPY,
         ))
         .host(&mut host));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
 
         let interpreter = run(RunConfig::new(stack_code(
             [Word::from(0xbeef), Word::MAX, Word::from(0), Word::from(1)],
             op::EXTCODECOPY,
         ))
         .host(&mut host));
-        assert!(matches!(interpreter.err, InstrStop::InvalidOperandOOG));
+        assert_matches!(interpreter.err, InstrStop::InvalidOperandOOG);
     }
 
     #[test]
@@ -450,11 +451,11 @@ mod tests {
         let interpreter = run(RunConfig::new([op::RETURNDATASIZE, op::STOP])
             .spec(SpecId::BYZANTIUM)
             .return_data(Bytes::from_static(&[0xaa, 0xbb, 0xcc])));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [Word::from(3)]);
 
         let interpreter = run(RunConfig::new([op::RETURNDATASIZE]).spec(SpecId::FRONTIER));
-        assert!(matches!(interpreter.err, InstrStop::InvalidOpcode));
+        assert_matches!(interpreter.err, InstrStop::InvalidOpcode);
     }
 
     #[test]
@@ -472,7 +473,7 @@ mod tests {
             run(RunConfig::new(code).return_data(Bytes::from_static(&[0xaa, 0xbb, 0xcc])));
         let mut expected = [0_u8; 32];
         expected[..2].copy_from_slice(&[0xbb, 0xcc]);
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [Word::from_be_bytes(expected)]);
 
         let interpreter = run(RunConfig::new(stack_code(
@@ -481,7 +482,7 @@ mod tests {
         ))
         .spec(SpecId::BYZANTIUM)
         .return_data(Bytes::from_static(&[0xaa, 0xbb, 0xcc])));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
 
         let interpreter = run(RunConfig::new(stack_code(
             [Word::from(0), Word::from(4), Word::from(0)],
@@ -489,7 +490,7 @@ mod tests {
         ))
         .spec(SpecId::BYZANTIUM)
         .return_data(Bytes::from_static(&[0xaa, 0xbb, 0xcc])));
-        assert!(matches!(interpreter.err, InstrStop::OutOfOffset));
+        assert_matches!(interpreter.err, InstrStop::OutOfOffset);
 
         let interpreter = run(RunConfig::new(stack_code(
             [Word::MAX, Word::from(0), Word::from(1)],
@@ -497,14 +498,14 @@ mod tests {
         ))
         .spec(SpecId::BYZANTIUM)
         .return_data(Bytes::from_static(&[0xaa])));
-        assert!(matches!(interpreter.err, InstrStop::InvalidOperandOOG));
+        assert_matches!(interpreter.err, InstrStop::InvalidOperandOOG);
 
         let interpreter = run(RunConfig::new(stack_code(
             [Word::from(0), Word::from(0), Word::from(0)],
             op::RETURNDATACOPY,
         ))
         .spec(SpecId::FRONTIER));
-        assert!(matches!(interpreter.err, InstrStop::InvalidOpcode));
+        assert_matches!(interpreter.err, InstrStop::InvalidOpcode);
     }
 
     #[test]
@@ -514,12 +515,12 @@ mod tests {
         let interpreter = run(RunConfig::new([op::PUSH1, 0xbe, op::EXTCODEHASH, op::STOP])
             .host(&mut host)
             .spec(SpecId::PETERSBURG));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [b256_to_word(hash)]);
 
         let interpreter = run(RunConfig::new([op::PUSH1, 0xbe, op::EXTCODEHASH, op::STOP])
             .host(&mut host)
             .spec(SpecId::BYZANTIUM));
-        assert!(matches!(interpreter.err, InstrStop::InvalidOpcode));
+        assert_matches!(interpreter.err, InstrStop::InvalidOpcode);
     }
 }

--- a/crates/evm2/src/interpreter/instructions/host.rs
+++ b/crates/evm2/src/interpreter/instructions/host.rs
@@ -138,6 +138,7 @@ mod tests {
     };
     use alloc::vec::Vec;
     use alloy_primitives::{Address, B256, Bytes};
+    use core::assert_matches;
 
     #[test]
     fn sload_opcode() {
@@ -148,14 +149,14 @@ mod tests {
         push(&mut code, 1);
         code.extend([op::SLOAD, op::STOP]);
         let interpreter = run(RunConfig::new(code).host(&mut host));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [Word::from(0xbeef)]);
 
         let mut code = Vec::new();
         push(&mut code, 2);
         code.extend([op::SLOAD, op::STOP]);
         let interpreter = run(RunConfig::new(code).host(&mut host));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [0]);
     }
 
@@ -170,7 +171,7 @@ mod tests {
         code.extend([op::SLOAD, op::STOP]);
 
         let interpreter = run(RunConfig::new(code).host(&mut host).gas_limit(30_000));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [Word::from(0xbeef)]);
         assert_eq!(
             host.storage.get(&StorageKey::new(Address::ZERO, Word::from(1))),
@@ -187,7 +188,7 @@ mod tests {
         code.extend([op::SSTORE, op::STOP]);
 
         let interpreter = run(RunConfig::new(code).host(&mut host).staticcall());
-        assert!(matches!(interpreter.err, InstrStop::StateChangeDuringStaticCall));
+        assert_matches!(interpreter.err, InstrStop::StateChangeDuringStaticCall);
         assert!(interpreter.stack().is_empty());
         assert_eq!(host.storage.get(&StorageKey::new(Address::ZERO, Word::from(1))), None);
     }
@@ -204,7 +205,7 @@ mod tests {
 
         let interpreter = run(RunConfig::new(code).host(&mut host).message(message));
 
-        assert!(matches!(interpreter.err, InstrStop::StateChangeDuringStaticCall));
+        assert_matches!(interpreter.err, InstrStop::StateChangeDuringStaticCall);
         assert!(interpreter.stack().is_empty());
         assert_eq!(host.storage.get(&StorageKey::new(Address::ZERO, Word::from(1))), None);
     }
@@ -219,7 +220,7 @@ mod tests {
 
         let interpreter =
             run(RunConfig::new(code).host(&mut host).spec(SpecId::ISTANBUL).gas_limit(2306));
-        assert!(matches!(interpreter.err, InstrStop::ReentrancySentryOOG));
+        assert_matches!(interpreter.err, InstrStop::ReentrancySentryOOG);
         assert_eq!(host.storage.get(&StorageKey::new(Address::ZERO, Word::from(1))), None);
     }
 
@@ -230,7 +231,7 @@ mod tests {
             .host(&mut host)
             .spec(SpecId::FRONTIER)
             .gas_limit(6000));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.gas_remaining(), 994);
     }
 
@@ -242,7 +243,7 @@ mod tests {
             .spec(SpecId::BERLIN)
             .gas_limit(3000));
 
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.gas_remaining(), 2894);
     }
 
@@ -260,7 +261,7 @@ mod tests {
         let interpreter =
             run(RunConfig::new(code).host(&mut host).spec(SpecId::BERLIN).gas_limit(50_000));
 
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.gas_remaining(), 29_888);
         assert_eq!(interpreter.gas_refunded(), 0);
     }
@@ -280,7 +281,7 @@ mod tests {
         let interpreter =
             run(RunConfig::new(code).host(&mut host).spec(SpecId::BERLIN).gas_limit(50_000));
 
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.gas_remaining(), 46_988);
         assert_eq!(interpreter.gas_refunded(), 2_800);
     }
@@ -293,7 +294,7 @@ mod tests {
             .spec(SpecId::AMSTERDAM)
             .gas_limit(100_000));
 
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.gas_remaining(), 59_526);
         assert_eq!(interpreter.state_gas_spent(), 37_568);
     }
@@ -308,13 +309,13 @@ mod tests {
         push(&mut code, 1);
         code.extend([op::TLOAD, op::STOP]);
         let interpreter = run(RunConfig::new(code).host(&mut host).spec(SpecId::CANCUN));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [Word::from(0xcafe)]);
 
         let interpreter = run(RunConfig::new([op::PUSH1, 0, op::TLOAD, op::STOP])
             .host(&mut host)
             .spec(SpecId::SHANGHAI));
-        assert!(matches!(interpreter.err, InstrStop::InvalidOpcode));
+        assert_matches!(interpreter.err, InstrStop::InvalidOpcode);
         assert_eq!(interpreter.stack(), [0]);
     }
 
@@ -329,7 +330,7 @@ mod tests {
         code.extend([op::TLOAD, op::STOP]);
 
         let interpreter = run(RunConfig::new(code).host(&mut host).spec(SpecId::CANCUN));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [Word::from(0xcafe)]);
         assert_eq!(
             host.transient_storage.get(&StorageKey::new(Address::ZERO, Word::from(1))),
@@ -339,7 +340,7 @@ mod tests {
         let interpreter = run(RunConfig::new([op::PUSH1, 0, op::PUSH1, 0, op::TSTORE, op::STOP])
             .host(&mut host)
             .spec(SpecId::SHANGHAI));
-        assert!(matches!(interpreter.err, InstrStop::InvalidOpcode));
+        assert_matches!(interpreter.err, InstrStop::InvalidOpcode);
         assert_eq!(interpreter.stack(), [0, 0]);
     }
 
@@ -353,7 +354,7 @@ mod tests {
 
         let interpreter =
             run(RunConfig::new(code).host(&mut host).spec(SpecId::CANCUN).staticcall());
-        assert!(matches!(interpreter.err, InstrStop::StateChangeDuringStaticCall));
+        assert_matches!(interpreter.err, InstrStop::StateChangeDuringStaticCall);
         assert!(interpreter.stack().is_empty());
         assert_eq!(
             host.transient_storage.get(&StorageKey::new(Address::ZERO, Word::from(1))),
@@ -382,7 +383,7 @@ mod tests {
         let address = Address::from([0x11; 20]);
         let message = Message { destination: address, gas_limit: 10_000, ..Default::default() };
         let interpreter = run(RunConfig::new(log_code(30, 2, [])).host(&mut host).message(message));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert!(interpreter.stack().is_empty());
         assert_eq!(host.logs.len(), 1);
         assert_eq!(host.logs[0].address, address);
@@ -394,7 +395,7 @@ mod tests {
     fn log1_opcode() {
         let mut host = TestHost::default();
         let interpreter = run(RunConfig::new(log_code(30, 2, [Word::from(1)])).host(&mut host));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(host.logs[0].topics(), &[B256::from(Word::from(1).to_be_bytes::<32>())]);
         assert_eq!(host.logs[0].data.data, Bytes::from_static(&[0xbe, 0xef]));
     }
@@ -404,7 +405,7 @@ mod tests {
         let mut host = TestHost::default();
         let interpreter =
             run(RunConfig::new(log_code(30, 0, [Word::from(1), Word::from(2)])).host(&mut host));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(
             host.logs[0].topics(),
             &[
@@ -421,7 +422,7 @@ mod tests {
         let interpreter =
             run(RunConfig::new(log_code(30, 1, [Word::from(1), Word::from(2), Word::from(3)]))
                 .host(&mut host));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(host.logs[0].topics().len(), 3);
         assert_eq!(host.logs[0].data.data, Bytes::from_static(&[0xbe]));
     }
@@ -435,7 +436,7 @@ mod tests {
             [Word::from(1), Word::from(2), Word::from(3), Word::from(4)],
         ))
         .host(&mut host));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(host.logs[0].topics().len(), 4);
         assert_eq!(host.logs[0].data.data, Bytes::from_static(&[0xbe]));
     }
@@ -444,7 +445,7 @@ mod tests {
     fn log_staticcall_check() {
         let mut host = TestHost::default();
         let interpreter = run(RunConfig::new(log_code(30, 2, [])).host(&mut host).staticcall());
-        assert!(matches!(interpreter.err, InstrStop::StateChangeDuringStaticCall));
+        assert_matches!(interpreter.err, InstrStop::StateChangeDuringStaticCall);
         assert!(host.logs.is_empty());
     }
 
@@ -456,7 +457,7 @@ mod tests {
         push(&mut code, Word::MAX);
         code.extend([op::LOG0, op::STOP]);
         let interpreter = run(RunConfig::new(code).host(&mut host));
-        assert!(matches!(interpreter.err, InstrStop::InvalidOperandOOG));
+        assert_matches!(interpreter.err, InstrStop::InvalidOperandOOG);
         assert!(host.logs.is_empty());
     }
 }

--- a/crates/evm2/src/interpreter/instructions/memory.rs
+++ b/crates/evm2/src/interpreter/instructions/memory.rs
@@ -56,6 +56,7 @@ mod tests {
     };
     use alloc::vec::Vec;
     use alloy_primitives::Bytes;
+    use core::assert_matches;
 
     #[test]
     fn mload_opcode() {
@@ -69,12 +70,12 @@ mod tests {
         code.push(op::STOP);
 
         let mut interpreter = run(RunConfig::new(code));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [value]);
         assert_eq!(interpreter.memory(30, 2), [0xfe, 0xed]);
 
         let interpreter = run_stack([Word::MAX], op::MLOAD);
-        assert!(matches!(interpreter.err, InstrStop::InvalidOperandOOG));
+        assert_matches!(interpreter.err, InstrStop::InvalidOperandOOG);
     }
 
     #[test]
@@ -88,12 +89,12 @@ mod tests {
         code.push(op::STOP);
 
         let mut interpreter = run(RunConfig::new(code));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [Word::from(64)]);
         assert_eq!(interpreter.memory(38, 2), [0xfe, 0xed]);
 
         let interpreter = run_stack([Word::MAX, Word::from(0)], op::MSTORE);
-        assert!(matches!(interpreter.err, InstrStop::InvalidOperandOOG));
+        assert_matches!(interpreter.err, InstrStop::InvalidOperandOOG);
     }
 
     #[test]
@@ -114,7 +115,7 @@ mod tests {
         let mut host = TestHost::default();
         let err = interpreter.run(&config, &mut host);
 
-        assert!(matches!(err, InstrStop::MemoryLimitOOG));
+        assert_matches!(err, InstrStop::MemoryLimitOOG);
         assert_eq!(interpreter.memory_len(), 0);
     }
 
@@ -129,18 +130,18 @@ mod tests {
         code.push(op::STOP);
 
         let mut interpreter = run(RunConfig::new(code));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.memory(4, 1), [0xab]);
         assert_eq!(interpreter.stack()[0] >> 248, Word::from(0xab));
 
         let interpreter = run_stack([Word::MAX, Word::from(0)], op::MSTORE8);
-        assert!(matches!(interpreter.err, InstrStop::InvalidOperandOOG));
+        assert_matches!(interpreter.err, InstrStop::InvalidOperandOOG);
     }
 
     #[test]
     fn msize_opcode() {
         let interpreter = run(RunConfig::new([op::MSIZE, op::STOP]));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [0]);
 
         let mut code = Vec::new();
@@ -150,7 +151,7 @@ mod tests {
         code.push(op::MSIZE);
         code.push(op::STOP);
         let interpreter = run(RunConfig::new(code));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [Word::from(96)]);
     }
 
@@ -170,7 +171,7 @@ mod tests {
         code.push(op::STOP);
 
         let interpreter = run(RunConfig::new(code));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [value]);
 
         let mut code = Vec::new();
@@ -181,14 +182,14 @@ mod tests {
         code.push(op::MSIZE);
         code.push(op::STOP);
         let interpreter = run(RunConfig::new(code));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [0]);
 
         let interpreter = run_stack([Word::MAX, Word::MAX, Word::from(0)], op::MCOPY);
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
 
         let interpreter = run_stack([Word::MAX, Word::from(0), Word::from(1)], op::MCOPY);
-        assert!(matches!(interpreter.err, InstrStop::InvalidOperandOOG));
+        assert_matches!(interpreter.err, InstrStop::InvalidOperandOOG);
     }
 
     #[test]
@@ -204,6 +205,6 @@ mod tests {
 
         let interpreter = run(RunConfig::new(code).spec(SpecId::CANCUN).gas_limit(26));
 
-        assert!(matches!(interpreter.err, InstrStop::OutOfGas));
+        assert_matches!(interpreter.err, InstrStop::OutOfGas);
     }
 }

--- a/crates/evm2/src/interpreter/instructions/stack.rs
+++ b/crates/evm2/src/interpreter/instructions/stack.rs
@@ -69,69 +69,70 @@ mod tests {
         },
     };
     use alloc::{vec, vec::Vec};
+    use core::assert_matches;
 
     #[test]
     fn pop_opcode() {
         let interpreter = run_stack([1], op::POP);
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert!(interpreter.stack().is_empty());
 
         let interpreter =
             run(RunConfig::new([op::PUSH1, 0x01, op::PUSH1, 0x02, op::POP, op::STOP]));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [Word::from(1)]);
     }
 
     #[test]
     fn stack_underflow() {
         let interpreter = run(RunConfig::new([op::POP]));
-        assert!(matches!(interpreter.err, InstrStop::StackUnderflow));
+        assert_matches!(interpreter.err, InstrStop::StackUnderflow);
 
         let interpreter = run(RunConfig::new([op::DUP1]));
-        assert!(matches!(interpreter.err, InstrStop::StackUnderflow));
+        assert_matches!(interpreter.err, InstrStop::StackUnderflow);
 
         let interpreter = run(RunConfig::new([op::PUSH0, op::SWAP1]));
-        assert!(matches!(interpreter.err, InstrStop::StackUnderflow));
+        assert_matches!(interpreter.err, InstrStop::StackUnderflow);
 
         let interpreter = run(RunConfig::new([op::DUPN, 0x80]).spec(SpecId::AMSTERDAM));
-        assert!(matches!(interpreter.err, InstrStop::StackUnderflow));
+        assert_matches!(interpreter.err, InstrStop::StackUnderflow);
 
         let interpreter = run(RunConfig::new([op::PUSH0, op::SWAPN, 0x80]).spec(SpecId::AMSTERDAM));
-        assert!(matches!(interpreter.err, InstrStop::StackUnderflow));
+        assert_matches!(interpreter.err, InstrStop::StackUnderflow);
 
         let interpreter =
             run(RunConfig::new([op::PUSH0, op::EXCHANGE, 0x8e]).spec(SpecId::AMSTERDAM));
-        assert!(matches!(interpreter.err, InstrStop::StackUnderflow));
+        assert_matches!(interpreter.err, InstrStop::StackUnderflow);
     }
 
     #[test]
     fn stack_overflow() {
         let mut code = vec![op::PUSH0; StackMut::CAPACITY];
         let interpreter = run(RunConfig::new(code.clone()));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         code.extend([op::PUSH0]);
         let interpreter = run(RunConfig::new(code));
-        assert!(matches!(interpreter.err, InstrStop::StackOverflow));
+        assert_matches!(interpreter.err, InstrStop::StackOverflow);
 
         let mut code = vec![op::PUSH0; StackMut::CAPACITY];
         code.extend([op::PUSH1, 0x00, op::STOP]);
         let interpreter = run(RunConfig::new(code));
-        assert!(matches!(interpreter.err, InstrStop::StackOverflow));
+        assert_matches!(interpreter.err, InstrStop::StackOverflow);
 
         let mut code = vec![op::PUSH0; StackMut::CAPACITY];
         code.extend([op::DUP1, op::STOP]);
         let interpreter = run(RunConfig::new(code));
-        assert!(matches!(interpreter.err, InstrStop::StackOverflow));
+        assert_matches!(interpreter.err, InstrStop::StackOverflow);
     }
 
     #[test]
     fn push0_opcode() {
         let interpreter = run(RunConfig::new([op::PUSH0, op::STOP]));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [0]);
 
         let interpreter = run(RunConfig::new([op::PUSH0, op::PUSH0, op::STOP]));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [0, 0]);
     }
 
@@ -143,7 +144,7 @@ mod tests {
             code.push(op::STOP);
 
             let interpreter = run(RunConfig::new(code));
-            assert!(matches!(interpreter.err, InstrStop::Stop));
+            assert_matches!(interpreter.err, InstrStop::Stop);
             assert_eq!(interpreter.stack(), [Word::from_be_slice(&bytes)]);
         }
     }
@@ -204,7 +205,7 @@ mod tests {
             code.push(op::STOP);
 
             let interpreter = run(RunConfig::new(code));
-            assert!(matches!(interpreter.err, InstrStop::Stop));
+            assert_matches!(interpreter.err, InstrStop::Stop);
             assert_eq!(interpreter.stack().len(), 17);
             assert_eq!(interpreter.stack()[16], Word::from(17 - n + offset));
         }
@@ -250,7 +251,7 @@ mod tests {
             code.push(op::STOP);
 
             let interpreter = run(RunConfig::new(code));
-            assert!(matches!(interpreter.err, InstrStop::Stop));
+            assert_matches!(interpreter.err, InstrStop::Stop);
             assert_eq!(interpreter.stack().len(), 17);
             assert_eq!(interpreter.stack()[16], Word::from(17 - n + offset));
             assert_eq!(interpreter.stack()[16 - n], Word::from(17 + offset));
@@ -293,7 +294,7 @@ mod tests {
         code.extend(core::iter::repeat_n(op::DUP1, 15));
         code.extend([op::DUPN, 0x80, op::STOP]);
         let interpreter = run(RunConfig::new(code).spec(SpecId::AMSTERDAM));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack().len(), 18);
         assert_eq!(interpreter.stack()[17], Word::from(1));
         assert_eq!(interpreter.stack()[0], Word::from(1));
@@ -307,7 +308,7 @@ mod tests {
         }
         code.extend([op::DUPN, 0xff, op::STOP]);
         let interpreter = run(RunConfig::new(code).spec(SpecId::AMSTERDAM));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack().len(), 146);
         assert_eq!(interpreter.stack()[145], Word::from(1));
     }
@@ -318,7 +319,7 @@ mod tests {
         code.extend(core::iter::repeat_n(op::DUP1, 15));
         code.extend([op::PUSH1, 0x02, op::SWAPN, 0x80, op::STOP]);
         let interpreter = run(RunConfig::new(code).spec(SpecId::AMSTERDAM));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack().len(), 18);
         assert_eq!(interpreter.stack()[17], Word::from(1));
         assert_eq!(interpreter.stack()[0], Word::from(2));
@@ -332,7 +333,7 @@ mod tests {
         }
         code.extend([op::SWAPN, 0xff, op::STOP]);
         let interpreter = run(RunConfig::new(code).spec(SpecId::AMSTERDAM));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack()[0], Word::from(144));
         assert_eq!(interpreter.stack()[144], 0);
     }
@@ -351,7 +352,7 @@ mod tests {
             op::STOP,
         ])
         .spec(SpecId::AMSTERDAM));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [Word::from(1), Word::from(0), Word::from(2)]);
 
         let mut code = Vec::new();
@@ -360,7 +361,7 @@ mod tests {
         }
         code.extend([op::EXCHANGE, 0xff, op::STOP]);
         let interpreter = run(RunConfig::new(code).spec(SpecId::AMSTERDAM));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack()[0], Word::from(21));
         assert_eq!(interpreter.stack()[21], 0);
         assert_eq!(interpreter.stack()[22], Word::from(22));
@@ -369,12 +370,12 @@ mod tests {
     #[test]
     fn relative_stack_opcodes_are_not_enabled_before_amsterdam() {
         let interpreter = run(RunConfig::new([op::DUPN, 0x80]).spec(SpecId::OSAKA));
-        assert!(matches!(interpreter.err, InstrStop::InvalidOpcode));
+        assert_matches!(interpreter.err, InstrStop::InvalidOpcode);
 
         let interpreter = run(RunConfig::new([op::SWAPN, 0x80]).spec(SpecId::OSAKA));
-        assert!(matches!(interpreter.err, InstrStop::InvalidOpcode));
+        assert_matches!(interpreter.err, InstrStop::InvalidOpcode);
 
         let interpreter = run(RunConfig::new([op::EXCHANGE, 0x8e]).spec(SpecId::OSAKA));
-        assert!(matches!(interpreter.err, InstrStop::InvalidOpcode));
+        assert_matches!(interpreter.err, InstrStop::InvalidOpcode);
     }
 }

--- a/crates/evm2/src/interpreter/instructions/system.rs
+++ b/crates/evm2/src/interpreter/instructions/system.rs
@@ -397,6 +397,7 @@ mod tests {
     };
     use alloc::vec::Vec;
     use alloy_primitives::{Address, Bytes};
+    use core::assert_matches;
 
     fn push_all<const N: usize>(code: &mut Vec<u8>, values: [Word; N]) {
         for value in values {
@@ -429,7 +430,7 @@ mod tests {
             gas_limit: 10_000,
             ..Default::default()
         }));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [Word::from(1)]);
         assert_eq!(host.calls.len(), 1);
         assert_eq!(host.calls[0].kind, MessageKind::Call);
@@ -457,7 +458,7 @@ mod tests {
         code.extend([op::CALL, op::STOP]);
 
         let interpreter = run(RunConfig::new(code).host(&mut host).staticcall());
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(host.calls.len(), 1);
         assert_eq!(host.calls[0].kind, MessageKind::Call);
         assert!(host.call_static_flags[0]);
@@ -487,7 +488,7 @@ mod tests {
             .spec(SpecId::BERLIN)
             .message(Message { depth: CALL_DEPTH_LIMIT, ..Default::default() })
             .gas_limit(50_000));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [Word::ZERO]);
         assert_eq!(interpreter.gas_remaining(), 15_679);
         assert!(host.calls.is_empty());
@@ -521,7 +522,7 @@ mod tests {
             .spec(SpecId::TANGERINE)
             .message(Message { depth: CALL_DEPTH_LIMIT, ..Default::default() })
             .gas_limit(50_000));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.gas_remaining(), 42_553);
         assert!(host.calls.is_empty());
     }
@@ -550,7 +551,7 @@ mod tests {
             .spec(SpecId::TANGERINE)
             .message(Message { depth: CALL_DEPTH_LIMIT, ..Default::default() })
             .gas_limit(50_000));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [Word::ZERO]);
         assert_eq!(interpreter.gas_remaining(), 24_279);
         assert!(host.calls.is_empty());
@@ -581,7 +582,7 @@ mod tests {
             .spec(SpecId::TANGERINE)
             .message(Message { depth: CALL_DEPTH_LIMIT, ..Default::default() })
             .gas_limit(50_000));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [Word::ZERO]);
         assert_eq!(interpreter.gas_remaining(), 49_279);
         assert!(host.calls.is_empty());
@@ -607,7 +608,7 @@ mod tests {
         code.extend([op::CALLCODE, op::STOP]);
 
         let interpreter = run(RunConfig::new(code).host(&mut host).staticcall().gas_limit(20_000));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(host.calls.len(), 1);
         assert_eq!(host.calls[0].kind, MessageKind::CallCode);
         assert_eq!(host.calls[0].value, Word::from(7));
@@ -638,7 +639,7 @@ mod tests {
             .host(&mut host)
             .message(Message { destination, ..Default::default() })
             .gas_limit(20_000));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [Word::from(1)]);
         assert_eq!(host.calls[0].kind, MessageKind::CallCode);
         assert_eq!(host.calls[0].destination, destination);
@@ -671,7 +672,7 @@ mod tests {
             gas_limit: 10_000,
             ..Default::default()
         }));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [Word::from(1)]);
         assert_eq!(host.calls[0].kind, MessageKind::DelegateCall);
         assert_eq!(host.calls[0].caller, caller);
@@ -694,7 +695,7 @@ mod tests {
             op::DELEGATECALL,
         ])
         .spec(SpecId::FRONTIER));
-        assert!(matches!(interpreter.err, InstrStop::InvalidOpcode));
+        assert_matches!(interpreter.err, InstrStop::InvalidOpcode);
     }
 
     #[test]
@@ -716,7 +717,7 @@ mod tests {
         code.extend([op::STATICCALL, op::STOP]);
 
         let interpreter = run(RunConfig::new(code).host(&mut host));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [Word::from(1)]);
         assert_eq!(host.calls[0].kind, MessageKind::StaticCall);
         assert!(host.call_static_flags[0]);
@@ -737,7 +738,7 @@ mod tests {
             op::STATICCALL,
         ])
         .spec(SpecId::HOMESTEAD));
-        assert!(matches!(interpreter.err, InstrStop::InvalidOpcode));
+        assert_matches!(interpreter.err, InstrStop::InvalidOpcode);
     }
 
     #[test]
@@ -756,7 +757,7 @@ mod tests {
         code.extend([op::CREATE, op::STOP]);
 
         let interpreter = run(RunConfig::new(code).host(&mut host).gas_limit(50_000));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [address_to_word(&created)]);
         assert_eq!(host.calls.len(), 1);
         assert_eq!(host.calls[0].kind, MessageKind::Create);
@@ -779,7 +780,7 @@ mod tests {
         code.extend([op::CREATE, op::RETURNDATASIZE, op::STOP]);
 
         let interpreter = run(RunConfig::new(code).host(&mut host).gas_limit(50_000));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [address_to_word(&created), Word::ZERO]);
     }
 
@@ -798,7 +799,7 @@ mod tests {
         code.extend([op::CREATE, op::RETURNDATASIZE, op::STOP]);
 
         let interpreter = run(RunConfig::new(code).host(&mut host).gas_limit(50_000));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [Word::ZERO, Word::from(2)]);
     }
 
@@ -814,7 +815,7 @@ mod tests {
             .spec(SpecId::BERLIN)
             .message(Message { depth: CALL_DEPTH_LIMIT, ..Default::default() })
             .gas_limit(50_000));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [Word::ZERO]);
         assert_eq!(interpreter.gas_remaining(), 17_991);
         assert!(host.calls.is_empty());
@@ -829,7 +830,7 @@ mod tests {
 
         let interpreter =
             run(RunConfig::new(code).host(&mut host).spec(SpecId::SHANGHAI).gas_limit(50_000));
-        assert!(matches!(interpreter.err, InstrStop::CreateInitCodeSizeLimit));
+        assert_matches!(interpreter.err, InstrStop::CreateInitCodeSizeLimit);
         assert!(host.calls.is_empty());
     }
 
@@ -849,7 +850,7 @@ mod tests {
         code.extend([op::CREATE2, op::STOP]);
 
         let interpreter = run(RunConfig::new(code).host(&mut host).gas_limit(50_000));
-        assert!(matches!(interpreter.err, InstrStop::Stop));
+        assert_matches!(interpreter.err, InstrStop::Stop);
         assert_eq!(interpreter.stack(), [address_to_word(&created)]);
         assert_eq!(host.calls[0].kind, MessageKind::Create2);
 
@@ -865,7 +866,7 @@ mod tests {
             op::CREATE2,
         ])
         .spec(SpecId::BYZANTIUM));
-        assert!(matches!(interpreter.err, InstrStop::InvalidOpcode));
+        assert_matches!(interpreter.err, InstrStop::InvalidOpcode);
     }
 
     #[test]
@@ -882,7 +883,7 @@ mod tests {
             gas_limit: 10_000,
             ..Default::default()
         }));
-        assert!(matches!(interpreter.err, InstrStop::SelfDestruct));
+        assert_matches!(interpreter.err, InstrStop::SelfDestruct);
         assert_eq!(host.selfdestructs, [(contract, target, false)]);
     }
 }

--- a/crates/evm2/src/interpreter/instructions/tests.rs
+++ b/crates/evm2/src/interpreter/instructions/tests.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 use alloc::{boxed::Box, vec::Vec};
 use alloy_primitives::{Address, B256, Bytes, Log};
-use core::ops::Range;
+use core::{assert_matches, ops::Range};
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub(crate) struct TestTypes;
@@ -363,7 +363,7 @@ pub(super) fn assert_stack_words(inputs: &[Word], opcode: u8, expected: &[Word])
     }
     code.extend([opcode, op::STOP]);
     let interpreter = run(RunConfig::new(code));
-    assert!(matches!(interpreter.err, InstrStop::Stop));
+    assert_matches!(interpreter.err, InstrStop::Stop);
     assert_eq!(interpreter.stack(), expected);
 }
 

--- a/crates/evm2/src/interpreter/memory.rs
+++ b/crates/evm2/src/interpreter/memory.rs
@@ -237,6 +237,7 @@ fn resize_memory_cold(gas: &mut Gas, memory: &mut Memory, new_num_words: usize) 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use core::assert_matches;
 
     #[test]
     fn test_num_words() {
@@ -285,10 +286,10 @@ mod tests {
         resize_memory(&mut gas, &mut memory, 0, 64).unwrap();
         assert_eq!(memory.len(), 64);
 
-        assert!(matches!(
+        assert_matches!(
             resize_memory(&mut gas, &mut memory, 0, 96),
             Err(InstrStop::MemoryLimitOOG)
-        ));
+        );
         assert_eq!(memory.len(), 64);
         assert_eq!(gas.memory().words_num, 2);
     }

--- a/crates/evm2/src/interpreter/stack.rs
+++ b/crates/evm2/src/interpreter/stack.rs
@@ -1,7 +1,7 @@
 use super::{InstrStop, Result};
 use crate::constants::STACK_LIMIT;
 use alloy_primitives::U256;
-use core::{fmt, hint::cold_path, mem::MaybeUninit};
+use core::{debug_assert_matches, fmt, hint::cold_path, mem::MaybeUninit};
 
 /// EVM stack word.
 pub type Word = U256;
@@ -143,7 +143,7 @@ impl<'a> StackMut<'a> {
     #[inline(always)]
     fn check_bounds_(len: usize, input: usize, output: usize) -> Result {
         debug_assert!(len <= Self::CAPACITY);
-        debug_assert!(matches!(output, 0 | 1));
+        debug_assert_matches!(output, 0 | 1);
         if len < input {
             cold_path();
             return Err(InstrStop::StackUnderflow);
@@ -359,6 +359,7 @@ impl<'a> StackMut<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use core::assert_matches;
 
     fn run(f: impl FnOnce(&mut StackMut<'_>)) {
         let mut backing = [MaybeUninit::new(Word::MAX); StackMut::CAPACITY];
@@ -382,19 +383,19 @@ mod tests {
         run_with_len(0, |stack| {
             assert!(stack.check_bounds(0, 0).is_ok());
             assert!(stack.check_bounds(0, 1).is_ok());
-            assert!(matches!(stack.check_bounds(1, 0), Err(InstrStop::StackUnderflow)));
-            assert!(matches!(stack.check_bounds(1, 1), Err(InstrStop::StackUnderflow)));
+            assert_matches!(stack.check_bounds(1, 0), Err(InstrStop::StackUnderflow));
+            assert_matches!(stack.check_bounds(1, 1), Err(InstrStop::StackUnderflow));
         });
 
         run_with_len(1, |stack| {
             assert!(stack.check_bounds(1, 0).is_ok());
             assert!(stack.check_bounds(1, 1).is_ok());
-            assert!(matches!(stack.check_bounds(2, 0), Err(InstrStop::StackUnderflow)));
+            assert_matches!(stack.check_bounds(2, 0), Err(InstrStop::StackUnderflow));
         });
 
         run_with_len(StackMut::CAPACITY, |stack| {
             assert!(stack.check_bounds(1, 1).is_ok());
-            assert!(matches!(stack.check_bounds(0, 1), Err(InstrStop::StackOverflow)));
+            assert_matches!(stack.check_bounds(0, 1), Err(InstrStop::StackOverflow));
         });
     }
 
@@ -406,11 +407,11 @@ mod tests {
             assert_eq!(stack.as_slice(), [Word::from(1), Word::from(2)]);
             assert_eq!(stack.pop().unwrap(), Word::from(2));
             assert_eq!(stack.popn::<1>().unwrap(), [Word::from(1)]);
-            assert!(matches!(stack.pop(), Err(InstrStop::StackUnderflow)));
+            assert_matches!(stack.pop(), Err(InstrStop::StackUnderflow));
         });
 
         run_with_len(StackMut::CAPACITY, |stack| {
-            assert!(matches!(stack.push(Word::ZERO), Err(InstrStop::StackOverflow)));
+            assert_matches!(stack.push(Word::ZERO), Err(InstrStop::StackOverflow));
         });
     }
 
@@ -425,7 +426,7 @@ mod tests {
         });
 
         run_with_len(2, |stack| {
-            assert!(matches!(stack.popn_top::<2>(), Err(InstrStop::StackUnderflow)));
+            assert_matches!(stack.popn_top::<2>(), Err(InstrStop::StackUnderflow));
         });
     }
 
@@ -438,7 +439,7 @@ mod tests {
         });
 
         run_with_len(2, |stack| {
-            assert!(matches!(stack.popn_dyn(3).map(|_| ()), Err(InstrStop::StackUnderflow)));
+            assert_matches!(stack.popn_dyn(3).map(|_| ()), Err(InstrStop::StackUnderflow));
             assert_eq!(stack.as_slice(), [Word::from(0), Word::from(1)]);
         });
     }
@@ -466,13 +467,13 @@ mod tests {
         });
 
         run_with_len(1, |stack| {
-            assert!(matches!(stack.dup(2), Err(InstrStop::StackUnderflow)));
-            assert!(matches!(stack.swap(1), Err(InstrStop::StackUnderflow)));
-            assert!(matches!(stack.exchange(0, 1), Err(InstrStop::StackUnderflow)));
+            assert_matches!(stack.dup(2), Err(InstrStop::StackUnderflow));
+            assert_matches!(stack.swap(1), Err(InstrStop::StackUnderflow));
+            assert_matches!(stack.exchange(0, 1), Err(InstrStop::StackUnderflow));
         });
 
         run_with_len(StackMut::CAPACITY, |stack| {
-            assert!(matches!(stack.dup(1), Err(InstrStop::StackOverflow)));
+            assert_matches!(stack.dup(1), Err(InstrStop::StackOverflow));
         });
     }
 
@@ -519,7 +520,7 @@ mod tests {
         });
 
         run_with_len(StackMut::CAPACITY, |stack| {
-            assert!(matches!(stack.push_slice(&[42]), Err(InstrStop::StackOverflow)));
+            assert_matches!(stack.push_slice(&[42]), Err(InstrStop::StackOverflow));
         });
     }
 }

--- a/crates/evm2/src/precompiles/bn254/mod.rs
+++ b/crates/evm2/src/precompiles/bn254/mod.rs
@@ -269,6 +269,7 @@ mod tests {
         },
     };
     use alloy_primitives::hex;
+    use core::assert_matches;
 
     use super::*;
 
@@ -323,7 +324,7 @@ mod tests {
 
         let res = run_add(&input, BYZANTIUM_ADD_GAS_COST, &mut GasTracker::new(499));
 
-        assert!(matches!(res, Err(PrecompileError::Halt(PrecompileHalt::OutOfGas))));
+        assert_matches!(res, Err(PrecompileError::Halt(PrecompileHalt::OutOfGas)));
 
         // No input test
         let input = [0u8; 0];
@@ -348,8 +349,9 @@ mod tests {
         .unwrap();
 
         let res = run_add(&input, BYZANTIUM_ADD_GAS_COST, &mut GasTracker::new(500));
-        assert!(
-            matches!(res, Err(ref f) if *f == PrecompileError::Halt(PrecompileHalt::Bn254AffineGFailedToCreate))
+        assert_matches!(
+            res,
+            Err(ref f) if *f == PrecompileError::Halt(PrecompileHalt::Bn254AffineGFailedToCreate),
         );
     }
 
@@ -383,7 +385,7 @@ mod tests {
         .unwrap();
 
         let res = run_mul(&input, BYZANTIUM_MUL_GAS_COST, &mut GasTracker::new(39_999));
-        assert!(matches!(res, Err(PrecompileError::Halt(PrecompileHalt::OutOfGas))));
+        assert_matches!(res, Err(PrecompileError::Halt(PrecompileHalt::OutOfGas)));
 
         // Zero multiplication test
         let input = hex::decode(
@@ -427,8 +429,9 @@ mod tests {
         .unwrap();
 
         let res = run_mul(&input, BYZANTIUM_MUL_GAS_COST, &mut GasTracker::new(40_000));
-        assert!(
-            matches!(res, Err(ref f) if *f == PrecompileError::Halt(PrecompileHalt::Bn254AffineGFailedToCreate))
+        assert_matches!(
+            res,
+            Err(ref f) if *f == PrecompileError::Halt(PrecompileHalt::Bn254AffineGFailedToCreate),
         );
     }
 
@@ -487,7 +490,7 @@ mod tests {
             BYZANTIUM_PAIR_BASE,
             &mut GasTracker::new(259_999),
         );
-        assert!(matches!(res, Err(PrecompileError::Halt(PrecompileHalt::OutOfGas))));
+        assert_matches!(res, Err(PrecompileError::Halt(PrecompileHalt::OutOfGas)));
 
         // No input test
         let input = [0u8; 0];
@@ -522,8 +525,9 @@ mod tests {
             BYZANTIUM_PAIR_BASE,
             &mut GasTracker::new(260_000),
         );
-        assert!(
-            matches!(res, Err(ref f) if *f == PrecompileError::Halt(PrecompileHalt::Bn254AffineGFailedToCreate))
+        assert_matches!(
+            res,
+            Err(ref f) if *f == PrecompileError::Halt(PrecompileHalt::Bn254AffineGFailedToCreate),
         );
 
         // Invalid input length
@@ -542,7 +546,7 @@ mod tests {
             BYZANTIUM_PAIR_BASE,
             &mut GasTracker::new(260_000),
         );
-        assert!(matches!(res, Err(PrecompileError::Halt(PrecompileHalt::Bn254PairLength))));
+        assert_matches!(res, Err(PrecompileError::Halt(PrecompileHalt::Bn254PairLength)));
 
         // Test with point at infinity - should return true (identity element)
         // G1 point at infinity (0,0) followed by a valid G2 point

--- a/crates/evm2/src/precompiles/modexp.rs
+++ b/crates/evm2/src/precompiles/modexp.rs
@@ -325,6 +325,7 @@ mod tests {
     use crate::precompiles::PrecompileError;
     use alloc::{vec, vec::Vec};
     use alloy_primitives::hex;
+    use core::assert_matches;
 
     struct Test {
         input: &'static str,
@@ -785,8 +786,9 @@ mod tests {
         .unwrap();
 
         let res = run_osaka(&input_fail, &mut GasTracker::new(100_000_000));
-        assert!(
-            matches!(res, Err(PrecompileError::Halt(PrecompileHalt::ModexpEip7823LimitSize))),
+        assert_matches!(
+            res,
+            Err(PrecompileError::Halt(PrecompileHalt::ModexpEip7823LimitSize)),
             "1025-byte base should be rejected"
         );
     }
@@ -878,8 +880,9 @@ mod tests {
 
         // Provide insufficient gas
         let res = run_byzantium(&input, &mut GasTracker::new(1000));
-        assert!(
-            matches!(res, Err(PrecompileError::Halt(PrecompileHalt::OutOfGas))),
+        assert_matches!(
+            res,
+            Err(PrecompileError::Halt(PrecompileHalt::OutOfGas)),
             "Should return OutOfGas error with insufficient gas"
         );
     }

--- a/crates/evm2/src/utils.rs
+++ b/crates/evm2/src/utils.rs
@@ -178,31 +178,32 @@ pub(crate) const fn bool_to_b256(value: bool) -> &'static B256 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use core::assert_matches;
 
     #[test]
     fn get_with_right_padding() {
         let data = [1, 2, 3, 4];
         let padded = right_pad_with_offset::<8>(&data, 4);
-        assert!(matches!(padded, Cow::Owned(_)));
+        assert_matches!(padded, Cow::Owned(_));
         assert_eq!(padded[..], [0, 0, 0, 0, 0, 0, 0, 0]);
         let padded = right_pad_with_offset_vec(&data, 4, 8);
-        assert!(matches!(padded, Cow::Owned(_)));
+        assert_matches!(padded, Cow::Owned(_));
         assert_eq!(padded[..], [0, 0, 0, 0, 0, 0, 0, 0]);
 
         let data = [1, 2, 3, 4, 5, 6, 7, 8];
         let padded = right_pad_with_offset::<8>(&data, 0);
-        assert!(matches!(padded, Cow::Borrowed(_)));
+        assert_matches!(padded, Cow::Borrowed(_));
         assert_eq!(padded[..], [1, 2, 3, 4, 5, 6, 7, 8]);
         let padded = right_pad_with_offset_vec(&data, 0, 8);
-        assert!(matches!(padded, Cow::Borrowed(_)));
+        assert_matches!(padded, Cow::Borrowed(_));
         assert_eq!(padded[..], [1, 2, 3, 4, 5, 6, 7, 8]);
 
         let data = [1, 2, 3, 4, 5, 6, 7, 8];
         let padded = right_pad_with_offset::<8>(&data, 4);
-        assert!(matches!(padded, Cow::Owned(_)));
+        assert_matches!(padded, Cow::Owned(_));
         assert_eq!(padded[..], [5, 6, 7, 8, 0, 0, 0, 0]);
         let padded = right_pad_with_offset_vec(&data, 4, 8);
-        assert!(matches!(padded, Cow::Owned(_)));
+        assert_matches!(padded, Cow::Owned(_));
         assert_eq!(padded[..], [5, 6, 7, 8, 0, 0, 0, 0]);
     }
 
@@ -210,18 +211,18 @@ mod tests {
     fn right_padding() {
         let data = [1, 2, 3, 4];
         let padded = right_pad::<8>(&data);
-        assert!(matches!(padded, Cow::Owned(_)));
+        assert_matches!(padded, Cow::Owned(_));
         assert_eq!(padded[..], [1, 2, 3, 4, 0, 0, 0, 0]);
         let padded = right_pad_vec(&data, 8);
-        assert!(matches!(padded, Cow::Owned(_)));
+        assert_matches!(padded, Cow::Owned(_));
         assert_eq!(padded[..], [1, 2, 3, 4, 0, 0, 0, 0]);
 
         let data = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
         let padded = right_pad::<8>(&data);
-        assert!(matches!(padded, Cow::Borrowed(_)));
+        assert_matches!(padded, Cow::Borrowed(_));
         assert_eq!(padded[..], [1, 2, 3, 4, 5, 6, 7, 8]);
         let padded = right_pad_vec(&data, 8);
-        assert!(matches!(padded, Cow::Borrowed(_)));
+        assert_matches!(padded, Cow::Borrowed(_));
         assert_eq!(padded[..], [1, 2, 3, 4, 5, 6, 7, 8]);
     }
 
@@ -229,18 +230,18 @@ mod tests {
     fn left_padding() {
         let data = [1, 2, 3, 4];
         let padded = left_pad::<8>(&data);
-        assert!(matches!(padded, Cow::Owned(_)));
+        assert_matches!(padded, Cow::Owned(_));
         assert_eq!(padded[..], [0, 0, 0, 0, 1, 2, 3, 4]);
         let padded = left_pad_vec(&data, 8);
-        assert!(matches!(padded, Cow::Owned(_)));
+        assert_matches!(padded, Cow::Owned(_));
         assert_eq!(padded[..], [0, 0, 0, 0, 1, 2, 3, 4]);
 
         let data = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
         let padded = left_pad::<8>(&data);
-        assert!(matches!(padded, Cow::Borrowed(_)));
+        assert_matches!(padded, Cow::Borrowed(_));
         assert_eq!(padded[..], [1, 2, 3, 4, 5, 6, 7, 8]);
         let padded = left_pad_vec(&data, 8);
-        assert!(matches!(padded, Cow::Borrowed(_)));
+        assert_matches!(padded, Cow::Borrowed(_));
         assert_eq!(padded[..], [1, 2, 3, 4, 5, 6, 7, 8]);
     }
 
@@ -248,17 +249,17 @@ mod tests {
     fn left_padding_be() {
         let data = [1, 2, 3, 4];
         let padded = left_pad_vec_be(&data, 8);
-        assert!(matches!(padded, Cow::Owned(_)));
+        assert_matches!(padded, Cow::Owned(_));
         assert_eq!(padded[..], [0, 0, 0, 0, 1, 2, 3, 4]);
 
         let data = [0, 0, 1, 2, 3, 4];
         let padded = left_pad_vec_be(&data, 4);
-        assert!(matches!(padded, Cow::Borrowed(_)));
+        assert_matches!(padded, Cow::Borrowed(_));
         assert_eq!(padded[..], [1, 2, 3, 4]);
 
         let data = [1, 2, 3, 4];
         let padded = left_pad_vec_be(&data, 4);
-        assert!(matches!(padded, Cow::Borrowed(_)));
+        assert_matches!(padded, Cow::Borrowed(_));
         assert_eq!(padded[..], [1, 2, 3, 4]);
     }
 


### PR DESCRIPTION
This bumps the workspace MSRV to Rust 1.96 and switches the existing assert!(matches!(...)) and debug_assert!(matches!(...)) call sites to the core assert_matches! and debug_assert_matches! macros now available at that MSRV.