### PR TITLE
feat(evm): relax erased send bounds

### DIFF
--- a/crates/evm2/src/evm/async.rs
+++ b/crates/evm2/src/evm/async.rs
@@ -432,26 +432,26 @@ pub trait AsyncDatabase: Any {
     fn get_account(
         &mut self,
         address: Address,
-    ) -> impl Future<Output = Result<Option<AccountInfo>, Self::Error>> + '_;
+    ) -> impl Future<Output = Result<Option<AccountInfo>, Self::Error>> + Send + '_;
 
     /// Loads bytecode by code hash.
     fn get_code_by_hash(
         &mut self,
         code_hash: B256,
-    ) -> impl Future<Output = Result<Bytecode, Self::Error>> + '_;
+    ) -> impl Future<Output = Result<Bytecode, Self::Error>> + Send + '_;
 
     /// Loads a persistent storage slot.
     fn get_storage(
         &mut self,
         address: Address,
         key: Word,
-    ) -> impl Future<Output = Result<Word, Self::Error>> + '_;
+    ) -> impl Future<Output = Result<Word, Self::Error>> + Send + '_;
 
     /// Loads a historical block hash.
     fn get_block_hash(
         &mut self,
         number: Word,
-    ) -> impl Future<Output = Result<Option<B256>, Self::Error>> + '_;
+    ) -> impl Future<Output = Result<Option<B256>, Self::Error>> + Send + '_;
 }
 
 /// Adapter that exposes an [`AsyncDatabase`] through the synchronous [`DynDatabase`] interface.
@@ -694,6 +694,16 @@ mod tests {
         let code = poll_ready(code).unwrap();
 
         assert_eq!(db.error(code).to_string(), "storage read failed");
+    }
+
+    #[test]
+    fn async_database_inner_futures_are_send() {
+        let mut db = TestDb;
+
+        drop(assert_send(db.get_account(Address::ZERO)));
+        drop(assert_send(db.get_code_by_hash(B256::ZERO)));
+        drop(assert_send(db.get_storage(Address::ZERO, Word::ZERO)));
+        drop(assert_send(db.get_block_hash(Word::ZERO)));
     }
 
     #[test]

