### PR TITLE
Integrate stumpalo frame journal

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,7 @@ revm = { version = "38", default-features = true, features = ["asm-keccak"] }
 rstest = "0.26.0"
 serde = { version = "1.0", default-features = false }
 serde_json = { version = "1.0", default-features = false }
+stumpalo = { git = "https://github.com/alloy-rs/stumpalo", rev = "ffadd23b80792a9e42ca13df8fa3c94e530e1d09", default-features = false }
 thiserror = { version = "2.0", default-features = false }
 tokio = { version = "1", default-features = false }
 walkdir = { version = "2.5", default-features = false }

--- a/crates/evm2/Cargo.toml
+++ b/crates/evm2/Cargo.toml
@@ -32,6 +32,7 @@ phf = { workspace = true, features = ["macros"], optional = true }
 
 # "serde"
 serde = { workspace = true, features = ["derive", "alloc"], optional = true }
+stumpalo.workspace = true
 
 # "async"
 tokio = { workspace = true, features = ["rt-multi-thread"], optional = true }

--- a/crates/evm2/src/ethereum/eip1559.rs
+++ b/crates/evm2/src/ethereum/eip1559.rs
@@ -65,7 +65,13 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
         ..TxEnv::default()
     };
     let (bytecode, mut message) =
-        initial_message(req.host, caller, tx.nonce, tx.to, &tx.input, tx.value, gas_limit)?;
+        match initial_message(req.host, caller, tx.nonce, tx.to, &tx.input, tx.value, gas_limit) {
+            Ok(message) => message,
+            Err(err) => {
+                req.host.state.rollback(execution_checkpoint, req.host.version().features);
+                return Err(err);
+            }
+        };
     let mut result = req.host.execute_message(&tx_env, bytecode, &mut message, false);
     rollback_failed_execution(req.host, execution_checkpoint, &mut result);
 

--- a/crates/evm2/src/ethereum/eip2930.rs
+++ b/crates/evm2/src/ethereum/eip2930.rs
@@ -59,7 +59,13 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
         ..TxEnv::default()
     };
     let (bytecode, mut message) =
-        initial_message(req.host, caller, tx.nonce, tx.to, &tx.input, tx.value, gas_limit)?;
+        match initial_message(req.host, caller, tx.nonce, tx.to, &tx.input, tx.value, gas_limit) {
+            Ok(message) => message,
+            Err(err) => {
+                req.host.state.rollback(execution_checkpoint, req.host.version().features);
+                return Err(err);
+            }
+        };
     let mut result = req.host.execute_message(&tx_env, bytecode, &mut message, false);
     rollback_failed_execution(req.host, execution_checkpoint, &mut result);
 

--- a/crates/evm2/src/ethereum/eip4844.rs
+++ b/crates/evm2/src/ethereum/eip4844.rs
@@ -79,8 +79,21 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
         ext: T::TxEnvExt::default(),
         _non_exhaustive: (),
     };
-    let (bytecode, mut message) =
-        initial_message(req.host, caller, tx.nonce, tx.to.into(), &tx.input, tx.value, gas_limit)?;
+    let (bytecode, mut message) = match initial_message(
+        req.host,
+        caller,
+        tx.nonce,
+        tx.to.into(),
+        &tx.input,
+        tx.value,
+        gas_limit,
+    ) {
+        Ok(message) => message,
+        Err(err) => {
+            req.host.state.rollback(execution_checkpoint, req.host.version().features);
+            return Err(err);
+        }
+    };
     let mut result = req.host.execute_message(&tx_env, bytecode, &mut message, false);
     rollback_failed_execution(req.host, execution_checkpoint, &mut result);
 

--- a/crates/evm2/src/ethereum/eip7702.rs
+++ b/crates/evm2/src/ethereum/eip7702.rs
@@ -72,8 +72,21 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
         chain_id: U256::from(req.host.version().chain_id),
         ..TxEnv::default()
     };
