### PR TITLE
perf: enable asm keccak for revm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ once_cell = { version = "1.21", default-features = false }
 paste = { version = "1.0", default-features = false }
 phf = { version = "0.13", default-features = false }
 rand = "0.10"
+revm = { version = "38", default-features = true, features = ["asm-keccak"] }
 rstest = "0.26.0"
 serde = { version = "1.0", default-features = false }
 serde_json = { version = "1.0", default-features = false }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -37,7 +37,7 @@ alloy-primitives = { workspace = true, features = ["keccak-cache-global", "secp2
 alloy-rlp = { workspace = true, features = ["std"] }
 clap.workspace = true
 rand.workspace = true
-revm = { version = "38", default-features = true }
+revm.workspace = true
 secp256k1 = { workspace = true, features = ["global-context", "recovery"] }
 serde = { workspace = true, features = ["derive", "std"] }
 serde_json = { workspace = true, features = ["std"] }

--- a/crates/evm2/Cargo.toml
+++ b/crates/evm2/Cargo.toml
@@ -91,7 +91,7 @@ rstest.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
 [target.'cfg(not(target_family = "wasm"))'.dev-dependencies]
-revm = { version = "38", default-features = true, features = ["test-types"] }
+revm = { workspace = true, features = ["test-types"] }
 
 [[bench]]
 name = "evm"


### PR DESCRIPTION
Moves revm into the workspace dependency table and enables asm-keccak there, matching the optimized keccak path used by evm2. The CLI and evm2 dev-dependency now inherit that shared revm configuration while evm2 tests still opt into revm test-types at the call site.
