### PR TITLE
fix(bn254): reject non-canonical mcl fields

### DIFF
--- a/crates/evm2/src/precompiles/bn254/mcl.rs
+++ b/crates/evm2/src/precompiles/bn254/mcl.rs
@@ -2,8 +2,12 @@
 
 use super::{Bn254Ops, FQ_LEN, FQ2_LEN, G1_LEN, SCALAR_LEN};
 use crate::precompiles::PrecompileHalt;
+use alloy_primitives::hex;
 use mcl_rust::{CurveType, Fp, Fp2, Fr, G1, G2, GT};
 use std::sync::Once;
+
+const FQ_MODULUS: [u8; FQ_LEN] =
+    hex!("30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001");
 
 #[inline]
 fn ensure_init() {
@@ -143,6 +147,10 @@ impl Bn254Ops for MclOps {
 
 #[inline]
 fn read_fp(input: &[u8]) -> Result<Fp, PrecompileHalt> {
+    if input >= FQ_MODULUS.as_slice() {
+        return Err(PrecompileHalt::Bn254FieldPointNotAMember);
+    }
+
     let mut le_bytes = [0u8; FQ_LEN];
     le_bytes.copy_from_slice(&input[..FQ_LEN]);
     le_bytes.reverse();

--- a/crates/evm2/src/precompiles/bn254/mcl.rs
+++ b/crates/evm2/src/precompiles/bn254/mcl.rs
@@ -2,12 +2,8 @@
 
 use super::{Bn254Ops, FQ_LEN, FQ2_LEN, G1_LEN, SCALAR_LEN};
 use crate::precompiles::PrecompileHalt;
-use alloy_primitives::hex;
 use mcl_rust::{CurveType, Fp, Fp2, Fr, G1, G2, GT};
 use std::sync::Once;
-
-const FQ_MODULUS: [u8; FQ_LEN] =
-    hex!("30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001");
 
 #[inline]
 fn ensure_init() {
@@ -147,16 +143,15 @@ impl Bn254Ops for MclOps {
 
 #[inline]
 fn read_fp(input: &[u8]) -> Result<Fp, PrecompileHalt> {
-    if input >= FQ_MODULUS.as_slice() {
-        return Err(PrecompileHalt::Bn254FieldPointNotAMember);
-    }
-
     let mut le_bytes = [0u8; FQ_LEN];
     le_bytes.copy_from_slice(&input[..FQ_LEN]);
     le_bytes.reverse();
 
     let mut fp = Fp::zero();
     if !fp.set_little_endian(&le_bytes) {
+        return Err(PrecompileHalt::Bn254FieldPointNotAMember);
+    }
+    if encode_fp(&fp).as_slice() != input {
         return Err(PrecompileHalt::Bn254FieldPointNotAMember);
     }
     Ok(fp)

--- a/crates/evm2/src/precompiles/bn254/mod.rs
+++ b/crates/evm2/src/precompiles/bn254/mod.rs
@@ -360,6 +360,24 @@ mod tests {
             res,
             Err(ref f) if *f == PrecompileError::Halt(PrecompileHalt::Bn254FieldPointNotAMember),
         );
+
+        let input = hex::decode(
+            "\
+            0000000000000000000000000000000000000000000000000000000000000001\
+            30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd45\
+            0000000000000000000000000000000000000000000000000000000000000001\
+            30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd45",
+        )
+        .unwrap();
+        let expected = hex::decode(
+            "\
+            030644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd3\
+            1a76dae6d3272396d0cbe61fced2bc532edac647851e3ac53ce1cc9c7e645a83",
+        )
+        .unwrap();
+
+        let outcome = run_add(&input, BYZANTIUM_ADD_GAS_COST, &mut GasTracker::new(500)).unwrap();
+        assert_eq!(outcome.bytes(), expected);
     }
 
     #[test]
@@ -447,6 +465,24 @@ mod tests {
             res,
             Err(ref f) if *f == PrecompileError::Halt(PrecompileHalt::Bn254FieldPointNotAMember),
         );
+
+        let input = hex::decode(
+            "\
+            0000000000000000000000000000000000000000000000000000000000000001\
+            30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd45\
+            0000000000000000000000000000000000000000000000000000000000000002",
+        )
+        .unwrap();
+        let expected = hex::decode(
+            "\
+            030644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd3\
+            1a76dae6d3272396d0cbe61fced2bc532edac647851e3ac53ce1cc9c7e645a83",
+        )
+        .unwrap();
+
+        let outcome =
+            run_mul(&input, BYZANTIUM_MUL_GAS_COST, &mut GasTracker::new(40_000)).unwrap();
+        assert_eq!(outcome.bytes(), expected);
     }
 
     #[test]

--- a/crates/evm2/src/precompiles/bn254/mod.rs
+++ b/crates/evm2/src/precompiles/bn254/mod.rs
@@ -353,6 +353,13 @@ mod tests {
             res,
             Err(ref f) if *f == PrecompileError::Halt(PrecompileHalt::Bn254AffineGFailedToCreate),
         );
+
+        // Short input is right-padded. This makes the first field element non-canonical.
+        let res = run_add(&[0x40], BYZANTIUM_ADD_GAS_COST, &mut GasTracker::new(500));
+        assert_matches!(
+            res,
+            Err(ref f) if *f == PrecompileError::Halt(PrecompileHalt::Bn254FieldPointNotAMember),
+        );
     }
 
     #[test]
@@ -432,6 +439,13 @@ mod tests {
         assert_matches!(
             res,
             Err(ref f) if *f == PrecompileError::Halt(PrecompileHalt::Bn254AffineGFailedToCreate),
+        );
+
+        // Short input is right-padded. This makes the point x-coordinate non-canonical.
+        let res = run_mul(&[0x40], BYZANTIUM_MUL_GAS_COST, &mut GasTracker::new(40_000));
+        assert_matches!(
+            res,
+            Err(ref f) if *f == PrecompileError::Halt(PrecompileHalt::Bn254FieldPointNotAMember),
         );
     }
 
@@ -528,6 +542,19 @@ mod tests {
         assert_matches!(
             res,
             Err(ref f) if *f == PrecompileError::Halt(PrecompileHalt::Bn254AffineGFailedToCreate),
+        );
+
+        let mut input = [0u8; PAIR_ELEMENT_LEN];
+        input[0] = 0x40;
+        let res = run_pair(
+            &input,
+            BYZANTIUM_PAIR_PER_POINT,
+            BYZANTIUM_PAIR_BASE,
+            &mut GasTracker::new(180_000),
+        );
+        assert_matches!(
+            res,
+            Err(ref f) if *f == PrecompileError::Halt(PrecompileHalt::Bn254FieldPointNotAMember),
         );
 
         // Invalid input length


### PR DESCRIPTION
This fixes the BN254 MCL backend so field decoding rejects non-canonical 32-byte field elements before handing them to MCL. MCL accepts the fuzzer's right-padded short input as a field value, while the copied revm backends reject it during field parsing, which caused differential gas accounting to diverge on BN254 precompile failure.

The regression cases cover add, mul, and pairing inputs whose first field element is non-canonical after EVM right-padding.
