### PR TITLE
refactor(interpreter): rename interp locals

### DIFF
--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -652,9 +652,9 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
         gas_limit: u64,
         stop: InstrStop,
     ) -> MessageResult<T> {
-        let interpreter = self.interpreter_pool.last_mut().unwrap();
-        let mut gas = interpreter.gas();
-        let mut output = Bytes::copy_from_slice(interpreter.output());
+        let interp = self.interpreter_pool.last_mut().unwrap();
+        let mut gas = interp.gas();
+        let mut output = Bytes::copy_from_slice(interp.output());
         if stop.is_success() {
             if let Err(stop) = self.validate_create_output(&mut gas, &mut output) {
                 self.state.rollback(checkpoint, self.features);
@@ -819,9 +819,9 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
         checkpoint: StateCheckpoint,
         stop: InstrStop,
     ) -> MessageResult<T> {
-        let interpreter = self.interpreter_pool.last_mut().unwrap();
-        let child_gas = interpreter.gas();
-        let output = Bytes::copy_from_slice(interpreter.output());
+        let interp = self.interpreter_pool.last_mut().unwrap();
+        let child_gas = interp.gas();
+        let output = Bytes::copy_from_slice(interp.output());
         if !stop.is_success() {
             self.state.rollback(checkpoint, self.features);
         }
@@ -860,25 +860,25 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
         message: &'frame Message<T>,
         caller_is_static: bool,
     ) -> InstrStop {
-        let mut interpreter = self.interpreter_pool.pop();
+        let mut interp = self.interpreter_pool.pop();
         let _guard = self.enter_execution();
-        let interpreter_ref = interpreter.as_mut();
-        interpreter_ref.init(bytecode, tx_env, message, caller_is_static);
+        let interp_ref = interp.as_mut();
+        interp_ref.init(bytecode, tx_env, message, caller_is_static);
         // SAFETY: `execution_config` points to a private field that host execution does not
         // replace or mutate, so the pointee remains valid here.
         let execution_config = unsafe { trustme::decouple_lt(&self.execution_config) };
-        self.inspect_initialize_interp(interpreter_ref);
+        self.inspect_initialize_interp(interp_ref);
         let inspector = self.inspector.as_deref_mut().map(|inspector| {
             // SAFETY: The inspector is stored in `self` and remains alive for the duration of the
             // interpreter run.
             unsafe { trustme::decouple_lt_mut(inspector) }
         });
         let stop = if let Some(inspector) = inspector {
-            interpreter_ref.run_inspect(execution_config, self, inspector)
+            interp_ref.run_inspect(execution_config, self, inspector)
         } else {
-            interpreter_ref.run(execution_config, self)
+            interp_ref.run(execution_config, self)
         };
-        self.interpreter_pool.push(interpreter);
+        self.interpreter_pool.push(interp);
         stop
     }
 

--- a/crates/evm2/src/interpreter/instructions/arithmetic.rs
+++ b/crates/evm2/src/interpreter/instructions/arithmetic.rs
@@ -157,9 +157,9 @@ mod tests {
         push(&mut code, 2);
         code.extend([op::EXP, op::STOP]);
 
-        let interpreter = run(RunConfig::new(code).spec(SpecId::FRONTIER).gas_limit(25));
+        let interp = run(RunConfig::new(code).spec(SpecId::FRONTIER).gas_limit(25));
 
-        assert_matches!(interpreter.err, InstrStop::OutOfGas);
+        assert_matches!(interp.err, InstrStop::OutOfGas);
     }
 
     #[test]

--- a/crates/evm2/src/interpreter/instructions/block.rs
+++ b/crates/evm2/src/interpreter/instructions/block.rs
@@ -112,42 +112,42 @@ mod tests {
         code.push(op::BLOCKHASH);
         code.push(op::STOP);
 
-        let interpreter = run(RunConfig::new(code).host(&mut host));
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.stack(), [b256_to_word(B256::with_last_byte(9))]);
+        let interp = run(RunConfig::new(code).host(&mut host));
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.stack(), [b256_to_word(B256::with_last_byte(9))]);
 
         let mut code = Vec::new();
         push(&mut code, 10);
         code.push(op::BLOCKHASH);
         code.push(op::STOP);
-        let interpreter = run(RunConfig::new(code).host(&mut host));
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.stack(), [0]);
+        let interp = run(RunConfig::new(code).host(&mut host));
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.stack(), [0]);
     }
 
     #[test]
     fn coinbase_opcode() {
         let beneficiary = Address::from([0x44; 20]);
         let mut host = test_host(BlockEnv { beneficiary, ..BlockEnv::default() });
-        let interpreter = run(RunConfig::new([op::COINBASE, op::STOP]).host(&mut host));
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.stack(), [address_to_word(&beneficiary)]);
+        let interp = run(RunConfig::new([op::COINBASE, op::STOP]).host(&mut host));
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.stack(), [address_to_word(&beneficiary)]);
     }
 
     #[test]
     fn timestamp_opcode() {
         let mut host = test_host(BlockEnv { timestamp: Word::from(12), ..BlockEnv::default() });
-        let interpreter = run(RunConfig::new([op::TIMESTAMP, op::STOP]).host(&mut host));
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.stack(), [Word::from(12)]);
+        let interp = run(RunConfig::new([op::TIMESTAMP, op::STOP]).host(&mut host));
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.stack(), [Word::from(12)]);
     }
 
     #[test]
     fn number_opcode() {
         let mut host = test_host(BlockEnv { number: Word::from(13), ..BlockEnv::default() });
-        let interpreter = run(RunConfig::new([op::NUMBER, op::STOP]).host(&mut host));
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.stack(), [Word::from(13)]);
+        let interp = run(RunConfig::new([op::NUMBER, op::STOP]).host(&mut host));
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.stack(), [Word::from(13)]);
     }
 
     #[test]
@@ -158,35 +158,35 @@ mod tests {
             prevrandao: b256_to_word(randao),
             ..BlockEnv::default()
         });
-        let interpreter =
+        let interp =
             run(RunConfig::new([op::DIFFICULTY, op::STOP]).host(&mut host).spec(SpecId::FRONTIER));
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.stack(), [Word::from(14)]);
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.stack(), [Word::from(14)]);
 
-        let interpreter =
+        let interp =
             run(RunConfig::new([op::DIFFICULTY, op::STOP]).host(&mut host).spec(SpecId::MERGE));
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.stack(), [b256_to_word(randao)]);
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.stack(), [b256_to_word(randao)]);
     }
 
     #[test]
     fn gaslimit_opcode() {
         let mut host = test_host(BlockEnv { gas_limit: Word::from(15), ..BlockEnv::default() });
-        let interpreter = run(RunConfig::new([op::GASLIMIT, op::STOP]).host(&mut host));
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.stack(), [Word::from(15)]);
+        let interp = run(RunConfig::new([op::GASLIMIT, op::STOP]).host(&mut host));
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.stack(), [Word::from(15)]);
     }
 
     #[test]
     fn chainid_opcode() {
         let mut host = TestHost::default();
         let tx_env = TxEnv { chain_id: Word::from(1), ..TxEnv::default() };
-        let interpreter = run(RunConfig::new([op::CHAINID, op::STOP])
+        let interp = run(RunConfig::new([op::CHAINID, op::STOP])
             .host(&mut host)
             .tx_env(tx_env)
             .spec(SpecId::ISTANBUL));
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.stack(), [Word::from(1)]);
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.stack(), [Word::from(1)]);
     }
 
     #[test]
@@ -194,19 +194,19 @@ mod tests {
         let address = Address::from([0x66; 20]);
         let mut host = TestHost::default();
         let message = Message { destination: address, gas_limit: 10_000, ..Default::default() };
-        let interpreter =
+        let interp =
             run(RunConfig::new([op::SELFBALANCE, op::STOP]).host(&mut host).message(message));
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.stack(), [address_to_word(&address)]);
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.stack(), [address_to_word(&address)]);
     }
 
     #[test]
     fn basefee_opcode() {
         let mut host = test_host(BlockEnv { basefee: Word::from(16), ..BlockEnv::default() });
-        let interpreter =
+        let interp =
             run(RunConfig::new([op::BASEFEE, op::STOP]).host(&mut host).spec(SpecId::LONDON));
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.stack(), [Word::from(16)]);
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.stack(), [Word::from(16)]);
     }
 
     #[test]
@@ -215,36 +215,36 @@ mod tests {
         let mut host = TestHost::default();
         let tx_env = TxEnv { blob_hashes: Vec::from([b256_to_word(hash)]), ..TxEnv::default() };
 
-        let interpreter = run(RunConfig::new([op::PUSH0, op::BLOBHASH, op::STOP])
+        let interp = run(RunConfig::new([op::PUSH0, op::BLOBHASH, op::STOP])
             .host(&mut host)
             .tx_env(tx_env.clone())
             .spec(SpecId::CANCUN));
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.stack(), [b256_to_word(hash)]);
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.stack(), [b256_to_word(hash)]);
 
-        let interpreter = run(RunConfig::new([op::PUSH1, 0x01, op::BLOBHASH, op::STOP])
+        let interp = run(RunConfig::new([op::PUSH1, 0x01, op::BLOBHASH, op::STOP])
             .host(&mut host)
             .tx_env(tx_env)
             .spec(SpecId::CANCUN));
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.stack(), [0]);
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.stack(), [0]);
     }
 
     #[test]
     fn blobbasefee_opcode() {
         let mut host = test_host(BlockEnv { blob_basefee: Word::from(17), ..BlockEnv::default() });
-        let interpreter =
+        let interp =
             run(RunConfig::new([op::BLOBBASEFEE, op::STOP]).host(&mut host).spec(SpecId::CANCUN));
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.stack(), [Word::from(17)]);
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.stack(), [Word::from(17)]);
     }
 
     #[test]
     fn slotnum_opcode() {
         let mut host = test_host(BlockEnv { slot_num: Word::from(18), ..BlockEnv::default() });
-        let interpreter =
+        let interp =
             run(RunConfig::new([op::SLOTNUM, op::STOP]).host(&mut host).spec(SpecId::AMSTERDAM));
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.stack(), [Word::from(18)]);
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.stack(), [Word::from(18)]);
     }
 }

