### PR TITLE
feat(precompile): pass evm to providers

### DIFF
--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -1106,33 +1106,33 @@ mod tests {
         })
     }
 
-    #[derive(Default)]
-    struct HostObservingPrecompile {
-        seen_block_number: Option<U256>,
-    }
-
-    impl PrecompileProvider<BaseEvmTypes> for HostObservingPrecompile {
-        fn contains(&self, address: &Address) -> bool {
-            *address == Address::with_last_byte(0x42)
-        }
-
-        fn execute(
-            &mut self,
-            evm: &mut Evm<BaseEvmTypes>,
-            address: Address,
-            _input: &[u8],
-            _gas: &mut GasTracker,
-        ) -> Option<Result<PrecompileOutput, PrecompileError>> {
-            if !self.contains(&address) {
-                return None;
-            }
-            self.seen_block_number = Some(evm.block.number);
-            Some(Ok(PrecompileOutput::new(Bytes::copy_from_slice(&[0x42]))))
-        }
-    }
-
     #[test]
     fn passes_evm_to_precompile_provider() {
+        #[derive(Default)]
+        struct HostObservingPrecompile {
+            seen_block_number: Option<U256>,
+        }
+
+        impl PrecompileProvider<BaseEvmTypes> for HostObservingPrecompile {
+            fn contains(&self, address: &Address) -> bool {
+                *address == Address::with_last_byte(0x42)
+            }
+
+            fn execute(
+                &mut self,
+                evm: &mut Evm<BaseEvmTypes>,
+                address: Address,
+                _input: &[u8],
+                _gas: &mut GasTracker,
+            ) -> Option<Result<PrecompileOutput, PrecompileError>> {
+                if !self.contains(&address) {
+                    return None;
+                }
+                self.seen_block_number = Some(evm.block.number);
+                Some(Ok(PrecompileOutput::new(Bytes::copy_from_slice(&[0x42]))))
+            }
+        }
+
         let address = Address::with_last_byte(0x42);
         let block = BlockEnv { number: U256::from(17), ..BlockEnv::default() };
         let mut evm = Evm::<BaseEvmTypes>::new(
@@ -1167,57 +1167,57 @@ mod tests {
         );
     }
 
-    #[derive(Default)]
-    struct NestedPrecompile {
-        outer_called: bool,
-        inner_called: bool,
-    }
-
-    impl NestedPrecompile {
-        const OUTER: Address = Address::with_last_byte(0x42);
-        const INNER: Address = Address::with_last_byte(0x43);
-    }
-
-    impl PrecompileProvider<BaseEvmTypes> for NestedPrecompile {
-        fn contains(&self, address: &Address) -> bool {
-            *address == Self::OUTER || *address == Self::INNER
-        }
-
-        fn execute(
-            &mut self,
-            evm: &mut Evm<BaseEvmTypes>,
-            address: Address,
-            _input: &[u8],
-            gas: &mut GasTracker,
-        ) -> Option<Result<PrecompileOutput, PrecompileError>> {
-            if address == Self::INNER {
-                self.inner_called = true;
-                return Some(Ok(PrecompileOutput::new(Bytes::from_static(b"inner"))));
-            }
-            if address != Self::OUTER {
-                return None;
-            }
-            self.outer_called = true;
-            let message = Message {
-                kind: MessageKind::Call,
-                depth: 0,
-                gas_limit: 30_000,
-                destination: Self::INNER,
-                caller: Address::ZERO,
-                input: Bytes::new(),
-                value: U256::ZERO,
-                code_address: Self::INNER,
-                disable_precompiles: false,
-                salt: B256::ZERO,
-                ext: (),
-                _non_exhaustive: (),
-            };
-            Some(evm.execute_precompile(&message, gas))
-        }
-    }
-
     #[test]
     fn precompile_can_call_another_precompile() {
+        #[derive(Default)]
+        struct NestedPrecompile {
+            outer_called: bool,
+            inner_called: bool,
+        }
+
+        impl NestedPrecompile {
+            const OUTER: Address = Address::with_last_byte(0x42);
+            const INNER: Address = Address::with_last_byte(0x43);
+        }
+
+        impl PrecompileProvider<BaseEvmTypes> for NestedPrecompile {
+            fn contains(&self, address: &Address) -> bool {
+                *address == Self::OUTER || *address == Self::INNER
+            }
+
+            fn execute(
+                &mut self,
+                evm: &mut Evm<BaseEvmTypes>,
+                address: Address,
+                _input: &[u8],
+                gas: &mut GasTracker,
+            ) -> Option<Result<PrecompileOutput, PrecompileError>> {
+                if address == Self::INNER {
+                    self.inner_called = true;
+                    return Some(Ok(PrecompileOutput::new(Bytes::from_static(b"inner"))));
+                }
+                if address != Self::OUTER {
+                    return None;
+                }
+                self.outer_called = true;
+                let message = Message {
+                    kind: MessageKind::Call,
+                    depth: 0,
+                    gas_limit: 30_000,
+                    destination: Self::INNER,
+                    caller: Address::ZERO,
+                    input: Bytes::new(),
+                    value: U256::ZERO,
+                    code_address: Self::INNER,
+                    disable_precompiles: false,
+                    salt: B256::ZERO,
+                    ext: (),
+                    _non_exhaustive: (),
+                };
+                Some(evm.execute_precompile(&message, gas))
+            }
+        }
+
         let mut evm = Evm::<BaseEvmTypes>::new(
             SpecId::OSAKA,
             BlockEnv::default(),

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -2,7 +2,7 @@
 
 use self::{
     inspector::Inspector,
-    precompile::{PrecompileOutput, PrecompileProvider},
+    precompile::{NoPrecompiles, PrecompileOutput, PrecompileProvider},
 };
 use crate::{
     EvmConfigSelector, EvmTypes, ExecutionConfig, PrecompileError, PrecompileHalt, SpecId,
@@ -64,7 +64,7 @@ pub struct Evm<T: EvmTypes> {
     #[derive_where(skip)]
     pub(crate) state: State,
     #[derive_where(skip)]
-    precompiles: Box<dyn PrecompileProvider>,
+    precompiles: Box<dyn PrecompileProvider<T>>,
     #[derive_where(skip)]
     interpreter_pool: InterpreterPool<T>,
     #[derive_where(skip)]
@@ -84,7 +84,7 @@ impl<T: EvmTypes> Evm<T> {
         block: BlockEnv<T>,
         registry: TxRegistry<T, TxResult<T>>,
         database: impl DynDatabase,
-        precompiles: impl PrecompileProvider,
+        precompiles: impl PrecompileProvider<T>,
     ) -> Self {
         Self::new_with_execution_config(
             <T::ConfigSelector as EvmConfigSelector<T>>::execution_config(spec_id),
@@ -104,7 +104,7 @@ impl<T: EvmTypes> Evm<T> {
         block: BlockEnv<T>,
         registry: TxRegistry<T, TxResult<T>>,
         database: impl DynDatabase,
-        precompiles: impl PrecompileProvider,
+        precompiles: impl PrecompileProvider<T>,
     ) -> Self {
         Self::new_mono(
             execution_config,
@@ -123,7 +123,7 @@ impl<T: EvmTypes> Evm<T> {
         block: BlockEnv<T>,
         registry: TxRegistry<T, TxResult<T>>,
         database: Box<dyn DynDatabase>,
-        precompiles: Box<dyn PrecompileProvider>,
+        precompiles: Box<dyn PrecompileProvider<T>>,
     ) -> Self {
         assert_eq!(
             spec_id.into(),
@@ -157,9 +157,13 @@ impl<T: EvmTypes> Evm<T> {
         message: &Message<T>,
         gas: &mut GasTracker,
     ) -> Result<PrecompileOutput, PrecompileError> {
-        self.precompiles
-            .execute(message.code_address, &message.input, gas)
-            .expect("precompile was checked before execution")
+        let mut precompiles =
+            core::mem::replace(&mut self.precompiles, Box::new(NoPrecompiles::default()));
+        let result = precompiles
+            .execute(self, message.code_address, &message.input, gas)
+            .expect("precompile was checked before execution");
+        self.precompiles = precompiles;
+        result
     }
 }
 
@@ -226,31 +230,31 @@ impl<T: EvmTypes> Evm<T> {
 
     /// Returns the precompile provider.
     #[inline]
-    pub fn precompiles(&self) -> &dyn PrecompileProvider {
+    pub fn precompiles(&self) -> &dyn PrecompileProvider<T> {
         self.precompiles.as_ref()
     }
 
     /// Returns the precompile provider mutably.
     #[inline]
-    pub fn precompiles_mut(&mut self) -> &mut dyn PrecompileProvider {
+    pub fn precompiles_mut(&mut self) -> &mut dyn PrecompileProvider<T> {
         self.precompiles.as_mut()
     }
 
     /// Replaces the precompile provider.
     #[inline]
-    pub fn set_precompiles(&mut self, precompiles: impl PrecompileProvider) {
+    pub fn set_precompiles(&mut self, precompiles: impl PrecompileProvider<T>) {
         self.precompiles = Box::new(precompiles);
     }
 
     /// Returns the precompile provider as `P` if it has that concrete type.
     #[inline]
-    pub fn precompiles_as<P: PrecompileProvider>(&self) -> Option<&P> {
+    pub fn precompiles_as<P: PrecompileProvider<T>>(&self) -> Option<&P> {
         <dyn core::any::Any>::downcast_ref(self.precompiles())
     }
 
     /// Returns the precompile provider mutably as `P` if it has that concrete type.
     #[inline]
-    pub fn precompiles_as_mut<P: PrecompileProvider>(&mut self) -> Option<&mut P> {
+    pub fn precompiles_as_mut<P: PrecompileProvider<T>>(&mut self) -> Option<&mut P> {
         <dyn core::any::Any>::downcast_mut(self.precompiles_mut())
     }
 
@@ -1065,7 +1069,7 @@ mod tests {
         BaseEvmConfigSelector, BaseEvmTypes, Precompiles, SpecId, Version,
         bytecode::Bytecode,
         ethereum::RecoveredTxEnvelope,
-        interpreter::{MessageKind, op},
+        interpreter::{GasTracker, MessageKind, op},
         registry::TxRequest,
     };
     use alloc::{string::ToString, vec, vec::Vec};
@@ -1097,6 +1101,67 @@ mod tests {
             gas_used: req.host.version().tx_gas_limit_cap,
             ..TxResult::default()
         })
+    }
+
+    #[derive(Default)]
+    struct HostObservingPrecompile {
+        seen_block_number: Option<U256>,
+    }
+
+    impl PrecompileProvider<BaseEvmTypes> for HostObservingPrecompile {
+        fn contains(&self, address: &Address) -> bool {
+            *address == Address::with_last_byte(0x42)
+        }
+
+        fn execute(
+            &mut self,
+            evm: &mut Evm<BaseEvmTypes>,
+            address: Address,
+            _input: &[u8],
+            _gas: &mut GasTracker,
+        ) -> Option<Result<PrecompileOutput, PrecompileError>> {
+            if !self.contains(&address) {
+                return None;
+            }
+            self.seen_block_number = Some(evm.block.number);
+            Some(Ok(PrecompileOutput::new(Bytes::copy_from_slice(&[0x42]))))
+        }
+    }
+
+    #[test]
+    fn passes_evm_to_precompile_provider() {
+        let address = Address::with_last_byte(0x42);
+        let block = BlockEnv { number: U256::from(17), ..BlockEnv::default() };
+        let mut evm = Evm::<BaseEvmTypes>::new(
+            SpecId::OSAKA,
+            block,
+            TxRegistry::new(),
+            InMemoryDB::default(),
+            HostObservingPrecompile::default(),
+        );
+        let message = Message {
+            kind: MessageKind::Call,
+            depth: 0,
+            gas_limit: 30_000,
+            destination: address,
+            caller: Address::ZERO,
+            input: Bytes::new(),
+            value: U256::ZERO,
+            code_address: address,
+            disable_precompiles: false,
+            salt: B256::ZERO,
+            ext: (),
+            _non_exhaustive: (),
+        };
+        let output = evm
+            .execute_precompile(&message, &mut GasTracker::new(30_000))
+            .expect("precompile succeeds");
+
+        assert_eq!(output.bytes(), &[0x42]);
+        assert_eq!(
+            evm.precompiles_as::<HostObservingPrecompile>().unwrap().seen_block_number,
+            Some(U256::from(17))
+        );
     }
 
     #[test]

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -2,7 +2,7 @@
 
 use self::{
     inspector::Inspector,
-    precompile::{NoPrecompiles, PrecompileOutput, PrecompileProvider},
+    precompile::{PrecompileOutput, PrecompileProvider},
 };
 use crate::{
     EvmConfigSelector, EvmTypes, ExecutionConfig, PrecompileError, PrecompileHalt, SpecId,
@@ -157,13 +157,16 @@ impl<T: EvmTypes> Evm<T> {
         message: &Message<T>,
         gas: &mut GasTracker,
     ) -> Result<PrecompileOutput, PrecompileError> {
-        let mut precompiles =
-            core::mem::replace(&mut self.precompiles, Box::new(NoPrecompiles::default()));
-        let result = precompiles
-            .execute(self, message.code_address, &message.input, gas)
-            .expect("precompile was checked before execution");
-        self.precompiles = precompiles;
-        result
+        let precompiles = self.precompiles.as_mut() as *mut dyn PrecompileProvider<T>;
+        let evm = self as *mut Self;
+        // SAFETY: Precompile execution may need access to both the provider and the host EVM.
+        // The provider is not moved or replaced during this call, and `execute` is expected to
+        // preserve `Evm` invariants while using the host reference.
+        unsafe {
+            (&mut *precompiles)
+                .execute(&mut *evm, message.code_address, &message.input, gas)
+                .expect("precompile was checked before execution")
+        }
     }
 }
 
@@ -1162,6 +1165,89 @@ mod tests {
             evm.precompiles_as::<HostObservingPrecompile>().unwrap().seen_block_number,
             Some(U256::from(17))
         );
+    }
+
+    #[derive(Default)]
+    struct NestedPrecompile {
+        outer_called: bool,
+        inner_called: bool,
+    }
+
+    impl NestedPrecompile {
+        const OUTER: Address = Address::with_last_byte(0x42);
+        const INNER: Address = Address::with_last_byte(0x43);
+    }
+
+    impl PrecompileProvider<BaseEvmTypes> for NestedPrecompile {
+        fn contains(&self, address: &Address) -> bool {
+            *address == Self::OUTER || *address == Self::INNER
+        }
+
+        fn execute(
+            &mut self,
+            evm: &mut Evm<BaseEvmTypes>,
+            address: Address,
+            _input: &[u8],
+            gas: &mut GasTracker,
+        ) -> Option<Result<PrecompileOutput, PrecompileError>> {
+            if address == Self::INNER {
+                self.inner_called = true;
+                return Some(Ok(PrecompileOutput::new(Bytes::from_static(b"inner"))));
+            }
+            if address != Self::OUTER {
+                return None;
+            }
+            self.outer_called = true;
+            let message = Message {
+                kind: MessageKind::Call,
+                depth: 0,
+                gas_limit: 30_000,
+                destination: Self::INNER,
+                caller: Address::ZERO,
+                input: Bytes::new(),
+                value: U256::ZERO,
+                code_address: Self::INNER,
+                disable_precompiles: false,
+                salt: B256::ZERO,
+                ext: (),
+                _non_exhaustive: (),
+            };
+            Some(evm.execute_precompile(&message, gas))
+        }
+    }
+
+    #[test]
+    fn precompile_can_call_another_precompile() {
+        let mut evm = Evm::<BaseEvmTypes>::new(
+            SpecId::OSAKA,
+            BlockEnv::default(),
+            TxRegistry::new(),
+            InMemoryDB::default(),
+            NestedPrecompile::default(),
+        );
+        let message = Message {
+            kind: MessageKind::Call,
+            depth: 0,
+            gas_limit: 30_000,
+            destination: NestedPrecompile::OUTER,
+            caller: Address::ZERO,
+            input: Bytes::new(),
+            value: U256::ZERO,
+            code_address: NestedPrecompile::OUTER,
+            disable_precompiles: false,
+            salt: B256::ZERO,
+            ext: (),
+            _non_exhaustive: (),
+        };
+
+        let output = evm
+            .execute_precompile(&message, &mut GasTracker::new(30_000))
+            .expect("precompile succeeds");
+
+        let precompile = evm.precompiles_as::<NestedPrecompile>().unwrap();
+        assert_eq!(output.bytes(), b"inner");
+        assert!(precompile.outer_called);
+        assert!(precompile.inner_called);
     }
 
     #[test]

--- a/crates/evm2/src/evm/precompile.rs
+++ b/crates/evm2/src/evm/precompile.rs
@@ -1,6 +1,7 @@
 //! Precompile dispatch interface.
 
-use crate::{PrecompileError, interpreter::GasTracker};
+use super::Evm;
+use crate::{EvmTypes, PrecompileError, interpreter::GasTracker};
 use alloc::{boxed::Box, vec::Vec};
 use alloy_primitives::{Address, Bytes};
 use core::any::Any;
@@ -33,7 +34,7 @@ impl PrecompileOutput {
 }
 
 /// Precompile execution hook.
-pub trait PrecompileProvider: Any + Send {
+pub trait PrecompileProvider<T: EvmTypes>: Any + Send {
     /// Returns precompile addresses that should be warm at transaction start.
     fn warm_addresses(&self) -> Vec<Address> {
         Vec::new()
@@ -45,13 +46,14 @@ pub trait PrecompileProvider: Any + Send {
     /// Executes the precompile at `address`, if one is registered.
     fn execute(
         &mut self,
+        evm: &mut Evm<T>,
         address: Address,
         input: &[u8],
         gas: &mut GasTracker,
     ) -> Option<Result<PrecompileOutput, PrecompileError>>;
 }
 
-impl PrecompileProvider for Box<dyn PrecompileProvider> {
+impl<T: EvmTypes> PrecompileProvider<T> for Box<dyn PrecompileProvider<T>> {
     #[inline]
     fn warm_addresses(&self) -> Vec<Address> {
         self.as_ref().warm_addresses()
@@ -65,11 +67,12 @@ impl PrecompileProvider for Box<dyn PrecompileProvider> {
     #[inline]
     fn execute(
         &mut self,
+        evm: &mut Evm<T>,
         address: Address,
         input: &[u8],
         gas: &mut GasTracker,
     ) -> Option<Result<PrecompileOutput, PrecompileError>> {
-        self.as_mut().execute(address, input, gas)
+        self.as_mut().execute(evm, address, input, gas)
     }
 }
 
@@ -78,7 +81,7 @@ impl PrecompileProvider for Box<dyn PrecompileProvider> {
 #[derive(Default)]
 pub struct NoPrecompiles(());
 
-impl PrecompileProvider for NoPrecompiles {
+impl<T: EvmTypes> PrecompileProvider<T> for NoPrecompiles {
     #[inline]
     fn warm_addresses(&self) -> Vec<Address> {
         Vec::new()
@@ -92,6 +95,7 @@ impl PrecompileProvider for NoPrecompiles {
     #[inline]
     fn execute(
         &mut self,
+        _evm: &mut Evm<T>,
         _address: Address,
         _input: &[u8],
         _gas: &mut GasTracker,

--- a/crates/evm2/src/precompiles/mod.rs
+++ b/crates/evm2/src/precompiles/mod.rs
@@ -1,7 +1,8 @@
 //! EVM precompiled contracts.
 
 use crate::{
-    SpecId, evm::precompile::PrecompileProvider, interpreter::GasTracker, once_lock::OnceLock,
+    Evm, EvmTypes, SpecId, evm::precompile::PrecompileProvider, interpreter::GasTracker,
+    once_lock::OnceLock,
 };
 use alloc::{borrow::Cow, vec::Vec};
 use alloy_primitives::Address;
@@ -96,9 +97,113 @@ impl Precompiles {
     pub fn map(precompiles: impl IntoIterator<Item = Precompile>) -> PrecompileMap {
         PrecompileMap::from_precompiles(precompiles)
     }
+
+    /// Returns the underlying precompile map.
+    #[inline]
+    pub fn as_map(&self) -> &PrecompileMap {
+        self.map.as_ref()
+    }
+
+    /// Returns the underlying precompile map mutably.
+    #[inline]
+    pub fn as_map_mut(&mut self) -> &mut PrecompileMap {
+        self.map.to_mut()
+    }
+
+    /// Extends this provider with precompile descriptors.
+    #[inline]
+    pub fn extend_precompiles(&mut self, precompiles: impl IntoIterator<Item = Precompile>) {
+        self.as_map_mut().extend_precompiles(precompiles);
+    }
+
+    /// Maps the precompile at `address`, if it exists.
+    #[inline]
+    pub fn map_precompile<F>(&mut self, address: &Address, f: F)
+    where
+        F: FnOnce(Precompile) -> Precompile,
+    {
+        self.as_map_mut().map_precompile(address, f);
+    }
+
+    /// Maps all precompiles.
+    #[inline]
+    pub fn map_precompiles<F>(&mut self, f: F)
+    where
+        F: FnMut(&Address, Precompile) -> Precompile,
+    {
+        self.as_map_mut().map_precompiles(f);
+    }
+
+    /// Applies a transformation to the precompile at `address`.
+    #[inline]
+    pub fn apply_precompile<F>(&mut self, address: &Address, f: F)
+    where
+        F: FnOnce(Option<Precompile>) -> Option<Precompile>,
+    {
+        self.as_map_mut().apply_precompile(address, f);
+    }
+
+    /// Moves precompiles from source addresses to destination addresses.
+    #[inline]
+    pub fn move_precompiles<I>(&mut self, moves: I) -> Result<(), MovePrecompileError>
+    where
+        I: IntoIterator<Item = (Address, Address)>,
+    {
+        self.as_map_mut().move_precompiles(moves)
+    }
+
+    /// Builder-style version of [`Self::extend_precompiles`].
+    #[inline]
+    pub fn with_extended_precompiles(
+        mut self,
+        precompiles: impl IntoIterator<Item = Precompile>,
+    ) -> Self {
+        self.extend_precompiles(precompiles);
+        self
+    }
+
+    /// Builder-style version of [`Self::map_precompile`].
+    #[inline]
+    pub fn with_mapped_precompile<F>(mut self, address: &Address, f: F) -> Self
+    where
+        F: FnOnce(Precompile) -> Precompile,
+    {
+        self.map_precompile(address, f);
+        self
+    }
+
+    /// Builder-style version of [`Self::map_precompiles`].
+    #[inline]
+    pub fn with_mapped_precompiles<F>(mut self, f: F) -> Self
+    where
+        F: FnMut(&Address, Precompile) -> Precompile,
+    {
+        self.map_precompiles(f);
+        self
+    }
+
+    /// Builder-style version of [`Self::apply_precompile`].
+    #[inline]
+    pub fn with_applied_precompile<F>(mut self, address: &Address, f: F) -> Self
+    where
+        F: FnOnce(Option<Precompile>) -> Option<Precompile>,
+    {
+        self.apply_precompile(address, f);
+        self
+    }
+
+    /// Builder-style version of [`Self::move_precompiles`].
+    #[inline]
+    pub fn with_moved_precompiles<I>(mut self, moves: I) -> Result<Self, MovePrecompileError>
+    where
+        I: IntoIterator<Item = (Address, Address)>,
+    {
+        self.move_precompiles(moves)?;
+        Ok(self)
+    }
 }
 
-impl PrecompileProvider for Precompiles {
+impl<T: EvmTypes> PrecompileProvider<T> for Precompiles {
     #[inline]
     fn warm_addresses(&self) -> Vec<Address> {
         self.map.as_ref().addresses().collect()
@@ -112,6 +217,7 @@ impl PrecompileProvider for Precompiles {
     #[inline]
     fn execute(
         &mut self,
+        _evm: &mut Evm<T>,
         address: Address,
         input: &[u8],
         gas: &mut GasTracker,
@@ -186,4 +292,23 @@ fn base_precompiles(spec: SpecId) -> &'static PrecompileMap {
 
         precompiles
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::address;
+
+    #[test]
+    fn provider_helpers_clone_static_base_on_mutation() {
+        let identity = IDENTITY.address();
+        let moved = address!("0x0000000000000000000000000000000000001000");
+        let mut precompiles = Precompiles::base(SpecId::BERLIN);
+
+        precompiles.move_precompiles([(identity, moved)]).unwrap();
+
+        assert!(!precompiles.as_map().contains(&identity));
+        assert!(precompiles.as_map().contains(&moved));
+        assert!(Precompiles::base(SpecId::BERLIN).as_map().contains(&identity));
+    }
 }

--- a/crates/evm2/src/precompiles/mod.rs
+++ b/crates/evm2/src/precompiles/mod.rs
@@ -109,98 +109,6 @@ impl Precompiles {
     pub fn as_map_mut(&mut self) -> &mut PrecompileMap {
         self.map.to_mut()
     }
-
-    /// Extends this provider with precompile descriptors.
-    #[inline]
-    pub fn extend_precompiles(&mut self, precompiles: impl IntoIterator<Item = Precompile>) {
-        self.as_map_mut().extend_precompiles(precompiles);
-    }
-
-    /// Maps the precompile at `address`, if it exists.
-    #[inline]
-    pub fn map_precompile<F>(&mut self, address: &Address, f: F)
-    where
-        F: FnOnce(Precompile) -> Precompile,
-    {
-        self.as_map_mut().map_precompile(address, f);
-    }
-
-    /// Maps all precompiles.
-    #[inline]
-    pub fn map_precompiles<F>(&mut self, f: F)
-    where
-        F: FnMut(&Address, Precompile) -> Precompile,
-    {
-        self.as_map_mut().map_precompiles(f);
-    }
-
-    /// Applies a transformation to the precompile at `address`.
-    #[inline]
-    pub fn apply_precompile<F>(&mut self, address: &Address, f: F)
-    where
-        F: FnOnce(Option<Precompile>) -> Option<Precompile>,
-    {
-        self.as_map_mut().apply_precompile(address, f);
-    }
-
-    /// Moves precompiles from source addresses to destination addresses.
-    #[inline]
-    pub fn move_precompiles<I>(&mut self, moves: I) -> Result<(), MovePrecompileError>
-    where
-        I: IntoIterator<Item = (Address, Address)>,
-    {
-        self.as_map_mut().move_precompiles(moves)
-    }
-
-    /// Builder-style version of [`Self::extend_precompiles`].
-    #[inline]
-    pub fn with_extended_precompiles(
-        mut self,
-        precompiles: impl IntoIterator<Item = Precompile>,
-    ) -> Self {
-        self.extend_precompiles(precompiles);
-        self
-    }
-
-    /// Builder-style version of [`Self::map_precompile`].
-    #[inline]
-    pub fn with_mapped_precompile<F>(mut self, address: &Address, f: F) -> Self
-    where
-        F: FnOnce(Precompile) -> Precompile,
-    {
-        self.map_precompile(address, f);
-        self
-    }
-
-    /// Builder-style version of [`Self::map_precompiles`].
-    #[inline]
-    pub fn with_mapped_precompiles<F>(mut self, f: F) -> Self
-    where
-        F: FnMut(&Address, Precompile) -> Precompile,
-    {
-        self.map_precompiles(f);
-        self
-    }
-
-    /// Builder-style version of [`Self::apply_precompile`].
-    #[inline]
-    pub fn with_applied_precompile<F>(mut self, address: &Address, f: F) -> Self
-    where
-        F: FnOnce(Option<Precompile>) -> Option<Precompile>,
-    {
-        self.apply_precompile(address, f);
-        self
-    }
-
-    /// Builder-style version of [`Self::move_precompiles`].
-    #[inline]
-    pub fn with_moved_precompiles<I>(mut self, moves: I) -> Result<Self, MovePrecompileError>
-    where
-        I: IntoIterator<Item = (Address, Address)>,
-    {
-        self.move_precompiles(moves)?;
-        Ok(self)
-    }
 }
 
 impl<T: EvmTypes> PrecompileProvider<T> for Precompiles {
@@ -305,7 +213,7 @@ mod tests {
         let moved = address!("0x0000000000000000000000000000000000001000");
         let mut precompiles = Precompiles::base(SpecId::BERLIN);
 
-        precompiles.move_precompiles([(identity, moved)]).unwrap();
+        precompiles.as_map_mut().move_precompiles([(identity, moved)]).unwrap();
 
         assert!(!precompiles.as_map().contains(&identity));
         assert!(precompiles.as_map().contains(&moved));

--- a/crates/evm2/src/precompiles/table.rs
+++ b/crates/evm2/src/precompiles/table.rs
@@ -5,7 +5,9 @@ use crate::{
         kzg_point_evaluation, modexp, secp256k1, secp256r1,
     },
 };
+use alloc::vec::Vec;
 use alloy_primitives::{Address, map::AddressMap};
+use core::fmt::{self, Display};
 
 /// Precompile implementation function.
 pub type PrecompileFn = fn(&[u8], &mut GasTracker) -> PrecompileResult;
@@ -30,6 +32,12 @@ impl Precompile {
     #[inline]
     pub const fn address(&self) -> Address {
         self.address
+    }
+
+    /// Returns this precompile descriptor with a different address.
+    #[inline]
+    pub fn with_address(self, address: Address) -> Self {
+        Self { address, data: self.data }
     }
 
     /// Consumes the precompile descriptor and returns its data.
@@ -109,6 +117,14 @@ impl PrecompileMap {
         }
     }
 
+    /// Extends this map with precompile descriptors.
+    ///
+    /// This is a convenience alias for [`Self::extend`].
+    #[inline]
+    pub fn extend_precompiles(&mut self, precompiles: impl IntoIterator<Item = Precompile>) {
+        self.extend(precompiles);
+    }
+
     /// Inserts a precompile descriptor, replacing any existing precompile at the same address.
     #[inline]
     pub fn insert(&mut self, precompile: Precompile) -> Option<Precompile> {
@@ -138,6 +154,124 @@ impl PrecompileMap {
     #[inline]
     pub(super) fn get_data(&self, address: &Address) -> Option<&PrecompileData> {
         self.inner.get(address)
+    }
+
+    /// Maps the precompile at `address`, if it exists.
+    #[inline]
+    pub fn map_precompile<F>(&mut self, address: &Address, f: F)
+    where
+        F: FnOnce(Precompile) -> Precompile,
+    {
+        if let Some(precompile) = self.remove(*address) {
+            self.insert(f(precompile).with_address(*address));
+        }
+    }
+
+    /// Maps all precompiles.
+    #[inline]
+    pub fn map_precompiles<F>(&mut self, mut f: F)
+    where
+        F: FnMut(&Address, Precompile) -> Precompile,
+    {
+        let entries = core::mem::take(&mut self.inner);
+        let mut inner = AddressMap::with_capacity_and_hasher(entries.len(), Default::default());
+        for (address, data) in entries {
+            let precompile = Precompile { address, data };
+            let precompile = f(&address, precompile).with_address(address);
+            inner.insert(address, precompile.into_data());
+        }
+        self.inner = inner;
+    }
+
+    /// Applies a transformation to the precompile at `address`.
+    ///
+    /// The closure receives the existing precompile, if any, and returns the precompile that should
+    /// be installed at `address`.
+    #[inline]
+    pub fn apply_precompile<F>(&mut self, address: &Address, f: F)
+    where
+        F: FnOnce(Option<Precompile>) -> Option<Precompile>,
+    {
+        let current = self.remove(*address);
+        if let Some(precompile) = f(current) {
+            self.insert(precompile.with_address(*address));
+        }
+    }
+
+    /// Builder-style version of [`Self::map_precompile`].
+    #[inline]
+    pub fn with_mapped_precompile<F>(mut self, address: &Address, f: F) -> Self
+    where
+        F: FnOnce(Precompile) -> Precompile,
+    {
+        self.map_precompile(address, f);
+        self
+    }
+
+    /// Builder-style version of [`Self::map_precompiles`].
+    #[inline]
+    pub fn with_mapped_precompiles<F>(mut self, f: F) -> Self
+    where
+        F: FnMut(&Address, Precompile) -> Precompile,
+    {
+        self.map_precompiles(f);
+        self
+    }
+
+    /// Builder-style version of [`Self::apply_precompile`].
+    #[inline]
+    pub fn with_applied_precompile<F>(mut self, address: &Address, f: F) -> Self
+    where
+        F: FnOnce(Option<Precompile>) -> Option<Precompile>,
+    {
+        self.apply_precompile(address, f);
+        self
+    }
+
+    /// Builder-style version of [`Self::extend_precompiles`].
+    #[inline]
+    pub fn with_extended_precompiles(
+        mut self,
+        precompiles: impl IntoIterator<Item = Precompile>,
+    ) -> Self {
+        self.extend_precompiles(precompiles);
+        self
+    }
+
+    /// Moves precompiles from source addresses to destination addresses.
+    ///
+    /// All sources are validated before the map is mutated.
+    pub fn move_precompiles<I>(&mut self, moves: I) -> Result<(), MovePrecompileError>
+    where
+        I: IntoIterator<Item = (Address, Address)>,
+    {
+        let moves = moves.into_iter().filter(|(source, dest)| source != dest).collect::<Vec<_>>();
+
+        for (source, _) in &moves {
+            if !self.contains(source) {
+                return Err(MovePrecompileError::NotAPrecompile(*source));
+            }
+        }
+
+        let mut moved = Vec::with_capacity(moves.len());
+        for (source, dest) in moves {
+            if let Some(precompile) = self.remove(source) {
+                moved.push(precompile.with_address(dest));
+            }
+        }
+
+        self.extend(moved);
+        Ok(())
+    }
+
+    /// Builder-style version of [`Self::move_precompiles`].
+    #[inline]
+    pub fn with_moved_precompiles<I>(mut self, moves: I) -> Result<Self, MovePrecompileError>
+    where
+        I: IntoIterator<Item = (Address, Address)>,
+    {
+        self.move_precompiles(moves)?;
+        Ok(self)
     }
 
     /// Returns all precompile addresses.
@@ -170,6 +304,25 @@ impl PrecompileMap {
         self.inner.shrink_to_fit();
     }
 }
+
+/// Error that can occur when moving precompiles.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MovePrecompileError {
+    /// The source address is not a precompile.
+    NotAPrecompile(Address),
+}
+
+impl Display for MovePrecompileError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NotAPrecompile(address) => {
+                write!(f, "source address {address} is not a precompile")
+            }
+        }
+    }
+}
+
+impl core::error::Error for MovePrecompileError {}
 
 /// Defines precompile constants.
 #[macro_export]
@@ -243,4 +396,106 @@ define_precompiles! {
     pub const P256VERIFY = (0x100, PrecompileId::P256Verify) => secp256r1::run;
     /// secp256r1 signature verification precompile with Osaka gas rules.
     pub const P256VERIFY_OSAKA = (0x100, PrecompileId::P256Verify) => secp256r1::run_osaka;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::evm::precompile::PrecompileOutput;
+    use alloy_primitives::{Bytes, address};
+
+    fn test_run_a(_input: &[u8], _gas: &mut GasTracker) -> PrecompileResult {
+        Ok(PrecompileOutput::new(Bytes::from_static(b"a")))
+    }
+
+    fn test_run_b(_input: &[u8], _gas: &mut GasTracker) -> PrecompileResult {
+        Ok(PrecompileOutput::new(Bytes::from_static(b"b")))
+    }
+
+    #[test]
+    fn map_precompile_preserves_target_address() {
+        let address = IDENTITY.address();
+        let other = address!("0x0000000000000000000000000000000000000100");
+        let mut map = PrecompileMap::from_precompiles([IDENTITY]);
+
+        map.map_precompile(&address, |_| Precompile::new(other, PrecompileId::Sha256, test_run_a));
+
+        let precompile = map.get(&address).unwrap();
+        assert_eq!(precompile.address(), address);
+        assert_eq!(precompile.id(), &PrecompileId::Sha256);
+        assert!(!map.contains(&other));
+    }
+
+    #[test]
+    fn apply_precompile_inserts_and_removes_at_target_address() {
+        let address = address!("0x0000000000000000000000000000000000000101");
+        let other = address!("0x0000000000000000000000000000000000000102");
+        let mut map = PrecompileMap::new();
+
+        map.apply_precompile(&address, |_| {
+            Some(Precompile::new(other, PrecompileId::Identity, test_run_a))
+        });
+
+        assert!(map.contains(&address));
+        assert!(!map.contains(&other));
+
+        map.apply_precompile(&address, |_| None);
+
+        assert!(!map.contains(&address));
+    }
+
+    #[test]
+    fn map_precompiles_preserves_existing_addresses() {
+        let mut map = PrecompileMap::from_precompiles([IDENTITY, SHA256]);
+
+        map.map_precompiles(|_, precompile| {
+            Precompile::new(precompile.address(), PrecompileId::Ripemd160, test_run_b)
+        });
+
+        assert_eq!(map.get(&IDENTITY.address()).unwrap().id(), &PrecompileId::Ripemd160);
+        assert_eq!(map.get(&SHA256.address()).unwrap().id(), &PrecompileId::Ripemd160);
+    }
+
+    #[test]
+    fn move_precompiles_validates_before_mutating() {
+        let source = IDENTITY.address();
+        let missing = address!("0x0000000000000000000000000000000000000999");
+        let dest = address!("0x0000000000000000000000000000000000001000");
+        let mut map = PrecompileMap::from_precompiles([IDENTITY]);
+
+        let err = map.move_precompiles([(source, dest), (missing, SHA256.address())]);
+
+        assert_eq!(err, Err(MovePrecompileError::NotAPrecompile(missing)));
+        assert!(map.contains(&source));
+        assert!(!map.contains(&dest));
+    }
+
+    #[test]
+    fn move_precompiles_moves_after_validation() {
+        let identity = IDENTITY.address();
+        let sha256 = SHA256.address();
+        let new_identity = address!("0x0000000000000000000000000000000000001001");
+        let new_sha256 = address!("0x0000000000000000000000000000000000001002");
+        let mut map = PrecompileMap::from_precompiles([IDENTITY, SHA256]);
+
+        map.move_precompiles([(identity, new_identity), (sha256, new_sha256)]).unwrap();
+
+        assert!(!map.contains(&identity));
+        assert!(!map.contains(&sha256));
+        assert!(map.contains(&new_identity));
+        assert!(map.contains(&new_sha256));
+    }
+
+    #[test]
+    fn move_precompiles_skips_duplicate_sources_after_first_move() {
+        let identity = IDENTITY.address();
+        let first = address!("0x0000000000000000000000000000000000001001");
+        let second = address!("0x0000000000000000000000000000000000001002");
+        let mut map = PrecompileMap::from_precompiles([IDENTITY]);
+
+        map.move_precompiles([(identity, first), (identity, second)]).unwrap();
+
+        assert!(map.contains(&first));
+        assert!(!map.contains(&second));
+    }
 }

--- a/crates/evm2/src/precompiles/table.rs
+++ b/crates/evm2/src/precompiles/table.rs
@@ -40,9 +40,21 @@ impl Precompile {
         Self { address, data: self.data }
     }
 
+    /// Returns this precompile descriptor with different data.
+    #[inline]
+    pub fn with_data(self, data: PrecompileData) -> Self {
+        Self { address: self.address, data }
+    }
+
+    /// Returns the precompile data.
+    #[inline]
+    pub const fn data(&self) -> &PrecompileData {
+        &self.data
+    }
+
     /// Consumes the precompile descriptor and returns its data.
     #[inline]
-    pub(super) fn into_data(self) -> PrecompileData {
+    pub fn into_data(self) -> PrecompileData {
         self.data
     }
 
@@ -59,9 +71,13 @@ impl Precompile {
     }
 }
 
+fn dummy_precompile(_input: &[u8], _gas: &mut GasTracker) -> PrecompileResult {
+    unreachable!("dummy precompile data must be replaced before use")
+}
+
 /// Address-free precompile data.
 #[derive(Clone, Debug)]
-pub(super) struct PrecompileData {
+pub struct PrecompileData {
     /// Precompile implementation function.
     run: PrecompileFn,
     /// Precompile ID.
@@ -69,21 +85,35 @@ pub(super) struct PrecompileData {
 }
 
 impl PrecompileData {
+    const DUMMY: Self = Self::new(PrecompileId::custom("__dummy__"), dummy_precompile);
+
     /// Creates precompile data.
     #[inline]
-    pub(super) const fn new(id: PrecompileId, f: PrecompileFn) -> Self {
+    pub const fn new(id: PrecompileId, f: PrecompileFn) -> Self {
         Self { id, run: f }
+    }
+
+    /// Returns this precompile data with a different ID.
+    #[inline]
+    pub fn with_id(self, id: PrecompileId) -> Self {
+        Self { id, run: self.run }
+    }
+
+    /// Returns this precompile data with a different implementation function.
+    #[inline]
+    pub fn with_run(self, f: PrecompileFn) -> Self {
+        Self { id: self.id, run: f }
     }
 
     /// Returns the precompile ID.
     #[inline]
-    pub(super) const fn id(&self) -> &PrecompileId {
+    pub const fn id(&self) -> &PrecompileId {
         &self.id
     }
 
     /// Returns the precompile implementation function.
     #[inline]
-    pub(super) const fn run(&self) -> PrecompileFn {
+    pub const fn run(&self) -> PrecompileFn {
         self.run
     }
 }
@@ -152,10 +182,10 @@ impl PrecompileMap {
     #[inline]
     pub fn map_precompile<F>(&mut self, address: &Address, f: F)
     where
-        F: FnOnce(Precompile) -> Precompile,
+        F: FnOnce(PrecompileData) -> PrecompileData,
     {
-        if let Some(precompile) = self.remove(*address) {
-            self.insert(f(precompile).with_address(*address));
+        if let Some(data) = self.inner.get_mut(address) {
+            *data = f(core::mem::replace(data, PrecompileData::DUMMY));
         }
     }
 
@@ -163,30 +193,31 @@ impl PrecompileMap {
     #[inline]
     pub fn map_precompiles<F>(&mut self, mut f: F)
     where
-        F: FnMut(&Address, Precompile) -> Precompile,
+        F: FnMut(&Address, PrecompileData) -> PrecompileData,
     {
-        let entries = core::mem::take(&mut self.inner);
-        let mut inner = AddressMap::with_capacity_and_hasher(entries.len(), Default::default());
-        for (address, data) in entries {
-            let precompile = Precompile { address, data };
-            let precompile = f(&address, precompile).with_address(address);
-            inner.insert(address, precompile.into_data());
+        for (address, data) in &mut self.inner {
+            *data = f(address, core::mem::replace(data, PrecompileData::DUMMY));
         }
-        self.inner = inner;
     }
 
     /// Applies a transformation to the precompile at `address`.
     ///
-    /// The closure receives the existing precompile, if any, and returns the precompile that should
+    /// The closure receives the existing precompile data, if any, and returns the data that should
     /// be installed at `address`.
     #[inline]
     pub fn apply_precompile<F>(&mut self, address: &Address, f: F)
     where
-        F: FnOnce(Option<Precompile>) -> Option<Precompile>,
+        F: FnOnce(Option<PrecompileData>) -> Option<PrecompileData>,
     {
-        let current = self.remove(*address);
-        if let Some(precompile) = f(current) {
-            self.insert(precompile.with_address(*address));
+        if let Some(data) = self.inner.get_mut(address) {
+            let current = core::mem::replace(data, PrecompileData::DUMMY);
+            if let Some(new_data) = f(Some(current)) {
+                *data = new_data;
+            } else {
+                self.inner.remove(address);
+            }
+        } else if let Some(data) = f(None) {
+            self.inner.insert(*address, data);
         }
     }
 
@@ -194,7 +225,7 @@ impl PrecompileMap {
     #[inline]
     pub fn with_mapped_precompile<F>(mut self, address: &Address, f: F) -> Self
     where
-        F: FnOnce(Precompile) -> Precompile,
+        F: FnOnce(PrecompileData) -> PrecompileData,
     {
         self.map_precompile(address, f);
         self
@@ -204,7 +235,7 @@ impl PrecompileMap {
     #[inline]
     pub fn with_mapped_precompiles<F>(mut self, f: F) -> Self
     where
-        F: FnMut(&Address, Precompile) -> Precompile,
+        F: FnMut(&Address, PrecompileData) -> PrecompileData,
     {
         self.map_precompiles(f);
         self
@@ -214,7 +245,7 @@ impl PrecompileMap {
     #[inline]
     pub fn with_applied_precompile<F>(mut self, address: &Address, f: F) -> Self
     where
-        F: FnOnce(Option<Precompile>) -> Option<Precompile>,
+        F: FnOnce(Option<PrecompileData>) -> Option<PrecompileData>,
     {
         self.apply_precompile(address, f);
         self
@@ -395,6 +426,7 @@ mod tests {
     use super::*;
     use crate::evm::precompile::PrecompileOutput;
     use alloy_primitives::{Bytes, address};
+    use core::assert_matches;
 
     fn test_run_a(_input: &[u8], _gas: &mut GasTracker) -> PrecompileResult {
         Ok(PrecompileOutput::new(Bytes::from_static(b"a")))
@@ -405,31 +437,29 @@ mod tests {
     }
 
     #[test]
-    fn map_precompile_preserves_target_address() {
+    fn map_precompile_updates_data_at_target_address() {
         let address = IDENTITY.address();
-        let other = address!("0x0000000000000000000000000000000000000100");
         let mut map = PrecompileMap::from_precompiles([IDENTITY]);
 
-        map.map_precompile(&address, |_| Precompile::new(other, PrecompileId::Sha256, test_run_a));
+        map.map_precompile(&address, |precompile| {
+            precompile.with_id(PrecompileId::Sha256).with_run(test_run_a)
+        });
 
         let precompile = map.get(&address).unwrap();
         assert_eq!(precompile.address(), address);
         assert_eq!(precompile.id(), &PrecompileId::Sha256);
-        assert!(!map.contains(&other));
     }
 
     #[test]
     fn apply_precompile_inserts_and_removes_at_target_address() {
         let address = address!("0x0000000000000000000000000000000000000101");
-        let other = address!("0x0000000000000000000000000000000000000102");
         let mut map = PrecompileMap::new();
 
         map.apply_precompile(&address, |_| {
-            Some(Precompile::new(other, PrecompileId::Identity, test_run_a))
+            Some(PrecompileData::new(PrecompileId::Identity, test_run_a))
         });
 
         assert!(map.contains(&address));
-        assert!(!map.contains(&other));
 
         map.apply_precompile(&address, |_| None);
 
@@ -441,7 +471,8 @@ mod tests {
         let mut map = PrecompileMap::from_precompiles([IDENTITY, SHA256]);
 
         map.map_precompiles(|_, precompile| {
-            Precompile::new(precompile.address(), PrecompileId::Ripemd160, test_run_b)
+            assert_matches!(precompile.id(), PrecompileId::Identity | PrecompileId::Sha256);
+            precompile.with_id(PrecompileId::Ripemd160).with_run(test_run_b)
         });
 
         assert_eq!(map.get(&IDENTITY.address()).unwrap().id(), &PrecompileId::Ripemd160);

--- a/crates/evm2/src/precompiles/table.rs
+++ b/crates/evm2/src/precompiles/table.rs
@@ -117,14 +117,6 @@ impl PrecompileMap {
         }
     }
 
-    /// Extends this map with precompile descriptors.
-    ///
-    /// This is a convenience alias for [`Self::extend`].
-    #[inline]
-    pub fn extend_precompiles(&mut self, precompiles: impl IntoIterator<Item = Precompile>) {
-        self.extend(precompiles);
-    }
-
     /// Inserts a precompile descriptor, replacing any existing precompile at the same address.
     #[inline]
     pub fn insert(&mut self, precompile: Precompile) -> Option<Precompile> {
@@ -228,13 +220,13 @@ impl PrecompileMap {
         self
     }
 
-    /// Builder-style version of [`Self::extend_precompiles`].
+    /// Builder-style version of [`Self::extend`].
     #[inline]
     pub fn with_extended_precompiles(
         mut self,
         precompiles: impl IntoIterator<Item = Precompile>,
     ) -> Self {
-        self.extend_precompiles(precompiles);
+        self.extend(precompiles);
         self
     }
 


### PR DESCRIPTION
This extracts the precompile provider changes from the broader alloy EVM API branch.

Precompile providers are now typed by EVM types and receive the active EVM host during execution, which lets custom providers inspect host state while preserving the existing built-in precompile map behavior.
