### PR TITLE
perf(cli): decode trace RPC off runtime

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -44,6 +44,6 @@ rand.workspace = true
 revm.workspace = true
 secp256k1 = { workspace = true, features = ["global-context", "recovery"] }
 serde = { workspace = true, features = ["derive", "std"] }
-serde_json = { workspace = true, features = ["std"] }
+serde_json = { workspace = true, features = ["raw_value", "std"] }
 thiserror = { workspace = true, features = ["std"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "sync", "time"] }

--- a/crates/cli/src/capture/error.rs
+++ b/crates/cli/src/capture/error.rs
@@ -18,8 +18,8 @@ pub(crate) enum CaptureError {
     EncodeJson(#[source] serde_json::Error),
     #[error("failed to decode RPC trace response")]
     DecodeTrace(#[source] serde_json::Error),
-    #[error("failed to join blocking RPC trace decoder")]
-    JoinTraceDecoder(#[source] tokio::task::JoinError),
+    #[error("failed to join blocking capture block preparation")]
+    JoinBlockPreparation(#[source] tokio::task::JoinError),
     #[error(
         "block {block_number} trace transaction count mismatch: expected {expected}, prestate {prestate}, diff {diff}"
     )]

--- a/crates/cli/src/capture/error.rs
+++ b/crates/cli/src/capture/error.rs
@@ -16,6 +16,10 @@ pub(crate) enum CaptureError {
     Runtime(#[source] std::io::Error),
     #[error("failed to encode JSON")]
     EncodeJson(#[source] serde_json::Error),
+    #[error("failed to decode RPC trace response")]
+    DecodeTrace(#[source] serde_json::Error),
+    #[error("failed to join blocking RPC trace decoder")]
+    JoinTraceDecoder(#[source] tokio::task::JoinError),
     #[error(
         "block {block_number} trace transaction count mismatch: expected {expected}, prestate {prestate}, diff {diff}"
     )]

--- a/crates/cli/src/capture/mod.rs
+++ b/crates/cli/src/capture/mod.rs
@@ -13,7 +13,7 @@ use alloy_consensus::{
     Block as ConsensusBlock, EthereumTxEnvelope, TxEip4844, transaction::SignerRecoverable,
 };
 use futures_util::{StreamExt, stream};
-use serde_json::Value;
+use serde_json::{Value, value::RawValue};
 use std::{fs::File, io::BufWriter, time::Instant};
 
 type MainnetBlock = ConsensusBlock<EthereumTxEnvelope<TxEip4844>>;
@@ -76,17 +76,8 @@ async fn capture(
 
     while let Some(block) = blocks.next().await {
         let block_started_at = Instant::now();
-        let FetchedBlock { number, consensus_block, pre_traces, diff_traces } = block?;
-        if pre_traces.len() != consensus_block.body.transactions.len()
-            || diff_traces.len() != consensus_block.body.transactions.len()
-        {
-            return Err(CaptureError::TraceTransactionCountMismatch {
-                block_number: number,
-                expected: consensus_block.body.transactions.len(),
-                prestate: pre_traces.len(),
-                diff: diff_traces.len(),
-            });
-        }
+        let PreparedBlock { number, consensus_block, pre_traces, diff_traces, transactions } =
+            block?;
 
         for (tx_index, ((pre_trace, diff_trace), tx)) in pre_traces
             .iter()
@@ -106,16 +97,6 @@ async fn capture(
 
         let spec = ethereum::mainnet_spec_for_header(&consensus_block.header);
         let _version_index = builder.version_index(spec)?;
-        let transactions = consensus_block
-            .body
-            .transactions
-            .iter()
-            .map(|tx| {
-                let signer = tx.recover_signer().map_err(CaptureError::RecoverSigner)?;
-                Ok(model::CapturedTransaction { signer })
-            })
-            .collect::<std::result::Result<Vec<_>, CaptureError>>()?;
-
         let block_transaction_count = transactions.len();
         transaction_count += block_transaction_count;
         block_inputs.push(model::CapturedBlock { block: consensus_block, transactions });
@@ -153,18 +134,59 @@ async fn capture(
 struct FetchedBlock {
     number: u64,
     consensus_block: MainnetBlock,
+    pre_traces: Box<RawValue>,
+    diff_traces: Box<RawValue>,
+}
+
+struct PreparedBlock {
+    number: u64,
+    consensus_block: MainnetBlock,
     pre_traces: Vec<Value>,
     diff_traces: Vec<Value>,
+    transactions: Vec<model::CapturedTransaction>,
 }
 
 async fn fetch_block(
     rpc: &rpc::RpcEndpoint,
     number: u64,
-) -> std::result::Result<FetchedBlock, CaptureError> {
+) -> std::result::Result<PreparedBlock, CaptureError> {
     let (consensus_block, pre_traces, diff_traces) = tokio::try_join!(
         rpc.block(number),
         rpc.trace_block(number, rpc::TraceMode::PreState),
         rpc.trace_block(number, rpc::TraceMode::Diff),
     )?;
-    Ok(FetchedBlock { number, consensus_block, pre_traces, diff_traces })
+    prepare_block(FetchedBlock { number, consensus_block, pre_traces, diff_traces }).await
+}
+
+async fn prepare_block(block: FetchedBlock) -> std::result::Result<PreparedBlock, CaptureError> {
+    tokio::task::spawn_blocking(move || {
+        let FetchedBlock { number, consensus_block, pre_traces, diff_traces } = block;
+        let pre_traces: Vec<Value> =
+            serde_json::from_str(pre_traces.get()).map_err(CaptureError::DecodeTrace)?;
+        let diff_traces: Vec<Value> =
+            serde_json::from_str(diff_traces.get()).map_err(CaptureError::DecodeTrace)?;
+        let expected = consensus_block.body.transactions.len();
+        if pre_traces.len() != expected || diff_traces.len() != expected {
+            return Err(CaptureError::TraceTransactionCountMismatch {
+                block_number: number,
+                expected,
+                prestate: pre_traces.len(),
+                diff: diff_traces.len(),
+            });
+        }
+
+        let transactions = consensus_block
+            .body
+            .transactions
+            .iter()
+            .map(|tx| {
+                let signer = tx.recover_signer().map_err(CaptureError::RecoverSigner)?;
+                Ok(model::CapturedTransaction { signer })
+            })
+            .collect::<std::result::Result<Vec<_>, CaptureError>>()?;
+
+        Ok(PreparedBlock { number, consensus_block, pre_traces, diff_traces, transactions })
+    })
+    .await
+    .map_err(CaptureError::JoinBlockPreparation)?
 }

--- a/crates/cli/src/capture/rpc.rs
+++ b/crates/cli/src/capture/rpc.rs
@@ -4,7 +4,7 @@ use alloy_provider::{Provider, RootProvider};
 use alloy_rpc_client::RpcClient;
 use alloy_rpc_types_eth::BlockNumberOrTag;
 use alloy_rpc_types_trace::geth::{GethDebugTracingOptions, PreStateConfig};
-use serde_json::Value;
+use serde_json::{Value, value::RawValue};
 use std::{borrow::Cow, sync::Arc, time::Duration};
 use tokio::sync::Semaphore;
 
@@ -78,13 +78,22 @@ impl RpcEndpoint {
         };
         let options =
             GethDebugTracingOptions::prestate_tracer(config).with_timeout(Duration::from_secs(120));
-        self.call(|| {
-            self.provider.raw_request(
-                Cow::Borrowed("debug_traceBlockByNumber"),
-                (BlockNumberOrTag::Number(block_number), &options),
-            )
-        })
-        .await
+        let raw = self
+            .call(|| {
+                self.provider.raw_request(
+                    Cow::Borrowed("debug_traceBlockByNumber"),
+                    (BlockNumberOrTag::Number(block_number), &options),
+                )
+            })
+            .await?;
+        Self::decode_trace(raw).await
+    }
+
+    async fn decode_trace(raw: Box<RawValue>) -> Result<Vec<Value>, CaptureError> {
+        tokio::task::spawn_blocking(move || serde_json::from_str(raw.get()))
+            .await
+            .map_err(CaptureError::JoinTraceDecoder)?
+            .map_err(CaptureError::DecodeTrace)
     }
 
     async fn call<R, F, Fut>(&self, call: F) -> Result<R, CaptureError>

--- a/crates/cli/src/capture/rpc.rs
+++ b/crates/cli/src/capture/rpc.rs
@@ -4,7 +4,7 @@ use alloy_provider::{Provider, RootProvider};
 use alloy_rpc_client::RpcClient;
 use alloy_rpc_types_eth::BlockNumberOrTag;
 use alloy_rpc_types_trace::geth::{GethDebugTracingOptions, PreStateConfig};
-use serde_json::{Value, value::RawValue};
+use serde_json::value::RawValue;
 use std::{borrow::Cow, sync::Arc, time::Duration};
 use tokio::sync::Semaphore;
 
@@ -71,29 +71,20 @@ impl RpcEndpoint {
         &self,
         block_number: u64,
         mode: TraceMode,
-    ) -> Result<Vec<Value>, CaptureError> {
+    ) -> Result<Box<RawValue>, CaptureError> {
         let config = match mode {
             TraceMode::PreState => PreStateConfig::default(),
             TraceMode::Diff => PreStateConfig { diff_mode: Some(true), ..Default::default() },
         };
         let options =
             GethDebugTracingOptions::prestate_tracer(config).with_timeout(Duration::from_secs(120));
-        let raw = self
-            .call(|| {
-                self.provider.raw_request(
-                    Cow::Borrowed("debug_traceBlockByNumber"),
-                    (BlockNumberOrTag::Number(block_number), &options),
-                )
-            })
-            .await?;
-        Self::decode_trace(raw).await
-    }
-
-    async fn decode_trace(raw: Box<RawValue>) -> Result<Vec<Value>, CaptureError> {
-        tokio::task::spawn_blocking(move || serde_json::from_str(raw.get()))
-            .await
-            .map_err(CaptureError::JoinTraceDecoder)?
-            .map_err(CaptureError::DecodeTrace)
+        self.call(|| {
+            self.provider.raw_request(
+                Cow::Borrowed("debug_traceBlockByNumber"),
+                (BlockNumberOrTag::Number(block_number), &options),
+            )
+        })
+        .await
     }
 
     async fn call<R, F, Fut>(&self, call: F) -> Result<R, CaptureError>


### PR DESCRIPTION
Moves capture trace RPC decoding off the Tokio runtime worker threads. The debug trace calls now ask Alloy for the raw JSON result payload, then deserialize the large `Vec<Value>` trace body in `spawn_blocking`, keeping the existing Alloy provider, retry layer, and request concurrency limit intact.

This targets the large `debug_traceBlockByNumber` responses without changing the capture output format or ordered overlay application.