--- a/crates/evm2/src/interpreter/instructions/control.rs
+++ b/crates/evm2/src/interpreter/instructions/control.rs
@@ -107,44 +107,44 @@ mod tests {
 
     #[test]
     fn stop_opcode() {
-        let interpreter = run(RunConfig::new([op::STOP]));
-        assert_matches!(interpreter.err, InstrStop::Stop);
+        let interp = run(RunConfig::new([op::STOP]));
+        assert_matches!(interp.err, InstrStop::Stop);
 
-        let interpreter = run(RunConfig::new([op::STOP, op::INVALID]));
-        assert_matches!(interpreter.err, InstrStop::Stop);
+        let interp = run(RunConfig::new([op::STOP, op::INVALID]));
+        assert_matches!(interp.err, InstrStop::Stop);
     }
 
     #[test]
     fn invalid_opcode() {
-        let interpreter = run(RunConfig::new([op::INVALID]));
-        assert_matches!(interpreter.err, InstrStop::InvalidOpcode);
+        let interp = run(RunConfig::new([op::INVALID]));
+        assert_matches!(interp.err, InstrStop::InvalidOpcode);
 
-        let interpreter = run(RunConfig::new([0x0c]));
-        assert_matches!(interpreter.err, InstrStop::InvalidOpcode);
+        let interp = run(RunConfig::new([0x0c]));
+        assert_matches!(interp.err, InstrStop::InvalidOpcode);
     }
 
     #[test]
     fn jump_opcode() {
-        let interpreter = run(RunConfig::new([op::PUSH1, 0x03, op::JUMP, op::JUMPDEST, op::STOP]));
-        assert_matches!(interpreter.err, InstrStop::Stop);
+        let interp = run(RunConfig::new([op::PUSH1, 0x03, op::JUMP, op::JUMPDEST, op::STOP]));
+        assert_matches!(interp.err, InstrStop::Stop);
 
-        let interpreter = run(RunConfig::new([op::PUSH1, 0x00, op::JUMP, op::JUMPDEST, op::STOP]));
-        assert_matches!(interpreter.err, InstrStop::InvalidJump);
+        let interp = run(RunConfig::new([op::PUSH1, 0x00, op::JUMP, op::JUMPDEST, op::STOP]));
+        assert_matches!(interp.err, InstrStop::InvalidJump);
 
         let mut code = Vec::new();
         push(&mut code, Word::MAX);
         code.push(op::JUMP);
-        let interpreter = run(RunConfig::new(code));
-        assert_matches!(interpreter.err, InstrStop::InvalidJump);
+        let interp = run(RunConfig::new(code));
+        assert_matches!(interp.err, InstrStop::InvalidJump);
 
-        let interpreter =
+        let interp =
             run(RunConfig::new([op::PUSH1, 0x04, op::JUMP, op::STOP, op::JUMPDEST, op::STOP]));
-        assert_matches!(interpreter.err, InstrStop::Stop);
+        assert_matches!(interp.err, InstrStop::Stop);
     }
 
     #[test]
     fn jumpi_opcode() {
-        let interpreter = run(RunConfig::new([
+        let interp = run(RunConfig::new([
             op::PUSH1,
             0x01,
             op::PUSH1,
@@ -154,9 +154,9 @@ mod tests {
             op::JUMPDEST,
             op::STOP,
         ]));
-        assert_matches!(interpreter.err, InstrStop::Stop);
+        assert_matches!(interp.err, InstrStop::Stop);
 
-        let interpreter = run(RunConfig::new([
+        let interp = run(RunConfig::new([
             op::PUSH1,
             0x00,
             op::PUSH1,
@@ -165,65 +165,65 @@ mod tests {
             op::JUMPDEST,
             op::STOP,
         ]));
-        assert_matches!(interpreter.err, InstrStop::Stop);
+        assert_matches!(interp.err, InstrStop::Stop);
 
-        let interpreter =
+        let interp =
             run(RunConfig::new([op::PUSH1, 0x01, op::PUSH1, 0x05, op::JUMPI, op::STOP, op::STOP]));
-        assert_matches!(interpreter.err, InstrStop::InvalidJump);
+        assert_matches!(interp.err, InstrStop::InvalidJump);
 
         let mut code = Vec::new();
         push(&mut code, 1);
         push(&mut code, Word::MAX);
         code.push(op::JUMPI);
-        let interpreter = run(RunConfig::new(code));
-        assert_matches!(interpreter.err, InstrStop::InvalidJump);
+        let interp = run(RunConfig::new(code));
+        assert_matches!(interp.err, InstrStop::InvalidJump);
     }
 
     #[test]
     fn pc_opcode() {
-        let interpreter = run(RunConfig::new([op::PC, op::JUMPDEST, op::STOP]));
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.stack(), [0]);
+        let interp = run(RunConfig::new([op::PC, op::JUMPDEST, op::STOP]));
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.stack(), [0]);
 
-        let interpreter = run(RunConfig::new([op::JUMPDEST, op::PC, op::STOP]));
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.stack(), [Word::from(1)]);
+        let interp = run(RunConfig::new([op::JUMPDEST, op::PC, op::STOP]));
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.stack(), [Word::from(1)]);
     }
 
     #[test]
     fn gas_opcode() {
-        let interpreter = run(RunConfig::new([op::GAS, op::STOP]));
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.stack().len(), 1);
-        assert!(interpreter.stack()[0] < Word::from(10_000));
+        let interp = run(RunConfig::new([op::GAS, op::STOP]));
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.stack().len(), 1);
+        assert!(interp.stack()[0] < Word::from(10_000));
 
-        let interpreter = run(RunConfig::new([op::GAS, op::GAS, op::STOP]));
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.stack().len(), 2);
-        assert!(interpreter.stack()[1] < interpreter.stack()[0]);
+        let interp = run(RunConfig::new([op::GAS, op::GAS, op::STOP]));
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.stack().len(), 2);
+        assert!(interp.stack()[1] < interp.stack()[0]);
     }
 
     #[test]
     fn jumpdest_opcode() {
-        let interpreter = run(RunConfig::new([op::JUMPDEST, op::STOP]));
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert!(interpreter.stack().is_empty());
+        let interp = run(RunConfig::new([op::JUMPDEST, op::STOP]));
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert!(interp.stack().is_empty());
 
-        let interpreter = run(RunConfig::new([op::JUMPDEST, op::JUMPDEST, op::STOP]));
-        assert_matches!(interpreter.err, InstrStop::Stop);
+        let interp = run(RunConfig::new([op::JUMPDEST, op::JUMPDEST, op::STOP]));
+        assert_matches!(interp.err, InstrStop::Stop);
     }
 
     #[test]
     fn return_opcode() {
-        let mut interpreter = run_stack([0, 0], op::RETURN);
-        assert_matches!(interpreter.err, InstrStop::Return);
-        assert!(interpreter.memory(0, 0).is_empty());
-        assert!(interpreter.output().is_empty());
+        let mut interp = run_stack([0, 0], op::RETURN);
+        assert_matches!(interp.err, InstrStop::Return);
+        assert!(interp.memory(0, 0).is_empty());
+        assert!(interp.output().is_empty());
 
-        let mut interpreter = run_stack([0, 1], op::RETURN);
-        assert_matches!(interpreter.err, InstrStop::Return);
-        assert_eq!(interpreter.memory(0, 1), [0]);
-        assert_eq!(interpreter.output(), [0]);
+        let mut interp = run_stack([0, 1], op::RETURN);
+        assert_matches!(interp.err, InstrStop::Return);
+        assert_eq!(interp.memory(0, 1), [0]);
+        assert_eq!(interp.output(), [0]);
 
         let mut code = Vec::new();
         push(&mut code, Word::from(0xab));
@@ -232,28 +232,28 @@ mod tests {
         push(&mut code, Word::from(3));
         push(&mut code, Word::from(2));
         code.push(op::RETURN);
-        let interpreter = run(RunConfig::new(code));
-        assert_matches!(interpreter.err, InstrStop::Return);
-        assert_eq!(interpreter.output(), [0xab, 0, 0]);
+        let interp = run(RunConfig::new(code));
+        assert_matches!(interp.err, InstrStop::Return);
+        assert_eq!(interp.output(), [0xab, 0, 0]);
 
-        let interpreter = run_stack([Word::from(0), Word::MAX], op::RETURN);
-        assert_matches!(interpreter.err, InstrStop::InvalidOperandOOG);
+        let interp = run_stack([Word::from(0), Word::MAX], op::RETURN);
+        assert_matches!(interp.err, InstrStop::InvalidOperandOOG);
 
-        let interpreter = run_stack([Word::from(u32::MAX), Word::from(1)], op::RETURN);
-        assert_matches!(interpreter.err, InstrStop::MemoryLimitOOG);
+        let interp = run_stack([Word::from(u32::MAX), Word::from(1)], op::RETURN);
+        assert_matches!(interp.err, InstrStop::MemoryLimitOOG);
     }
 
     #[test]
     fn revert_opcode() {
-        let mut interpreter = run_stack([0, 0], op::REVERT);
-        assert_matches!(interpreter.err, InstrStop::Revert);
-        assert!(interpreter.memory(0, 0).is_empty());
-        assert!(interpreter.output().is_empty());
+        let mut interp = run_stack([0, 0], op::REVERT);
+        assert_matches!(interp.err, InstrStop::Revert);
+        assert!(interp.memory(0, 0).is_empty());
+        assert!(interp.output().is_empty());
 
-        let mut interpreter = run_stack([2, 3], op::REVERT);
-        assert_matches!(interpreter.err, InstrStop::Revert);
-        assert_eq!(interpreter.memory(2, 3), [0, 0, 0]);
-        assert_eq!(interpreter.output(), [0, 0, 0]);
+        let mut interp = run_stack([2, 3], op::REVERT);
+        assert_matches!(interp.err, InstrStop::Revert);
+        assert_eq!(interp.memory(2, 3), [0, 0, 0]);
+        assert_eq!(interp.output(), [0, 0, 0]);
 
         let mut code = Vec::new();
         push(&mut code, Word::from(0xcd));
@@ -262,14 +262,14 @@ mod tests {
         push(&mut code, Word::from(2));
         push(&mut code, Word::from(4));
         code.push(op::REVERT);
-        let interpreter = run(RunConfig::new(code));
-        assert_matches!(interpreter.err, InstrStop::Revert);
-        assert_eq!(interpreter.output(), [0xcd, 0]);
+        let interp = run(RunConfig::new(code));
+        assert_matches!(interp.err, InstrStop::Revert);
+        assert_eq!(interp.output(), [0xcd, 0]);
 
-        let interpreter = run_stack([Word::from(0), Word::MAX], op::REVERT);
-        assert_matches!(interpreter.err, InstrStop::InvalidOperandOOG);
+        let interp = run_stack([Word::from(0), Word::MAX], op::REVERT);
+        assert_matches!(interp.err, InstrStop::InvalidOperandOOG);
 
-        let interpreter = run_stack([Word::from(u32::MAX), Word::from(1)], op::REVERT);
-        assert_matches!(interpreter.err, InstrStop::MemoryLimitOOG);
+        let interp = run_stack([Word::from(u32::MAX), Word::from(1)], op::REVERT);
+        assert_matches!(interp.err, InstrStop::MemoryLimitOOG);
     }
 }

--- a/crates/evm2/src/interpreter/instructions/crypto.rs
+++ b/crates/evm2/src/interpreter/instructions/crypto.rs
@@ -40,9 +40,9 @@ mod tests {
         push(&mut code, 0);
         code.push(op::KECCAK256);
         code.push(op::STOP);
-        let interpreter = run(RunConfig::new(code));
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.stack(), [b256_to_word(keccak256([]))]);
+        let interp = run(RunConfig::new(code));
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.stack(), [b256_to_word(keccak256([]))]);
 
         let mut code = Vec::new();
         push(&mut code, Word::from(0x80));
@@ -52,15 +52,15 @@ mod tests {
         push(&mut code, 0);
         code.push(op::KECCAK256);
         code.push(op::STOP);
-        let interpreter = run(RunConfig::new(code));
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.stack(), [b256_to_word(keccak256([0x80]))]);
+        let interp = run(RunConfig::new(code));
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.stack(), [b256_to_word(keccak256([0x80]))]);
 
