### PR TITLE
fix(cli): move perf features from evm2 defaults

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -21,7 +21,11 @@ workspace = true
 evm2-eest = { path = "../eest", version = "0.1.0" }
 evm2 = { workspace = true, default-features = true, features = [
     "asm-keccak",
+    "blst",
+    "c-kzg",
     "map-foldhash",
+    "p256-aws-lc-rs",
+    "secp256k1",
 ] }
 
 alloy-consensus = { workspace = true, features = ["k256", "secp256k1", "std"] }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -22,7 +22,8 @@ evm2-eest = { path = "../eest", version = "0.1.0" }
 evm2 = { workspace = true, default-features = true, features = [
     "asm-keccak",
     "blst",
-    "c-kzg",
+    # c-kzg doesn't play well with nextest.
+    # "c-kzg",
     "map-foldhash",
     "p256-aws-lc-rs",
     "secp256k1",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -19,7 +19,10 @@ workspace = true
 
 [dependencies]
 evm2-eest = { path = "../eest", version = "0.1.0" }
-evm2 = { workspace = true, default-features = true }
+evm2 = { workspace = true, default-features = true, features = [
+    "asm-keccak",
+    "map-foldhash",
+] }
 
 alloy-consensus = { workspace = true, features = ["k256", "secp256k1", "std"] }
 alloy-chains.workspace = true

--- a/crates/evm2/Cargo.toml
+++ b/crates/evm2/Cargo.toml
@@ -109,9 +109,6 @@ default = [
     # "c-kzg",
     "portable",
     "bn254-mcl",
-    # TODO: probably shouldn't enable these library-wide.
-    "asm-keccak",
-    "map-foldhash",
 ]
 std = [
     "alloy-consensus/std",


### PR DESCRIPTION
This removes `asm-keccak` and `map-foldhash` from the `evm2` crate's default feature set and enables them only for the CLI's dependency on `evm2`. These are performance-oriented choices rather than library-wide semantic requirements, so the library default set stays narrower while the CLI keeps the same optimized configuration it had through default feature unification.

For comparison, current Reth keeps `revm` itself with `default-features = false`, enables `alloy-primitives/map-foldhash` at the workspace dependency level, and gates `asm-keccak` through binary or node features. Its Ethereum node and EF test crates explicitly enable the required `revm` execution features such as `secp256k1`, `blst`, `c-kzg`, `memory_limit`, and `p256-aws-lc-rs`; this PR enables the matching `evm2` equivalents in the CLI where they exist and are suitable as defaults (`secp256k1`, `blst`, and `p256-aws-lc-rs`). `c-kzg` is left commented out in the CLI for the same nextest issue noted on the `evm2` default feature list, and `evm2` does not currently expose a `memory_limit` feature.

Current upstream `revm` has the same split for these two knobs: the `revm` crate default features are `std`, `secp256k1`, `portable`, `tracer`, `c-kzg`, and `blst`, while `asm-keccak` and `map-foldhash` are separate opt-in features. The `revme` binary defaults `map-foldhash` through its own feature set, but does not make `asm-keccak` a default, which matches moving these choices out of the library default surface and into binary/application-level configuration.
