### PR TITLE
feat: expose overlay database

### DIFF
--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -211,6 +211,18 @@ impl<T: EvmTypes> Evm<T> {
         self.state.initial_mut()
     }
 
+    /// Returns the accepted database overlay.
+    #[inline]
+    pub fn overlay_db(&self) -> &CacheDB<Box<dyn DynDatabase>> {
+        self.state.overlay_db()
+    }
+
+    /// Returns the accepted database overlay mutably.
+    #[inline]
+    pub fn overlay_db_mut(&mut self) -> &mut CacheDB<Box<dyn DynDatabase>> {
+        self.state.overlay_db_mut()
+    }
+
     /// Returns the latest database error code raised during execution.
     #[inline]
     pub const fn db_error_code(&self) -> Option<DbErrorCode> {

--- a/crates/evm2/src/evm/state.rs
+++ b/crates/evm2/src/evm/state.rs
@@ -413,6 +413,18 @@ impl State {
         self.database.db.as_mut()
     }
 
+    /// Returns the accepted database overlay.
+    #[inline]
+    pub const fn overlay_db(&self) -> &CacheDB<Box<dyn DynDatabase>> {
+        &self.database
+    }
+
+    /// Returns the accepted database overlay mutably.
+    #[inline]
+    pub const fn overlay_db_mut(&mut self) -> &mut CacheDB<Box<dyn DynDatabase>> {
+        &mut self.database
+    }
+
     /// Replaces the initial database and clears all in-memory state layers.
     #[inline]
     pub fn set_initial(&mut self, initial: impl DynDatabase) {


### PR DESCRIPTION
This exposes the accepted `CacheDB` overlay through `State::overlay_db`, `State::overlay_db_mut`, `Evm::overlay_db`, and `Evm::overlay_db_mut`.

The existing `initial`/`database` accessors continue to return the wrapped backing database, while the new accessors make the accepted in-memory overlay directly available to callers that need it.