-        let interpreter = run_stack([Word::MAX, Word::from(0)], op::KECCAK256);
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.stack(), [b256_to_word(keccak256([]))]);
+        let interp = run_stack([Word::MAX, Word::from(0)], op::KECCAK256);
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.stack(), [b256_to_word(keccak256([]))]);
 
-        let interpreter = run_stack([Word::MAX, Word::from(1)], op::KECCAK256);
-        assert_matches!(interpreter.err, InstrStop::InvalidOperandOOG);
+        let interp = run_stack([Word::MAX, Word::from(1)], op::KECCAK256);
+        assert_matches!(interp.err, InstrStop::InvalidOperandOOG);
     }
 }

--- a/crates/evm2/src/interpreter/instructions/env.rs
+++ b/crates/evm2/src/interpreter/instructions/env.rs
@@ -203,10 +203,9 @@ mod tests {
         let address = Address::from([0x11; 20]);
         let mut host = TestHost::default();
         let message = Message { destination: address, ..test_message() };
-        let interpreter =
-            run(RunConfig::new([op::ADDRESS, op::STOP]).host(&mut host).message(message));
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.stack(), [address_to_word(&address)]);
+        let interp = run(RunConfig::new([op::ADDRESS, op::STOP]).host(&mut host).message(message));
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.stack(), [address_to_word(&address)]);
     }
 
     #[test]
@@ -219,22 +218,22 @@ mod tests {
     #[test]
     fn balance_cold_account_cost() {
         let mut host = TestHost { is_cold: true, ..TestHost::default() };
-        let interpreter = run(RunConfig::new([op::PUSH1, 0xbe, op::BALANCE, op::STOP])
+        let interp = run(RunConfig::new([op::PUSH1, 0xbe, op::BALANCE, op::STOP])
             .host(&mut host)
             .spec(SpecId::BERLIN));
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.stack(), [Word::from(0xbe)]);
-        assert_eq!(interpreter.gas_remaining(), 7_397);
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.stack(), [Word::from(0xbe)]);
+        assert_eq!(interp.gas_remaining(), 7_397);
     }
 
     #[test]
     fn balance_cold_account_skip_oog() {
         let mut host = TestHost { is_cold: true, ..TestHost::default() };
-        let interpreter = run(RunConfig::new([op::PUSH1, 0xbe, op::BALANCE, op::STOP])
+        let interp = run(RunConfig::new([op::PUSH1, 0xbe, op::BALANCE, op::STOP])
             .host(&mut host)
             .spec(SpecId::BERLIN)
             .gas_limit(103));
-        assert_matches!(interpreter.err, InstrStop::OutOfGas);
+        assert_matches!(interp.err, InstrStop::OutOfGas);
     }
 
     #[test]
@@ -242,10 +241,9 @@ mod tests {
         let origin = Address::from([0x22; 20]);
         let mut host = TestHost::default();
         let tx_env = TxEnv { origin, ..TxEnv::default() };
-        let interpreter =
-            run(RunConfig::new([op::ORIGIN, op::STOP]).host(&mut host).tx_env(tx_env));
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.stack(), [address_to_word(&origin)]);
+        let interp = run(RunConfig::new([op::ORIGIN, op::STOP]).host(&mut host).tx_env(tx_env));
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.stack(), [address_to_word(&origin)]);
     }
 
     #[test]
@@ -253,20 +251,19 @@ mod tests {
         let caller = Address::from([0x33; 20]);
         let mut host = TestHost::default();
         let message = Message { caller, ..test_message() };
-        let interpreter =
-            run(RunConfig::new([op::CALLER, op::STOP]).host(&mut host).message(message));
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.stack(), [address_to_word(&caller)]);
+        let interp = run(RunConfig::new([op::CALLER, op::STOP]).host(&mut host).message(message));
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.stack(), [address_to_word(&caller)]);
     }
 
     #[test]
     fn callvalue_opcode() {
         let mut host = TestHost::default();
         let message = Message { value: Word::from(0xbeef), ..test_message() };
-        let interpreter =
+        let interp =
             run(RunConfig::new([op::CALLVALUE, op::STOP]).host(&mut host).message(message));
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.stack(), [Word::from(0xbeef)]);
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.stack(), [Word::from(0xbeef)]);
     }
 
     #[test]
@@ -275,19 +272,19 @@ mod tests {
         let mut host = TestHost::default();
         let message = Message { input, ..test_message() };
 
-        let interpreter = run(RunConfig::new([op::PUSH0, op::CALLDATALOAD, op::STOP])
+        let interp = run(RunConfig::new([op::PUSH0, op::CALLDATALOAD, op::STOP])
             .host(&mut host)
             .message(message.clone()));
         let mut expected = [0_u8; 32];
         expected[..3].copy_from_slice(&[1, 2, 3]);
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.stack(), [Word::from_be_bytes(expected)]);
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.stack(), [Word::from_be_bytes(expected)]);
 
-        let interpreter = run(RunConfig::new([op::PUSH1, 0x20, op::CALLDATALOAD, op::STOP])
+        let interp = run(RunConfig::new([op::PUSH1, 0x20, op::CALLDATALOAD, op::STOP])
             .host(&mut host)
             .message(message));
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.stack(), [0]);
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.stack(), [0]);
     }
 
     #[test]
@@ -295,10 +292,10 @@ mod tests {
         let input = Bytes::from(Vec::from([1_u8, 2, 3, 4]));
         let mut host = TestHost::default();
         let message = Message { input, ..test_message() };
-        let interpreter =
+        let interp =
             run(RunConfig::new([op::CALLDATASIZE, op::STOP]).host(&mut host).message(message));
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.stack(), [Word::from(4)]);
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.stack(), [Word::from(4)]);
     }
 
     #[test]
@@ -315,30 +312,30 @@ mod tests {
         code.push(op::MLOAD);
         code.push(op::STOP);
 
-        let interpreter = run(RunConfig::new(code).host(&mut host).message(message.clone()));
+        let interp = run(RunConfig::new(code).host(&mut host).message(message.clone()));
         let mut expected = [0_u8; 32];
         expected[..2].copy_from_slice(&[0xbb, 0xcc]);
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.stack(), [Word::from_be_bytes(expected)]);
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.stack(), [Word::from_be_bytes(expected)]);
 
-        let interpreter = run(RunConfig::new(stack_code(
+        let interp = run(RunConfig::new(stack_code(
             [Word::MAX, Word::MAX, Word::from(0)],
             op::CALLDATACOPY,
         ))
         .host(&mut host)
         .message(message));
-        assert_matches!(interpreter.err, InstrStop::Stop);
+        assert_matches!(interp.err, InstrStop::Stop);
     }
 
     #[test]
     fn codesize_opcode() {
-        let interpreter = run(RunConfig::new([op::CODESIZE, op::STOP]));
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.stack(), [Word::from(2)]);
+        let interp = run(RunConfig::new([op::CODESIZE, op::STOP]));
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.stack(), [Word::from(2)]);
 
-        let interpreter = run(RunConfig::new([op::PUSH1, 0x00, op::CODESIZE, op::STOP]));
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.stack(), [Word::from(0), Word::from(4)]);
+        let interp = run(RunConfig::new([op::PUSH1, 0x00, op::CODESIZE, op::STOP]));
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.stack(), [Word::from(0), Word::from(4)]);
     }
 
     #[test]
@@ -352,11 +349,11 @@ mod tests {
         code.push(op::MLOAD);
         code.push(op::STOP);
 
-        let interpreter = run(RunConfig::new(code));
+        let interp = run(RunConfig::new(code));
         let mut expected = [0u8; 32];
         expected[..2].copy_from_slice(&[0, op::CODECOPY]);
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.stack(), [Word::from_be_bytes(expected)]);
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.stack(), [Word::from_be_bytes(expected)]);
 
         let mut code = Vec::new();
         push(&mut code, Word::from(1));
@@ -366,34 +363,33 @@ mod tests {
         push(&mut code, 0);
         code.push(op::MLOAD);
         code.push(op::STOP);
-        let interpreter = run(RunConfig::new(code));
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.stack(), [0]);
+        let interp = run(RunConfig::new(code));
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.stack(), [0]);
 
-        let interpreter = run_stack([Word::MAX, Word::MAX, Word::from(0)], op::CODECOPY);
-        assert_matches!(interpreter.err, InstrStop::Stop);
+        let interp = run_stack([Word::MAX, Word::MAX, Word::from(0)], op::CODECOPY);
+        assert_matches!(interp.err, InstrStop::Stop);
 
-        let interpreter = run_stack([Word::MAX, Word::from(0), Word::from(1)], op::CODECOPY);
-        assert_matches!(interpreter.err, InstrStop::InvalidOperandOOG);
+        let interp = run_stack([Word::MAX, Word::from(0), Word::from(1)], op::CODECOPY);
+        assert_matches!(interp.err, InstrStop::InvalidOperandOOG);
     }
 
     #[test]
     fn gasprice_opcode() {
         let mut host = TestHost::default();
         let tx_env = TxEnv { gas_price: Word::from(0x1234), ..TxEnv::default() };
-        let interpreter =
-            run(RunConfig::new([op::GASPRICE, op::STOP]).host(&mut host).tx_env(tx_env));
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.stack(), [Word::from(0x1234)]);
+        let interp = run(RunConfig::new([op::GASPRICE, op::STOP]).host(&mut host).tx_env(tx_env));
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.stack(), [Word::from(0x1234)]);
     }
 
     #[test]
     fn extcodesize_opcode() {
         let mut host = TestHost { code: Bytes::from(vec![0; 0x42]), ..TestHost::default() };
-        let interpreter =
+        let interp =
             run(RunConfig::new([op::PUSH1, 0xbe, op::EXTCODESIZE, op::STOP]).host(&mut host));
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.stack(), [Word::from(0x42)]);
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.stack(), [Word::from(0x42)]);
     }
 
     #[test]
@@ -410,11 +406,11 @@ mod tests {
         code.push(op::MLOAD);
         code.push(op::STOP);
 
-        let interpreter = run(RunConfig::new(code).host(&mut host));
+        let interp = run(RunConfig::new(code).host(&mut host));
         let mut expected = [0_u8; 32];
         expected[..2].copy_from_slice(&[0xbb, 0xcc]);
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.stack(), [Word::from_be_bytes(expected)]);
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.stack(), [Word::from_be_bytes(expected)]);
 
         let mut code = Vec::new();
         push(&mut code, 4);
@@ -425,37 +421,37 @@ mod tests {
         push(&mut code, 0);
         code.push(op::MLOAD);
         code.push(op::STOP);
-        let interpreter = run(RunConfig::new(code).host(&mut host));
+        let interp = run(RunConfig::new(code).host(&mut host));
         let mut expected = [0_u8; 32];
         expected[..1].copy_from_slice(&[0xcc]);
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.stack(), [Word::from_be_bytes(expected)]);
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.stack(), [Word::from_be_bytes(expected)]);
 