-    let (bytecode, mut message) =
-        initial_message(req.host, caller, tx.nonce, tx.to.into(), &tx.input, tx.value, gas_limit)?;
+    let (bytecode, mut message) = match initial_message(
+        req.host,
+        caller,
+        tx.nonce,
+        tx.to.into(),
+        &tx.input,
+        tx.value,
+        gas_limit,
+    ) {
+        Ok(message) => message,
+        Err(err) => {
+            req.host.state.rollback(execution_checkpoint, req.host.version().features);
+            return Err(err);
+        }
+    };
     let mut result = req.host.execute_message(&tx_env, bytecode, &mut message, false);
     rollback_failed_execution(req.host, execution_checkpoint, &mut result);
     result.gas.set_refunded(

--- a/crates/evm2/src/ethereum/legacy.rs
+++ b/crates/evm2/src/ethereum/legacy.rs
@@ -49,7 +49,13 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
         ..TxEnv::default()
     };
     let (bytecode, mut message) =
-        initial_message(req.host, caller, tx.nonce, tx.to, &tx.input, tx.value, gas_limit)?;
+        match initial_message(req.host, caller, tx.nonce, tx.to, &tx.input, tx.value, gas_limit) {
+            Ok(message) => message,
+            Err(err) => {
+                req.host.state.rollback(execution_checkpoint, req.host.version().features);
+                return Err(err);
+            }
+        };
     let mut result = req.host.execute_message(&tx_env, bytecode, &mut message, false);
     rollback_failed_execution(req.host, execution_checkpoint, &mut result);
 

--- a/crates/evm2/src/ethereum/mod.rs
+++ b/crates/evm2/src/ethereum/mod.rs
@@ -415,6 +415,8 @@ pub(super) fn rollback_failed_execution<T: EvmTypes<Host = Evm<T>>>(
         if result.stop.is_halt() {
             result.gas.set_remaining(0);
         }
+    } else {
+        host.state.commit(checkpoint);
     }
 }
 

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -672,6 +672,7 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
                 self.state.rollback(checkpoint, self.features);
                 return Self::error_message_result(self.db_error_stop(code), gas_limit);
             }
+            self.state.commit(checkpoint);
         } else {
             self.state.rollback(checkpoint, self.features);
         }
