### PR TITLE
fix captured block hashes

### DIFF
--- a/crates/cli/src/capture/export.rs
+++ b/crates/cli/src/capture/export.rs
@@ -13,8 +13,8 @@ use evm2::SpecId;
 use evm2_eest::{
     AccessListItem, TestAuthorization,
     blockchaintest::{
-        Account, Block, BlockHeader, BlockchainTest, BlockchainTestCase, ForkSpec, SealEngine,
-        State as EestState, Transaction, Withdrawal,
+        Account, Block, BlockHash as EestBlockHash, BlockHeader, BlockchainTest,
+        BlockchainTestCase, ForkSpec, SealEngine, State as EestState, Transaction, Withdrawal,
     },
 };
 use serde_json::json;
@@ -48,12 +48,25 @@ pub(super) fn suite(capture: &CapturedCase) -> Result<BlockchainTest, CaptureErr
             blocks: decoded_blocks,
             post_state: capture.post_state.as_ref().map(|state| export_state(capture, state).0),
             pre: export_state(capture, &capture.pre_state),
+            block_hashes: export_block_hashes(capture),
             lastblockhash,
             network,
             seal_engine: SealEngine::NoProof,
         },
     );
     Ok(BlockchainTest(cases))
+}
+
+fn export_block_hashes(capture: &CapturedCase) -> Vec<EestBlockHash> {
+    capture
+        .pre_state
+        .block_hashes
+        .iter()
+        .map(|block_hash| EestBlockHash {
+            number: U256::from(block_hash.number),
+            hash: block_hash.hash,
+        })
+        .collect()
 }
 
 const fn captured_blocks(capture: &CapturedCase) -> Result<&[CapturedBlock], CaptureError> {

--- a/crates/eest/src/blockchaintest/execute.rs
+++ b/crates/eest/src/blockchaintest/execute.rs
@@ -104,7 +104,7 @@ fn execute_case(
 ) -> Result<(), TestError> {
     let mut database =
         parse_state(&test_case.pre.0).map_err(|err| TestError::case(path, name, err))?;
-    database.insert_block_hash(&U256::ZERO, &test_case.genesis_block_header.hash);
+    seed_block_hashes(&mut database, test_case);
 
     let spec = fork_to_spec_id(test_case.network);
     let mut parent_block_hash = Some(test_case.genesis_block_header.hash);
@@ -134,6 +134,16 @@ fn execute_case(
     }
 
     Ok(())
+}
+
+fn seed_block_hashes(database: &mut InMemoryDB, test_case: &BlockchainTestCase) {
+    for block_hash in &test_case.block_hashes {
+        database.insert_block_hash(&block_hash.number, &block_hash.hash);
+    }
+    database.insert_block_hash(
+        &test_case.genesis_block_header.number,
+        &test_case.genesis_block_header.hash,
+    );
 }
 
 #[expect(clippy::too_many_arguments)]

--- a/crates/eest/src/blockchaintest/mod.rs
+++ b/crates/eest/src/blockchaintest/mod.rs
@@ -13,6 +13,6 @@ pub use execute::{
 pub use runner::run;
 pub(crate) use runner::suite;
 pub use types::{
-    Account, Block, BlockHeader, BlockchainTest, BlockchainTestCase, DecodedBlock, ForkSpec,
-    SealEngine, State, Transaction, Withdrawal,
+    Account, Block, BlockHash, BlockHeader, BlockchainTest, BlockchainTestCase, DecodedBlock,
+    ForkSpec, SealEngine, State, Transaction, Withdrawal,
 };

--- a/crates/eest/src/blockchaintest/types.rs
+++ b/crates/eest/src/blockchaintest/types.rs
@@ -29,6 +29,9 @@ pub struct BlockchainTestCase {
     pub post_state: Option<BTreeMap<Address, Account>>,
     /// Pre-state accounts.
     pub pre: State,
+    /// Historical block hashes available to the `BLOCKHASH` opcode before the first block.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub block_hashes: Vec<BlockHash>,
     /// Last block hash.
     pub lastblockhash: B256,
     /// Network specification.
@@ -36,6 +39,16 @@ pub struct BlockchainTestCase {
     /// Seal engine type.
     #[serde(default)]
     pub seal_engine: SealEngine,
+}
+
+/// Historical block hash entry.
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BlockHash {
+    /// Block number.
+    pub number: U256,
+    /// Block hash.
+    pub hash: B256,
 }
 
 /// Block header structure.


### PR DESCRIPTION
Replay seeded the genesis header hash at block 0, so captured mainnet ranges fell through to the dummy DB for BLOCKHASH lookups before the first block.

Serialize captured historical hashes and seed them by real block number.