-        let interpreter = run(RunConfig::new(stack_code(
+        let interp = run(RunConfig::new(stack_code(
             [Word::from(0xbeef), Word::MAX, Word::MAX, Word::from(0)],
             op::EXTCODECOPY,
         ))
         .host(&mut host));
-        assert_matches!(interpreter.err, InstrStop::Stop);
+        assert_matches!(interp.err, InstrStop::Stop);
 
-        let interpreter = run(RunConfig::new(stack_code(
+        let interp = run(RunConfig::new(stack_code(
             [Word::from(0xbeef), Word::MAX, Word::from(0), Word::from(1)],
             op::EXTCODECOPY,
         ))
         .host(&mut host));
-        assert_matches!(interpreter.err, InstrStop::InvalidOperandOOG);
+        assert_matches!(interp.err, InstrStop::InvalidOperandOOG);
     }
 
     #[test]
     fn returndatasize_opcode() {
-        let interpreter = run(RunConfig::new([op::RETURNDATASIZE, op::STOP])
+        let interp = run(RunConfig::new([op::RETURNDATASIZE, op::STOP])
             .spec(SpecId::BYZANTIUM)
             .return_data(Bytes::from_static(&[0xaa, 0xbb, 0xcc])));
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.stack(), [Word::from(3)]);
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.stack(), [Word::from(3)]);
 
-        let interpreter = run(RunConfig::new([op::RETURNDATASIZE]).spec(SpecId::FRONTIER));
-        assert_matches!(interpreter.err, InstrStop::InvalidOpcode);
+        let interp = run(RunConfig::new([op::RETURNDATASIZE]).spec(SpecId::FRONTIER));
+        assert_matches!(interp.err, InstrStop::InvalidOpcode);
     }
 
     #[test]
@@ -469,58 +465,57 @@ mod tests {
         code.push(op::MLOAD);
         code.push(op::STOP);
 
-        let interpreter =
-            run(RunConfig::new(code).return_data(Bytes::from_static(&[0xaa, 0xbb, 0xcc])));
+        let interp = run(RunConfig::new(code).return_data(Bytes::from_static(&[0xaa, 0xbb, 0xcc])));
         let mut expected = [0_u8; 32];
         expected[..2].copy_from_slice(&[0xbb, 0xcc]);
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.stack(), [Word::from_be_bytes(expected)]);
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.stack(), [Word::from_be_bytes(expected)]);
 
-        let interpreter = run(RunConfig::new(stack_code(
+        let interp = run(RunConfig::new(stack_code(
             [Word::from(0), Word::from(3), Word::from(0)],
             op::RETURNDATACOPY,
         ))
         .spec(SpecId::BYZANTIUM)
         .return_data(Bytes::from_static(&[0xaa, 0xbb, 0xcc])));
-        assert_matches!(interpreter.err, InstrStop::Stop);
+        assert_matches!(interp.err, InstrStop::Stop);
 
-        let interpreter = run(RunConfig::new(stack_code(
+        let interp = run(RunConfig::new(stack_code(
             [Word::from(0), Word::from(4), Word::from(0)],
             op::RETURNDATACOPY,
         ))
         .spec(SpecId::BYZANTIUM)
         .return_data(Bytes::from_static(&[0xaa, 0xbb, 0xcc])));
-        assert_matches!(interpreter.err, InstrStop::OutOfOffset);
+        assert_matches!(interp.err, InstrStop::OutOfOffset);
 
-        let interpreter = run(RunConfig::new(stack_code(
+        let interp = run(RunConfig::new(stack_code(
             [Word::MAX, Word::from(0), Word::from(1)],
             op::RETURNDATACOPY,
         ))
         .spec(SpecId::BYZANTIUM)
         .return_data(Bytes::from_static(&[0xaa])));
-        assert_matches!(interpreter.err, InstrStop::InvalidOperandOOG);
+        assert_matches!(interp.err, InstrStop::InvalidOperandOOG);
 
-        let interpreter = run(RunConfig::new(stack_code(
+        let interp = run(RunConfig::new(stack_code(
             [Word::from(0), Word::from(0), Word::from(0)],
             op::RETURNDATACOPY,
         ))
         .spec(SpecId::FRONTIER));
-        assert_matches!(interpreter.err, InstrStop::InvalidOpcode);
+        assert_matches!(interp.err, InstrStop::InvalidOpcode);
     }
 
     #[test]
     fn extcodehash_opcode() {
         let hash = B256::with_last_byte(0x77);
         let mut host = TestHost { code_hash: hash, ..TestHost::default() };
-        let interpreter = run(RunConfig::new([op::PUSH1, 0xbe, op::EXTCODEHASH, op::STOP])
+        let interp = run(RunConfig::new([op::PUSH1, 0xbe, op::EXTCODEHASH, op::STOP])
             .host(&mut host)
             .spec(SpecId::PETERSBURG));
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.stack(), [b256_to_word(hash)]);
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.stack(), [b256_to_word(hash)]);
 
-        let interpreter = run(RunConfig::new([op::PUSH1, 0xbe, op::EXTCODEHASH, op::STOP])
+        let interp = run(RunConfig::new([op::PUSH1, 0xbe, op::EXTCODEHASH, op::STOP])
             .host(&mut host)
             .spec(SpecId::BYZANTIUM));
-        assert_matches!(interpreter.err, InstrStop::InvalidOpcode);
+        assert_matches!(interp.err, InstrStop::InvalidOpcode);
     }
 }

--- a/crates/evm2/src/interpreter/instructions/host.rs
+++ b/crates/evm2/src/interpreter/instructions/host.rs
@@ -148,16 +148,16 @@ mod tests {
         let mut code = Vec::new();
         push(&mut code, 1);
         code.extend([op::SLOAD, op::STOP]);
-        let interpreter = run(RunConfig::new(code).host(&mut host));
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.stack(), [Word::from(0xbeef)]);
+        let interp = run(RunConfig::new(code).host(&mut host));
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.stack(), [Word::from(0xbeef)]);
 
         let mut code = Vec::new();
         push(&mut code, 2);
         code.extend([op::SLOAD, op::STOP]);
-        let interpreter = run(RunConfig::new(code).host(&mut host));
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.stack(), [0]);
+        let interp = run(RunConfig::new(code).host(&mut host));
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.stack(), [0]);
     }
 
     #[test]
@@ -170,9 +170,9 @@ mod tests {
         push(&mut code, 1);
         code.extend([op::SLOAD, op::STOP]);
 
-        let interpreter = run(RunConfig::new(code).host(&mut host).gas_limit(30_000));
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.stack(), [Word::from(0xbeef)]);
+        let interp = run(RunConfig::new(code).host(&mut host).gas_limit(30_000));
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.stack(), [Word::from(0xbeef)]);
         assert_eq!(
             host.storage.get(&StorageKey::new(Address::ZERO, Word::from(1))),
             Some(&Word::from(0xbeef))
@@ -187,9 +187,9 @@ mod tests {
         push(&mut code, 1);
         code.extend([op::SSTORE, op::STOP]);
 
-        let interpreter = run(RunConfig::new(code).host(&mut host).staticcall());
-        assert_matches!(interpreter.err, InstrStop::StateChangeDuringStaticCall);
-        assert!(interpreter.stack().is_empty());
+        let interp = run(RunConfig::new(code).host(&mut host).staticcall());
+        assert_matches!(interp.err, InstrStop::StateChangeDuringStaticCall);
+        assert!(interp.stack().is_empty());
         assert_eq!(host.storage.get(&StorageKey::new(Address::ZERO, Word::from(1))), None);
     }
 
@@ -203,10 +203,10 @@ mod tests {
         let message =
             Message { kind: MessageKind::StaticCall, gas_limit: 10_000, ..Default::default() };
 
-        let interpreter = run(RunConfig::new(code).host(&mut host).message(message));
+        let interp = run(RunConfig::new(code).host(&mut host).message(message));
 
-        assert_matches!(interpreter.err, InstrStop::StateChangeDuringStaticCall);
-        assert!(interpreter.stack().is_empty());
+        assert_matches!(interp.err, InstrStop::StateChangeDuringStaticCall);
+        assert!(interp.stack().is_empty());
         assert_eq!(host.storage.get(&StorageKey::new(Address::ZERO, Word::from(1))), None);
     }
 
@@ -218,33 +218,33 @@ mod tests {
         push(&mut code, 1);
         code.extend([op::SSTORE, op::STOP]);
 
-        let interpreter =
+        let interp =
             run(RunConfig::new(code).host(&mut host).spec(SpecId::ISTANBUL).gas_limit(2306));
-        assert_matches!(interpreter.err, InstrStop::ReentrancySentryOOG);
+        assert_matches!(interp.err, InstrStop::ReentrancySentryOOG);
         assert_eq!(host.storage.get(&StorageKey::new(Address::ZERO, Word::from(1))), None);
     }
 
     #[test]
     fn sstore_static_gas() {
         let mut host = TestHost::default();
-        let interpreter = run(RunConfig::new([op::PUSH1, 0, op::PUSH1, 0, op::SSTORE, op::STOP])
+        let interp = run(RunConfig::new([op::PUSH1, 0, op::PUSH1, 0, op::SSTORE, op::STOP])
             .host(&mut host)
             .spec(SpecId::FRONTIER)
             .gas_limit(6000));
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.gas_remaining(), 994);
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.gas_remaining(), 994);
     }
 
     #[test]
     fn sstore_noop_uses_warm_load_gas() {
         let mut host = TestHost::default();
-        let interpreter = run(RunConfig::new([op::PUSH1, 0, op::PUSH1, 0, op::SSTORE, op::STOP])
+        let interp = run(RunConfig::new([op::PUSH1, 0, op::PUSH1, 0, op::SSTORE, op::STOP])
             .host(&mut host)
             .spec(SpecId::BERLIN)
             .gas_limit(3000));
 
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.gas_remaining(), 2894);
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.gas_remaining(), 2894);
     }
 
     #[test]
@@ -258,12 +258,12 @@ mod tests {
         push(&mut code, 0);
         code.extend([op::SSTORE, op::STOP]);
 
-        let interpreter =
+        let interp =
             run(RunConfig::new(code).host(&mut host).spec(SpecId::BERLIN).gas_limit(50_000));
 
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.gas_remaining(), 29_888);
-        assert_eq!(interpreter.gas_refunded(), 0);
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.gas_remaining(), 29_888);
+        assert_eq!(interp.gas_refunded(), 0);
     }
 
     #[test]
@@ -278,25 +278,25 @@ mod tests {
         push(&mut code, 0);
         code.extend([op::SSTORE, op::STOP]);
 
-        let interpreter =
+        let interp =
             run(RunConfig::new(code).host(&mut host).spec(SpecId::BERLIN).gas_limit(50_000));
 
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.gas_remaining(), 46_988);
-        assert_eq!(interpreter.gas_refunded(), 2_800);
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.gas_remaining(), 46_988);
+        assert_eq!(interp.gas_refunded(), 2_800);
     }
 
     #[test]
     fn sstore_amsterdam_new_slot_charges_state_gas() {
         let mut host = TestHost::default();
-        let interpreter = run(RunConfig::new([op::PUSH1, 1, op::PUSH1, 0, op::SSTORE, op::STOP])
+        let interp = run(RunConfig::new([op::PUSH1, 1, op::PUSH1, 0, op::SSTORE, op::STOP])
             .host(&mut host)
             .spec(SpecId::AMSTERDAM)
             .gas_limit(100_000));
 
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.gas_remaining(), 59_526);
-        assert_eq!(interpreter.state_gas_spent(), 37_568);
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.gas_remaining(), 59_526);
+        assert_eq!(interp.state_gas_spent(), 37_568);
     }
 
     #[test]
@@ -308,15 +308,15 @@ mod tests {
         let mut code = Vec::new();
         push(&mut code, 1);
         code.extend([op::TLOAD, op::STOP]);
-        let interpreter = run(RunConfig::new(code).host(&mut host).spec(SpecId::CANCUN));
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.stack(), [Word::from(0xcafe)]);
+        let interp = run(RunConfig::new(code).host(&mut host).spec(SpecId::CANCUN));
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.stack(), [Word::from(0xcafe)]);
 
-        let interpreter = run(RunConfig::new([op::PUSH1, 0, op::TLOAD, op::STOP])
+        let interp = run(RunConfig::new([op::PUSH1, 0, op::TLOAD, op::STOP])
             .host(&mut host)
             .spec(SpecId::SHANGHAI));
-        assert_matches!(interpreter.err, InstrStop::InvalidOpcode);
-        assert_eq!(interpreter.stack(), [0]);
+        assert_matches!(interp.err, InstrStop::InvalidOpcode);
+        assert_eq!(interp.stack(), [0]);
     }
 
     #[test]
@@ -329,19 +329,19 @@ mod tests {
         push(&mut code, 1);
         code.extend([op::TLOAD, op::STOP]);
 
-        let interpreter = run(RunConfig::new(code).host(&mut host).spec(SpecId::CANCUN));
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.stack(), [Word::from(0xcafe)]);
+        let interp = run(RunConfig::new(code).host(&mut host).spec(SpecId::CANCUN));
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.stack(), [Word::from(0xcafe)]);
         assert_eq!(
             host.transient_storage.get(&StorageKey::new(Address::ZERO, Word::from(1))),
             Some(&Word::from(0xcafe))
         );
 