@@ -763,10 +764,12 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
             || match self.state.transfer(&message.caller, &message.destination, &message.value) {
                 Ok(result) => result,
                 Err(code) => {
+                    self.state.rollback(checkpoint, self.features);
                     return Self::error_message_result(self.db_error_stop(code), message.gas_limit);
                 }
             };
         if transfers_balance && !transfer_succeeded {
+            self.state.rollback(checkpoint, self.features);
             return Self::error_message_result(InstrStop::OutOfFunds, message.gas_limit);
         }
         if transfers_balance {
@@ -802,6 +805,8 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
         };
         if !stop.is_success() {
             self.state.rollback(checkpoint, self.features);
+        } else {
+            self.state.commit(checkpoint);
         }
         MessageResult {
             stop,
@@ -824,6 +829,8 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
         let output = Bytes::copy_from_slice(interp.output());
         if !stop.is_success() {
             self.state.rollback(checkpoint, self.features);
+        } else {
+            self.state.commit(checkpoint);
         }
 
         MessageResult {

--- a/crates/evm2/src/evm/state.rs
+++ b/crates/evm2/src/evm/state.rs
@@ -18,6 +18,7 @@ use alloy_primitives::{
 };
 use core::mem;
 use derive_where::derive_where;
+use stumpalo::{FrameStack, StackFrame};
 
 /// A value tracked together with the value it had at the start of the current
 /// transaction.
@@ -263,7 +264,7 @@ pub struct StorageChangeSet {
 #[derive(Debug, Eq, PartialEq)]
 pub struct StateCheckpoint {
     /// Revert journal length at the checkpoint.
-    journal_len: usize,
+    journal_frame: StackFrame<JournalEntry>,
     /// Emitted log count at the checkpoint.
     logs_len: usize,
 }
@@ -352,7 +353,7 @@ pub struct State {
     /// Persistent storage writes for the current transaction.
     storage: AddressMap<StorageOverlay>,
     /// Revert journal.
-    journal: Vec<JournalEntry>,
+    journal: FrameStack<JournalEntry>,
     /// Logs emitted by the current transaction.
     logs: Vec<Log>,
     /// Accounts touched for transaction-finalization account-lifetime rules.
@@ -385,7 +386,7 @@ impl State {
             database: CacheDB::new(initial),
             accounts: AddressMap::default(),
             storage: AddressMap::default(),
-            journal: Vec::new(),
+            journal: FrameStack::new(),
             logs: Vec::new(),
             touched: AddressSet::default(),
             selfdestructs: AddressSet::default(),
@@ -397,8 +398,8 @@ impl State {
 
     /// Returns a checkpoint for later rollback.
     #[inline]
-    pub const fn checkpoint(&self) -> StateCheckpoint {
-        StateCheckpoint { journal_len: self.journal.len(), logs_len: self.logs.len() }
+    pub fn checkpoint(&mut self) -> StateCheckpoint {
+        StateCheckpoint { journal_frame: self.journal.checkpoint(), logs_len: self.logs.len() }
     }
 
     /// Returns the initial database.
@@ -588,7 +589,7 @@ impl State {
     fn ensure_transaction_account<'a>(
         database: &mut dyn DynDatabase,
         accounts: &'a mut AddressMap<Option<Account>>,
-        journal: &mut Vec<JournalEntry>,
+        journal: &mut FrameStack<JournalEntry>,
         address: &Address,
     ) -> DbResult<&'a mut Option<Account>> {
         match accounts.entry(*address) {
@@ -949,13 +950,10 @@ impl State {
     /// Reverts state changes after the checkpoint.
     #[inline(never)]
     pub fn rollback(&mut self, checkpoint: StateCheckpoint, features: EvmFeatures) {
-        assert!(checkpoint.journal_len <= self.journal.len(), "checkpoint is past journal length");
         assert!(checkpoint.logs_len <= self.logs.len(), "checkpoint is past logs length");
         self.logs.truncate(checkpoint.logs_len);
-        while self.journal.len() != checkpoint.journal_len {
-            let Some(entry) = self.journal.pop() else {
-                unreachable!("checkpoint is checked above")
-            };
+        let entries: Vec<_> = self.journal.rollback(checkpoint.journal_frame).collect();
+        for entry in entries {
             match entry {
                 JournalEntry::AccountChange { address, previous } => {
                     if let Some(account) = self.accounts.get_mut(&address) {
@@ -1013,6 +1011,12 @@ impl State {
                 }
             }
         }
+    }
+
+    /// Commits state changes after the checkpoint.
+    #[inline]
+    pub fn commit(&mut self, checkpoint: StateCheckpoint) {
+        self.journal.commit(checkpoint.journal_frame);
     }
 
     /// Returns whether an existing account is dead by the EIP-161 definition.


### PR DESCRIPTION
## Summary
- depend on the `alloy-rs/stumpalo` fork via pinned git rev `ffadd23b80792a9e42ca13df8fa3c94e530e1d09`
- replace the raw EVM state revert `Vec<JournalEntry>` with `stumpalo::FrameStack<JournalEntry>`
- resolve checkpoints explicitly on success or failure across call/create/precompile/transaction execution paths

## Fork
- https://github.com/alloy-rs/stumpalo

## Tests
- `cargo test` in `alloy-rs/stumpalo`
- `CARGO_NET_GIT_FETCH_WITH_CLI=true cargo test -p evm2 --no-default-features evm::state::tests`
- `cargo fmt --check`

## Notes
- `cargo test -p evm2 evm::state::tests` with default features is blocked in this sandbox by missing system GMP for `mcl_rust`.