### PR TITLE
refactor: clean up async exports

### DIFF
--- a/crates/evm2/src/evm/async.rs
+++ b/crates/evm2/src/evm/async.rs
@@ -1,7 +1,7 @@
 //! Async execution support for synchronous EVM hosts.
 //!
 //! This module runs the synchronous EVM on a native fiber. Synchronous host methods can then use
-//! [`block_on_current`] to poll an async operation; if that operation is pending, the fiber is
+//! `block_on_current` to poll an async operation; if that operation is pending, the fiber is
 //! suspended and the outer async task returns `Poll::Pending`.
 
 use crate::{

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -376,7 +376,8 @@ impl<T: EvmTypes<Tx: Typed2718>> Evm<T> {
     /// Dispatches the transaction to the handler registered for its EIP-2718 type byte on an async
     /// fiber.
     ///
-    /// This must be used with an async database adapter such as `evm::async::AsyncDb` to take
+    /// This must be used with an async database adapter such as
+    /// [`evm::async::AsyncDb`](crate::evm::async::AsyncDb) to take
     /// advantage of yielding database I/O. With a synchronous database this is mostly equivalent to
     /// running the synchronous transaction on a fiber.
     #[cfg(feature = "async")]

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -20,6 +20,8 @@ use crate::{
 use alloc::{boxed::Box, vec};
 use alloy_eips::eip2718::Typed2718;
 use alloy_primitives::{Address, B256, Bytes, Log, LogData};
+#[cfg(feature = "async")]
+use core::future::Future;
 use derive_where::derive_where;
 
 #[cfg(feature = "async")]
@@ -384,10 +386,7 @@ impl<T: EvmTypes<Tx: Typed2718>> Evm<T> {
     pub fn transact_async<'a>(
         &'a mut self,
         tx: &'a T::Tx,
-    ) -> impl core::future::Future<
-        Output = r#async::AsyncResult<TxResult<T>, registry::HandlerError>,
-    > + Send
-    + 'a
+    ) -> impl Future<Output = r#async::AsyncResult<TxResult<T>, registry::HandlerError>> + Send + 'a
     where
         T::TxResultExt: Send,
     {

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -22,6 +22,8 @@ use alloy_eips::eip2718::Typed2718;
 use alloy_primitives::{Address, B256, Bytes, Log, LogData};
 use derive_where::derive_where;
 
+#[cfg(feature = "async")]
+pub mod r#async;
 pub mod config;
 pub mod env;
 pub mod inspector;
@@ -67,7 +69,7 @@ pub struct Evm<T: EvmTypes> {
     inspector: Option<Box<dyn Inspector<T>>>,
     #[cfg(feature = "async")]
     #[derive_where(skip)]
-    async_stack: crate::async_::FiberStack,
+    async_stack: r#async::FiberStack,
     db_error_code: Option<DbErrorCode>,
 }
 
@@ -137,7 +139,7 @@ impl<T: EvmTypes> Evm<T> {
             interpreter_pool: InterpreterPool::new(),
             inspector: None,
             #[cfg(feature = "async")]
-            async_stack: crate::async_::FiberStack::default(),
+            async_stack: r#async::FiberStack::default(),
             db_error_code: None,
         }
     }
@@ -192,7 +194,7 @@ impl<T: EvmTypes> Evm<T> {
 
     #[cfg(feature = "async")]
     #[inline]
-    fn async_stack(&mut self) -> core::ptr::NonNull<crate::async_::FiberStack> {
+    fn async_stack(&mut self) -> core::ptr::NonNull<r#async::FiberStack> {
         core::ptr::NonNull::from(&mut self.async_stack)
     }
 
@@ -374,15 +376,16 @@ impl<T: EvmTypes<Tx: Typed2718>> Evm<T> {
     /// Dispatches the transaction to the handler registered for its EIP-2718 type byte on an async
     /// fiber.
     ///
-    /// This must be used with an async database adapter such as [`crate::AsyncDb`] to take
+    /// This must be used with an async database adapter such as `evm::async::AsyncDb` to take
     /// advantage of yielding database I/O. With a synchronous database this is mostly equivalent to
     /// running the synchronous transaction on a fiber.
     #[cfg(feature = "async")]
     pub fn transact_async<'a>(
         &'a mut self,
         tx: &'a T::Tx,
-    ) -> impl core::future::Future<Output = crate::AsyncResult<TxResult<T>, registry::HandlerError>>
-    + Send
+    ) -> impl core::future::Future<
+        Output = r#async::AsyncResult<TxResult<T>, registry::HandlerError>,
+    > + Send
     + 'a
     where
         T::TxResultExt: Send,
@@ -390,7 +393,7 @@ impl<T: EvmTypes<Tx: Typed2718>> Evm<T> {
         let stack = self.async_stack();
         // SAFETY: The returned future owns the exclusive `&mut self` borrow, so nothing else can
         // access the EVM stack slot until that future is dropped.
-        unsafe { crate::async_::on_fiber_result_with_stack(stack, move || self.transact(tx)) }
+        unsafe { r#async::on_fiber_result_with_stack(stack, move || self.transact(tx)) }
     }
 
     /// Dispatches each transaction to its registered EIP-2718 handler.

--- a/crates/evm2/src/evm/system.rs
+++ b/crates/evm2/src/evm/system.rs
@@ -6,6 +6,8 @@
 //! before calling [`Evm::system_call`]. Calling an address without code succeeds as an empty call
 //! and produces no state changes.
 
+#[cfg(feature = "async")]
+use super::r#async;
 use super::{Evm, TxResult};
 use crate::{
     EvmTypes,
@@ -57,7 +59,7 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
         system_contract_address: Address,
         data: Bytes,
     ) -> impl core::future::Future<
-        Output = super::r#async::AsyncResult<TxResult<T>, core::convert::Infallible>,
+        Output = r#async::AsyncResult<TxResult<T>, core::convert::Infallible>,
     > + Send
     + '_
     where
@@ -67,7 +69,7 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
         // SAFETY: The returned future owns the exclusive `&mut self` borrow, so nothing else can
         // access the EVM stack slot until that future is dropped.
         unsafe {
-            super::r#async::on_fiber_with_stack(stack, move || {
+            r#async::on_fiber_with_stack(stack, move || {
                 self.system_call(system_contract_address, data)
             })
         }
@@ -151,7 +153,7 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
         system_contract_address: Address,
         data: Bytes,
     ) -> impl core::future::Future<