-        let interpreter = run(RunConfig::new([op::PUSH1, 0, op::PUSH1, 0, op::TSTORE, op::STOP])
+        let interp = run(RunConfig::new([op::PUSH1, 0, op::PUSH1, 0, op::TSTORE, op::STOP])
             .host(&mut host)
             .spec(SpecId::SHANGHAI));
-        assert_matches!(interpreter.err, InstrStop::InvalidOpcode);
-        assert_eq!(interpreter.stack(), [0, 0]);
+        assert_matches!(interp.err, InstrStop::InvalidOpcode);
+        assert_eq!(interp.stack(), [0, 0]);
     }
 
     #[test]
@@ -352,10 +352,9 @@ mod tests {
         push(&mut code, 1);
         code.extend([op::TSTORE, op::STOP]);
 
-        let interpreter =
-            run(RunConfig::new(code).host(&mut host).spec(SpecId::CANCUN).staticcall());
-        assert_matches!(interpreter.err, InstrStop::StateChangeDuringStaticCall);
-        assert!(interpreter.stack().is_empty());
+        let interp = run(RunConfig::new(code).host(&mut host).spec(SpecId::CANCUN).staticcall());
+        assert_matches!(interp.err, InstrStop::StateChangeDuringStaticCall);
+        assert!(interp.stack().is_empty());
         assert_eq!(
             host.transient_storage.get(&StorageKey::new(Address::ZERO, Word::from(1))),
             None
@@ -382,9 +381,9 @@ mod tests {
         let mut host = TestHost::default();
         let address = Address::from([0x11; 20]);
         let message = Message { destination: address, gas_limit: 10_000, ..Default::default() };
-        let interpreter = run(RunConfig::new(log_code(30, 2, [])).host(&mut host).message(message));
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert!(interpreter.stack().is_empty());
+        let interp = run(RunConfig::new(log_code(30, 2, [])).host(&mut host).message(message));
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert!(interp.stack().is_empty());
         assert_eq!(host.logs.len(), 1);
         assert_eq!(host.logs[0].address, address);
         assert!(host.logs[0].topics().is_empty());
@@ -394,8 +393,8 @@ mod tests {
     #[test]
     fn log1_opcode() {
         let mut host = TestHost::default();
-        let interpreter = run(RunConfig::new(log_code(30, 2, [Word::from(1)])).host(&mut host));
-        assert_matches!(interpreter.err, InstrStop::Stop);
+        let interp = run(RunConfig::new(log_code(30, 2, [Word::from(1)])).host(&mut host));
+        assert_matches!(interp.err, InstrStop::Stop);
         assert_eq!(host.logs[0].topics(), &[B256::from(Word::from(1).to_be_bytes::<32>())]);
         assert_eq!(host.logs[0].data.data, Bytes::from_static(&[0xbe, 0xef]));
     }
@@ -403,9 +402,9 @@ mod tests {
     #[test]
     fn log2_opcode() {
         let mut host = TestHost::default();
-        let interpreter =
+        let interp =
             run(RunConfig::new(log_code(30, 0, [Word::from(1), Word::from(2)])).host(&mut host));
-        assert_matches!(interpreter.err, InstrStop::Stop);
+        assert_matches!(interp.err, InstrStop::Stop);
         assert_eq!(
             host.logs[0].topics(),
             &[
@@ -419,10 +418,10 @@ mod tests {
     #[test]
     fn log3_opcode() {
         let mut host = TestHost::default();
-        let interpreter =
+        let interp =
             run(RunConfig::new(log_code(30, 1, [Word::from(1), Word::from(2), Word::from(3)]))
                 .host(&mut host));
-        assert_matches!(interpreter.err, InstrStop::Stop);
+        assert_matches!(interp.err, InstrStop::Stop);
         assert_eq!(host.logs[0].topics().len(), 3);
         assert_eq!(host.logs[0].data.data, Bytes::from_static(&[0xbe]));
     }
@@ -430,13 +429,13 @@ mod tests {
     #[test]
     fn log4_opcode() {
         let mut host = TestHost::default();
-        let interpreter = run(RunConfig::new(log_code(
+        let interp = run(RunConfig::new(log_code(
             30,
             1,
             [Word::from(1), Word::from(2), Word::from(3), Word::from(4)],
         ))
         .host(&mut host));
-        assert_matches!(interpreter.err, InstrStop::Stop);
+        assert_matches!(interp.err, InstrStop::Stop);
         assert_eq!(host.logs[0].topics().len(), 4);
         assert_eq!(host.logs[0].data.data, Bytes::from_static(&[0xbe]));
     }
@@ -444,8 +443,8 @@ mod tests {
     #[test]
     fn log_staticcall_check() {
         let mut host = TestHost::default();
-        let interpreter = run(RunConfig::new(log_code(30, 2, [])).host(&mut host).staticcall());
-        assert_matches!(interpreter.err, InstrStop::StateChangeDuringStaticCall);
+        let interp = run(RunConfig::new(log_code(30, 2, [])).host(&mut host).staticcall());
+        assert_matches!(interp.err, InstrStop::StateChangeDuringStaticCall);
         assert!(host.logs.is_empty());
     }
 
@@ -456,8 +455,8 @@ mod tests {
         push(&mut code, 1);
         push(&mut code, Word::MAX);
         code.extend([op::LOG0, op::STOP]);
-        let interpreter = run(RunConfig::new(code).host(&mut host));
-        assert_matches!(interpreter.err, InstrStop::InvalidOperandOOG);
+        let interp = run(RunConfig::new(code).host(&mut host));
+        assert_matches!(interp.err, InstrStop::InvalidOperandOOG);
         assert!(host.logs.is_empty());
     }
 }

--- a/crates/evm2/src/interpreter/instructions/macro_tests.rs
+++ b/crates/evm2/src/interpreter/instructions/macro_tests.rs
@@ -100,27 +100,27 @@ fn instruction_macro_stack_inputs_and_output() {
     push(&mut code, 3);
     code.extend([ADD_OPCODE, op::STOP]);
 
-    let interpreter = run(RunConfig::new(code));
+    let interp = run(RunConfig::new(code));
 
-    assert_eq!(interpreter.err, InstrStop::Stop);
-    assert_eq!(interpreter.stack(), [Word::from(5)]);
+    assert_eq!(interp.err, InstrStop::Stop);
+    assert_eq!(interp.stack(), [Word::from(5)]);
 }
 
 #[test]
 fn instruction_macro_dynamic_gas_attribute() {
-    let interpreter = run(RunConfig::new([DYNAMIC_GAS_OPCODE, op::STOP]));
+    let interp = run(RunConfig::new([DYNAMIC_GAS_OPCODE, op::STOP]));
 
-    assert_eq!(interpreter.err, InstrStop::Stop);
-    assert_eq!(interpreter.stack(), [Word::from(0xda_u64)]);
-    assert_eq!(interpreter.gas_remaining(), 9_995);
+    assert_eq!(interp.err, InstrStop::Stop);
+    assert_eq!(interp.stack(), [Word::from(0xda_u64)]);
+    assert_eq!(interp.gas_remaining(), 9_995);
 }
 
 #[test]
 fn instruction_macro_no_stack_preamble_attribute() {
-    let interpreter = run(RunConfig::new([NO_STACK_PREAMBLE_OPCODE, op::STOP]));
+    let interp = run(RunConfig::new([NO_STACK_PREAMBLE_OPCODE, op::STOP]));
 
-    assert_eq!(interpreter.err, InstrStop::Stop);
-    assert_eq!(interpreter.stack(), [Word::from(0xbeef_u64)]);
+    assert_eq!(interp.err, InstrStop::Stop);
+    assert_eq!(interp.stack(), [Word::from(0xbeef_u64)]);
 }
 
 #[test]
@@ -129,10 +129,10 @@ fn instruction_macro_concrete_evm_types_equals_attribute() {
         block: BlockEnv { number: Word::from(42), ..BlockEnv::default() },
         ..TestHost::default()
     };
-    let interpreter = run(RunConfig::new([CONCRETE_EQ_OPCODE, op::STOP]).host(&mut host));
+    let interp = run(RunConfig::new([CONCRETE_EQ_OPCODE, op::STOP]).host(&mut host));
 
-    assert_eq!(interpreter.err, InstrStop::Stop);
-    assert_eq!(interpreter.stack(), [Word::from(42)]);
+    assert_eq!(interp.err, InstrStop::Stop);
+    assert_eq!(interp.stack(), [Word::from(42)]);
 }
 
 #[test]
@@ -141,10 +141,10 @@ fn instruction_macro_evm_types_colon_bound_attribute() {
         block: BlockEnv { number: Word::from(31337), ..BlockEnv::default() },
         ..TestHost::default()
     };
-    let interpreter = run(RunConfig::new([TYPE_BOUND_OPCODE, op::STOP]).host(&mut host));
+    let interp = run(RunConfig::new([TYPE_BOUND_OPCODE, op::STOP]).host(&mut host));
 
-    assert_eq!(interpreter.err, InstrStop::Stop);
-    assert!(interpreter.stack().is_empty());
+    assert_eq!(interp.err, InstrStop::Stop);
+    assert!(interp.stack().is_empty());
 }
 
 #[test]
@@ -153,8 +153,8 @@ fn instruction_macro_evm_types_assoc_colon_bound_attribute() {
         block: BlockEnv { number: Word::from(31337), ..BlockEnv::default() },
         ..TestHost::default()
     };
-    let interpreter = run(RunConfig::new([ASSOC_BOUND_OPCODE, op::STOP]).host(&mut host));
+    let interp = run(RunConfig::new([ASSOC_BOUND_OPCODE, op::STOP]).host(&mut host));
 
-    assert_eq!(interpreter.err, InstrStop::Stop);
-    assert_eq!(interpreter.stack(), [Word::from(31337)]);
+    assert_eq!(interp.err, InstrStop::Stop);
+    assert_eq!(interp.stack(), [Word::from(31337)]);
 }

--- a/crates/evm2/src/interpreter/instructions/memory.rs
+++ b/crates/evm2/src/interpreter/instructions/memory.rs
@@ -69,13 +69,13 @@ mod tests {
         code.push(op::MLOAD);
         code.push(op::STOP);
 
-        let mut interpreter = run(RunConfig::new(code));
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.stack(), [value]);
-        assert_eq!(interpreter.memory(30, 2), [0xfe, 0xed]);
+        let mut interp = run(RunConfig::new(code));
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.stack(), [value]);
+        assert_eq!(interp.memory(30, 2), [0xfe, 0xed]);
 
-        let interpreter = run_stack([Word::MAX], op::MLOAD);
-        assert_matches!(interpreter.err, InstrStop::InvalidOperandOOG);
+        let interp = run_stack([Word::MAX], op::MLOAD);
+        assert_matches!(interp.err, InstrStop::InvalidOperandOOG);
     }
 
     #[test]
@@ -88,13 +88,13 @@ mod tests {
         code.push(op::MSIZE);
         code.push(op::STOP);
 
-        let mut interpreter = run(RunConfig::new(code));
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.stack(), [Word::from(64)]);
-        assert_eq!(interpreter.memory(38, 2), [0xfe, 0xed]);
+        let mut interp = run(RunConfig::new(code));
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.stack(), [Word::from(64)]);
+        assert_eq!(interp.memory(38, 2), [0xfe, 0xed]);
 
-        let interpreter = run_stack([Word::MAX, Word::from(0)], op::MSTORE);
-        assert_matches!(interpreter.err, InstrStop::InvalidOperandOOG);
+        let interp = run_stack([Word::MAX, Word::from(0)], op::MSTORE);
+        assert_matches!(interp.err, InstrStop::InvalidOperandOOG);
     }
 
     #[test]
@@ -111,12 +111,12 @@ mod tests {
         let tx_env = TxEnv::default();
         let message = Message { gas_limit: 10_000, ..Message::default() };
         let bytecode = Bytecode::new_legacy(Bytes::from(code));
-        let mut interpreter = Interpreter::<TestTypes>::new(bytecode, &tx_env, &message, false);
+        let mut interp = Interpreter::<TestTypes>::new(bytecode, &tx_env, &message, false);
         let mut host = TestHost::default();
-        let err = interpreter.run(&config, &mut host);
+        let err = interp.run(&config, &mut host);
 
         assert_matches!(err, InstrStop::MemoryLimitOOG);
-        assert_eq!(interpreter.memory_len(), 0);
+        assert_eq!(interp.memory_len(), 0);
     }
 
     #[test]
@@ -129,20 +129,20 @@ mod tests {
         code.push(op::MLOAD);
         code.push(op::STOP);
 
-        let mut interpreter = run(RunConfig::new(code));
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.memory(4, 1), [0xab]);
-        assert_eq!(interpreter.stack()[0] >> 248, Word::from(0xab));
+        let mut interp = run(RunConfig::new(code));
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.memory(4, 1), [0xab]);
+        assert_eq!(interp.stack()[0] >> 248, Word::from(0xab));
 
-        let interpreter = run_stack([Word::MAX, Word::from(0)], op::MSTORE8);
-        assert_matches!(interpreter.err, InstrStop::InvalidOperandOOG);
+        let interp = run_stack([Word::MAX, Word::from(0)], op::MSTORE8);
+        assert_matches!(interp.err, InstrStop::InvalidOperandOOG);
     }
 
     #[test]
     fn msize_opcode() {
-        let interpreter = run(RunConfig::new([op::MSIZE, op::STOP]));
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.stack(), [0]);
+        let interp = run(RunConfig::new([op::MSIZE, op::STOP]));
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.stack(), [0]);
 
         let mut code = Vec::new();
         push(&mut code, 0);
@@ -150,9 +150,9 @@ mod tests {
         code.push(op::MSTORE);
         code.push(op::MSIZE);
         code.push(op::STOP);
-        let interpreter = run(RunConfig::new(code));
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.stack(), [Word::from(96)]);
+        let interp = run(RunConfig::new(code));
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.stack(), [Word::from(96)]);
     }
 
     #[test]
@@ -170,9 +170,9 @@ mod tests {
         code.push(op::MLOAD);
         code.push(op::STOP);
 
-        let interpreter = run(RunConfig::new(code));
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.stack(), [value]);
+        let interp = run(RunConfig::new(code));
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.stack(), [value]);
 
         let mut code = Vec::new();
         push(&mut code, 0);
