### PR TITLE
perf(cli): enable keccak cache

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -33,7 +33,7 @@ alloy-consensus = { workspace = true, features = ["k256", "secp256k1", "std"] }
 alloy-chains.workspace = true
 alloy-eips = { workspace = true, features = ["serde", "std"] }
 alloy-hardforks.workspace = true
-alloy-primitives = { workspace = true, features = ["secp256k1", "serde", "std"] }
+alloy-primitives = { workspace = true, features = ["keccak-cache-global", "secp256k1", "serde", "std"] }
 alloy-rlp = { workspace = true, features = ["std"] }
 clap.workspace = true
 rand.workspace = true


### PR DESCRIPTION
Enables alloy-primitives global keccak caching for the CLI crate so repeated keccak calls can reuse the shared cache provided by alloy. This keeps the feature scoped to the command-line binary dependency without changing the core evm2 crate feature set.
