### PR TITLE
fix: narrow bn254 dead code expectation

### DIFF
--- a/crates/evm2/src/precompiles/bn254/mod.rs
+++ b/crates/evm2/src/precompiles/bn254/mod.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use alloc::vec::Vec;
 
-#[cfg_attr(any(feature = "bn", feature = "bn254-mcl"), expect(dead_code))]
+#[cfg_attr(all(feature = "bn", not(feature = "bn254-mcl")), expect(dead_code))]
 pub(crate) mod arkworks;
 
 cfg_if::cfg_if! {


### PR DESCRIPTION
The bn254-mcl backend still uses the arkworks implementation for pairing, so expecting dead_code on the entire arkworks module is unfulfilled in the default feature set. This narrows the expectation to the configuration where the bn backend is selected without bn254-mcl, which is when arkworks is actually unused.