--- a/crates/evm2/src/evm/async.rs
+++ b/crates/evm2/src/evm/async.rs
@@ -364,8 +364,7 @@ fn current_tokio_handle() -> Option<Handle> {
 
 fn block_on_handle<F>(handle: &Handle, future: F) -> F::Output
 where
-    F: Future + Send,
-    F::Output: Send,
+    F: Future,
 {
     let should_use_block_in_place = Handle::try_current()
         .ok()
@@ -383,8 +382,7 @@ where
 
 fn block_on_runtime<F>(runtime: Option<&Handle>, future: F) -> AsyncResult<F::Output>
 where
-    F: Future + Send,
-    F::Output: Send,
+    F: Future,
 {
     if CURRENT.get().is_some() {
         return block_on_current(future);
@@ -399,9 +397,7 @@ where
 
 fn block_on_runtime_result<F, T, E>(runtime: Option<&Handle>, future: F) -> AsyncResult<T, E>
 where
-    F: Future<Output = Result<T, E>> + Send,
-    T: Send,
-    E: Send,
+    F: Future<Output = Result<T, E>>,
 {
     match block_on_runtime(runtime, future).map_err(AsyncError::with_inner_error)? {
         Ok(value) => Ok(value),
@@ -428,7 +424,7 @@ unsafe fn restore_context_lifetime<'a>(cx: &'a mut Context<'static>) -> &'a mut 
 /// async EVM entrypoints such as [`crate::Evm::transact_async`]. Calling synchronous EVM
 /// entrypoints with an [`AsyncDb`] can still execute the futures by blocking on Tokio, but it
 /// cannot suspend the EVM fiber and yield back to the caller.
-pub trait AsyncDatabase: Any + Send {
+pub trait AsyncDatabase: Any {
     /// Database error type.
     type Error: Error + Send + 'static;
 
@@ -436,26 +432,26 @@ pub trait AsyncDatabase: Any + Send {
     fn get_account(
         &mut self,
         address: Address,
-    ) -> impl Future<Output = Result<Option<AccountInfo>, Self::Error>> + Send + '_;
+    ) -> impl Future<Output = Result<Option<AccountInfo>, Self::Error>> + '_;
 
     /// Loads bytecode by code hash.
     fn get_code_by_hash(
         &mut self,
         code_hash: B256,
-    ) -> impl Future<Output = Result<Bytecode, Self::Error>> + Send + '_;
+    ) -> impl Future<Output = Result<Bytecode, Self::Error>> + '_;
 
     /// Loads a persistent storage slot.
     fn get_storage(
         &mut self,
         address: Address,
         key: Word,
-    ) -> impl Future<Output = Result<Word, Self::Error>> + Send + '_;
+    ) -> impl Future<Output = Result<Word, Self::Error>> + '_;
 
     /// Loads a historical block hash.
     fn get_block_hash(
         &mut self,
         number: Word,
-    ) -> impl Future<Output = Result<Option<B256>, Self::Error>> + Send + '_;
+    ) -> impl Future<Output = Result<Option<B256>, Self::Error>> + '_;
 }
 
 /// Adapter that exposes an [`AsyncDatabase`] through the synchronous [`DynDatabase`] interface.
@@ -572,7 +568,7 @@ impl<D: AsyncDatabase> DynDatabase for AsyncDb<D> {
     }
 
     #[inline]
-    fn error(&mut self, code: DbErrorCode) -> Box<dyn Error + Send> {
+    fn error(&mut self, code: DbErrorCode) -> Box<dyn Error> {
         if code == stored_error_code()
             && let Some(error) = self.error.take()
         {
@@ -593,11 +589,12 @@ impl<D: AsyncDatabase + fmt::Debug> fmt::Debug for AsyncDb<D> {
 mod tests {
     use super::{AsyncDatabase, AsyncDb, AsyncError, block_on_current, on_fiber};
     use crate::{
-        BaseEvmTypes, Evm, Precompiles, SpecId, TxResult,
+        BaseEvmTypes, Evm, PrecompileError, Precompiles, SpecId, TxResult,
         bytecode::Bytecode,
         env::BlockEnv,
-        evm::{DynDatabase, InMemoryDB},
-        interpreter::Word,
+        evm::{Database, Db, DynDatabase, InMemoryDB, PrecompileProvider},
+        interpreter::{GasTracker, Message, Word},
+        precompile::PrecompileOutput,
         registry::{HandlerError, HandlerResult, TxRegistry, TxRequest},
     };
     use alloy_consensus::{TxLegacy, transaction::Recovered};
@@ -609,6 +606,7 @@ mod tests {
     use corosensei::stack::Stack;
     use std::{
         error::Error,
+        rc::Rc,
         task::{Context, Waker},
     };
 
@@ -712,11 +710,117 @@ mod tests {
             InMemoryDB::default(),
             Precompiles::base(SpecId::OSAKA),
         );
+        evm.evm_is_send::<InMemoryDB, Precompiles<BaseEvmTypes>>();
         let tx = test_tx(41);
 
         let result = poll_ready(evm.transact_async(&tx)).unwrap();
 
         assert_eq!(result.gas_used, 42);
+    }
+
+    #[test]
+    fn transaction_async_future_is_send_with_send_erased_fields() {
+        let registry = TxRegistry::new().with_handler(
+            TEST_TX_TYPE,
+            crate::ethereum::RecoveredTxEnvelope::as_legacy,
+            handle_test_tx,
+        );
+        let mut evm = Evm::<BaseEvmTypes>::new(
+            SpecId::OSAKA,
+            BlockEnv::default(),
+            registry,
+            InMemoryDB::default(),
+            Precompiles::base(SpecId::OSAKA),
+        );
+        evm.evm_is_send::<InMemoryDB, Precompiles<BaseEvmTypes>>();
+        let tx = test_tx(41);
+
+        let result = poll_ready(assert_send(evm.transact_async(&tx))).unwrap();
+
+        assert_eq!(result.gas_used, 42);
+    }
+
+    #[test]
+    fn transaction_async_future_is_send_after_type_check() {
+        let registry = TxRegistry::new().with_handler(
+            TEST_TX_TYPE,
+            crate::ethereum::RecoveredTxEnvelope::as_legacy,
+            handle_test_tx,
+        );
+        let mut evm = Evm::<BaseEvmTypes>::new(
+            SpecId::OSAKA,
+            BlockEnv::default(),
+            registry,
+            InMemoryDB::default(),
+            Precompiles::base(SpecId::OSAKA),
+        );
+        evm.set_inspector(SendInspector);
+        evm.evm_is_send_with_inspector::<InMemoryDB, Precompiles<BaseEvmTypes>, SendInspector>();
+        let tx = test_tx(41);
+
+        let result = poll_ready(assert_send(evm.transact_async(&tx))).unwrap();
+
+        assert_eq!(result.gas_used, 42);
+    }
+
+    #[test]
+    #[should_panic = "async EVM execution requires EVM erased fields to be verified as Send with Evm::evm_is_send"]
+    fn transaction_async_panics_with_non_send_erased_fields() {
+        let mut evm = Evm::<BaseEvmTypes>::new(
+            SpecId::OSAKA,
+            BlockEnv::default(),
+            TxRegistry::new(),
+            InMemoryDB::default(),
+            Precompiles::base(SpecId::OSAKA),
+        );
+        let tx = test_tx(41);
+
+        drop(evm.transact_async(&tx));
+    }
+
+    #[test]
+    #[should_panic = "async EVM execution requires EVM erased fields to be verified as Send with Evm::evm_is_send"]
+    fn transaction_async_panics_after_non_send_setter() {
+        let marker = Rc::new(());
+        let registry = TxRegistry::new().with_handler(
+            TEST_TX_TYPE,
+            crate::ethereum::RecoveredTxEnvelope::as_legacy,
+            handle_test_tx,
+        );
+        let mut evm = Evm::<BaseEvmTypes>::new(
+            SpecId::OSAKA,
+            BlockEnv::default(),
+            registry,
+            InMemoryDB::default(),
+            Precompiles::base(SpecId::OSAKA),
+        );
+        evm.evm_is_send::<InMemoryDB, Precompiles<BaseEvmTypes>>();
+        evm.set_inspector(NonSendInspector { marker });
+        let tx = test_tx(41);
+
+        drop(evm.transact_async(&tx));
+    }
+
+    #[test]
+    fn evm_accepts_non_send_erased_fields() {
+        let marker = Rc::new(());
+        let database = Db::new(NonSendDb { marker: Rc::clone(&marker) });
+        let precompiles = NonSendPrecompiles { marker: Rc::clone(&marker) };
+        let mut evm = Evm::<BaseEvmTypes>::new(
+            SpecId::OSAKA,
+            BlockEnv::default(),
+            TxRegistry::new(),
+            database,
+            precompiles,
+        );
+
+        evm.set_inspector(NonSendInspector { marker });
+
+        let address = Address::ZERO;
+        let key = Word::from(7);
+        let value = evm.database_mut().get_storage(&address, &key).unwrap();
+
+        assert_eq!(value, Word::from(9));
     }
 
     #[test]
@@ -728,6 +832,7 @@ mod tests {
             InMemoryDB::default(),
             Precompiles::base(SpecId::OSAKA),
         );
+        evm.evm_is_send::<InMemoryDB, Precompiles<BaseEvmTypes>>();
         let tx = test_tx(41);
 
         let result = poll_ready(evm.transact_async(&tx));
@@ -800,6 +905,7 @@ mod tests {
             AsyncDb::new(TokioDb),
             Precompiles::base(SpecId::OSAKA),
         );
+        evm.evm_is_send::<AsyncDb<TokioDb>, Precompiles<BaseEvmTypes>>();
         let address = Address::ZERO;
         let key = Word::from(7);
 
@@ -818,6 +924,7 @@ mod tests {
             InMemoryDB::default(),
             Precompiles::base(SpecId::OSAKA),
         );
+        evm.evm_is_send::<InMemoryDB, Precompiles<BaseEvmTypes>>();
 
         let result = poll_ready(evm.system_call_async(contract, Bytes::new())).unwrap();
 
@@ -867,6 +974,73 @@ mod tests {
             Poll::Pending => panic!("future unexpectedly pending"),
         }
     }
+
+    fn assert_send<F: Future + Send>(future: F) -> F {
+        future
+    }
+
+    struct NonSendDb {
+        marker: Rc<()>,
+    }
+
+    impl Database for NonSendDb {
+        type Error = Infallible;
+
+        fn get_account(
+            &mut self,
+            _address: &Address,
+        ) -> Result<Option<crate::evm::AccountInfo>, Self::Error> {
+            let _ = Rc::strong_count(&self.marker);
+            Ok(None)
+        }
+
+        fn get_code_by_hash(&mut self, _code_hash: &B256) -> Result<Bytecode, Self::Error> {
+            Ok(Bytecode::default())
+        }
+
+        fn get_storage(&mut self, _address: &Address, _key: &Word) -> Result<Word, Self::Error> {
+            let _ = Rc::strong_count(&self.marker);
+            Ok(Word::from(9))
+        }
+
+        fn get_block_hash(&mut self, _number: &Word) -> Result<Option<B256>, Self::Error> {
+            Ok(None)
+        }
+    }
+
+    struct NonSendPrecompiles {
+        marker: Rc<()>,
+    }
+
+    impl PrecompileProvider<BaseEvmTypes> for NonSendPrecompiles {
+        fn contains(&self, _address: &Address) -> bool {
+            let _ = Rc::strong_count(&self.marker);
+            false
+        }
+
+        fn execute(
+            &mut self,
+            _evm: &mut Evm<BaseEvmTypes>,
+            _message: &Message<BaseEvmTypes>,
+            _gas: &mut GasTracker,
+        ) -> Option<Result<PrecompileOutput, PrecompileError>> {
+            None
+        }
+    }
+
+    struct NonSendInspector {
+        marker: Rc<()>,
+    }
+
+    impl crate::evm::Inspector<BaseEvmTypes> for NonSendInspector {
+        fn step(&mut self, _interp: &mut crate::interpreter::Interpreter<'_, BaseEvmTypes>) {
+            let _ = Rc::strong_count(&self.marker);
+        }
+    }
+
+    struct SendInspector;
+
+    impl crate::evm::Inspector<BaseEvmTypes> for SendInspector {}
 
     struct PendingOnce {
         pending: bool,

--- a/crates/evm2/src/evm/db.rs
+++ b/crates/evm2/src/evm/db.rs
@@ -215,34 +215,7 @@ impl core::ops::DerefMut for dyn DynDatabase + '_ {
     }
 }
 
-impl DynDatabase for Box<dyn DynDatabase> {
-    #[inline]
-    fn get_account(&mut self, address: &Address) -> DbResult<Option<AccountInfo>> {
-        self.as_mut().get_account(address)
-    }
-
-    #[inline]
-    fn get_code_by_hash(&mut self, code_hash: &B256) -> DbResult<Bytecode> {
-        self.as_mut().get_code_by_hash(code_hash)
-    }
-
-    #[inline]
-    fn get_storage(&mut self, address: &Address, key: &Word) -> DbResult<Word> {
-        self.as_mut().get_storage(address, key)
-    }
-
-    #[inline]
-    fn get_block_hash(&mut self, number: &Word) -> DbResult<Option<B256>> {
-        self.as_mut().get_block_hash(number)
-    }
-
-    #[inline]
-    fn error(&mut self, code: DbErrorCode) -> Box<dyn Error> {
-        self.as_mut().error(code)
-    }
-}
-
-impl DynDatabase for Box<dyn DynDatabase + Send> {
+impl<T: DynDatabase + ?Sized> DynDatabase for Box<T> {
     #[inline]
     fn get_account(&mut self, address: &Address) -> DbResult<Option<AccountInfo>> {
         self.as_mut().get_account(address)

--- a/crates/evm2/src/evm/db.rs
+++ b/crates/evm2/src/evm/db.rs
@@ -48,9 +48,9 @@ impl DbErrorCode {
 pub type DbResult<T> = Result<T, DbErrorCode>;
 
 /// Backing database implementation with a concrete error type.
-pub trait Database: Any + Send {
+pub trait Database: Any {
     /// Database error type.
-    type Error: Error + Send + 'static;
+    type Error: Error + 'static;
 
     /// Loads account information.
     fn get_account(&mut self, address: &Address) -> Result<Option<AccountInfo>, Self::Error>;
@@ -143,7 +143,7 @@ impl fmt::Display for DbErrorUnavailable {
 impl Error for DbErrorUnavailable {}
 
 #[inline]
-pub(crate) fn db_error_unavailable(code: DbErrorCode) -> Box<dyn Error + Send> {
+pub(crate) fn db_error_unavailable(code: DbErrorCode) -> Box<dyn Error> {
     Box::new(DbErrorUnavailable(code))
 }
 
@@ -169,7 +169,7 @@ impl<T: Database> DynDatabase for Db<T> {
     }
 
     #[inline]
-    fn error(&mut self, code: DbErrorCode) -> Box<dyn Error + Send> {
+    fn error(&mut self, code: DbErrorCode) -> Box<dyn Error> {
         if code == stored_error_code()
             && let Some(err) = self.result.take()
         {
@@ -180,7 +180,7 @@ impl<T: Database> DynDatabase for Db<T> {
 }
 
 /// Backing database view used to initialize mutable [`super::State`].
-pub trait DynDatabase: Any + Send {
+pub trait DynDatabase: Any {
     /// Loads account information.
     fn get_account(&mut self, address: &Address) -> DbResult<Option<AccountInfo>>;
 
@@ -194,7 +194,7 @@ pub trait DynDatabase: Any + Send {
     fn get_block_hash(&mut self, number: &Word) -> DbResult<Option<B256>>;
 
     /// Retrieves the full error for a previously returned error code.
-    fn error(&mut self, code: DbErrorCode) -> Box<dyn Error + Send> {
+    fn error(&mut self, code: DbErrorCode) -> Box<dyn Error> {
         db_error_unavailable(code)
     }
 }
@@ -237,7 +237,34 @@ impl DynDatabase for Box<dyn DynDatabase> {
     }
 
     #[inline]
-    fn error(&mut self, code: DbErrorCode) -> Box<dyn Error + Send> {
+    fn error(&mut self, code: DbErrorCode) -> Box<dyn Error> {
+        self.as_mut().error(code)
+    }
+}
+
+impl DynDatabase for Box<dyn DynDatabase + Send> {
+    #[inline]
+    fn get_account(&mut self, address: &Address) -> DbResult<Option<AccountInfo>> {
+        self.as_mut().get_account(address)
+    }
+
+    #[inline]
+    fn get_code_by_hash(&mut self, code_hash: &B256) -> DbResult<Bytecode> {
+        self.as_mut().get_code_by_hash(code_hash)
+    }
+
+    #[inline]
+    fn get_storage(&mut self, address: &Address, key: &Word) -> DbResult<Word> {
+        self.as_mut().get_storage(address, key)
+    }
+
+    #[inline]
+    fn get_block_hash(&mut self, number: &Word) -> DbResult<Option<B256>> {
+        self.as_mut().get_block_hash(number)
+    }
+
+    #[inline]
+    fn error(&mut self, code: DbErrorCode) -> Box<dyn Error> {
         self.as_mut().error(code)
     }
 }

--- a/crates/evm2/src/evm/db/cache.rs
+++ b/crates/evm2/src/evm/db/cache.rs
@@ -235,7 +235,7 @@ impl<ExtDB: DynDatabase> DynDatabase for CacheDB<ExtDB> {
     }
 
     #[inline]
-    fn error(&mut self, code: DbErrorCode) -> alloc::boxed::Box<dyn core::error::Error + Send> {
+    fn error(&mut self, code: DbErrorCode) -> alloc::boxed::Box<dyn core::error::Error> {
         self.db.error(code)
     }
 }

--- a/crates/evm2/src/evm/inspector.rs
+++ b/crates/evm2/src/evm/inspector.rs
@@ -8,7 +8,7 @@ use alloy_primitives::{Address, Log, U256};
 use core::any::Any;
 
 /// EVM execution inspector.
-pub trait Inspector<T: EvmTypes>: Any + Send {
+pub trait Inspector<T: EvmTypes>: Any {
     /// Called after a frame interpreter has been initialized.
     #[inline]
     fn initialize_interp(&mut self, interp: &mut Interpreter<'_, T>) {

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -22,7 +22,7 @@ use alloy_eips::eip2718::Typed2718;
 use alloy_primitives::{Address, B256, Bytes, Log, LogData};
 use core::any::TypeId;
 #[cfg(feature = "async")]
-use core::{future::Future, marker::PhantomData, ptr::NonNull};
+use core::future::Future;
 use derive_where::derive_where;
 
 #[cfg(feature = "async")]
@@ -477,8 +477,7 @@ impl Drop for ExecutionGuard {
 
 #[cfg(feature = "async")]
 struct SendEvmRef<'a, T: EvmTypes> {
-    evm: NonNull<Evm<T>>,
-    _marker: PhantomData<&'a mut Evm<T>>,
+    evm: &'a mut Evm<T>,
 }
 
 #[cfg(feature = "async")]
@@ -500,15 +499,8 @@ where
 #[cfg(feature = "async")]
 impl<'a, T: EvmTypes> SendEvmRef<'a, T> {
     #[inline]
-    fn new(evm: &'a mut Evm<T>) -> Self {
-        Self { evm: NonNull::from(evm), _marker: PhantomData }
-    }
-
-    #[inline]
-    const fn as_mut(&mut self) -> &mut Evm<T> {
-        // SAFETY: The returned future owns the exclusive `&mut Evm` borrow represented by
-        // `_marker`, and all access goes through this wrapper until it is dropped.
-        unsafe { self.evm.as_mut() }
+    const fn new(evm: &'a mut Evm<T>) -> Self {
+        Self { evm }
     }
 }
 
@@ -516,7 +508,7 @@ impl<'a, T: EvmTypes> SendEvmRef<'a, T> {
 impl<T: EvmTypes<Tx: Typed2718, Host = Evm<T>>> SendEvmRef<'_, T> {
     #[inline]
     fn transact(&mut self, tx: &T::Tx) -> HandlerResult<TxResult<T>> {
-        self.as_mut().transact(tx)
+        self.evm.transact(tx)
     }
 }
 

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -20,8 +20,9 @@ use crate::{
 use alloc::{boxed::Box, vec};
 use alloy_eips::eip2718::Typed2718;
 use alloy_primitives::{Address, B256, Bytes, Log, LogData};
+use core::any::TypeId;
 #[cfg(feature = "async")]
-use core::future::Future;
+use core::{future::Future, marker::PhantomData, ptr::NonNull};
 use derive_where::derive_where;
 
 #[cfg(feature = "async")]
@@ -74,6 +75,7 @@ pub struct Evm<T: EvmTypes> {
     #[cfg(feature = "async")]
     #[derive_where(skip)]
     async_stack: r#async::FiberStack,
+    evm_send: bool,
     db_error_code: Option<DbErrorCode>,
 }
 
@@ -145,6 +147,7 @@ impl<T: EvmTypes> Evm<T> {
             running: false,
             #[cfg(feature = "async")]
             async_stack: r#async::FiberStack::default(),
+            evm_send: false,
             db_error_code: None,
         }
     }
@@ -218,12 +221,77 @@ impl<T: EvmTypes> Evm<T> {
     #[inline]
     pub fn set_database(&mut self, database: impl DynDatabase) {
         self.state.set_initial(database);
+        self.evm_send = false;
     }
 
     #[cfg(feature = "async")]
     #[inline]
     fn async_stack(&mut self) -> core::ptr::NonNull<r#async::FiberStack> {
         core::ptr::NonNull::from(&mut self.async_stack)
+    }
+
+    #[cfg(feature = "async")]
+    #[inline]
+    fn assert_erased_send(&self) {
+        assert!(
+            self.evm_send,
+            "async EVM execution requires EVM erased fields to be verified as Send with \
+             Evm::evm_is_send"
+        );
+    }
+
+    /// Marks this EVM as thread-sendable after checking the current erased field types.
+    ///
+    /// This requires no active inspector. Use [`Self::evm_is_send_with_inspector`] when an
+    /// inspector is installed.
+    #[inline]
+    pub fn evm_is_send<D, P>(&mut self) -> &mut Self
+    where
+        D: DynDatabase + Send,
+        P: PrecompileProvider<T> + Send,
+    {
+        self.assert_database_type::<D>();
+        self.assert_precompiles_type::<P>();
+        assert!(self.inspector.is_none(), "inspector type mismatch");
+        self.evm_send = true;
+        self
+    }
+
+    /// Marks this EVM as thread-sendable after checking the current erased field types.
+    #[inline]
+    pub fn evm_is_send_with_inspector<D, P, I>(&mut self) -> &mut Self
+    where
+        D: DynDatabase + Send,
+        P: PrecompileProvider<T> + Send,
+        I: Inspector<T> + Send,
+    {
+        self.assert_database_type::<D>();
+        self.assert_precompiles_type::<P>();
+        self.assert_inspector_type::<I>();
+        self.evm_send = true;
+        self
+    }
+
+    #[inline]
+    fn assert_database_type<D: DynDatabase>(&self) {
+        assert_eq!(self.database().type_id(), TypeId::of::<D>(), "database type mismatch");
+    }
+
+    #[inline]
+    fn assert_precompiles_type<P: PrecompileProvider<T>>(&self) {
+        assert_eq!(
+            self.precompiles().type_id(),
+            TypeId::of::<P>(),
+            "precompile provider type mismatch"
+        );
+    }
+
+    #[inline]
+    fn assert_inspector_type<I: Inspector<T>>(&self) {
+        let Some(inspector) = self.inspector() else {
+            panic!("inspector type mismatch");
+        };
+        assert_eq!(inspector.type_id(), TypeId::of::<I>(), "inspector type mismatch");
     }
 
     /// Returns the backing database as `D` if it has that concrete type.
@@ -268,6 +336,7 @@ impl<T: EvmTypes> Evm<T> {
     pub fn set_precompiles(&mut self, precompiles: impl PrecompileProvider<T>) {
         self.assert_precompiles_mutable();
         self.precompiles = Box::new(precompiles);
+        self.evm_send = false;
     }
 
     /// Returns the precompile provider as `P` if it has that concrete type.
@@ -334,6 +403,7 @@ impl<T: EvmTypes> Evm<T> {
     pub fn set_inspector<I: Inspector<T> + 'static>(&mut self, inspector: I) {
         self.assert_inspector_mutable();
         self.inspector = Some(Box::new(inspector));
+        self.evm_send = false;
     }
 
     /// Sets the active boxed execution inspector.
@@ -341,12 +411,14 @@ impl<T: EvmTypes> Evm<T> {
     pub fn set_boxed_inspector(&mut self, inspector: Box<dyn Inspector<T>>) {
         self.assert_inspector_mutable();
         self.inspector = Some(inspector);
+        self.evm_send = false;
     }
 
     /// Removes the active execution inspector.
     #[inline]
     pub fn clear_inspector(&mut self) -> Option<Box<dyn Inspector<T>>> {
         self.assert_inspector_mutable();
+        self.evm_send = false;
         self.inspector.take()
     }
 
@@ -403,6 +475,51 @@ impl Drop for ExecutionGuard {
     }
 }
 
+#[cfg(feature = "async")]
+struct SendEvmRef<'a, T: EvmTypes> {
+    evm: NonNull<Evm<T>>,
+    _marker: PhantomData<&'a mut Evm<T>>,
+}
+
+#[cfg(feature = "async")]
+// SAFETY: `SendEvmRef` is only constructed by async entrypoints after `Evm::evm_is_send` has
+// verified the concrete erased field types as `Send`.
+unsafe impl<T> Send for SendEvmRef<'_, T>
+where
+    T: EvmTypes,
+    T::SpecId: Send,
+    T::Tx: Send,
+    T::MessageExt: Send,
+    T::MessageResultExt: Send,
+    T::TxEnvExt: Send,
+    T::TxResultExt: Send,
+    T::BlockEnvExt: Send,
+{
+}
+
+#[cfg(feature = "async")]
+impl<'a, T: EvmTypes> SendEvmRef<'a, T> {
+    #[inline]
+    fn new(evm: &'a mut Evm<T>) -> Self {
+        Self { evm: NonNull::from(evm), _marker: PhantomData }
+    }
+
+    #[inline]
+    const fn as_mut(&mut self) -> &mut Evm<T> {
+        // SAFETY: The returned future owns the exclusive `&mut Evm` borrow represented by
+        // `_marker`, and all access goes through this wrapper until it is dropped.
+        unsafe { self.evm.as_mut() }
+    }
+}
+
+#[cfg(feature = "async")]
+impl<T: EvmTypes<Tx: Typed2718, Host = Evm<T>>> SendEvmRef<'_, T> {
+    #[inline]
+    fn transact(&mut self, tx: &T::Tx) -> HandlerResult<TxResult<T>> {
+        self.as_mut().transact(tx)
+    }
+}
+
 impl<T: EvmTypes<Tx: Typed2718, Host = Self>> Evm<T> {
     /// Dispatches the transaction to the handler registered for its EIP-2718 type byte.
     pub fn transact(&mut self, tx: &T::Tx) -> HandlerResult<TxResult<T>> {
@@ -430,18 +547,26 @@ impl<T: EvmTypes<Tx: Typed2718, Host = Self>> Evm<T> {
     /// [`evm::async::AsyncDb`](crate::evm::async::AsyncDb) to take
     /// advantage of yielding database I/O. With a synchronous database this is mostly equivalent to
     /// running the synchronous transaction on a fiber.
+    ///
+    /// This returns a `Send` future. Before calling it, the current erased database, precompile
+    /// provider, and optional inspector must be verified with [`Self::evm_is_send`] or
+    /// [`Self::evm_is_send_with_inspector`].
     #[cfg(feature = "async")]
     pub fn transact_async<'a>(
         &'a mut self,
         tx: &'a T::Tx,
     ) -> impl Future<Output = r#async::AsyncResult<TxResult<T>, registry::HandlerError>> + Send + 'a
     where
+        T::Tx: Sync,
         T::TxResultExt: Send,
     {
+        self.assert_erased_send();
         let stack = self.async_stack();
+        let mut evm = SendEvmRef::new(self);
         // SAFETY: The returned future owns the exclusive `&mut self` borrow, so nothing else can
-        // access the EVM stack slot until that future is dropped.
-        unsafe { r#async::on_fiber_result_with_stack(stack, move || self.transact(tx)) }
+        // access the EVM stack slot until that future is dropped. The send marker checked above
+        // requires all erased EVM fields to have been verified by `Evm::evm_is_send`.
+        unsafe { r#async::on_fiber_result_with_stack(stack, move || evm.transact(tx)) }
     }
 
     /// Dispatches each transaction to its registered EIP-2718 handler.

--- a/crates/evm2/src/evm/precompile.rs
+++ b/crates/evm2/src/evm/precompile.rs
@@ -55,7 +55,7 @@ pub trait PrecompileProvider<T: EvmTypes>: Any {
     ) -> Option<Result<PrecompileOutput, PrecompileError>>;
 }
 
-impl<T: EvmTypes> PrecompileProvider<T> for Box<dyn PrecompileProvider<T>> {
+impl<T: EvmTypes, P: PrecompileProvider<T> + ?Sized> PrecompileProvider<T> for Box<P> {
     #[inline]
     fn warm_addresses(&self) -> Vec<Address> {
         self.as_ref().warm_addresses()

--- a/crates/evm2/src/evm/precompile.rs
+++ b/crates/evm2/src/evm/precompile.rs
@@ -37,7 +37,7 @@ impl PrecompileOutput {
 }
 
 /// Precompile execution hook.
-pub trait PrecompileProvider<T: EvmTypes>: Any + Send {
+pub trait PrecompileProvider<T: EvmTypes>: Any {
     /// Returns precompile addresses that should be warm at transaction start.
     fn warm_addresses(&self) -> Vec<Address> {
         Vec::new()

--- a/crates/evm2/src/evm/system.rs
+++ b/crates/evm2/src/evm/system.rs
@@ -185,7 +185,7 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
 impl<T: EvmTypes<Host = Evm<T>>> SendEvmRef<'_, T> {
     #[inline]
     fn system_call(&mut self, system_contract_address: Address, data: Bytes) -> TxResult<T> {
-        self.as_mut().system_call(system_contract_address, data)
+        self.evm.system_call(system_contract_address, data)
     }
 
     #[inline]
@@ -195,7 +195,7 @@ impl<T: EvmTypes<Host = Evm<T>>> SendEvmRef<'_, T> {
         system_contract_address: Address,
         data: Bytes,
     ) -> TxResult<T> {
-        self.as_mut().system_call_with_caller(caller, system_contract_address, data)
+        self.evm.system_call_with_caller(caller, system_contract_address, data)
     }
 }
 

--- a/crates/evm2/src/evm/system.rs
+++ b/crates/evm2/src/evm/system.rs
@@ -7,6 +7,8 @@
 //! and produces no state changes.
 
 #[cfg(feature = "async")]
+use super::SendEvmRef;
+#[cfg(feature = "async")]
 use super::r#async;
 use super::{Evm, TxResult};
 use crate::{
@@ -54,6 +56,10 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
     /// [`evm::async::AsyncDb`](crate::evm::async::AsyncDb) to take
     /// advantage of yielding database I/O. With a synchronous database this is mostly equivalent to
     /// running the synchronous system call on a fiber.
+    ///
+    /// This returns a `Send` future. Before calling it, the current erased database, precompile
+    /// provider, and optional inspector must be verified with [`Evm::evm_is_send`] or
+    /// [`Evm::evm_is_send_with_inspector`].
     #[cfg(feature = "async")]
     #[inline]
     pub fn system_call_async(
@@ -64,12 +70,15 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
     where
         T::TxResultExt: Send,
     {
+        self.assert_erased_send();
         let stack = self.async_stack();
+        let mut evm = SendEvmRef::new(self);
         // SAFETY: The returned future owns the exclusive `&mut self` borrow, so nothing else can
-        // access the EVM stack slot until that future is dropped.
+        // access the EVM stack slot until that future is dropped. The send marker checked above
+        // requires all erased EVM fields to have been verified by `Evm::evm_is_send`.
         unsafe {
             r#async::on_fiber_with_stack(stack, move || {
-                self.system_call(system_contract_address, data)
+                evm.system_call(system_contract_address, data)
             })
         }
     }
@@ -143,6 +152,10 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
     /// [`evm::async::AsyncDb`](crate::evm::async::AsyncDb) to take
     /// advantage of yielding database I/O. With a synchronous database this is mostly equivalent to
     /// running the synchronous system call on a fiber.
+    ///
+    /// This returns a `Send` future. Before calling it, the current erased database, precompile
+    /// provider, and optional inspector must be verified with [`Evm::evm_is_send`] or
+    /// [`Evm::evm_is_send_with_inspector`].
     #[cfg(feature = "async")]
     #[inline]
     pub fn system_call_with_caller_async(
@@ -154,14 +167,35 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
     where
         T::TxResultExt: Send,
     {
+        self.assert_erased_send();
         let stack = self.async_stack();
+        let mut evm = SendEvmRef::new(self);
         // SAFETY: The returned future owns the exclusive `&mut self` borrow, so nothing else can
-        // access the EVM stack slot until that future is dropped.
+        // access the EVM stack slot until that future is dropped. The send marker checked above
+        // requires all erased EVM fields to have been verified by `Evm::evm_is_send`.
         unsafe {
             r#async::on_fiber_with_stack(stack, move || {
-                self.system_call_with_caller(caller, system_contract_address, data)
+                evm.system_call_with_caller(caller, system_contract_address, data)
             })
         }
+    }
+}
+
+#[cfg(feature = "async")]
+impl<T: EvmTypes<Host = Evm<T>>> SendEvmRef<'_, T> {
+    #[inline]
+    fn system_call(&mut self, system_contract_address: Address, data: Bytes) -> TxResult<T> {
+        self.as_mut().system_call(system_contract_address, data)
+    }
+
+    #[inline]
+    fn system_call_with_caller(
+        &mut self,
+        caller: Address,
+        system_contract_address: Address,
+        data: Bytes,
+    ) -> TxResult<T> {
+        self.as_mut().system_call_with_caller(caller, system_contract_address, data)
     }
 }
 


### PR DESCRIPTION
This removes the default `Send` requirement from erased EVM database, precompile provider, inspector, and async database futures so local/non-threaded users can store non-`Send` implementations.

Async EVM entrypoints still return `Send` futures for Tokio spawning, but callers must first prove the currently erased concrete field types with `Evm::evm_is_send` or `Evm::evm_is_send_with_inspector`. Those methods check the current erased `TypeId`s and require the named concrete types to be `Send`; mutating erased fields clears the marker. The async entrypoints assert this marker and then capture a private send wrapper around the borrowed EVM rather than making `Evm` itself implement `Send`.

`AsyncDb` keeps a `Send` error type so it can be naturally `Send` without an unsafe impl, while its async operation futures no longer need to be `Send`.