-        Output = super::r#async::AsyncResult<TxResult<T>, core::convert::Infallible>,
+        Output = r#async::AsyncResult<TxResult<T>, core::convert::Infallible>,
     > + Send
     + '_
     where
@@ -161,7 +163,7 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
         // SAFETY: The returned future owns the exclusive `&mut self` borrow, so nothing else can
         // access the EVM stack slot until that future is dropped.
         unsafe {
-            super::r#async::on_fiber_with_stack(stack, move || {
+            r#async::on_fiber_with_stack(stack, move || {
                 self.system_call_with_caller(caller, system_contract_address, data)
             })
         }

--- a/crates/evm2/src/evm/system.rs
+++ b/crates/evm2/src/evm/system.rs
@@ -46,7 +46,8 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
     /// Executes a system call from [`SYSTEM_ADDRESS`] to `system_contract_address` on an async
     /// fiber.
     ///
-    /// This must be used with an async database adapter such as `evm::async::AsyncDb` to take
+    /// This must be used with an async database adapter such as
+    /// [`evm::async::AsyncDb`](crate::evm::async::AsyncDb) to take
     /// advantage of yielding database I/O. With a synchronous database this is mostly equivalent to
     /// running the synchronous system call on a fiber.
     #[cfg(feature = "async")]
@@ -138,7 +139,8 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
 
     /// Executes a system call from `caller` to `system_contract_address` on an async fiber.
     ///
-    /// This must be used with an async database adapter such as `evm::async::AsyncDb` to take
+    /// This must be used with an async database adapter such as
+    /// [`evm::async::AsyncDb`](crate::evm::async::AsyncDb) to take
     /// advantage of yielding database I/O. With a synchronous database this is mostly equivalent to
     /// running the synchronous system call on a fiber.
     #[cfg(feature = "async")]

--- a/crates/evm2/src/evm/system.rs
+++ b/crates/evm2/src/evm/system.rs
@@ -46,7 +46,7 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
     /// Executes a system call from [`SYSTEM_ADDRESS`] to `system_contract_address` on an async
     /// fiber.
     ///
-    /// This must be used with an async database adapter such as [`crate::AsyncDb`] to take
+    /// This must be used with an async database adapter such as `evm::async::AsyncDb` to take
     /// advantage of yielding database I/O. With a synchronous database this is mostly equivalent to
     /// running the synchronous system call on a fiber.
     #[cfg(feature = "async")]
@@ -56,7 +56,7 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
         system_contract_address: Address,
         data: Bytes,
     ) -> impl core::future::Future<
-        Output = crate::AsyncResult<TxResult<T>, core::convert::Infallible>,
+        Output = super::r#async::AsyncResult<TxResult<T>, core::convert::Infallible>,
     > + Send
     + '_
     where
@@ -66,7 +66,7 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
         // SAFETY: The returned future owns the exclusive `&mut self` borrow, so nothing else can
         // access the EVM stack slot until that future is dropped.
         unsafe {
-            crate::async_::on_fiber_with_stack(stack, move || {
+            super::r#async::on_fiber_with_stack(stack, move || {
                 self.system_call(system_contract_address, data)
             })
         }