@@ -181,15 +181,15 @@ mod tests {
         code.push(op::MCOPY);
         code.push(op::MSIZE);
         code.push(op::STOP);
-        let interpreter = run(RunConfig::new(code));
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.stack(), [0]);
+        let interp = run(RunConfig::new(code));
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.stack(), [0]);
 
-        let interpreter = run_stack([Word::MAX, Word::MAX, Word::from(0)], op::MCOPY);
-        assert_matches!(interpreter.err, InstrStop::Stop);
+        let interp = run_stack([Word::MAX, Word::MAX, Word::from(0)], op::MCOPY);
+        assert_matches!(interp.err, InstrStop::Stop);
 
-        let interpreter = run_stack([Word::MAX, Word::from(0), Word::from(1)], op::MCOPY);
-        assert_matches!(interpreter.err, InstrStop::InvalidOperandOOG);
+        let interp = run_stack([Word::MAX, Word::from(0), Word::from(1)], op::MCOPY);
+        assert_matches!(interp.err, InstrStop::InvalidOperandOOG);
     }
 
     #[test]
@@ -203,8 +203,8 @@ mod tests {
         push(&mut code, 0);
         code.extend([op::MCOPY, op::STOP]);
 
-        let interpreter = run(RunConfig::new(code).spec(SpecId::CANCUN).gas_limit(26));
+        let interp = run(RunConfig::new(code).spec(SpecId::CANCUN).gas_limit(26));
 
-        assert_matches!(interpreter.err, InstrStop::OutOfGas);
+        assert_matches!(interp.err, InstrStop::OutOfGas);
     }
 }

--- a/crates/evm2/src/interpreter/instructions/stack.rs
+++ b/crates/evm2/src/interpreter/instructions/stack.rs
@@ -73,67 +73,65 @@ mod tests {
 
     #[test]
     fn pop_opcode() {
-        let interpreter = run_stack([1], op::POP);
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert!(interpreter.stack().is_empty());
+        let interp = run_stack([1], op::POP);
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert!(interp.stack().is_empty());
 
-        let interpreter =
-            run(RunConfig::new([op::PUSH1, 0x01, op::PUSH1, 0x02, op::POP, op::STOP]));
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.stack(), [Word::from(1)]);
+        let interp = run(RunConfig::new([op::PUSH1, 0x01, op::PUSH1, 0x02, op::POP, op::STOP]));
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.stack(), [Word::from(1)]);
     }
 
     #[test]
     fn stack_underflow() {
-        let interpreter = run(RunConfig::new([op::POP]));
-        assert_matches!(interpreter.err, InstrStop::StackUnderflow);
+        let interp = run(RunConfig::new([op::POP]));
+        assert_matches!(interp.err, InstrStop::StackUnderflow);
 
-        let interpreter = run(RunConfig::new([op::DUP1]));
-        assert_matches!(interpreter.err, InstrStop::StackUnderflow);
+        let interp = run(RunConfig::new([op::DUP1]));
+        assert_matches!(interp.err, InstrStop::StackUnderflow);
 
-        let interpreter = run(RunConfig::new([op::PUSH0, op::SWAP1]));
-        assert_matches!(interpreter.err, InstrStop::StackUnderflow);
+        let interp = run(RunConfig::new([op::PUSH0, op::SWAP1]));
+        assert_matches!(interp.err, InstrStop::StackUnderflow);
 
-        let interpreter = run(RunConfig::new([op::DUPN, 0x80]).spec(SpecId::AMSTERDAM));
-        assert_matches!(interpreter.err, InstrStop::StackUnderflow);
+        let interp = run(RunConfig::new([op::DUPN, 0x80]).spec(SpecId::AMSTERDAM));
+        assert_matches!(interp.err, InstrStop::StackUnderflow);
 
-        let interpreter = run(RunConfig::new([op::PUSH0, op::SWAPN, 0x80]).spec(SpecId::AMSTERDAM));
-        assert_matches!(interpreter.err, InstrStop::StackUnderflow);
+        let interp = run(RunConfig::new([op::PUSH0, op::SWAPN, 0x80]).spec(SpecId::AMSTERDAM));
+        assert_matches!(interp.err, InstrStop::StackUnderflow);
 
-        let interpreter =
-            run(RunConfig::new([op::PUSH0, op::EXCHANGE, 0x8e]).spec(SpecId::AMSTERDAM));
-        assert_matches!(interpreter.err, InstrStop::StackUnderflow);
+        let interp = run(RunConfig::new([op::PUSH0, op::EXCHANGE, 0x8e]).spec(SpecId::AMSTERDAM));
+        assert_matches!(interp.err, InstrStop::StackUnderflow);
     }
 
     #[test]
     fn stack_overflow() {
         let mut code = vec![op::PUSH0; StackMut::CAPACITY];
-        let interpreter = run(RunConfig::new(code.clone()));
-        assert_matches!(interpreter.err, InstrStop::Stop);
+        let interp = run(RunConfig::new(code.clone()));
+        assert_matches!(interp.err, InstrStop::Stop);
         code.extend([op::PUSH0]);
-        let interpreter = run(RunConfig::new(code));
-        assert_matches!(interpreter.err, InstrStop::StackOverflow);
+        let interp = run(RunConfig::new(code));
+        assert_matches!(interp.err, InstrStop::StackOverflow);
 
         let mut code = vec![op::PUSH0; StackMut::CAPACITY];
         code.extend([op::PUSH1, 0x00, op::STOP]);
-        let interpreter = run(RunConfig::new(code));
-        assert_matches!(interpreter.err, InstrStop::StackOverflow);
+        let interp = run(RunConfig::new(code));
+        assert_matches!(interp.err, InstrStop::StackOverflow);
 
         let mut code = vec![op::PUSH0; StackMut::CAPACITY];
         code.extend([op::DUP1, op::STOP]);
-        let interpreter = run(RunConfig::new(code));
-        assert_matches!(interpreter.err, InstrStop::StackOverflow);
+        let interp = run(RunConfig::new(code));
+        assert_matches!(interp.err, InstrStop::StackOverflow);
     }
 
     #[test]
     fn push0_opcode() {
-        let interpreter = run(RunConfig::new([op::PUSH0, op::STOP]));
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.stack(), [0]);
+        let interp = run(RunConfig::new([op::PUSH0, op::STOP]));
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.stack(), [0]);
 
