### PR TITLE
feat(evm): replace most remaining `SpecId` usages w features

### DIFF
--- a/crates/evm2/src/ethereum/mod.rs
+++ b/crates/evm2/src/ethereum/mod.rs
@@ -410,7 +410,8 @@ pub(super) fn rollback_failed_execution<T: EvmTypes<Host = Evm<T>>>(
     result: &mut MessageResult<T>,
 ) {
     if !result.stop.is_success() {
-        host.state.rollback(checkpoint, host.spec_id());
+        let features = host.version().features;
+        host.state.rollback(checkpoint, features);
         if result.stop.is_halt() {
             result.gas.set_remaining(0);
         }

--- a/crates/evm2/src/ethereum/mod.rs
+++ b/crates/evm2/src/ethereum/mod.rs
@@ -388,7 +388,7 @@ fn initial_call_code<T: EvmTypes<Host = Evm<T>>>(
     to: Address,
 ) -> HandlerResult<InitialCallCode> {
     let code = host.state.get_code(&to).map_err(|code| host.db_error_handler(code))?;
-    if host.spec_id().enables(SpecId::PRAGUE)
+    if host.feature(EvmFeatures::EIP7702)
         && let Some(delegated_address) = code.eip7702_address()
     {
         let _ = host.state.warm_account(&delegated_address);

--- a/crates/evm2/src/evm/config.rs
+++ b/crates/evm2/src/evm/config.rs
@@ -117,6 +117,7 @@ where
 /// an EVM instance. This is the data passed to the interpreter when it runs.
 #[derive_where(Debug)]
 pub struct ExecutionConfig<T: EvmTypes> {
+    base_spec_id: SpecId,
     pub(crate) version: Version,
     #[derive_where(skip)]
     pub(crate) instructions: &'static InstrTable<T>,
@@ -150,6 +151,7 @@ impl<T: EvmTypes> ExecutionConfig<T> {
     ) -> Self {
         let i = base_spec_id as usize;
         Self {
+            base_spec_id,
             version: Version::new(base_spec_id),
             instructions: &SelectorInstrTables::<T, F, CUSTOM_SPEC_ID>::INSTRUCTIONS[i],
             inspect_instructions:
@@ -162,6 +164,7 @@ impl<T: EvmTypes> ExecutionConfig<T> {
     pub const fn for_config<C: EvmConfig<T>>() -> Self {
         let base_spec_id = C::BASE_SPEC_ID;
         Self {
+            base_spec_id,
             version: Version::new(base_spec_id),
             instructions: ConfigInstrTables::<T, C>::INSTRUCTIONS,
             inspect_instructions: ConfigInstrTables::<T, C>::INSPECT_INSTRUCTIONS,
@@ -172,16 +175,21 @@ impl<T: EvmTypes> ExecutionConfig<T> {
     #[inline]
     pub fn for_spec_and_version(spec_id: T::SpecId, version: Version) -> Self {
         let config = <T::ConfigSelector as EvmConfigSelector<T>>::execution_config(spec_id);
-        assert_eq!(spec_id.into(), version.spec_id, "execution config version spec mismatch");
+        assert_eq!(spec_id.into(), config.base_spec_id, "execution config spec mismatch");
         config.with_version(version)
     }
 
     /// Replaces the runtime version data while keeping the same dispatch table.
     #[inline]
-    pub fn with_version(mut self, version: Version) -> Self {
-        assert_eq!(self.version.spec_id, version.spec_id, "execution config version spec mismatch");
+    pub const fn with_version(mut self, version: Version) -> Self {
         self.version = version;
         self
+    }
+
+    /// Returns the active base specification ID.
+    #[inline]
+    pub const fn base_spec_id(&self) -> SpecId {
+        self.base_spec_id
     }
 
     /// Returns the active EVM version.

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -867,8 +867,8 @@ impl<T: EvmTypes<Host = Self>> Host<T> for Evm<T> {
             .account_info(contract)
             .map_err(|code| self.db_error_stop(code))?
             .map_or(Word::ZERO, |info| info.balance);
-        let should_destroy = !self.spec_id().enables(SpecId::CANCUN)
-            || self.state.is_created_in_transaction(contract);
+        let should_destroy =
+            !self.feature(EvmFeatures::EIP6780) || self.state.is_created_in_transaction(contract);
 
         if contract != target {
             let transferred = self

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -123,8 +123,8 @@ impl<T: EvmTypes> Evm<T> {
     ) -> Self {
         assert_eq!(
             spec_id.into(),
-            execution_config.version().spec_id,
-            "execution config version spec mismatch"
+            execution_config.base_spec_id(),
+            "execution config spec mismatch"
         );
         Self {
             spec_id,
@@ -339,8 +339,8 @@ impl<T: EvmTypes> Evm<T> {
 
     /// Returns the active base specification ID.
     #[inline]
-    pub const fn spec_id(&self) -> SpecId {
-        self.version().spec_id
+    pub fn spec_id(&self) -> SpecId {
+        self.spec_id.into()
     }
 
     /// Returns the selector-specific runtime specification ID.

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -422,7 +422,7 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
         }
         let checkpoint = self.state.checkpoint();
         if let Err(stop) = self.create_message_account(message) {
-            self.state.rollback(checkpoint, self.spec_id());
+            self.state.rollback(checkpoint, self.features);
             return Self::error_message_result(stop, message.gas_limit);
         }
         message.code_address = message.destination;
@@ -463,7 +463,7 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
             &message.caller,
             &message.destination,
             &message.value,
-            self.spec_id(),
+            self.features,
         ) {
             Ok(result) => result,
             Err(code) => {
@@ -489,7 +489,7 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
         let mut output = Bytes::copy_from_slice(interpreter.output());
         if stop.is_success() {
             if let Err(stop) = self.validate_create_output(&mut gas, &mut output) {
-                self.state.rollback(checkpoint, self.spec_id());
+                self.state.rollback(checkpoint, self.features);
                 return MessageResult {
                     stop,
                     gas: Self::message_gas(*gas.tracker(), stop),
@@ -501,11 +501,11 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
             }
 
             if let Err(code) = self.state.set_code(address, Bytecode::new_legacy(output.clone())) {
-                self.state.rollback(checkpoint, self.spec_id());
+                self.state.rollback(checkpoint, self.features);
                 return Self::error_message_result(self.db_error_stop(code), gas_limit);
             }
         } else {
-            self.state.rollback(checkpoint, self.spec_id());
+            self.state.rollback(checkpoint, self.features);
         }
 
         MessageResult {
@@ -634,7 +634,7 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
             }
         };
         if !stop.is_success() {
-            self.state.rollback(checkpoint, self.spec_id());
+            self.state.rollback(checkpoint, self.features);
         }
         MessageResult {
             stop,
@@ -656,7 +656,7 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
         let child_gas = interpreter.gas();
         let output = Bytes::copy_from_slice(interpreter.output());
         if !stop.is_success() {
-            self.state.rollback(checkpoint, self.spec_id());
+            self.state.rollback(checkpoint, self.features);
         }
 
         MessageResult {
@@ -766,10 +766,10 @@ impl<T: EvmTypes<Host = Self>> Host<T> for Evm<T> {
     fn target_is_empty_for_new_account_gas(
         &mut self,
         address: &Address,
-        spec: SpecId,
+        features: EvmFeatures,
     ) -> Result<bool, InstrStop> {
         self.state
-            .target_is_empty_for_new_account_gas(address, spec)
+            .target_is_empty_for_new_account_gas(address, features)
             .map_err(|code| self.db_error_stop(code))
     }
 
@@ -861,8 +861,9 @@ impl<T: EvmTypes<Host = Self>> Host<T> for Evm<T> {
         if skip_cold_load && is_cold {
             return Err(InstrStop::OutOfGas);
         }
+        let features = self.features;
         let target_is_empty_for_new_account_gas =
-            self.target_is_empty_for_new_account_gas(target, self.spec_id())?;
+            self.target_is_empty_for_new_account_gas(target, features)?;
         let previously_destroyed = self.state.is_selfdestructed(contract);
         let balance = self
             .state

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -519,8 +519,7 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
     }
 
     fn validate_create_output(&self, gas: &mut Gas, output: &mut Bytes) -> Result<(), InstrStop> {
-        if self.spec_id().enables(SpecId::SPURIOUS_DRAGON)
-            && output.len() > self.version().max_code_size
+        if self.feature(EvmFeatures::CODE_SIZE_CHECK) && output.len() > self.version().max_code_size
         {
             return Err(InstrStop::CreateContractSizeLimit);
         }

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -735,7 +735,7 @@ impl<T: EvmTypes<Host = Self>> Host<T> for Evm<T> {
         load_code: bool,
         skip_cold_load: bool,
     ) -> Result<AccountLoad, InstrStop> {
-        let is_cold = if self.spec_id().enables(SpecId::BERLIN) {
+        let is_cold = if self.feature(EvmFeatures::EIP2929) {
             self.state.warm_account(address)
         } else {
             let _ = self.state.warm_account(address);
@@ -782,8 +782,7 @@ impl<T: EvmTypes<Host = Self>> Host<T> for Evm<T> {
         key: &Word,
         skip_cold_load: bool,
     ) -> Result<SLoad, InstrStop> {
-        let is_cold =
-            self.spec_id().enables(SpecId::BERLIN) && self.state.warm_storage(address, key);
+        let is_cold = self.feature(EvmFeatures::EIP2929) && self.state.warm_storage(address, key);
         if skip_cold_load && is_cold {
             return Err(InstrStop::OutOfGas);
         }
@@ -801,8 +800,7 @@ impl<T: EvmTypes<Host = Self>> Host<T> for Evm<T> {
         value: &Word,
         skip_cold_load: bool,
     ) -> Result<SStore, InstrStop> {
-        let is_cold =
-            self.spec_id().enables(SpecId::BERLIN) && self.state.warm_storage(address, key);
+        let is_cold = self.feature(EvmFeatures::EIP2929) && self.state.warm_storage(address, key);
         if skip_cold_load && is_cold {
             return Err(InstrStop::OutOfGas);
         }
@@ -851,7 +849,7 @@ impl<T: EvmTypes<Host = Self>> Host<T> for Evm<T> {
         target: &Address,
         skip_cold_load: bool,
     ) -> Result<SelfDestructResult, InstrStop> {
-        let is_cold = if self.spec_id().enables(SpecId::BERLIN) {
+        let is_cold = if self.feature(EvmFeatures::EIP2929) {
             self.state.warm_account(target)
         } else {
             let _ = self.state.warm_account(target);

--- a/crates/evm2/src/evm/registry.rs
+++ b/crates/evm2/src/evm/registry.rs
@@ -288,7 +288,7 @@ impl<T: EvmTypes, Output> TxRegistry<T, Output> {
 mod tests {
     use super::*;
     use crate::{
-        BaseEvmConfigSelector, EvmTypes, SpecId,
+        BaseEvmConfigSelector, EvmFeatures, EvmTypes, SpecId,
         bytecode::Bytecode,
         env::{BlockEnv, TxEnv},
         evm::{AccountLoad, SLoad, SStore, SelfDestructResult},
@@ -352,7 +352,7 @@ mod tests {
         fn target_is_empty_for_new_account_gas(
             &mut self,
             _address: &Address,
-            _spec: SpecId,
+            _features: EvmFeatures,
         ) -> Result<bool, InstrStop> {
             unimplemented!()
         }

--- a/crates/evm2/src/evm/state.rs
+++ b/crates/evm2/src/evm/state.rs
@@ -6,7 +6,7 @@ use super::{
     eip7708_burn_log,
 };
 use crate::{
-    EvmFeatures, SpecId, Version,
+    EvmFeatures, Version,
     bytecode::Bytecode,
     interpreter::{InstrStop, Word},
     storage_key::{StorageKey, StorageKeyMap, StorageKeySet},
@@ -651,9 +651,9 @@ impl State {
     pub(super) fn target_is_empty_for_new_account_gas(
         &mut self,
         address: &Address,
-        spec: SpecId,
+        features: EvmFeatures,
     ) -> DbResult<bool> {
-        if spec.enables(SpecId::SPURIOUS_DRAGON) {
+        if features.contains(EvmFeatures::EIP161) {
             return Ok(self.account_info(address)?.is_none_or(|info| info.is_empty()));
         }
         Ok(self.account_info(address)?.is_none() && !self.touched.contains(address))
@@ -810,7 +810,7 @@ impl State {
         caller: &Address,
         address: &Address,
         value: &Word,
-        spec: SpecId,
+        features: EvmFeatures,
     ) -> DbResult<Result<(), InstrStop>> {
         if let Some(info) = self.account_info(address)?
             && (info.nonce != 0 || info.code_hash != KECCAK256_EMPTY)
@@ -826,7 +826,7 @@ impl State {
         self.wipe_storage(address);
         let account = self.journal_account_change(address)?;
         *account = Account {
-            nonce: u64::from(spec.enables(SpecId::SPURIOUS_DRAGON)),
+            nonce: u64::from(features.contains(EvmFeatures::EIP161)),
             balance,
             code_hash: KECCAK256_EMPTY,
             code: Bytecode::default(),
@@ -926,7 +926,7 @@ impl State {
 
     /// Reverts state changes after the checkpoint.
     #[inline(never)]
-    pub fn rollback(&mut self, checkpoint: StateCheckpoint, spec: SpecId) {
+    pub fn rollback(&mut self, checkpoint: StateCheckpoint, features: EvmFeatures) {
         assert!(checkpoint.journal_len <= self.journal.len(), "checkpoint is past journal length");
         assert!(checkpoint.logs_len <= self.logs.len(), "checkpoint is past logs length");
         self.logs.truncate(checkpoint.logs_len);
@@ -945,7 +945,7 @@ impl State {
                 }
                 JournalEntry::Touch { address } => {
                     // EIP-161 preserves the historical Yellow Paper K.1 precompile-3 touch.
-                    if spec.enables(SpecId::SPURIOUS_DRAGON)
+                    if features.contains(EvmFeatures::EIP161)
                         && address == Address::with_last_byte(3)
                     {
                         continue;
@@ -1069,7 +1069,6 @@ impl State {
         let selfdestructs = mem::take(&mut self.selfdestructs);
         let touched = mem::take(&mut self.touched);
 
-        let spec = version.spec_id;
         let delayed_burn_logs =
             version.feature(EvmFeatures::EIP7708 | EvmFeatures::EIP7708_DELAYED_BURN);
         if delayed_burn_logs {
@@ -1098,7 +1097,7 @@ impl State {
             self.delete_account_for_finalization(address)?;
         }
 
-        if spec.enables(SpecId::SPURIOUS_DRAGON) {
+        if version.feature(EvmFeatures::EIP161) {
             for address in &touched {
                 // EIP-161 deletes touched dead accounts at transaction finalization.
                 if self.is_existing_dead(address)? {
@@ -1212,7 +1211,7 @@ impl State {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{constants::EIP7708_BURN_TOPIC, evm::CacheDB};
+    use crate::{SpecId, constants::EIP7708_BURN_TOPIC, evm::CacheDB};
     use alloy_primitives::Bytes;
 
     #[test]
@@ -1228,7 +1227,7 @@ mod tests {
         state.set_storage(&address, &Word::from(1), &Word::from(30)).unwrap();
 
         assert_eq!(state.storage(&address, &Word::from(1)).unwrap(), Word::from(30));
-        state.rollback(checkpoint, SpecId::FRONTIER);
+        state.rollback(checkpoint, Version::base(SpecId::FRONTIER).features);
         assert_eq!(state.storage(&address, &Word::from(1)).unwrap(), Word::from(10));
     }
 
@@ -1242,7 +1241,7 @@ mod tests {
         state.set_transient_storage(&address, &Word::from(1), &Word::from(20));
 
         assert_eq!(state.transient_storage(&address, &Word::from(1)), Word::from(20));
-        state.rollback(checkpoint, SpecId::FRONTIER);
+        state.rollback(checkpoint, Version::base(SpecId::FRONTIER).features);
         assert_eq!(state.transient_storage(&address, &Word::from(1)), Word::from(10));
     }
 
@@ -1255,7 +1254,7 @@ mod tests {
         state.mark_destructed(&address);
 
         assert!(state.is_selfdestructed(&address));
-        state.rollback(checkpoint, SpecId::FRONTIER);
+        state.rollback(checkpoint, Version::base(SpecId::FRONTIER).features);
         assert!(!state.is_selfdestructed(&address));
     }
 
@@ -1287,7 +1286,7 @@ mod tests {
                 }
             ]
         );
-        state.rollback(checkpoint, SpecId::FRONTIER);
+        state.rollback(checkpoint, Version::base(SpecId::FRONTIER).features);
         assert_eq!(state.logs(), &[kept]);
     }
 
@@ -1304,7 +1303,7 @@ mod tests {
         state.touch(&precompile3);
         state.touch(&other);
 
-        state.rollback(checkpoint, SpecId::SPURIOUS_DRAGON);
+        state.rollback(checkpoint, Version::base(SpecId::SPURIOUS_DRAGON).features);
         assert!(state.touched.contains(&precompile3));
         assert!(!state.touched.contains(&other));
     }
@@ -1327,7 +1326,7 @@ mod tests {
         assert!(state.warm_storage(&frame_storage, &key));
         assert_eq!(state.journal.len(), 2);
 
-        state.rollback(checkpoint, SpecId::FRONTIER);
+        state.rollback(checkpoint, Version::base(SpecId::FRONTIER).features);
         assert!(state.is_account_warm(&base_account));
         assert!(state.is_storage_warm(&base_storage, &key));
         assert!(!state.is_account_warm(&frame_account));

--- a/crates/evm2/src/interpreter/host.rs
+++ b/crates/evm2/src/interpreter/host.rs
@@ -58,11 +58,11 @@ impl<T: EvmTypes> MessageResult<T> {
 
     /// Calculates the final refund amount for a top-level transaction.
     #[inline]
-    pub const fn final_refund(&self, gas_limit: u64, is_london: bool) -> u64 {
+    pub const fn final_refund(&self, gas_limit: u64, is_eip3529: bool) -> u64 {
         if self.gas.refunded() <= 0 {
             return 0;
         }
-        let max_refund_quotient = if is_london { 5 } else { 2 };
+        let max_refund_quotient = if is_eip3529 { 5 } else { 2 };
         let spent = gas_limit.saturating_sub(self.gas.remaining());
         let refund = self.gas.refunded() as u64;
         let cap = spent / max_refund_quotient;
@@ -71,16 +71,16 @@ impl<T: EvmTypes> MessageResult<T> {
 
     /// Returns top-level gas remaining after applying the final refund cap.
     #[inline]
-    pub const fn gas_remaining_after_final_refund(&self, gas_limit: u64, is_london: bool) -> u64 {
-        let refunded = self.final_refund(gas_limit, is_london);
+    pub const fn gas_remaining_after_final_refund(&self, gas_limit: u64, is_eip3529: bool) -> u64 {
+        let refunded = self.final_refund(gas_limit, is_eip3529);
         let remaining = self.gas.remaining().saturating_add(refunded);
         if remaining < gas_limit { remaining } else { gas_limit }
     }
 
     /// Returns top-level gas used after applying the final refund cap.
     #[inline]
-    pub const fn gas_used_after_final_refund(&self, gas_limit: u64, is_london: bool) -> u64 {
-        gas_limit.saturating_sub(self.gas_remaining_after_final_refund(gas_limit, is_london))
+    pub const fn gas_used_after_final_refund(&self, gas_limit: u64, is_eip3529: bool) -> u64 {
+        gas_limit.saturating_sub(self.gas_remaining_after_final_refund(gas_limit, is_eip3529))
     }
 }
 

--- a/crates/evm2/src/interpreter/host.rs
+++ b/crates/evm2/src/interpreter/host.rs
@@ -1,6 +1,6 @@
 use super::{GasTracker, InstrStop, Message, Result, Word};
 use crate::{
-    BaseEvmTypes, EvmTypes, SpecId,
+    BaseEvmTypes, EvmFeatures, EvmTypes, SpecId,
     bytecode::Bytecode,
     env::{BlockEnv, TxEnv},
     evm::{AccountLoad, SLoad, SStore, SelfDestructResult},
@@ -104,7 +104,7 @@ pub trait Host<T: EvmTypes> {
     fn target_is_empty_for_new_account_gas(
         &mut self,
         address: &Address,
-        spec: SpecId,
+        features: EvmFeatures,
     ) -> Result<bool, InstrStop>;
 
     /// Returns a historical block hash.

--- a/crates/evm2/src/interpreter/instructions/block.rs
+++ b/crates/evm2/src/interpreter/instructions/block.rs
@@ -1,5 +1,5 @@
 use crate::{
-    SpecId,
+    EvmFeatures,
     constants::BLOCK_HASH_HISTORY,
     interpreter::{Host, InstrStop, Word},
     utils::{address_to_word, b256_to_word, word_to_usize_saturated},
@@ -40,7 +40,7 @@ pub(crate) fn block_number(cx: _) -> out {
 
 #[instruction]
 pub(crate) fn difficulty(cx: _) -> out {
-    *out = if cx.state.spec().enables(SpecId::MERGE) {
+    *out = if cx.state.feature(EvmFeatures::EIP4399) {
         cx.state.host().block_env().prevrandao
     } else {
         cx.state.host().block_env().difficulty

--- a/crates/evm2/src/interpreter/instructions/host.rs
+++ b/crates/evm2/src/interpreter/instructions/host.rs
@@ -37,11 +37,11 @@ pub(crate) fn sload(cx: _, [key]: [Word]) -> Result<out> {
 #[instruction(dynamic_gas)]
 pub(crate) fn sstore(cx: _, [key, value]: [Word]) -> Result {
     require_non_staticcall(cx.state)?;
-    let is_istanbul = cx.state.spec().enables(SpecId::ISTANBUL);
+    let is_eip2200 = cx.state.feature(EvmFeatures::EIP2200);
 
     // EIP-2200: SSTORE may not execute with only the value-transfer stipend left. This
     // check happens before any gas is charged or host storage is touched.
-    if is_istanbul && cx.gas.remaining() <= cx.state.gas_params().get(GasId::CallStipend).into() {
+    if is_eip2200 && cx.gas.remaining() <= cx.state.gas_params().get(GasId::CallStipend).into() {
         return Err(InstrStop::ReentrancySentryOOG);
     }
 
@@ -61,7 +61,7 @@ pub(crate) fn sstore(cx: _, [key, value]: [Word]) -> Result {
     // EIP-2200 net gas metering depends on original, present, and new slot values:
     // clean slots pay set/reset costs, dirty slots generally only pay the load cost,
     // and reset-to-original transitions are handled through refunds.
-    cx.gas.spend(cx.state.gas_params().sstore_dynamic_gas(is_istanbul, &state_load))?;
+    cx.gas.spend(cx.state.gas_params().sstore_dynamic_gas(is_eip2200, &state_load))?;
 
     // EIP-8037 / Amsterdam: creating a new storage slot (original == present == 0,
     // new != 0) also consumes state gas from the reservoir before spilling into
@@ -72,7 +72,7 @@ pub(crate) fn sstore(cx: _, [key, value]: [Word]) -> Result {
 
     // EIP-2200 and EIP-3529 refund rules, including negative refund adjustments for
     // dirty nonzero slots and London's reduced clearing-slot refund via gas params.
-    cx.gas.record_refund(cx.state.gas_params().sstore_refund(is_istanbul, &state_load));
+    cx.gas.record_refund(cx.state.gas_params().sstore_refund(is_eip2200, &state_load));
     Ok(())
 }
 

--- a/crates/evm2/src/interpreter/instructions/host.rs
+++ b/crates/evm2/src/interpreter/instructions/host.rs
@@ -1,5 +1,5 @@
 use crate::{
-    EvmFeatures, EvmTypes, SpecId,
+    EvmFeatures, EvmTypes,
     interpreter::{
         Host, InstrStop, InterpreterState, Result, StackMut, memory::resize_memory,
         private::GasInstructionCx,
@@ -25,7 +25,7 @@ pub(crate) fn sload(cx: _, [key]: [Word]) -> Result<out> {
     // touching the host/database if the frame cannot afford that cold surcharge.
     let additional_cold_cost = cx.state.gas_params().get(GasId::ColdStorageAdditionalCost).into();
     let skip_cold_load =
-        cx.state.spec().enables(SpecId::BERLIN) && cx.gas.remaining() < additional_cold_cost;
+        cx.state.feature(EvmFeatures::EIP2929) && cx.gas.remaining() < additional_cold_cost;
     let destination = &cx.state.message().destination;
     let load = cx.state.host().sload(destination, key, skip_cold_load)?;
     if load.is_cold {
@@ -53,7 +53,7 @@ pub(crate) fn sstore(cx: _, [key, value]: [Word]) -> Result {
     // EIP-2929: avoid performing a cold storage load if the frame cannot afford the
     // additional cold-load charge. The host performs the write and returns
     // original/present/new values for net metering.
-    let skip_cold_load = cx.state.spec().enables(SpecId::BERLIN)
+    let skip_cold_load = cx.state.feature(EvmFeatures::EIP2929)
         && cx.gas.remaining() < cx.state.gas_params().get(GasId::ColdStorageAdditionalCost).into();
     let destination = &cx.state.message().destination;
     let state_load = cx.state.host().sstore(destination, key, value, skip_cold_load)?;

--- a/crates/evm2/src/interpreter/instructions/system.rs
+++ b/crates/evm2/src/interpreter/instructions/system.rs
@@ -133,7 +133,7 @@ fn load_acc_and_calc_gas<T: EvmTypes>(
     }
     gas.spend(cost)?;
 
-    let mut gas_limit = if state.spec().enables(SpecId::TANGERINE) {
+    let mut gas_limit = if state.feature(EvmFeatures::EIP150) {
         min(state.gas_params().call_stipend_reduction(gas.remaining()), stack_gas_limit)
     } else {
         stack_gas_limit
@@ -317,7 +317,7 @@ fn create_inner<T: EvmTypes>(
         state.gas_params().get(GasId::Create).into()
     };
     gas.spend(create_cost)?;
-    let gas_limit = if state.spec().enables(SpecId::TANGERINE) {
+    let gas_limit = if state.feature(EvmFeatures::EIP150) {
         state.gas_params().call_stipend_reduction(gas.remaining())
     } else {
         gas.remaining()

--- a/crates/evm2/src/interpreter/instructions/system.rs
+++ b/crates/evm2/src/interpreter/instructions/system.rs
@@ -25,12 +25,11 @@ const fn require_non_staticcall<T: EvmTypes>(state: &InterpreterState<'_, T>) ->
 
 #[inline]
 const fn should_charge_new_account_gas(
-    spec: SpecId,
+    eip161: bool,
     transfers_value: bool,
     target_is_empty_for_new_account_gas: bool,
 ) -> bool {
-    target_is_empty_for_new_account_gas
-        && (!spec.enables(SpecId::SPURIOUS_DRAGON) || transfers_value)
+    target_is_empty_for_new_account_gas && (!eip161 || transfers_value)
 }
 
 #[inline]
@@ -121,12 +120,12 @@ fn load_acc_and_calc_gas<T: EvmTypes>(
         code = delegated_account.code;
         code_address = delegated_address;
     }
-    let spec = state.spec();
+    let features = state.version().features;
     if create_empty_account
         && should_charge_new_account_gas(
-            spec,
+            features.contains(EvmFeatures::EIP161),
             transfers_value,
-            state.host().target_is_empty_for_new_account_gas(&to, spec)?,
+            state.host().target_is_empty_for_new_account_gas(&to, features)?,
         )
     {
         cost += u64::from(state.gas_params().get(GasId::NewAccountCost));
@@ -374,8 +373,11 @@ pub(crate) fn selfdestruct(cx: _, [target]: [Word]) -> Result {
     let destination = &cx.state.message().destination;
     let res = cx.state.host().selfdestruct(destination, &target, skip_cold_load)?;
     cx.state.inspect_selfdestruct(destination, &target, &res.value);
-    let should_charge_topup =
-        should_charge_new_account_gas(cx.state.spec(), res.had_value, res.target_is_empty);
+    let should_charge_topup = should_charge_new_account_gas(
+        cx.state.feature(EvmFeatures::EIP161),
+        res.had_value,
+        res.target_is_empty,
+    );
     cx.gas.spend(cx.state.gas_params().selfdestruct_cost(should_charge_topup, res.is_cold))?;
     if !res.previously_destroyed {
         cx.gas.record_refund(cx.state.gas_params().get(GasId::SelfdestructRefund) as i64);

--- a/crates/evm2/src/interpreter/instructions/system.rs
+++ b/crates/evm2/src/interpreter/instructions/system.rs
@@ -1,7 +1,7 @@
 //! System opcode implementations.
 
 use crate::{
-    EvmFeatures, EvmTypes, SpecId,
+    EvmFeatures, EvmTypes,
     bytecode::Bytecode,
     constants::CALL_DEPTH_LIMIT,
     interpreter::{
@@ -104,7 +104,7 @@ fn load_acc_and_calc_gas<T: EvmTypes>(
     }
     let mut code = account.code;
     let mut code_address = to;
-    if state.spec().enables(SpecId::PRAGUE)
+    if state.feature(EvmFeatures::EIP7702)
         && let Some(delegated_address) = code.eip7702_address()
     {
         cost += u64::from(state.gas_params().get(GasId::WarmStorageReadCost));

--- a/crates/evm2/src/interpreter/instructions/tests.rs
+++ b/crates/evm2/src/interpreter/instructions/tests.rs
@@ -1,5 +1,5 @@
 use crate::{
-    BaseEvmConfigSelector, EvmTypes, ExecutionConfig, SpecId,
+    BaseEvmConfigSelector, EvmFeatures, EvmTypes, ExecutionConfig, SpecId,
     bytecode::Bytecode,
     env::{BlockEnv, TxEnv},
     evm::{AccountLoad, SLoad, SStore, SelfDestructResult},
@@ -111,9 +111,9 @@ impl Host<TestTypes> for TestHost {
     fn target_is_empty_for_new_account_gas(
         &mut self,
         _address: &Address,
-        spec: SpecId,
+        features: EvmFeatures,
     ) -> Result<bool, InstrStop> {
-        if spec.enables(SpecId::SPURIOUS_DRAGON) {
+        if features.contains(EvmFeatures::EIP161) {
             return Ok(!self.exists || self.is_empty);
         }
         Ok(!self.exists && !self.is_touched)

--- a/crates/evm2/src/interpreter/runtime.rs
+++ b/crates/evm2/src/interpreter/runtime.rs
@@ -3,7 +3,7 @@ use super::{
     StackBacking, Word,
 };
 use crate::{
-    EvmTypes, ExecutionConfig, SpecId, Version,
+    EvmTypes, ExecutionConfig, Version,
     bytecode::Bytecode,
     env::TxEnv,
     evm::inspector::Inspector,
@@ -38,7 +38,6 @@ pub struct Interpreter<'frame, T: EvmTypes> {
 
     pub(in crate::interpreter) gas: Gas,
     pub(in crate::interpreter) result: Result,
-    spec: SpecId,
     features: EvmFeatures,
     is_static: bool,
 }
@@ -66,7 +65,6 @@ impl<T: EvmTypes> Default for Interpreter<'_, T> {
             host: None,
             inspector: None,
             version: core::ptr::null(),
-            spec: SpecId::DEFAULT,
             features: EvmFeatures::empty(),
             // SAFETY: `MaybeUninit<Word>` does not need initialization.
             stack: unsafe { Box::new_uninit().assume_init() },
@@ -215,7 +213,6 @@ impl<'frame, T: EvmTypes> Interpreter<'frame, T> {
         self.host = Some(NonNull::from(host));
         self.inspector = inspector;
         self.version = version;
-        self.spec = version.spec_id;
         self.features = version.features;
 
         dispatch::run(self, instructions)
@@ -316,12 +313,6 @@ impl<'frame, T: EvmTypes> InterpreterState<'frame, T> {
     #[inline]
     pub const fn is_static(&self) -> bool {
         self.0.is_static
-    }
-
-    /// Returns the active spec identifier.
-    #[inline]
-    pub const fn spec(&self) -> SpecId {
-        self.0.spec
     }
 
     /// Returns `true` if the active feature set contains `feature`.

--- a/crates/evm2/src/version/features.rs
+++ b/crates/evm2/src/version/features.rs
@@ -128,42 +128,10 @@ evm_features! {
     ///
     /// Default: on
     BLOCK_GAS_LIMIT_CHECK,
-    /// Applies [EIP-2](https://eips.ethereum.org/EIPS/eip-2) create transaction intrinsic gas.
-    ///
-    /// Default: on since Homestead
-    EIP2,
-    /// Applies [EIP-2028](https://eips.ethereum.org/EIPS/eip-2028) transaction calldata repricing.
-    ///
-    /// Default: on since Istanbul
-    EIP2028,
-    /// Applies [EIP-3529](https://eips.ethereum.org/EIPS/eip-3529) refund reductions.
-    ///
-    /// Default: on since London
-    EIP3529,
-    /// Applies [EIP-3651](https://eips.ethereum.org/EIPS/eip-3651) warm coinbase at transaction start.
-    ///
-    /// Default: on since Shanghai
-    EIP3651,
-    /// Applies [EIP-3860](https://eips.ethereum.org/EIPS/eip-3860) initcode size limits and word gas.
-    ///
-    /// Default: on since Shanghai
-    EIP3860,
-    /// Applies [EIP-3541](https://eips.ethereum.org/EIPS/eip-3541) contract code prefix rejection.
-    ///
-    /// Default: on since London
-    EIP3541,
     /// Applies [EIP-3607](https://eips.ethereum.org/EIPS/eip-3607) sender code rejection.
     ///
     /// Default: on
     EIP3607,
-    /// Applies [EIP-7623](https://eips.ethereum.org/EIPS/eip-7623) calldata cost floor.
-    ///
-    /// Default: on since Prague
-    EIP7623,
-    /// Checks [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559) transaction fee caps against the block base fee.
-    ///
-    /// Default: on since London
-    BASE_FEE_CHECK,
     /// Checks [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559) max priority fee against max fee.
     ///
     /// Default: on
@@ -172,6 +140,70 @@ evm_features! {
     ///
     /// Default: on
     FEE_CHARGE,
+    /// Applies [EIP-2](https://eips.ethereum.org/EIPS/eip-2) create transaction intrinsic gas.
+    ///
+    /// Default: on since Homestead
+    EIP2,
+    /// Applies [EIP-150](https://eips.ethereum.org/EIPS/eip-150) call gas forwarding limits.
+    ///
+    /// Default: on since Tangerine Whistle
+    EIP150,
+    /// Applies [EIP-161](https://eips.ethereum.org/EIPS/eip-161) state clearing rules.
+    ///
+    /// Default: on since Spurious Dragon
+    EIP161,
+    /// Checks deployed contract bytecode sizes against the active size limit.
+    ///
+    /// Default: on since Spurious Dragon
+    CODE_SIZE_CHECK,
+    /// Applies [EIP-2028](https://eips.ethereum.org/EIPS/eip-2028) transaction calldata repricing.
+    ///
+    /// Default: on since Istanbul
+    EIP2028,
+    /// Applies [EIP-2200](https://eips.ethereum.org/EIPS/eip-2200) SSTORE net metering.
+    ///
+    /// Default: on since Istanbul
+    EIP2200,
+    /// Applies [EIP-2929](https://eips.ethereum.org/EIPS/eip-2929) warm/cold access rules.
+    ///
+    /// Default: on since Berlin
+    EIP2929,
+    /// Applies [EIP-3529](https://eips.ethereum.org/EIPS/eip-3529) refund reductions.
+    ///
+    /// Default: on since London
+    EIP3529,
+    /// Applies [EIP-3541](https://eips.ethereum.org/EIPS/eip-3541) contract code prefix rejection.
+    ///
+    /// Default: on since London
+    EIP3541,
+    /// Checks [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559) transaction fee caps against the block base fee.
+    ///
+    /// Default: on since London
+    BASE_FEE_CHECK,
+    /// Applies [EIP-4399](https://eips.ethereum.org/EIPS/eip-4399) PREVRANDAO opcode semantics.
+    ///
+    /// Default: on since Merge
+    EIP4399,
+    /// Applies [EIP-3651](https://eips.ethereum.org/EIPS/eip-3651) warm coinbase at transaction start.
+    ///
+    /// Default: on since Shanghai
+    EIP3651,
+    /// Applies [EIP-3860](https://eips.ethereum.org/EIPS/eip-3860) initcode size limits and word gas.
+    ///
+    /// Default: on since Shanghai
+    EIP3860,
+    /// Applies [EIP-6780](https://eips.ethereum.org/EIPS/eip-6780) SELFDESTRUCT restrictions.
+    ///
+    /// Default: on since Cancun
+    EIP6780,
+    /// Applies [EIP-7623](https://eips.ethereum.org/EIPS/eip-7623) calldata cost floor.
+    ///
+    /// Default: on since Prague
+    EIP7623,
+    /// Applies [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) delegation designators.
+    ///
+    /// Default: on since Prague
+    EIP7702,
     /// Applies [EIP-7981](https://eips.ethereum.org/EIPS/eip-7981) access-list data gas costs.
     ///
     /// Default: on since Amsterdam
@@ -188,38 +220,6 @@ evm_features! {
     ///
     /// Default: on since Amsterdam
     EIP7708_DELAYED_BURN,
-    /// Applies [EIP-150](https://eips.ethereum.org/EIPS/eip-150) call gas forwarding limits.
-    ///
-    /// Default: on since Tangerine Whistle
-    EIP150,
-    /// Applies [EIP-161](https://eips.ethereum.org/EIPS/eip-161) state clearing rules.
-    ///
-    /// Default: on since Spurious Dragon
-    EIP161,
-    /// Checks deployed contract bytecode sizes against the active size limit.
-    ///
-    /// Default: on since Spurious Dragon
-    CODE_SIZE_CHECK,
-    /// Applies [EIP-2200](https://eips.ethereum.org/EIPS/eip-2200) SSTORE net metering.
-    ///
-    /// Default: on since Istanbul
-    EIP2200,
-    /// Applies [EIP-2929](https://eips.ethereum.org/EIPS/eip-2929) warm/cold access rules.
-    ///
-    /// Default: on since Berlin
-    EIP2929,
-    /// Applies [EIP-4399](https://eips.ethereum.org/EIPS/eip-4399) PREVRANDAO opcode semantics.
-    ///
-    /// Default: on since Merge
-    EIP4399,
-    /// Applies [EIP-6780](https://eips.ethereum.org/EIPS/eip-6780) SELFDESTRUCT restrictions.
-    ///
-    /// Default: on since Cancun
-    EIP6780,
-    /// Applies [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) delegation designators.
-    ///
-    /// Default: on since Prague
-    EIP7702,
 }
 
 #[cfg(test)]

--- a/crates/evm2/src/version/features.rs
+++ b/crates/evm2/src/version/features.rs
@@ -216,6 +216,10 @@ evm_features! {
     ///
     /// Default: on since Cancun
     EIP6780,
+    /// Applies [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) delegation designators.
+    ///
+    /// Default: on since Prague
+    EIP7702,
 }
 
 #[cfg(test)]

--- a/crates/evm2/src/version/features.rs
+++ b/crates/evm2/src/version/features.rs
@@ -196,6 +196,10 @@ evm_features! {
     ///
     /// Default: on since Spurious Dragon
     EIP161,
+    /// Checks deployed contract bytecode sizes against the active size limit.
+    ///
+    /// Default: on since Spurious Dragon
+    CODE_SIZE_CHECK,
 }
 
 #[cfg(test)]

--- a/crates/evm2/src/version/features.rs
+++ b/crates/evm2/src/version/features.rs
@@ -208,6 +208,10 @@ evm_features! {
     ///
     /// Default: on since Berlin
     EIP2929,
+    /// Applies [EIP-4399](https://eips.ethereum.org/EIPS/eip-4399) PREVRANDAO opcode semantics.
+    ///
+    /// Default: on since Merge
+    EIP4399,
 }
 
 #[cfg(test)]

--- a/crates/evm2/src/version/features.rs
+++ b/crates/evm2/src/version/features.rs
@@ -200,6 +200,10 @@ evm_features! {
     ///
     /// Default: on since Spurious Dragon
     CODE_SIZE_CHECK,
+    /// Applies [EIP-2200](https://eips.ethereum.org/EIPS/eip-2200) SSTORE net metering.
+    ///
+    /// Default: on since Istanbul
+    EIP2200,
 }
 
 #[cfg(test)]

--- a/crates/evm2/src/version/features.rs
+++ b/crates/evm2/src/version/features.rs
@@ -188,6 +188,10 @@ evm_features! {
     ///
     /// Default: on since Amsterdam
     EIP7708_DELAYED_BURN,
+    /// Applies [EIP-150](https://eips.ethereum.org/EIPS/eip-150) call gas forwarding limits.
+    ///
+    /// Default: on since Tangerine Whistle
+    EIP150,
 }
 
 #[cfg(test)]

--- a/crates/evm2/src/version/features.rs
+++ b/crates/evm2/src/version/features.rs
@@ -212,6 +212,10 @@ evm_features! {
     ///
     /// Default: on since Merge
     EIP4399,
+    /// Applies [EIP-6780](https://eips.ethereum.org/EIPS/eip-6780) SELFDESTRUCT restrictions.
+    ///
+    /// Default: on since Cancun
+    EIP6780,
 }
 
 #[cfg(test)]

--- a/crates/evm2/src/version/features.rs
+++ b/crates/evm2/src/version/features.rs
@@ -204,6 +204,10 @@ evm_features! {
     ///
     /// Default: on since Istanbul
     EIP2200,
+    /// Applies [EIP-2929](https://eips.ethereum.org/EIPS/eip-2929) warm/cold access rules.
+    ///
+    /// Default: on since Berlin
+    EIP2929,
 }
 
 #[cfg(test)]

--- a/crates/evm2/src/version/features.rs
+++ b/crates/evm2/src/version/features.rs
@@ -192,6 +192,10 @@ evm_features! {
     ///
     /// Default: on since Tangerine Whistle
     EIP150,
+    /// Applies [EIP-161](https://eips.ethereum.org/EIPS/eip-161) state clearing rules.
+    ///
+    /// Default: on since Spurious Dragon
+    EIP161,
 }
 
 #[cfg(test)]

--- a/crates/evm2/src/version/gas_params.rs
+++ b/crates/evm2/src/version/gas_params.rs
@@ -301,8 +301,8 @@ impl GasParams {
 
     /// Calculates dynamic `SSTORE` gas.
     #[inline]
-    pub fn sstore_dynamic_gas(&self, is_istanbul: bool, vals: &SStore) -> u64 {
-        if !is_istanbul {
+    pub fn sstore_dynamic_gas(&self, is_eip2200: bool, vals: &SStore) -> u64 {
+        if !is_eip2200 {
             if vals.present_is_zero() && !vals.new_is_zero() {
                 return self.get(GasId::SstoreSetWithoutLoadCost) as u64;
             }
@@ -326,10 +326,10 @@ impl GasParams {
 
     /// Calculates `SSTORE` refund.
     #[inline]
-    pub fn sstore_refund(&self, is_istanbul: bool, vals: &SStore) -> i64 {
+    pub fn sstore_refund(&self, is_eip2200: bool, vals: &SStore) -> i64 {
         let clearing_slot_refund = self.get(GasId::SstoreClearingSlotRefund) as i64;
 
-        if !is_istanbul {
+        if !is_eip2200 {
             if !vals.present_is_zero() && vals.new_is_zero() {
                 return clearing_slot_refund;
             }

--- a/crates/evm2/src/version/mod.rs
+++ b/crates/evm2/src/version/mod.rs
@@ -259,6 +259,7 @@ mod tests {
         assert!(osaka.feature(EvmFeatures::EIP150));
         assert!(osaka.feature(EvmFeatures::EIP161));
         assert!(osaka.feature(EvmFeatures::EIP2028));
+        assert!(osaka.feature(EvmFeatures::EIP2200));
         assert!(osaka.feature(EvmFeatures::EIP3529));
         assert!(osaka.feature(EvmFeatures::EIP3651));
         assert!(osaka.feature(EvmFeatures::EIP3860));
@@ -571,6 +572,7 @@ evm_versions! {
     ISTANBUL {
         features: [
             EIP2028,
+            EIP2200,
         ],
         ops: [
             CHAINID: BASE,

--- a/crates/evm2/src/version/mod.rs
+++ b/crates/evm2/src/version/mod.rs
@@ -260,6 +260,7 @@ mod tests {
         assert!(osaka.feature(EvmFeatures::EIP161));
         assert!(osaka.feature(EvmFeatures::EIP2028));
         assert!(osaka.feature(EvmFeatures::EIP2200));
+        assert!(osaka.feature(EvmFeatures::EIP2929));
         assert!(osaka.feature(EvmFeatures::EIP3529));
         assert!(osaka.feature(EvmFeatures::EIP3651));
         assert!(osaka.feature(EvmFeatures::EIP3860));
@@ -595,6 +596,9 @@ evm_versions! {
     }
 
     BERLIN {
+        features: [
+            EIP2929,
+        ],
         static_gas: [
             SLOAD: WARM_STORAGE_READ_COST,
             BALANCE: WARM_STORAGE_READ_COST,

--- a/crates/evm2/src/version/mod.rs
+++ b/crates/evm2/src/version/mod.rs
@@ -264,6 +264,7 @@ mod tests {
         assert!(osaka.feature(EvmFeatures::EIP3529));
         assert!(osaka.feature(EvmFeatures::EIP3651));
         assert!(osaka.feature(EvmFeatures::EIP3860));
+        assert!(osaka.feature(EvmFeatures::EIP4399));
         assert!(osaka.feature(EvmFeatures::EIP3541));
         assert!(osaka.feature(EvmFeatures::EIP3607));
         assert!(osaka.feature(EvmFeatures::EIP7623));
@@ -646,7 +647,11 @@ evm_versions! {
         ],
     }
 
-    MERGE {}
+    MERGE {
+        features: [
+            EIP4399,
+        ],
+    }
 
     SHANGHAI {
         features: [

--- a/crates/evm2/src/version/mod.rs
+++ b/crates/evm2/src/version/mod.rs
@@ -265,6 +265,7 @@ mod tests {
         assert!(osaka.feature(EvmFeatures::EIP3651));
         assert!(osaka.feature(EvmFeatures::EIP3860));
         assert!(osaka.feature(EvmFeatures::EIP4399));
+        assert!(osaka.feature(EvmFeatures::EIP6780));
         assert!(osaka.feature(EvmFeatures::EIP3541));
         assert!(osaka.feature(EvmFeatures::EIP3607));
         assert!(osaka.feature(EvmFeatures::EIP7623));
@@ -671,6 +672,9 @@ evm_versions! {
     }
 
     CANCUN {
+        features: [
+            EIP6780,
+        ],
         ops: [
             BLOBHASH: VERYLOW,
             BLOBBASEFEE: BASE,

--- a/crates/evm2/src/version/mod.rs
+++ b/crates/evm2/src/version/mod.rs
@@ -254,6 +254,7 @@ mod tests {
         assert!(osaka.feature(EvmFeatures::NONCE_CHECK));
         assert!(osaka.feature(EvmFeatures::BALANCE_CHECK));
         assert!(osaka.feature(EvmFeatures::BLOCK_GAS_LIMIT_CHECK));
+        assert!(osaka.feature(EvmFeatures::CODE_SIZE_CHECK));
         assert!(osaka.feature(EvmFeatures::EIP2));
         assert!(osaka.feature(EvmFeatures::EIP150));
         assert!(osaka.feature(EvmFeatures::EIP161));
@@ -538,6 +539,7 @@ evm_versions! {
     SPURIOUS_DRAGON {
         features: [
             EIP161,
+            CODE_SIZE_CHECK,
         ],
         static_gas: [
             EXP: EXP,

--- a/crates/evm2/src/version/mod.rs
+++ b/crates/evm2/src/version/mod.rs
@@ -255,6 +255,7 @@ mod tests {
         assert!(osaka.feature(EvmFeatures::BALANCE_CHECK));
         assert!(osaka.feature(EvmFeatures::BLOCK_GAS_LIMIT_CHECK));
         assert!(osaka.feature(EvmFeatures::EIP2));
+        assert!(osaka.feature(EvmFeatures::EIP150));
         assert!(osaka.feature(EvmFeatures::EIP2028));
         assert!(osaka.feature(EvmFeatures::EIP3529));
         assert!(osaka.feature(EvmFeatures::EIP3651));
@@ -514,6 +515,9 @@ evm_versions! {
     }
 
     TANGERINE {
+        features: [
+            EIP150,
+        ],
         static_gas: [
             SLOAD: 200,
             BALANCE: 400,

--- a/crates/evm2/src/version/mod.rs
+++ b/crates/evm2/src/version/mod.rs
@@ -269,6 +269,7 @@ mod tests {
         assert!(osaka.feature(EvmFeatures::EIP3541));
         assert!(osaka.feature(EvmFeatures::EIP3607));
         assert!(osaka.feature(EvmFeatures::EIP7623));
+        assert!(osaka.feature(EvmFeatures::EIP7702));
         assert!(osaka.feature(EvmFeatures::BASE_FEE_CHECK));
         assert!(osaka.feature(EvmFeatures::PRIORITY_FEE_CHECK));
         assert!(osaka.feature(EvmFeatures::FEE_CHARGE));
@@ -687,6 +688,7 @@ evm_versions! {
     PRAGUE {
         features: [
             EIP7623,
+            EIP7702,
         ],
         dynamic_gas: [
             TxEip7702PerEmptyAccountCost: EIP7702_PER_EMPTY_ACCOUNT_COST,

--- a/crates/evm2/src/version/mod.rs
+++ b/crates/evm2/src/version/mod.rs
@@ -22,13 +22,10 @@ pub use opcode_config::OpcodeConfig;
 /// Runtime configuration data.
 ///
 /// The name is a bit misleading: this is a catch-all runtime configuration object. It stores fork
-/// configuration such as the active base `SpecId` and EVM features, and also stores regular runtime
-/// configuration values such as chain ID, memory limits, code size limits, gas caps, and gas
-/// parameters.
+/// configuration such as active EVM features, and also stores regular runtime configuration values
+/// such as chain ID, memory limits, code size limits, gas caps, and gas parameters.
 #[derive(Clone, Copy, Debug)]
 pub struct Version {
-    /// Active base specification ID.
-    pub spec_id: SpecId,
     /// Dynamic gas parameter table.
     // Gas params are data on the active version so changes automatically affect every
     // instruction that reads them. Tracking instruction dependencies on opcode config is not
@@ -111,7 +108,6 @@ const DEFAULT_CHAIN_ID: u64 = 1;
 static BASE_VERSIONS: [Version; SpecId::COUNT] = {
     let mut versions = [const {
         Version {
-            spec_id: SpecId::FRONTIER,
             gas_params: GasParams::empty(),
             features: EvmFeatures::empty(),
             chain_id: DEFAULT_CHAIN_ID,
@@ -128,7 +124,6 @@ static BASE_VERSIONS: [Version; SpecId::COUNT] = {
     while i < SpecId::COUNT {
         let spec_id = SpecId::try_from_u32(i as u32).unwrap();
         versions[i] = Version {
-            spec_id,
             gas_params: base_gas_params(spec_id),
             features: base_features(spec_id),
             chain_id: DEFAULT_CHAIN_ID,

--- a/crates/evm2/src/version/mod.rs
+++ b/crates/evm2/src/version/mod.rs
@@ -256,6 +256,7 @@ mod tests {
         assert!(osaka.feature(EvmFeatures::BLOCK_GAS_LIMIT_CHECK));
         assert!(osaka.feature(EvmFeatures::EIP2));
         assert!(osaka.feature(EvmFeatures::EIP150));
+        assert!(osaka.feature(EvmFeatures::EIP161));
         assert!(osaka.feature(EvmFeatures::EIP2028));
         assert!(osaka.feature(EvmFeatures::EIP3529));
         assert!(osaka.feature(EvmFeatures::EIP3651));
@@ -535,6 +536,9 @@ evm_versions! {
     }
 
     SPURIOUS_DRAGON {
+        features: [
+            EIP161,
+        ],
         static_gas: [
             EXP: EXP,
         ],


### PR DESCRIPTION
Adds `EvmFeatures` for fork-specific runtime behavior (EIP150, EIP161, CODE_SIZE_CHECK, EIP2200, EIP2929, EIP4399, EIP6780, and EIP7702) and switches interpreter/host checks from `SpecId` gates to feature checks.

Keeps tx-type, precompile, and block-transition gates on their existing paths.

Validated with `cargo +nightly fmt --all`, `cargo +nightly cl`, and `cargo +nightly docs`.