### PR TITLE
perf(state): split transaction layer from cache

### DIFF
--- a/crates/eest/src/blockchaintest/execute.rs
+++ b/crates/eest/src/blockchaintest/execute.rs
@@ -445,16 +445,12 @@ const fn block_reward(spec: SpecId, ommers: usize) -> u128 {
 }
 
 fn increment_balance(database: &mut InMemoryDB, address: Address, amount: U256) {
-    let info = database
-        .cache
-        .accounts
-        .entry(address)
-        .or_insert_with(|| Some(EvmAccountInfo::default()))
-        .get_or_insert_with(EvmAccountInfo::default);
+    let mut info = database.cache.accounts.get(&address).cloned().flatten().unwrap_or_default();
     info.balance = info.balance.saturating_add(amount);
     if info.code_hash.is_zero() {
         info.code_hash = KECCAK256_EMPTY;
     }
+    database.cache.accounts.insert(address, Some(info));
 }
 
 fn validate_post_state(
@@ -462,14 +458,7 @@ fn validate_post_state(
     expected: &std::collections::BTreeMap<Address, Account>,
 ) -> Result<(), TestErrorKind> {
     for (address, expected_account) in expected {
-        let default_info;
-        let info = match database.cache.accounts.get(address) {
-            Some(Some(info)) => info,
-            _ => {
-                default_info = EvmAccountInfo::default();
-                &default_info
-            }
-        };
+        let info = database.cache.accounts.get(address).cloned().flatten().unwrap_or_default();
         if info.balance != expected_account.balance {
             return Err(TestErrorKind::UnexpectedFailure(format!(
                 "balance mismatch for {address}: got {}, expected {}",
@@ -484,10 +473,10 @@ fn validate_post_state(
         }
 
         if !expected_account.code.is_empty() {
-            let actual_code = database
-                .cache
-                .contracts
-                .get(&info.code_hash)
+            let actual_code = info
+                .code
+                .as_ref()
+                .or_else(|| database.cache.contracts.get(&info.code_hash))
                 .map(|code| code.original_byte_slice())
                 .unwrap_or_default();
             if actual_code != expected_account.code.as_ref() {
@@ -505,8 +494,9 @@ fn validate_post_state(
                 && !expected_account.storage.contains_key(&key.key())
             {
                 return Err(TestErrorKind::UnexpectedFailure(format!(
-                    "unexpected storage for {address}[{}]: got {value}, expected 0",
-                    key.key()
+                    "unexpected storage for {address}[{}]: got {}, expected 0",
+                    key.key(),
+                    value
                 )));
             }
         }

--- a/crates/eest/src/blockchaintest/execute.rs
+++ b/crates/eest/src/blockchaintest/execute.rs
@@ -445,12 +445,16 @@ const fn block_reward(spec: SpecId, ommers: usize) -> u128 {
 }
 
 fn increment_balance(database: &mut InMemoryDB, address: Address, amount: U256) {
-    let mut info = database.cache.accounts.get(&address).cloned().unwrap_or_default();
+    let info = database
+        .cache
+        .accounts
+        .entry(address)
+        .or_insert_with(|| Some(EvmAccountInfo::default()))
+        .get_or_insert_with(EvmAccountInfo::default);
     info.balance = info.balance.saturating_add(amount);
     if info.code_hash.is_zero() {
         info.code_hash = KECCAK256_EMPTY;
     }
-    database.cache.accounts.insert(address, info);
 }
 
 fn validate_post_state(
@@ -458,7 +462,14 @@ fn validate_post_state(
     expected: &std::collections::BTreeMap<Address, Account>,
 ) -> Result<(), TestErrorKind> {
     for (address, expected_account) in expected {
-        let info = database.cache.accounts.get(address).cloned().unwrap_or_default();
+        let default_info;
+        let info = match database.cache.accounts.get(address) {
+            Some(Some(info)) => info,
+            _ => {
+                default_info = EvmAccountInfo::default();
+                &default_info
+            }
+        };
         if info.balance != expected_account.balance {
             return Err(TestErrorKind::UnexpectedFailure(format!(
                 "balance mismatch for {address}: got {}, expected {}",
@@ -473,10 +484,10 @@ fn validate_post_state(
         }
 
         if !expected_account.code.is_empty() {
-            let actual_code = info
-                .code
-                .as_ref()
-                .or_else(|| database.cache.contracts.get(&info.code_hash))
+            let actual_code = database
+                .cache
+                .contracts
+                .get(&info.code_hash)
                 .map(|code| code.original_byte_slice())
                 .unwrap_or_default();
             if actual_code != expected_account.code.as_ref() {
@@ -494,9 +505,8 @@ fn validate_post_state(
                 && !expected_account.storage.contains_key(&key.key())
             {
                 return Err(TestErrorKind::UnexpectedFailure(format!(
-                    "unexpected storage for {address}[{}]: got {}, expected 0",
-                    key.key(),
-                    value
+                    "unexpected storage for {address}[{}]: got {value}, expected 0",
+                    key.key()
                 )));
             }
         }

--- a/crates/eest/src/execute.rs
+++ b/crates/eest/src/execute.rs
@@ -296,9 +296,10 @@ fn logs_hash(logs: &[Log]) -> B256 {
 }
 
 fn state_root_from_database(state: &InMemoryDB) -> B256 {
-    let accounts = state.cache.accounts.iter().map(|(&address, info)| {
+    let accounts = state.cache.accounts.iter().filter_map(|(&address, info)| {
+        let info = info.as_ref()?;
         let storage = storage_for_root(state, address);
-        (
+        Some((
             address,
             TrieAccount {
                 nonce: info.nonce,
@@ -306,7 +307,7 @@ fn state_root_from_database(state: &InMemoryDB) -> B256 {
                 storage_root: storage_root_unhashed(storage),
                 code_hash: info.code_hash,
             },
-        )
+        ))
     });
 
     state_root_unhashed(accounts)

--- a/crates/eest/src/state.rs
+++ b/crates/eest/src/state.rs
@@ -40,6 +40,7 @@ pub(crate) fn system_contract_has_code(database: &InMemoryDB, address: Address) 
         .cache
         .accounts
         .get(&address)
+        .and_then(Option::as_ref)
         .and_then(|info| database.cache.contracts.get(&info.code_hash))
         .is_some_and(|code| !code.is_empty())
 }
@@ -53,7 +54,7 @@ pub(crate) fn storage_for_root(
         .cache
         .storage
         .iter()
-        .filter_map(|(&key, &value)| {
+        .filter_map(|(key, &value)| {
             (key.address() == address && !value.is_zero()).then_some((B256::from(key.key()), value))
         })
         .collect()

--- a/crates/eest/src/state.rs
+++ b/crates/eest/src/state.rs
@@ -54,7 +54,7 @@ pub(crate) fn storage_for_root(
         .cache
         .storage
         .iter()
-        .filter_map(|(key, &value)| {
+        .filter_map(|(&key, &value)| {
             (key.address() == address && !value.is_zero()).then_some((B256::from(key.key()), value))
         })
         .collect()

--- a/crates/evm2/src/evm/db/cache.rs
+++ b/crates/evm2/src/evm/db/cache.rs
@@ -112,19 +112,13 @@ impl<ExtDB> CacheDB<ExtDB> {
     /// Returns cached account info if the account exists in the cache.
     #[inline]
     pub fn account_info(&self, address: &Address) -> Option<&AccountInfo> {
-        self.account_ref(address)
+        self.cache.accounts.get(address).and_then(Option::as_ref)
     }
 
     /// Returns whether the account is known to be absent from the cache layer.
     #[inline]
     pub(crate) fn account_absent(&self, address: &Address) -> bool {
         self.cache.accounts.get(address).is_some_and(Option::is_none)
-    }
-
-    /// Returns the cached account if it exists in the cache.
-    #[inline]
-    pub(crate) fn account_ref(&self, address: &Address) -> Option<&AccountInfo> {
-        self.cache.accounts.get(address).and_then(Option::as_ref)
     }
 
     /// Returns a cached storage value if it is known without loading the wrapped database.
@@ -190,12 +184,12 @@ impl<ExtDB: DynDatabase> DynDatabase for CacheDB<ExtDB> {
         match accounts.entry(*address) {
             Entry::Occupied(entry) => Ok(entry.get().clone()),
             Entry::Vacant(entry) => {
-                let account = self.db.get_account(address)?.map(|mut info| {
-                    Self::insert_contract_inner(contracts, &mut info);
-                    info.code = None;
-                    info
-                });
-                Ok(entry.insert(account).clone())
+                let Some(mut info) = self.db.get_account(address)? else {
+                    return Ok(entry.insert(None).clone());
+                };
+                Self::insert_contract_inner(contracts, &mut info);
+                info.code = None;
+                Ok(entry.insert(Some(info)).clone())
             }
         }
     }
@@ -232,11 +226,10 @@ impl<ExtDB: DynDatabase> DynDatabase for CacheDB<ExtDB> {
         match self.cache.block_hashes.entry(*number) {
             Entry::Occupied(entry) => Ok(Some(*entry.get())),
             Entry::Vacant(entry) => {
-                let hash = self.db.get_block_hash(number)?;
-                if let Some(hash) = hash {
-                    entry.insert(hash);
-                }
-                Ok(hash)
+                let Some(hash) = self.db.get_block_hash(number)? else {
+                    return Ok(None);
+                };
+                Ok(Some(*entry.insert(hash)))
             }
         }
     }

--- a/crates/evm2/src/evm/db/cache.rs
+++ b/crates/evm2/src/evm/db/cache.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 use alloy_primitives::{
     Address, B256, KECCAK256_EMPTY,
-    map::{AddressMap, B256Map, U256Map, hash_map::Entry},
+    map::{AddressMap, AddressSet, B256Map, U256Map, hash_map::Entry},
 };
 
 /// A database implementation that stores initial state in memory.
@@ -18,15 +18,20 @@ pub type InMemoryDB = CacheDB<EmptyDB>;
 /// Cache used by [`CacheDB`].
 ///
 /// Accounts and code are stored separately: accounts carry the code hash, and
-/// bytecode is keyed by that hash in [`Self::contracts`].
+/// bytecode is keyed by that hash in [`Self::contracts`]. Account and storage
+/// entries are authoritative for this cache layer: a cached `None` account or wiped storage
+/// overlay shadows the wrapped database instead of falling through to it.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Cache {
-    /// Accounts keyed by address.
-    pub accounts: AddressMap<AccountInfo>,
+    /// Accounts keyed by address. `None` means the account is known to be absent/deleted.
+    pub accounts: AddressMap<Option<AccountInfo>>,
     /// Contracts keyed by code hash.
     pub contracts: B256Map<Bytecode>,
     /// Persistent storage keyed by account and slot.
     pub storage: StorageKeyMap<Word>,
+    /// Accounts whose missing storage slots are known to be zero because all pre-existing storage
+    /// was deleted.
+    pub wiped_storage: AddressSet,
     /// Cached block hashes keyed by block number.
     pub block_hashes: U256Map<B256>,
     #[doc(hidden)] // Not public API. Please use an existing constructor.
@@ -43,6 +48,7 @@ impl Default for Cache {
             accounts: AddressMap::default(),
             contracts,
             storage: StorageKeyMap::default(),
+            wiped_storage: AddressSet::default(),
             block_hashes: U256Map::default(),
             _non_exhaustive: (),
         }
@@ -100,19 +106,41 @@ impl<ExtDB> CacheDB<ExtDB> {
     pub fn insert_account_info(&mut self, address: &Address, mut info: AccountInfo) {
         self.insert_contract(&mut info);
         info.code = None;
-        self.cache.accounts.insert(*address, info);
+        self.cache.accounts.insert(*address, Some(info));
     }
 
     /// Returns cached account info if the account exists in the cache.
     #[inline]
     pub fn account_info(&self, address: &Address) -> Option<&AccountInfo> {
-        self.cache.accounts.get(address)
+        self.account_ref(address)
+    }
+
+    /// Returns whether the account is known to be absent from the cache layer.
+    #[inline]
+    pub(crate) fn account_absent(&self, address: &Address) -> bool {
+        self.cache.accounts.get(address).is_some_and(Option::is_none)
+    }
+
+    /// Returns the cached account if it exists in the cache.
+    #[inline]
+    pub(crate) fn account_ref(&self, address: &Address) -> Option<&AccountInfo> {
+        self.cache.accounts.get(address).and_then(Option::as_ref)
+    }
+
+    /// Returns a cached storage value if it is known without loading the wrapped database.
+    #[inline]
+    pub(crate) fn storage_ref(&self, address: &Address, key: &Word) -> Option<Word> {
+        self.cache
+            .storage
+            .get(&StorageKey::new(*address, *key))
+            .copied()
+            .or_else(|| self.cache.wiped_storage.contains(address).then_some(Word::ZERO))
     }
 
     /// Inserts persistent storage.
     #[inline]
     pub fn insert_account_storage(&mut self, address: &Address, key: &Word, value: &Word) {
-        self.cache.accounts.entry(*address).or_default();
+        self.cache.accounts.entry(*address).or_insert_with(|| Some(AccountInfo::default()));
         self.cache.storage.insert(StorageKey::new(*address, *key), *value);
     }
 
@@ -130,13 +158,15 @@ impl<ExtDB> DatabaseCommit for CacheDB<ExtDB> {
         }
         for (&address, storage) in &changes.storage {
             if storage.wipe {
+                self.cache.wiped_storage.insert(address);
                 self.cache.storage.retain(|key, _| key.address() != address);
             }
             for (&key, change) in &storage.slots {
-                if change.current.is_zero() {
-                    self.cache.storage.remove(&StorageKey::new(address, key));
+                let storage_key = StorageKey::new(address, key);
+                if storage.wipe && change.current.is_zero() {
+                    self.cache.storage.remove(&storage_key);
                 } else {
-                    self.cache.storage.insert(StorageKey::new(address, key), change.current);
+                    self.cache.storage.insert(storage_key, change.current);
                 }
             }
         }
@@ -144,7 +174,8 @@ impl<ExtDB> DatabaseCommit for CacheDB<ExtDB> {
             match &change.current {
                 Some(info) => self.insert_account_info(&address, info.clone()),
                 None => {
-                    self.cache.accounts.remove(&address);
+                    self.cache.accounts.insert(address, None);
+                    self.cache.wiped_storage.insert(address);
                     self.cache.storage.retain(|key, _| key.address() != address);
                 }
             }
@@ -157,14 +188,14 @@ impl<ExtDB: DynDatabase> DynDatabase for CacheDB<ExtDB> {
     fn get_account(&mut self, address: &Address) -> DbResult<Option<AccountInfo>> {
         let Cache { accounts, contracts, .. } = &mut self.cache;
         match accounts.entry(*address) {
-            Entry::Occupied(entry) => Ok(Some(entry.get().clone())),
+            Entry::Occupied(entry) => Ok(entry.get().clone()),
             Entry::Vacant(entry) => {
-                let Some(mut info) = self.db.get_account(address)? else {
-                    return Ok(None);
-                };
-                Self::insert_contract_inner(contracts, &mut info);
-                info.code = None;
-                Ok(Some(entry.insert(info).clone()))
+                let account = self.db.get_account(address)?.map(|mut info| {
+                    Self::insert_contract_inner(contracts, &mut info);
+                    info.code = None;
+                    info
+                });
+                Ok(entry.insert(account).clone())
             }
         }
     }
@@ -179,9 +210,17 @@ impl<ExtDB: DynDatabase> DynDatabase for CacheDB<ExtDB> {
 
     #[inline]
     fn get_storage(&mut self, address: &Address, key: &Word) -> DbResult<Word> {
-        match self.cache.storage.entry(StorageKey::new(*address, *key)) {
+        if self.account_absent(address) {
+            return Ok(Word::ZERO);
+        }
+
+        let storage_key = StorageKey::new(*address, *key);
+        match self.cache.storage.entry(storage_key) {
             Entry::Occupied(entry) => Ok(*entry.get()),
             Entry::Vacant(entry) => {
+                if self.cache.wiped_storage.contains(address) {
+                    return Ok(Word::ZERO);
+                }
                 let value = self.db.get_storage(address, key)?;
                 Ok(*entry.insert(value))
             }
@@ -193,10 +232,11 @@ impl<ExtDB: DynDatabase> DynDatabase for CacheDB<ExtDB> {
         match self.cache.block_hashes.entry(*number) {
             Entry::Occupied(entry) => Ok(Some(*entry.get())),
             Entry::Vacant(entry) => {
-                let Some(hash) = self.db.get_block_hash(number)? else {
-                    return Ok(None);
-                };
-                Ok(Some(*entry.insert(hash)))
+                let hash = self.db.get_block_hash(number)?;
+                if let Some(hash) = hash {
+                    entry.insert(hash);
+                }
+                Ok(hash)
             }
         }
     }

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -373,8 +373,7 @@ impl<T: EvmTypes<Tx: Typed2718, Host = Self>> Evm<T> {
                 result.stop = stop;
                 result.output = Bytes::new();
             } else {
-                result.state_changes = self.state.build_state_changes();
-                self.state.commit_transaction_overlay();
+                result.state_changes = self.state.accept_transaction();
             }
             result.db_error_code = self.db_error_code;
         };
@@ -783,7 +782,7 @@ impl<T: EvmTypes<Host = Self>> Host<T> for Evm<T> {
     }
 
     fn block_hash(&mut self, number: &Word) -> Result<Option<B256>, InstrStop> {
-        self.state.initial_mut().get_block_hash(number).map_err(|code| self.db_error_stop(code))
+        self.state.block_hash(number).map_err(|code| self.db_error_stop(code))
     }
 
     fn sload(

--- a/crates/evm2/src/evm/state.rs
+++ b/crates/evm2/src/evm/state.rs
@@ -2,7 +2,7 @@
 
 use super::{
     SStore,
-    db::{DbResult, DynDatabase},
+    db::{CacheDB, DatabaseCommit, DbResult, DynDatabase},
     eip7708_burn_log,
 };
 use crate::{
@@ -138,10 +138,6 @@ pub struct Account {
     pub code_hash: B256,
     /// Cached account bytecode.
     pub code: Bytecode,
-    /// Whether the account was created in the current transaction.
-    pub just_created: bool,
-    /// Whether the account code has been modified.
-    pub code_changed: bool,
     #[doc(hidden)] // Not public API. Please use an existing constructor.
     pub _non_exhaustive: (),
 }
@@ -155,8 +151,6 @@ impl Account {
             balance: info.balance,
             code_hash: info.code_hash,
             code: info.code.unwrap_or_default(),
-            just_created: false,
-            code_changed: false,
             _non_exhaustive: (),
         }
     }
@@ -183,11 +177,11 @@ impl Account {
 /// Persistent storage overlay for one account.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct StorageOverlay {
-    /// Whether consumers must delete all pre-existing storage for the account
-    /// before applying individual slot changes.
+    /// Whether missing storage slots are known to be zero because all pre-existing storage was
+    /// deleted.
     pub wiped: bool,
     /// Loaded or changed storage slots.
-    pub(crate) slots: U256Map<Tracked<Word>>,
+    pub slots: U256Map<Word>,
     #[doc(hidden)] // Not public API. Please use an existing constructor.
     pub _non_exhaustive: (),
 }
@@ -289,6 +283,11 @@ pub enum JournalEntry {
         /// Account address.
         address: Address,
     },
+    /// Account was marked as created in the current transaction.
+    Created {
+        /// Account address.
+        address: Address,
+    },
     /// Account was self-destructed.
     SelfDestruct {
         /// Account address.
@@ -340,21 +339,16 @@ pub enum JournalEntry {
     },
 }
 
-/// Mutable EVM state with an overlay and reversible journal.
+/// Mutable EVM state with an accepted-state cache, transaction layer, and reversible journal.
 #[derive_where(Debug)]
 #[non_exhaustive]
 pub struct State {
-    /// Read-only initial database.
+    /// Database plus accepted transaction-boundary state overlay.
     #[derive_where(skip)]
-    initial: Box<dyn DynDatabase>,
-    /// Account data overlay keyed by address.
-    ///
-    /// Entries are created when account state is loaded or mutated. The tracked
-    /// `original`/`current` pair is used to execute against the in-memory overlay
-    /// and later derive account-level [`StateChanges`]. Presence here does not by
-    /// itself mean the account was touched or warmed.
-    accounts: AddressMap<Tracked<Option<Account>>>,
-    /// Persistent storage overlay keyed by account address.
+    database: CacheDB<Box<dyn DynDatabase>>,
+    /// Account writes for the current transaction.
+    accounts: AddressMap<Option<Account>>,
+    /// Persistent storage writes for the current transaction.
     storage: AddressMap<StorageOverlay>,
     /// Revert journal.
     journal: Vec<JournalEntry>,
@@ -366,6 +360,8 @@ pub struct State {
     /// touched account may have no field changes, but can still matter for empty
     /// account deletion/materialization rules across forks.
     touched: AddressSet,
+    /// Accounts created in the current transaction.
+    created: AddressSet,
     /// Accounts self-destructed in the current transaction.
     selfdestructs: AddressSet,
     /// Transaction-scoped warm account set for EIP-2929 gas accounting.
@@ -387,12 +383,13 @@ impl State {
 
     pub(crate) fn new_mono(initial: Box<dyn DynDatabase>) -> Self {
         Self {
-            initial,
+            database: CacheDB::new(initial),
             accounts: AddressMap::default(),
             storage: AddressMap::default(),
             journal: Vec::new(),
             logs: Vec::new(),
             touched: AddressSet::default(),
+            created: AddressSet::default(),
             selfdestructs: AddressSet::default(),
             accessed_accounts: AddressSet::default(),
             accessed_storage: StorageKeySet::default(),
@@ -409,19 +406,26 @@ impl State {
     /// Returns the initial database.
     #[inline]
     pub fn initial(&self) -> &dyn DynDatabase {
-        self.initial.as_ref()
+        self.database.db.as_ref()
     }
 
     /// Returns the initial database mutably.
     #[inline]
     pub fn initial_mut(&mut self) -> &mut dyn DynDatabase {
-        self.initial.as_mut()
+        self.database.db.as_mut()
     }
 
-    /// Replaces the initial database.
+    /// Replaces the initial database and clears all in-memory state layers.
     #[inline]
     pub fn set_initial(&mut self, initial: impl DynDatabase) {
-        self.initial = Box::new(initial);
+        self.database = CacheDB::new(Box::new(initial));
+        self.clear_transaction_state();
+    }
+
+    /// Loads a historical block hash.
+    #[inline]
+    pub(crate) fn block_hash(&mut self, number: &Word) -> DbResult<Option<B256>> {
+        self.database.get_block_hash(number)
     }
 
     /// Returns logs emitted by the current in-flight transaction.
@@ -441,11 +445,19 @@ impl State {
     /// This is a non-mutating overlay lookup. It does not load the account or slot from the
     /// backing database; use [`Self::storage`] when database-backed loading is desired.
     #[inline]
-    pub fn storage_ref(&self, address: &Address, key: &Word) -> Option<&Tracked<Word>> {
-        self.storage.get(address)?.slots.get(key)
+    pub fn storage_ref(&self, address: &Address, key: &Word) -> Option<Word> {
+        if let Some(storage) = self.storage.get(address) {
+            if let Some(value) = storage.slots.get(key) {
+                return Some(*value);
+            }
+            if storage.wiped {
+                return Some(Word::ZERO);
+            }
+        }
+        self.database.storage_ref(address, key)
     }
 
-    /// Returns the current account overlay if present and not deleted.
+    /// Returns the current transaction account overlay if present and not deleted.
     ///
     /// This is a non-mutating overlay lookup. It does not load the account from the backing
     /// database; use [`Self::account_info`] or [`Self::find`] when database-backed loading is
@@ -453,7 +465,7 @@ impl State {
     #[inline]
     #[must_use]
     pub fn account_ref(&self, address: &Address) -> Option<&Account> {
-        self.accounts.get(address)?.current.as_ref()
+        self.accounts.get(address)?.as_ref()
     }
 
     /// Returns whether an account is warm in the current transaction.
@@ -560,8 +572,11 @@ impl State {
 
     /// Clears transaction-scoped substate.
     pub fn clear_transaction_state(&mut self) {
+        self.accounts.clear();
+        self.storage.clear();
         self.journal.clear();
         self.touched.clear();
+        self.created.clear();
         self.selfdestructs.clear();
         self.accessed_accounts.clear();
         self.accessed_storage.clear();
@@ -569,82 +584,63 @@ impl State {
         self.logs.clear();
     }
 
-    fn load_account(
-        &mut self,
-        address: &Address,
-    ) -> DbResult<Option<&mut Tracked<Option<Account>>>> {
-        match self.accounts.entry(*address) {
-            hash_map::Entry::Occupied(entry) => Ok(Some(entry.into_mut())),
-            hash_map::Entry::Vacant(entry) => {
-                let Some(info) = self.initial.get_account(address)? else {
-                    return Ok(None);
-                };
-                Ok(Some(entry.insert(Tracked::new(Some(Account::from_info(info))))))
-            }
-        }
+    fn load_account(&mut self, address: &Address) -> DbResult<Option<Account>> {
+        Ok(self.database.get_account(address)?.map(Account::from_info))
     }
 
-    fn ensure_account_overlay<'a>(
-        initial: &mut dyn DynDatabase,
-        accounts: &'a mut AddressMap<Tracked<Option<Account>>>,
+    fn ensure_transaction_account<'a>(
+        database: &mut dyn DynDatabase,
+        accounts: &'a mut AddressMap<Option<Account>>,
         journal: &mut Vec<JournalEntry>,
         address: &Address,
-    ) -> DbResult<&'a mut Tracked<Option<Account>>> {
+    ) -> DbResult<&'a mut Option<Account>> {
         match accounts.entry(*address) {
             hash_map::Entry::Occupied(entry) => Ok(entry.into_mut()),
             hash_map::Entry::Vacant(entry) => {
-                let original = initial.get_account(address)?.map(Account::from_info);
+                let original = database.get_account(address)?.map(Account::from_info);
                 journal.push(JournalEntry::AccountInserted { address: *address });
-                Ok(entry.insert(Tracked {
-                    original: original.clone(),
-                    current: original,
-                    _non_exhaustive: (),
-                }))
+                Ok(entry.insert(original))
             }
         }
     }
 
     /// Gets an existing account or inserts a new empty account.
     pub fn get_or_insert(&mut self, address: &Address) -> DbResult<&mut Account> {
-        let tracked = Self::ensure_account_overlay(
-            &mut self.initial,
+        let account = Self::ensure_transaction_account(
+            &mut self.database,
             &mut self.accounts,
             &mut self.journal,
             address,
         )?;
-        if tracked.current.is_none() {
+        if account.is_none() {
             self.journal.push(JournalEntry::AccountChange { address: *address, previous: None });
+            *account = Some(Account { code_hash: KECCAK256_EMPTY, ..Account::default() });
         }
-        Ok(tracked.current.get_or_insert_with(|| Account {
-            code_hash: KECCAK256_EMPTY,
-            code: Bytecode::default(),
-            ..Account::default()
-        }))
+        Ok(account.as_mut().expect("account was inserted above"))
     }
 
     fn journal_account_change(&mut self, address: &Address) -> DbResult<&mut Account> {
-        let tracked = Self::ensure_account_overlay(
-            &mut self.initial,
+        let account = Self::ensure_transaction_account(
+            &mut self.database,
             &mut self.accounts,
             &mut self.journal,
             address,
         )?;
-        let previous = tracked.current.clone();
+        let previous = account.clone();
         self.journal.push(JournalEntry::AccountChange { address: *address, previous });
-        Ok(tracked.current.get_or_insert_with(|| Account {
-            code_hash: KECCAK256_EMPTY,
-            code: Bytecode::default(),
-            ..Account::default()
-        }))
+        if account.is_none() {
+            *account = Some(Account { code_hash: KECCAK256_EMPTY, ..Account::default() });
+        }
+        Ok(account.as_mut().expect("account was inserted above"))
     }
 
     /// Returns account info.
     #[inline(never)]
     pub fn account_info(&mut self, address: &Address) -> DbResult<Option<AccountInfo>> {
         if let Some(account) = self.accounts.get(address) {
-            return Ok(account.current.as_ref().map(Account::info));
+            return Ok(account.as_ref().map(Account::info));
         }
-        self.initial.get_account(address)
+        self.database.get_account(address)
     }
 
     /// Returns whether an account is empty/non-existent for EIP-150 new-account gas checks.
@@ -661,50 +657,74 @@ impl State {
 
     /// Returns an account if it exists.
     pub fn find(&mut self, address: &Address) -> DbResult<Option<&Account>> {
-        Ok(self.load_account(address)?.and_then(|account| account.current.as_ref()))
+        let account = Self::ensure_transaction_account(
+            &mut self.database,
+            &mut self.accounts,
+            &mut self.journal,
+            address,
+        )?;
+        Ok(account.as_ref())
     }
 
     /// Gets account code.
     pub fn get_code(&mut self, address: &Address) -> DbResult<Bytecode> {
-        let Some((code_hash, code)) = self.find(address)?.map(|account| {
+        if let Some(account) = self.accounts.get(address).and_then(Option::as_ref) {
+            if account.code_hash == KECCAK256_EMPTY {
+                return Ok(Bytecode::default());
+            }
+            if !account.code.is_empty() {
+                return Ok(account.code.clone());
+            }
             let code_hash = account.code_hash;
-            let code = account.code.clone();
-            (code_hash, code)
-        }) else {
+            return self.database.get_code_by_hash(&code_hash);
+        }
+
+        let Some(info) = self.database.get_account(address)? else {
             return Ok(Bytecode::default());
         };
-        if code_hash == KECCAK256_EMPTY {
+        if info.code_hash == KECCAK256_EMPTY {
             return Ok(Bytecode::default());
         }
-        if !code.is_empty() {
+        if let Some(code) = info.code
+            && !code.is_empty()
+        {
             return Ok(code);
         }
-        self.initial.get_code_by_hash(&code_hash)
+        self.database.get_code_by_hash(&info.code_hash)
     }
 
-    fn storage_slot_mut(
-        &mut self,
-        address: &Address,
-        key: &Word,
-        journal_insert: bool,
-    ) -> DbResult<&mut Tracked<Word>> {
-        let Self { initial, accounts, storage, journal, .. } = self;
-        let account_created =
-            accounts.get(address).is_some_and(|account| account.original.is_none());
-        let storage = storage.entry(*address).or_default();
-        let storage_wiped = storage.wiped;
+    fn current_storage(&mut self, address: &Address, key: &Word) -> DbResult<Word> {
+        if let Some(storage) = self.storage.get(address) {
+            if let Some(value) = storage.slots.get(key) {
+                return Ok(*value);
+            }
+            if storage.wiped {
+                return Ok(Word::ZERO);
+            }
+        }
+        if self.database.account_absent(address) {
+            return Ok(Word::ZERO);
+        }
+        self.database.get_storage(address, key)
+    }
+
+    fn insert_transaction_storage(&mut self, address: &Address, key: &Word, value: Word) {
+        let storage = self.storage.entry(*address).or_default();
         match storage.slots.entry(*key) {
-            hash_map::Entry::Occupied(entry) => Ok(entry.into_mut()),
-            hash_map::Entry::Vacant(entry) => {
-                let initial = if storage_wiped || account_created {
-                    Word::ZERO
-                } else {
-                    initial.get_storage(address, key)?
-                };
-                if journal_insert {
-                    journal.push(JournalEntry::StorageInserted { address: *address, key: *key });
+            hash_map::Entry::Occupied(mut entry) => {
+                let previous = *entry.get();
+                if previous != value {
+                    entry.insert(value);
+                    self.journal.push(JournalEntry::StorageChange {
+                        address: *address,
+                        key: *key,
+                        previous,
+                    });
                 }
-                Ok(entry.insert(Tracked::new(initial)))
+            }
+            hash_map::Entry::Vacant(entry) => {
+                entry.insert(value);
+                self.journal.push(JournalEntry::StorageInserted { address: *address, key: *key });
             }
         }
     }
@@ -714,7 +734,7 @@ impl State {
         let Some(_) = self.account_info(address)? else {
             return Ok(Word::ZERO);
         };
-        Ok(self.storage_slot_mut(address, key, false)?.current)
+        self.current_storage(address, key)
     }
 
     /// Stores persistent storage and returns values needed for `SSTORE` gas metering.
@@ -727,22 +747,24 @@ impl State {
     pub fn set_storage(&mut self, address: &Address, key: &Word, value: &Word) -> DbResult<SStore> {
         let _ = self.get_or_insert(address)?;
         self.touch(address);
-        let slot = self.storage_slot_mut(address, key, true)?;
+        let storage = self.storage.get(address);
+        let original_value =
+            if storage.is_some_and(|s| s.wiped) || self.database.account_absent(address) {
+                Word::ZERO
+            } else {
+                self.database.get_storage(address, key)?
+            };
+        let present_value =
+            storage.and_then(|storage| storage.slots.get(key)).copied().unwrap_or(original_value);
         let result = SStore {
-            original_value: slot.original,
-            present_value: slot.current,
+            original_value,
+            present_value,
             new_value: *value,
             is_cold: false,
             _non_exhaustive: (),
         };
-        if slot.current != *value {
-            let previous = slot.current;
-            slot.current = *value;
-            self.journal.push(JournalEntry::StorageChange {
-                address: *address,
-                key: *key,
-                previous,
-            });
+        if present_value != *value {
+            self.insert_transaction_storage(address, key, *value);
         }
         Ok(result)
     }
@@ -830,10 +852,9 @@ impl State {
             balance,
             code_hash: KECCAK256_EMPTY,
             code: Bytecode::default(),
-            just_created: true,
-            code_changed: true,
             _non_exhaustive: (),
         };
+        self.mark_created(address);
         self.touch(address);
         Ok(Ok(()))
     }
@@ -843,18 +864,16 @@ impl State {
         let account = self.journal_account_change(address)?;
         account.code_hash = code.hash_slow();
         account.code = code;
-        account.code_changed = true;
         Ok(())
     }
 
     /// Marks all prior persistent storage for `address` as deleted.
     pub fn wipe_storage(&mut self, address: &Address) {
-        let previous = self.storage.get(address).cloned();
-        self.journal.push(JournalEntry::StorageWipe { address: *address, previous });
-        self.storage.insert(
+        let previous = self.storage.insert(
             *address,
             StorageOverlay { wiped: true, slots: U256Map::default(), _non_exhaustive: () },
         );
+        self.journal.push(JournalEntry::StorageWipe { address: *address, previous });
     }
 
     /// Loads transient storage.
@@ -896,10 +915,16 @@ impl State {
         }
     }
 
+    fn mark_created(&mut self, address: &Address) {
+        if self.created.insert(*address) {
+            self.journal.push(JournalEntry::Created { address: *address });
+        }
+    }
+
     /// Marks an account as self-destructed in the current transaction.
     pub fn mark_destructed(&mut self, address: &Address) {
-        let _ = Self::ensure_account_overlay(
-            &mut self.initial,
+        let _ = Self::ensure_transaction_account(
+            &mut self.database,
             &mut self.accounts,
             &mut self.journal,
             address,
@@ -921,7 +946,7 @@ impl State {
     #[inline]
     #[must_use]
     pub(super) fn is_created_in_transaction(&self, address: &Address) -> bool {
-        self.account_ref(address).is_some_and(|account| account.just_created)
+        self.created.contains(address)
     }
 
     /// Reverts state changes after the checkpoint.
@@ -937,7 +962,7 @@ impl State {
             match entry {
                 JournalEntry::AccountChange { address, previous } => {
                     if let Some(account) = self.accounts.get_mut(&address) {
-                        account.current = previous;
+                        *account = previous;
                     }
                 }
                 JournalEntry::AccountInserted { address } => {
@@ -952,14 +977,15 @@ impl State {
                     }
                     self.touched.remove(&address);
                 }
+                JournalEntry::Created { address } => {
+                    self.created.remove(&address);
+                }
                 JournalEntry::SelfDestruct { address } => {
                     self.selfdestructs.remove(&address);
                 }
                 JournalEntry::StorageChange { address, key, previous } => {
-                    if let Some(storage) = self.storage.get_mut(&address)
-                        && let Some(slot) = storage.slots.get_mut(&key)
-                    {
-                        slot.current = previous;
+                    if let Some(storage) = self.storage.get_mut(&address) {
+                        storage.slots.insert(key, previous);
                     }
                 }
                 JournalEntry::StorageInserted { address, key } => {
@@ -1001,47 +1027,44 @@ impl State {
     /// touched accounts stay non-existent.
     fn is_existing_dead(&mut self, address: &Address) -> DbResult<bool> {
         if let Some(account) = self.accounts.get(address) {
-            return Ok(account.current.as_ref().is_some_and(Account::is_empty)
-                || (account.current.is_none() && account.original.is_some()));
+            return Ok(account.as_ref().is_some_and(Account::is_empty)
+                || (account.is_none() && self.database.account_ref(address).is_some()));
         }
-        Ok(self.initial.get_account(address)?.is_some_and(|account| account.is_empty()))
+        Ok(self.load_account(address)?.as_ref().is_some_and(Account::is_empty))
     }
 
     fn account_exists(&mut self, address: &Address) -> DbResult<bool> {
         if let Some(account) = self.accounts.get(address) {
-            return Ok(account.current.is_some());
+            return Ok(account.is_some());
         }
-        Ok(self.initial.get_account(address)?.is_some())
+        Ok(self.load_account(address)?.is_some())
     }
 
     fn delete_account_for_finalization(&mut self, address: &Address) -> DbResult<()> {
-        let account = Self::ensure_account_overlay(
-            &mut self.initial,
+        let account = Self::ensure_transaction_account(
+            &mut self.database,
             &mut self.accounts,
             &mut self.journal,
             address,
         )?;
-        account.current = None;
-        self.storage.insert(
-            *address,
-            StorageOverlay { wiped: true, slots: U256Map::default(), _non_exhaustive: () },
-        );
+        let previous = account.clone();
+        self.journal.push(JournalEntry::AccountChange { address: *address, previous });
+        *account = None;
+        self.wipe_storage(address);
         Ok(())
     }
 
     fn materialize_empty_account_for_finalization(&mut self, address: &Address) -> DbResult<()> {
-        let account = Self::ensure_account_overlay(
-            &mut self.initial,
+        let original_exists = self.load_account(address)?.is_some();
+        let account = Self::ensure_transaction_account(
+            &mut self.database,
             &mut self.accounts,
             &mut self.journal,
             address,
         )?;
-        if account.original.is_none() {
-            account.current.get_or_insert_with(|| Account {
-                code_hash: KECCAK256_EMPTY,
-                code: Bytecode::default(),
-                ..Account::default()
-            });
+        if !original_exists && account.is_none() {
+            self.journal.push(JournalEntry::AccountChange { address: *address, previous: None });
+            *account = Some(Account { code_hash: KECCAK256_EMPTY, ..Account::default() });
         }
         Ok(())
     }
@@ -1077,7 +1100,7 @@ impl State {
                 if let Some(balance) = self
                     .accounts
                     .get(&address)
-                    .and_then(|account| account.current.as_ref())
+                    .and_then(Option::as_ref)
                     .map(|account| account.balance)
                     && !balance.is_zero()
                 {
@@ -1131,17 +1154,44 @@ impl State {
         let mut changes =
             StateChanges { logs: core::mem::take(&mut self.logs), ..StateChanges::default() };
 
-        for (&address, tracked) in &self.accounts {
-            if tracked.original != tracked.current {
-                let original = tracked.original.as_ref().map(Account::info);
-                let current = tracked.current.as_ref().map(Account::info);
-                changes
-                    .accounts
-                    .insert(address, Tracked { original, current, _non_exhaustive: () });
+        for (&address, current) in &self.accounts {
+            let original = self.database.account_ref(&address);
+            let current = current.as_ref();
+            let account_changed = match (original, current) {
+                (Some(original), Some(current)) => {
+                    original.balance != current.balance
+                        || original.nonce != current.nonce
+                        || original.code_hash != current.code_hash
+                }
+                (None, None) => false,
+                _ => true,
+            };
+            if account_changed {
+                changes.accounts.insert(
+                    address,
+                    Tracked {
+                        original: original.map(|info| AccountInfo {
+                            balance: info.balance,
+                            nonce: info.nonce,
+                            code_hash: info.code_hash,
+                            code: None,
+                            _non_exhaustive: (),
+                        }),
+                        current: current.map(|account| AccountInfo {
+                            balance: account.balance,
+                            nonce: account.nonce,
+                            code_hash: account.code_hash,
+                            code: None,
+                            _non_exhaustive: (),
+                        }),
+                        _non_exhaustive: (),
+                    },
+                );
             }
-            if let Some(account) = tracked.current.as_ref() {
+            if let Some(account) = current {
                 let code_hash = account.code_hash;
-                if account.code_changed
+                let code_changed = original.is_none_or(|original| original.code_hash != code_hash);
+                if code_changed
                     && !account.code.is_empty()
                     && !code_hash.is_zero()
                     && code_hash != KECCAK256_EMPTY
@@ -1151,22 +1201,21 @@ impl State {
             }
         }
 
-        for (&address, storage) in &self.storage {
+        let Self { database, storage, .. } = self;
+        for (&address, storage) in storage {
             let mut set = StorageChangeSet {
                 wipe: storage.wiped,
                 slots: BTreeMap::new(),
                 _non_exhaustive: (),
             };
-            for (&key, slot) in &storage.slots {
-                if slot.original != slot.current && (!set.wipe || !slot.current.is_zero()) {
-                    set.slots.insert(
-                        key,
-                        Tracked {
-                            original: slot.original,
-                            current: slot.current,
-                            _non_exhaustive: (),
-                        },
-                    );
+            for (&key, &current) in &storage.slots {
+                let original = if set.wipe {
+                    Word::ZERO
+                } else {
+                    database.storage_ref(&address, &key).unwrap_or_default()
+                };
+                if original != current && (!set.wipe || !current.is_zero()) {
+                    set.slots.insert(key, Tracked { original, current, _non_exhaustive: () });
                 }
             }
             if set.wipe || !set.slots.is_empty() {
@@ -1177,34 +1226,23 @@ impl State {
         changes
     }
 
-    /// Marks the current transaction's overlay values as the new baseline.
-    ///
-    /// After [`Self::finalize_transaction`] and [`Self::build_state_changes`] have
-    /// produced the transaction write-set, the overlay must stop treating those
-    /// writes as pending changes. This rolls the current account and storage
-    /// values forward into their `original` slots and applies local deletion/wipe
-    /// bookkeeping. It only advances the in-memory overlay; callers are still
-    /// responsible for committing the emitted write-set to their backing database
-    /// and clearing transaction-local state.
-    pub(super) fn commit_transaction_overlay(&mut self) {
-        for account in self.accounts.values_mut() {
-            if let Some(current) = &mut account.current {
-                current.just_created = false;
-                current.code_changed = false;
-            }
-            account.original.clone_from(&account.current);
-        }
+    /// Builds and accepts the current transaction's state transition.
+    pub(crate) fn accept_transaction(&mut self) -> StateChanges {
+        let changes = self.build_state_changes();
+        self.database.commit(&changes);
+        self.accounts.clear();
+        self.storage.clear();
+        changes
+    }
 
-        self.storage.retain(|_, storage| {
-            if storage.wiped {
-                storage.slots.retain(|_, slot| !slot.current.is_zero());
-            }
-            for slot in storage.slots.values_mut() {
-                slot.original = slot.current;
-            }
-            storage.wiped = false;
-            !storage.slots.is_empty()
-        });
+    /// Marks the current transaction's write layer as accepted state.
+    ///
+    /// This applies the transaction write-set to the accepted in-memory database overlay and clears
+    /// the transaction layer. It does not write to the wrapped backing database; callers remain
+    /// responsible for committing the emitted write-set.
+    #[cfg(test)]
+    pub(super) fn commit_transaction_overlay(&mut self) {
+        let _ = self.accept_transaction();
     }
 }
 
@@ -1368,7 +1406,7 @@ mod tests {
     #[test]
     fn spurious_dragon_deletes_touched_empty_existing_account() {
         let address = Address::from([0x44; 20]);
-        let empty = AccountInfo::default();
+        let empty = AccountInfo { code: None, ..AccountInfo::default() };
         let mut database = CacheDB::default();
         database.insert_account_info(&address, empty.clone());
         let mut state = State::new(database);

--- a/crates/evm2/src/evm/state.rs
+++ b/crates/evm2/src/evm/state.rs
@@ -609,11 +609,10 @@ impl State {
             &mut self.journal,
             address,
         )?;
-        if account.is_none() {
+        Ok(account.get_or_insert_with(|| {
             self.journal.push(JournalEntry::AccountChange { address: *address, previous: None });
-            *account = Some(Account { code_hash: KECCAK256_EMPTY, ..Account::default() });
-        }
-        Ok(account.as_mut().expect("account was inserted above"))
+            Account { code_hash: KECCAK256_EMPTY, ..Account::default() }
+        }))
     }
 
     fn journal_account_change(&mut self, address: &Address) -> DbResult<&mut Account> {
@@ -625,10 +624,8 @@ impl State {
         )?;
         let previous = account.clone();
         self.journal.push(JournalEntry::AccountChange { address: *address, previous });
-        if account.is_none() {
-            *account = Some(Account { code_hash: KECCAK256_EMPTY, ..Account::default() });
-        }
-        Ok(account.as_mut().expect("account was inserted above"))
+        Ok(account
+            .get_or_insert_with(|| Account { code_hash: KECCAK256_EMPTY, ..Account::default() }))
     }
 
     /// Returns account info.
@@ -1061,9 +1058,12 @@ impl State {
             &mut self.journal,
             address,
         )?;
-        if !original_exists && account.is_none() {
-            self.journal.push(JournalEntry::AccountChange { address: *address, previous: None });
-            *account = Some(Account { code_hash: KECCAK256_EMPTY, ..Account::default() });
+        if !original_exists {
+            account.get_or_insert_with(|| {
+                self.journal
+                    .push(JournalEntry::AccountChange { address: *address, previous: None });
+                Account { code_hash: KECCAK256_EMPTY, ..Account::default() }
+            });
         }
         Ok(())
     }

--- a/crates/evm2/src/evm/state.rs
+++ b/crates/evm2/src/evm/state.rs
@@ -138,6 +138,10 @@ pub struct Account {
     pub code_hash: B256,
     /// Cached account bytecode.
     pub code: Bytecode,
+    /// Whether the account was created in the current transaction.
+    pub just_created: bool,
+    /// Whether the account code has been modified.
+    pub code_changed: bool,
     #[doc(hidden)] // Not public API. Please use an existing constructor.
     pub _non_exhaustive: (),
 }
@@ -151,6 +155,8 @@ impl Account {
             balance: info.balance,
             code_hash: info.code_hash,
             code: info.code.unwrap_or_default(),
+            just_created: false,
+            code_changed: false,
             _non_exhaustive: (),
         }
     }
@@ -177,11 +183,11 @@ impl Account {
 /// Persistent storage overlay for one account.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct StorageOverlay {
-    /// Whether missing storage slots are known to be zero because all pre-existing storage was
-    /// deleted.
+    /// Whether consumers must delete all pre-existing storage for the account
+    /// before applying individual slot changes.
     pub wiped: bool,
     /// Loaded or changed storage slots.
-    pub slots: U256Map<Word>,
+    pub slots: U256Map<Tracked<Word>>,
     #[doc(hidden)] // Not public API. Please use an existing constructor.
     pub _non_exhaustive: (),
 }
@@ -283,11 +289,6 @@ pub enum JournalEntry {
         /// Account address.
         address: Address,
     },
-    /// Account was marked as created in the current transaction.
-    Created {
-        /// Account address.
-        address: Address,
-    },
     /// Account was self-destructed.
     SelfDestruct {
         /// Account address.
@@ -360,8 +361,6 @@ pub struct State {
     /// touched account may have no field changes, but can still matter for empty
     /// account deletion/materialization rules across forks.
     touched: AddressSet,
-    /// Accounts created in the current transaction.
-    created: AddressSet,
     /// Accounts self-destructed in the current transaction.
     selfdestructs: AddressSet,
     /// Transaction-scoped warm account set for EIP-2929 gas accounting.
@@ -389,7 +388,6 @@ impl State {
             journal: Vec::new(),
             logs: Vec::new(),
             touched: AddressSet::default(),
-            created: AddressSet::default(),
             selfdestructs: AddressSet::default(),
             accessed_accounts: AddressSet::default(),
             accessed_storage: StorageKeySet::default(),
@@ -447,8 +445,8 @@ impl State {
     #[inline]
     pub fn storage_ref(&self, address: &Address, key: &Word) -> Option<Word> {
         if let Some(storage) = self.storage.get(address) {
-            if let Some(value) = storage.slots.get(key) {
-                return Some(*value);
+            if let Some(slot) = storage.slots.get(key) {
+                return Some(slot.current);
             }
             if storage.wiped {
                 return Some(Word::ZERO);
@@ -576,7 +574,6 @@ impl State {
         self.storage.clear();
         self.journal.clear();
         self.touched.clear();
-        self.created.clear();
         self.selfdestructs.clear();
         self.accessed_accounts.clear();
         self.accessed_storage.clear();
@@ -695,8 +692,8 @@ impl State {
 
     fn current_storage(&mut self, address: &Address, key: &Word) -> DbResult<Word> {
         if let Some(storage) = self.storage.get(address) {
-            if let Some(value) = storage.slots.get(key) {
-                return Ok(*value);
+            if let Some(slot) = storage.slots.get(key) {
+                return Ok(slot.current);
             }
             if storage.wiped {
                 return Ok(Word::ZERO);
@@ -708,13 +705,19 @@ impl State {
         self.database.get_storage(address, key)
     }
 
-    fn insert_transaction_storage(&mut self, address: &Address, key: &Word, value: Word) {
+    fn insert_transaction_storage(
+        &mut self,
+        address: &Address,
+        key: &Word,
+        original: Word,
+        value: Word,
+    ) {
         let storage = self.storage.entry(*address).or_default();
         match storage.slots.entry(*key) {
             hash_map::Entry::Occupied(mut entry) => {
-                let previous = *entry.get();
+                let previous = entry.get().current;
                 if previous != value {
-                    entry.insert(value);
+                    entry.get_mut().current = value;
                     self.journal.push(JournalEntry::StorageChange {
                         address: *address,
                         key: *key,
@@ -723,7 +726,7 @@ impl State {
                 }
             }
             hash_map::Entry::Vacant(entry) => {
-                entry.insert(value);
+                entry.insert(Tracked { original, current: value, _non_exhaustive: () });
                 self.journal.push(JournalEntry::StorageInserted { address: *address, key: *key });
             }
         }
@@ -754,8 +757,9 @@ impl State {
             } else {
                 self.database.get_storage(address, key)?
             };
-        let present_value =
-            storage.and_then(|storage| storage.slots.get(key)).copied().unwrap_or(original_value);
+        let present_value = storage
+            .and_then(|storage| storage.slots.get(key))
+            .map_or(original_value, |slot| slot.current);
         let result = SStore {
             original_value,
             present_value,
@@ -764,7 +768,7 @@ impl State {
             _non_exhaustive: (),
         };
         if present_value != *value {
-            self.insert_transaction_storage(address, key, *value);
+            self.insert_transaction_storage(address, key, original_value, *value);
         }
         Ok(result)
     }
@@ -852,9 +856,10 @@ impl State {
             balance,
             code_hash: KECCAK256_EMPTY,
             code: Bytecode::default(),
+            just_created: true,
+            code_changed: true,
             _non_exhaustive: (),
         };
-        self.mark_created(address);
         self.touch(address);
         Ok(Ok(()))
     }
@@ -864,6 +869,7 @@ impl State {
         let account = self.journal_account_change(address)?;
         account.code_hash = code.hash_slow();
         account.code = code;
+        account.code_changed = true;
         Ok(())
     }
 
@@ -915,12 +921,6 @@ impl State {
         }
     }
 
-    fn mark_created(&mut self, address: &Address) {
-        if self.created.insert(*address) {
-            self.journal.push(JournalEntry::Created { address: *address });
-        }
-    }
-
     /// Marks an account as self-destructed in the current transaction.
     pub fn mark_destructed(&mut self, address: &Address) {
         let _ = Self::ensure_transaction_account(
@@ -946,7 +946,7 @@ impl State {
     #[inline]
     #[must_use]
     pub(super) fn is_created_in_transaction(&self, address: &Address) -> bool {
-        self.created.contains(address)
+        self.account_ref(address).is_some_and(|account| account.just_created)
     }
 
     /// Reverts state changes after the checkpoint.
@@ -977,15 +977,14 @@ impl State {
                     }
                     self.touched.remove(&address);
                 }
-                JournalEntry::Created { address } => {
-                    self.created.remove(&address);
-                }
                 JournalEntry::SelfDestruct { address } => {
                     self.selfdestructs.remove(&address);
                 }
                 JournalEntry::StorageChange { address, key, previous } => {
-                    if let Some(storage) = self.storage.get_mut(&address) {
-                        storage.slots.insert(key, previous);
+                    if let Some(storage) = self.storage.get_mut(&address)
+                        && let Some(slot) = storage.slots.get_mut(&key)
+                    {
+                        slot.current = previous;
                     }
                 }
                 JournalEntry::StorageInserted { address, key } => {
@@ -1028,7 +1027,7 @@ impl State {
     fn is_existing_dead(&mut self, address: &Address) -> DbResult<bool> {
         if let Some(account) = self.accounts.get(address) {
             return Ok(account.as_ref().is_some_and(Account::is_empty)
-                || (account.is_none() && self.database.account_ref(address).is_some()));
+                || (account.is_none() && self.database.account_info(address).is_some()));
         }
         Ok(self.load_account(address)?.as_ref().is_some_and(Account::is_empty))
     }
@@ -1155,7 +1154,7 @@ impl State {
             StateChanges { logs: core::mem::take(&mut self.logs), ..StateChanges::default() };
 
         for (&address, current) in &self.accounts {
-            let original = self.database.account_ref(&address);
+            let original = self.database.account_info(&address);
             let current = current.as_ref();
             let account_changed = match (original, current) {
                 (Some(original), Some(current)) => {
@@ -1170,28 +1169,15 @@ impl State {
                 changes.accounts.insert(
                     address,
                     Tracked {
-                        original: original.map(|info| AccountInfo {
-                            balance: info.balance,
-                            nonce: info.nonce,
-                            code_hash: info.code_hash,
-                            code: None,
-                            _non_exhaustive: (),
-                        }),
-                        current: current.map(|account| AccountInfo {
-                            balance: account.balance,
-                            nonce: account.nonce,
-                            code_hash: account.code_hash,
-                            code: None,
-                            _non_exhaustive: (),
-                        }),
+                        original: original.cloned(),
+                        current: current.map(Account::info),
                         _non_exhaustive: (),
                     },
                 );
             }
             if let Some(account) = current {
                 let code_hash = account.code_hash;
-                let code_changed = original.is_none_or(|original| original.code_hash != code_hash);
-                if code_changed
+                if account.code_changed
                     && !account.code.is_empty()
                     && !code_hash.is_zero()
                     && code_hash != KECCAK256_EMPTY
@@ -1201,21 +1187,22 @@ impl State {
             }
         }
 
-        let Self { database, storage, .. } = self;
-        for (&address, storage) in storage {
+        for (&address, storage) in &self.storage {
             let mut set = StorageChangeSet {
                 wipe: storage.wiped,
                 slots: BTreeMap::new(),
                 _non_exhaustive: (),
             };
-            for (&key, &current) in &storage.slots {
-                let original = if set.wipe {
-                    Word::ZERO
-                } else {
-                    database.storage_ref(&address, &key).unwrap_or_default()
-                };
-                if original != current && (!set.wipe || !current.is_zero()) {
-                    set.slots.insert(key, Tracked { original, current, _non_exhaustive: () });
+            for (&key, slot) in &storage.slots {
+                if slot.original != slot.current && (!set.wipe || !slot.current.is_zero()) {
+                    set.slots.insert(
+                        key,
+                        Tracked {
+                            original: slot.original,
+                            current: slot.current,
+                            _non_exhaustive: (),
+                        },
+                    );
                 }
             }
             if set.wipe || !set.slots.is_empty() {

--- a/crates/evm2/src/evm/system.rs
+++ b/crates/evm2/src/evm/system.rs
@@ -130,8 +130,7 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
             result.stop = stop;
             result.output = Bytes::new();
         } else {
-            result.state_changes = self.state.build_state_changes();
-            self.state.commit_transaction_overlay();
+            result.state_changes = self.state.accept_transaction();
         }
         result.db_error_code = self.db_error_code();
         self.state.clear_transaction_state();

--- a/crates/evm2/src/tests.rs
+++ b/crates/evm2/src/tests.rs
@@ -48,10 +48,7 @@ fn evm_executes_storage_transaction() {
 
     run_tx(&mut evm, contract, [op::PUSH1, 0x2a, op::PUSH1, 0x01, op::SSTORE, op::STOP]);
 
-    assert_eq!(
-        evm.state().storage_ref(&contract, &Word::from(1)).map(|slot| slot.current),
-        Some(Word::from(0x2a))
-    );
+    assert_eq!(evm.state().storage_ref(&contract, &Word::from(1)), Some(Word::from(0x2a)));
 }
 
 #[test]
@@ -86,15 +83,8 @@ fn evm_runs_transactions_against_initial_state() {
     );
     run_tx(&mut evm, contract, [op::PUSH1, 0x07, op::PUSH1, 0x01, op::SSTORE, op::STOP]);
 
-    assert!(evm.state().account_ref(&contract).is_some());
-    assert_eq!(
-        evm.state().storage_ref(&contract, &Word::from(1)).map(|slot| slot.current),
-        Some(Word::from(7))
-    );
-    assert_eq!(
-        evm.state().storage_ref(&contract, &Word::from(2)).map(|slot| slot.current),
-        Some(Word::from(42))
-    );
+    assert_eq!(evm.state().storage_ref(&contract, &Word::from(1)), Some(Word::from(7)));
+    assert_eq!(evm.state().storage_ref(&contract, &Word::from(2)), Some(Word::from(42)));
 }
 
 #[test]


### PR DESCRIPTION
Splits current-transaction scratch state from accepted `CacheDB` state so transaction accept/discard no longer walks accumulated overlay data.

Also trims avoidable account/storage cloning and copies on the state hot path while preserving the public cache shape.

This brings us from approx 1335 Mgas/s on multi-block sync to 2470 Mgas/s. The profile is now mostly dominated by compute-heavy precompiles like modexp.