-        let interpreter = run(RunConfig::new([op::PUSH0, op::PUSH0, op::STOP]));
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.stack(), [0, 0]);
+        let interp = run(RunConfig::new([op::PUSH0, op::PUSH0, op::STOP]));
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.stack(), [0, 0]);
     }
 
     fn assert_push_opcode(opcode: u8, n: usize) {
@@ -143,9 +141,9 @@ mod tests {
             code.extend_from_slice(&bytes);
             code.push(op::STOP);
 
-            let interpreter = run(RunConfig::new(code));
-            assert_matches!(interpreter.err, InstrStop::Stop);
-            assert_eq!(interpreter.stack(), [Word::from_be_slice(&bytes)]);
+            let interp = run(RunConfig::new(code));
+            assert_matches!(interp.err, InstrStop::Stop);
+            assert_eq!(interp.stack(), [Word::from_be_slice(&bytes)]);
         }
     }
 
@@ -204,10 +202,10 @@ mod tests {
             code.push(opcode);
             code.push(op::STOP);
 
-            let interpreter = run(RunConfig::new(code));
-            assert_matches!(interpreter.err, InstrStop::Stop);
-            assert_eq!(interpreter.stack().len(), 17);
-            assert_eq!(interpreter.stack()[16], Word::from(17 - n + offset));
+            let interp = run(RunConfig::new(code));
+            assert_matches!(interp.err, InstrStop::Stop);
+            assert_eq!(interp.stack().len(), 17);
+            assert_eq!(interp.stack()[16], Word::from(17 - n + offset));
         }
     }
 
@@ -250,11 +248,11 @@ mod tests {
             code.push(opcode);
             code.push(op::STOP);
 
-            let interpreter = run(RunConfig::new(code));
-            assert_matches!(interpreter.err, InstrStop::Stop);
-            assert_eq!(interpreter.stack().len(), 17);
-            assert_eq!(interpreter.stack()[16], Word::from(17 - n + offset));
-            assert_eq!(interpreter.stack()[16 - n], Word::from(17 + offset));
+            let interp = run(RunConfig::new(code));
+            assert_matches!(interp.err, InstrStop::Stop);
+            assert_eq!(interp.stack().len(), 17);
+            assert_eq!(interp.stack()[16], Word::from(17 - n + offset));
+            assert_eq!(interp.stack()[16 - n], Word::from(17 + offset));
         }
     }
 
@@ -293,13 +291,13 @@ mod tests {
         let mut code = vec![op::PUSH1, 0x01, op::PUSH1, 0x00];
         code.extend(core::iter::repeat_n(op::DUP1, 15));
         code.extend([op::DUPN, 0x80, op::STOP]);
-        let interpreter = run(RunConfig::new(code).spec(SpecId::AMSTERDAM));
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.stack().len(), 18);
-        assert_eq!(interpreter.stack()[17], Word::from(1));
-        assert_eq!(interpreter.stack()[0], Word::from(1));
+        let interp = run(RunConfig::new(code).spec(SpecId::AMSTERDAM));
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.stack().len(), 18);
+        assert_eq!(interp.stack()[17], Word::from(1));
+        assert_eq!(interp.stack()[0], Word::from(1));
         for i in 1..17 {
-            assert_eq!(interpreter.stack()[i], 0);
+            assert_eq!(interp.stack()[i], 0);
         }
 
         let mut code = Vec::new();
@@ -307,10 +305,10 @@ mod tests {
             push(&mut code, Word::from(value));
         }
         code.extend([op::DUPN, 0xff, op::STOP]);
-        let interpreter = run(RunConfig::new(code).spec(SpecId::AMSTERDAM));
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.stack().len(), 146);
-        assert_eq!(interpreter.stack()[145], Word::from(1));
+        let interp = run(RunConfig::new(code).spec(SpecId::AMSTERDAM));
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.stack().len(), 146);
+        assert_eq!(interp.stack()[145], Word::from(1));
     }
 
     #[test]
@@ -318,13 +316,13 @@ mod tests {
         let mut code = vec![op::PUSH1, 0x01, op::PUSH1, 0x00];
         code.extend(core::iter::repeat_n(op::DUP1, 15));
         code.extend([op::PUSH1, 0x02, op::SWAPN, 0x80, op::STOP]);
-        let interpreter = run(RunConfig::new(code).spec(SpecId::AMSTERDAM));
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.stack().len(), 18);
-        assert_eq!(interpreter.stack()[17], Word::from(1));
-        assert_eq!(interpreter.stack()[0], Word::from(2));
+        let interp = run(RunConfig::new(code).spec(SpecId::AMSTERDAM));
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.stack().len(), 18);
+        assert_eq!(interp.stack()[17], Word::from(1));
+        assert_eq!(interp.stack()[0], Word::from(2));
         for i in 1..17 {
-            assert_eq!(interpreter.stack()[i], 0);
+            assert_eq!(interp.stack()[i], 0);
         }
 
         let mut code = Vec::new();
@@ -332,15 +330,15 @@ mod tests {
             push(&mut code, Word::from(value));
         }
         code.extend([op::SWAPN, 0xff, op::STOP]);
-        let interpreter = run(RunConfig::new(code).spec(SpecId::AMSTERDAM));
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.stack()[0], Word::from(144));
-        assert_eq!(interpreter.stack()[144], 0);
+        let interp = run(RunConfig::new(code).spec(SpecId::AMSTERDAM));
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.stack()[0], Word::from(144));
+        assert_eq!(interp.stack()[144], 0);
     }
 
     #[test]
     fn exchange_opcode() {
-        let interpreter = run(RunConfig::new([
+        let interp = run(RunConfig::new([
             op::PUSH1,
             0x00,
             op::PUSH1,
@@ -352,30 +350,30 @@ mod tests {
             op::STOP,
         ])
         .spec(SpecId::AMSTERDAM));
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.stack(), [Word::from(1), Word::from(0), Word::from(2)]);
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.stack(), [Word::from(1), Word::from(0), Word::from(2)]);
 
         let mut code = Vec::new();
         for value in 0..23 {
             push(&mut code, Word::from(value));
         }
         code.extend([op::EXCHANGE, 0xff, op::STOP]);
-        let interpreter = run(RunConfig::new(code).spec(SpecId::AMSTERDAM));
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.stack()[0], Word::from(21));
-        assert_eq!(interpreter.stack()[21], 0);
-        assert_eq!(interpreter.stack()[22], Word::from(22));
+        let interp = run(RunConfig::new(code).spec(SpecId::AMSTERDAM));
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.stack()[0], Word::from(21));
+        assert_eq!(interp.stack()[21], 0);
+        assert_eq!(interp.stack()[22], Word::from(22));
     }
 
     #[test]
     fn relative_stack_opcodes_are_not_enabled_before_amsterdam() {
-        let interpreter = run(RunConfig::new([op::DUPN, 0x80]).spec(SpecId::OSAKA));
-        assert_matches!(interpreter.err, InstrStop::InvalidOpcode);
+        let interp = run(RunConfig::new([op::DUPN, 0x80]).spec(SpecId::OSAKA));
+        assert_matches!(interp.err, InstrStop::InvalidOpcode);
 
-        let interpreter = run(RunConfig::new([op::SWAPN, 0x80]).spec(SpecId::OSAKA));
-        assert_matches!(interpreter.err, InstrStop::InvalidOpcode);
+        let interp = run(RunConfig::new([op::SWAPN, 0x80]).spec(SpecId::OSAKA));
+        assert_matches!(interp.err, InstrStop::InvalidOpcode);
 
-        let interpreter = run(RunConfig::new([op::EXCHANGE, 0x8e]).spec(SpecId::OSAKA));
-        assert_matches!(interpreter.err, InstrStop::InvalidOpcode);
+        let interp = run(RunConfig::new([op::EXCHANGE, 0x8e]).spec(SpecId::OSAKA));
+        assert_matches!(interp.err, InstrStop::InvalidOpcode);
     }
 }

--- a/crates/evm2/src/interpreter/instructions/system.rs
+++ b/crates/evm2/src/interpreter/instructions/system.rs
@@ -427,13 +427,13 @@ mod tests {
         );
         code.extend([op::CALL, op::STOP]);
 
-        let interpreter = run(RunConfig::new(code).host(&mut host).message(Message {
+        let interp = run(RunConfig::new(code).host(&mut host).message(Message {
             destination: caller,
             gas_limit: 10_000,
             ..Default::default()
         }));
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.stack(), [Word::from(1)]);
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.stack(), [Word::from(1)]);
         assert_eq!(host.calls.len(), 1);
         assert_eq!(host.calls[0].kind, MessageKind::Call);
         assert_eq!(host.calls[0].destination, target);
@@ -459,8 +459,8 @@ mod tests {
         );
         code.extend([op::CALL, op::STOP]);
 
-        let interpreter = run(RunConfig::new(code).host(&mut host).staticcall());
-        assert_matches!(interpreter.err, InstrStop::Stop);
+        let interp = run(RunConfig::new(code).host(&mut host).staticcall());
+        assert_matches!(interp.err, InstrStop::Stop);
         assert_eq!(host.calls.len(), 1);
         assert_eq!(host.calls[0].kind, MessageKind::Call);
         assert!(host.call_static_flags[0]);
@@ -485,14 +485,14 @@ mod tests {
         );
         code.extend([op::CALL, op::STOP]);
 
-        let interpreter = run(RunConfig::new(code)
+        let interp = run(RunConfig::new(code)
             .host(&mut host)
             .spec(SpecId::BERLIN)
             .message(Message { depth: CALL_DEPTH_LIMIT, ..Default::default() })
             .gas_limit(50_000));
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.stack(), [Word::ZERO]);
-        assert_eq!(interpreter.gas_remaining(), 15_679);
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.stack(), [Word::ZERO]);
+        assert_eq!(interp.gas_remaining(), 15_679);
         assert!(host.calls.is_empty());
     }
 
@@ -519,13 +519,13 @@ mod tests {
             op::POP,
         ];
 
-        let interpreter = run(RunConfig::new(code)
+        let interp = run(RunConfig::new(code)
             .host(&mut host)
             .spec(SpecId::TANGERINE)
             .message(Message { depth: CALL_DEPTH_LIMIT, ..Default::default() })
             .gas_limit(50_000));
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.gas_remaining(), 42_553);
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.gas_remaining(), 42_553);
         assert!(host.calls.is_empty());
     }
 