@@ -138,7 +138,7 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
 
     /// Executes a system call from `caller` to `system_contract_address` on an async fiber.
     ///
-    /// This must be used with an async database adapter such as [`crate::AsyncDb`] to take
+    /// This must be used with an async database adapter such as `evm::async::AsyncDb` to take
     /// advantage of yielding database I/O. With a synchronous database this is mostly equivalent to
     /// running the synchronous system call on a fiber.
     #[cfg(feature = "async")]
@@ -149,7 +149,7 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
         system_contract_address: Address,
         data: Bytes,
     ) -> impl core::future::Future<
-        Output = crate::AsyncResult<TxResult<T>, core::convert::Infallible>,
+        Output = super::r#async::AsyncResult<TxResult<T>, core::convert::Infallible>,
     > + Send
     + '_
     where
@@ -159,7 +159,7 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
         // SAFETY: The returned future owns the exclusive `&mut self` borrow, so nothing else can
         // access the EVM stack slot until that future is dropped.
         unsafe {
-            crate::async_::on_fiber_with_stack(stack, move || {
+            super::r#async::on_fiber_with_stack(stack, move || {
                 self.system_call_with_caller(caller, system_contract_address, data)
             })
         }

--- a/crates/evm2/src/evm/system.rs
+++ b/crates/evm2/src/evm/system.rs
@@ -17,6 +17,8 @@ use crate::{
 };
 use alloc::vec::Vec;
 use alloy_primitives::{Address, Bytes, TxKind, U256, address};
+#[cfg(feature = "async")]
+use core::{convert::Infallible, future::Future};
 
 /// Caller address used by execution-layer system calls.
 pub const SYSTEM_ADDRESS: Address = address!("0xfffffffffffffffffffffffffffffffffffffffe");
@@ -58,10 +60,7 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
         &mut self,
         system_contract_address: Address,
         data: Bytes,
-    ) -> impl core::future::Future<
-        Output = r#async::AsyncResult<TxResult<T>, core::convert::Infallible>,
-    > + Send
-    + '_
+    ) -> impl Future<Output = r#async::AsyncResult<TxResult<T>, Infallible>> + Send + '_
     where
         T::TxResultExt: Send,
     {
@@ -152,10 +151,7 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
         caller: Address,
         system_contract_address: Address,
         data: Bytes,
-    ) -> impl core::future::Future<
-        Output = r#async::AsyncResult<TxResult<T>, core::convert::Infallible>,
-    > + Send
-    + '_
+    ) -> impl Future<Output = r#async::AsyncResult<TxResult<T>, Infallible>> + Send + '_
     where
         T::TxResultExt: Send,
     {

--- a/crates/evm2/src/lib.rs
+++ b/crates/evm2/src/lib.rs
@@ -13,11 +13,6 @@ pub mod ethereum;
 pub mod interpreter;
 pub mod utils;
 
-#[cfg(feature = "async")]
-mod async_;
-#[cfg(feature = "async")]
-pub use async_::{AsyncDatabase, AsyncDb, AsyncError, AsyncResult};
-
 pub mod evm;
 pub use evm::{
     Evm, TxResult, config,

--- a/crates/evm2/src/version/features.rs
+++ b/crates/evm2/src/version/features.rs
@@ -98,16 +98,16 @@ impl core::ops::Not for EvmFeatures {
 }
 
 macro_rules! evm_features {
-    (@impl $bit:expr;) => {};
-    (@impl $bit:expr; $(#[$attr:meta])* $name:ident, $($rest:tt)*) => {
-        impl EvmFeatures {
-            $(#[$attr])*
-            pub const $name: Self = Self::from_bit($bit);
-        }
-        evm_features!(@impl $bit + 1; $($rest)*);
+    (@const $bit:expr;) => {};
+    (@const $bit:expr; $(#[$attr:meta])* $name:ident, $($rest:tt)*) => {
+        $(#[$attr])*
+        pub const $name: Self = Self::from_bit($bit);
+        evm_features!(@const $bit + 1; $($rest)*);
     };
     ($($tokens:tt)*) => {
-        evm_features!(@impl 0; $($tokens)*);
+        impl EvmFeatures {
+            evm_features!(@const 0; $($tokens)*);
+        }
     };
 }
 


### PR DESCRIPTION
Moves the async support API under the EVM module as `evm::async`, removing the crate-root async type re-exports and keeping the async entrypoints pointed at the module-local types.

This also simplifies the EVM feature bitmap macro so the generated constants live in a single `impl EvmFeatures` block instead of emitting one impl per feature.