@@ -548,14 +548,14 @@ mod tests {
         );
         code.extend([op::CALL, op::STOP]);
 
-        let interpreter = run(RunConfig::new(code)
+        let interp = run(RunConfig::new(code)
             .host(&mut host)
             .spec(SpecId::TANGERINE)
             .message(Message { depth: CALL_DEPTH_LIMIT, ..Default::default() })
             .gas_limit(50_000));
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.stack(), [Word::ZERO]);
-        assert_eq!(interpreter.gas_remaining(), 24_279);
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.stack(), [Word::ZERO]);
+        assert_eq!(interp.gas_remaining(), 24_279);
         assert!(host.calls.is_empty());
     }
 
@@ -579,14 +579,14 @@ mod tests {
         );
         code.extend([op::CALL, op::STOP]);
 
-        let interpreter = run(RunConfig::new(code)
+        let interp = run(RunConfig::new(code)
             .host(&mut host)
             .spec(SpecId::TANGERINE)
             .message(Message { depth: CALL_DEPTH_LIMIT, ..Default::default() })
             .gas_limit(50_000));
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.stack(), [Word::ZERO]);
-        assert_eq!(interpreter.gas_remaining(), 49_279);
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.stack(), [Word::ZERO]);
+        assert_eq!(interp.gas_remaining(), 49_279);
         assert!(host.calls.is_empty());
     }
 
@@ -609,8 +609,8 @@ mod tests {
         );
         code.extend([op::CALLCODE, op::STOP]);
 
-        let interpreter = run(RunConfig::new(code).host(&mut host).staticcall().gas_limit(20_000));
-        assert_matches!(interpreter.err, InstrStop::Stop);
+        let interp = run(RunConfig::new(code).host(&mut host).staticcall().gas_limit(20_000));
+        assert_matches!(interp.err, InstrStop::Stop);
         assert_eq!(host.calls.len(), 1);
         assert_eq!(host.calls[0].kind, MessageKind::CallCode);
         assert_eq!(host.calls[0].value, Word::from(7));
@@ -637,12 +637,12 @@ mod tests {
         );
         code.extend([op::CALLCODE, op::STOP]);
 
-        let interpreter = run(RunConfig::new(code)
+        let interp = run(RunConfig::new(code)
             .host(&mut host)
             .message(Message { destination, ..Default::default() })
             .gas_limit(20_000));
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.stack(), [Word::from(1)]);
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.stack(), [Word::from(1)]);
         assert_eq!(host.calls[0].kind, MessageKind::CallCode);
         assert_eq!(host.calls[0].destination, destination);
         assert_eq!(host.calls[0].code_address, code_address);
@@ -668,20 +668,20 @@ mod tests {
         );
         code.extend([op::DELEGATECALL, op::STOP]);
 
-        let interpreter = run(RunConfig::new(code).host(&mut host).message(Message {
+        let interp = run(RunConfig::new(code).host(&mut host).message(Message {
             caller,
             value: Word::from(9),
             gas_limit: 10_000,
             ..Default::default()
         }));
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.stack(), [Word::from(1)]);
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.stack(), [Word::from(1)]);
         assert_eq!(host.calls[0].kind, MessageKind::DelegateCall);
         assert_eq!(host.calls[0].caller, caller);
         assert_eq!(host.calls[0].value, Word::from(9));
         assert_eq!(host.calls[0].code_address, code_address);
 
-        let interpreter = run(RunConfig::new([
+        let interp = run(RunConfig::new([
             op::PUSH1,
             0,
             op::PUSH1,
@@ -697,7 +697,7 @@ mod tests {
             op::DELEGATECALL,
         ])
         .spec(SpecId::FRONTIER));
-        assert_matches!(interpreter.err, InstrStop::InvalidOpcode);
+        assert_matches!(interp.err, InstrStop::InvalidOpcode);
     }
 
     #[test]
@@ -718,13 +718,13 @@ mod tests {
         );
         code.extend([op::STATICCALL, op::STOP]);
 
-        let interpreter = run(RunConfig::new(code).host(&mut host));
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.stack(), [Word::from(1)]);
+        let interp = run(RunConfig::new(code).host(&mut host));
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.stack(), [Word::from(1)]);
         assert_eq!(host.calls[0].kind, MessageKind::StaticCall);
         assert!(host.call_static_flags[0]);
 
-        let interpreter = run(RunConfig::new([
+        let interp = run(RunConfig::new([
             op::PUSH1,
             0,
             op::PUSH1,
@@ -740,7 +740,7 @@ mod tests {
             op::STATICCALL,
         ])
         .spec(SpecId::HOMESTEAD));
-        assert_matches!(interpreter.err, InstrStop::InvalidOpcode);
+        assert_matches!(interp.err, InstrStop::InvalidOpcode);
     }
 
     #[test]
@@ -758,9 +758,9 @@ mod tests {
         push_all(&mut code, [Word::from(0), Word::from(0), Word::from(0)]);
         code.extend([op::CREATE, op::STOP]);
 
-        let interpreter = run(RunConfig::new(code).host(&mut host).gas_limit(50_000));
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.stack(), [address_to_word(&created)]);
+        let interp = run(RunConfig::new(code).host(&mut host).gas_limit(50_000));
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.stack(), [address_to_word(&created)]);
         assert_eq!(host.calls.len(), 1);
         assert_eq!(host.calls[0].kind, MessageKind::Create);
     }
@@ -781,9 +781,9 @@ mod tests {
         push_all(&mut code, [Word::from(0), Word::from(0), Word::from(0)]);
         code.extend([op::CREATE, op::RETURNDATASIZE, op::STOP]);
 
-        let interpreter = run(RunConfig::new(code).host(&mut host).gas_limit(50_000));
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.stack(), [address_to_word(&created), Word::ZERO]);
+        let interp = run(RunConfig::new(code).host(&mut host).gas_limit(50_000));
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.stack(), [address_to_word(&created), Word::ZERO]);
     }
 
     #[test]
@@ -800,9 +800,9 @@ mod tests {
         push_all(&mut code, [Word::from(0), Word::from(0), Word::from(0)]);
         code.extend([op::CREATE, op::RETURNDATASIZE, op::STOP]);
 
-        let interpreter = run(RunConfig::new(code).host(&mut host).gas_limit(50_000));
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.stack(), [Word::ZERO, Word::from(2)]);
+        let interp = run(RunConfig::new(code).host(&mut host).gas_limit(50_000));
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.stack(), [Word::ZERO, Word::from(2)]);
     }
 
     #[test]
@@ -812,14 +812,14 @@ mod tests {
         push_all(&mut code, [Word::ZERO, Word::ZERO, Word::ZERO]);
         code.extend([op::CREATE, op::STOP]);
 
-        let interpreter = run(RunConfig::new(code)
+        let interp = run(RunConfig::new(code)
             .host(&mut host)
             .spec(SpecId::BERLIN)
             .message(Message { depth: CALL_DEPTH_LIMIT, ..Default::default() })
             .gas_limit(50_000));
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.stack(), [Word::ZERO]);
-        assert_eq!(interpreter.gas_remaining(), 17_991);
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.stack(), [Word::ZERO]);
+        assert_eq!(interp.gas_remaining(), 17_991);
         assert!(host.calls.is_empty());
     }
 
@@ -830,9 +830,9 @@ mod tests {
         push_all(&mut code, [Word::from(MAX_INITCODE_SIZE + 1), Word::ZERO, Word::ZERO]);
         code.extend([op::CREATE, op::STOP]);
 
-        let interpreter =
+        let interp =
             run(RunConfig::new(code).host(&mut host).spec(SpecId::SHANGHAI).gas_limit(50_000));
-        assert_matches!(interpreter.err, InstrStop::CreateInitCodeSizeLimit);
+        assert_matches!(interp.err, InstrStop::CreateInitCodeSizeLimit);
         assert!(host.calls.is_empty());
     }
 
@@ -851,12 +851,12 @@ mod tests {
         push_all(&mut code, [Word::from(0), Word::from(0), Word::from(0), Word::from(0)]);
         code.extend([op::CREATE2, op::STOP]);
 
-        let interpreter = run(RunConfig::new(code).host(&mut host).gas_limit(50_000));
-        assert_matches!(interpreter.err, InstrStop::Stop);
-        assert_eq!(interpreter.stack(), [address_to_word(&created)]);
+        let interp = run(RunConfig::new(code).host(&mut host).gas_limit(50_000));
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.stack(), [address_to_word(&created)]);
         assert_eq!(host.calls[0].kind, MessageKind::Create2);
 
-        let interpreter = run(RunConfig::new([
+        let interp = run(RunConfig::new([
             op::PUSH1,
             0,
             op::PUSH1,
@@ -868,7 +868,7 @@ mod tests {
             op::CREATE2,
         ])
         .spec(SpecId::BYZANTIUM));
-        assert_matches!(interpreter.err, InstrStop::InvalidOpcode);
+        assert_matches!(interp.err, InstrStop::InvalidOpcode);
     }
 
     #[test]
@@ -880,12 +880,12 @@ mod tests {
         push(&mut code, address_to_word(&target));
         code.push(op::SELFDESTRUCT);
 
-        let interpreter = run(RunConfig::new(code).host(&mut host).message(Message {
+        let interp = run(RunConfig::new(code).host(&mut host).message(Message {
             destination: contract,
             gas_limit: 10_000,
             ..Default::default()
         }));
-        assert_matches!(interpreter.err, InstrStop::SelfDestruct);
+        assert_matches!(interp.err, InstrStop::SelfDestruct);
         assert_eq!(host.selfdestructs, [(contract, target, false)]);
     }
 }

--- a/crates/evm2/src/interpreter/instructions/tests.rs
+++ b/crates/evm2/src/interpreter/instructions/tests.rs
@@ -362,9 +362,9 @@ pub(super) fn assert_stack_words(inputs: &[Word], opcode: u8, expected: &[Word])
         push(&mut code, *input);
     }
     code.extend([opcode, op::STOP]);
-    let interpreter = run(RunConfig::new(code));
-    assert_matches!(interpreter.err, InstrStop::Stop);
-    assert_eq!(interpreter.stack(), expected);
+    let interp = run(RunConfig::new(code));
+    assert_matches!(interp.err, InstrStop::Stop);
+    assert_eq!(interp.stack(), expected);
 }
 
 macro_rules! assert_stack {

--- a/crates/evm2/src/interpreter/runtime.rs
+++ b/crates/evm2/src/interpreter/runtime.rs
@@ -81,9 +81,9 @@ impl<'frame, T: EvmTypes> Interpreter<'frame, T> {
         message: &'frame Message<T>,
         caller_is_static: bool,
     ) -> Self {
-        let mut interpreter = Self::default();
-        interpreter.init(bytecode, tx_env, message, caller_is_static);
-        interpreter
+        let mut interp = Self::default();
+        interp.init(bytecode, tx_env, message, caller_is_static);
+        interp
     }
 
     /// Initializes this interpreter for a new frame, retaining reusable allocations.


### PR DESCRIPTION
Renames local variables named interpreter to interp where they refer to interpreter instances, without changing APIs.