### PR TITLE
feat(evm): add discard_with transaction resolution

### DIFF
--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -18,6 +18,7 @@
 //!   [`BlockStateAccumulator`];
 //! - [`ExecutedTx::commit_with`] streams writes to a [`StateChangeSink`] and then accepts them;
 //! - [`ExecutedTx::discard`] drops the writes and returns only the result;
+//! - [`ExecutedTx::discard_with`] streams writes to a [`StateChangeSink`] and then drops them;
 //! - [`ExecutedTx::detach`] materializes an owned [`TxResultWithState`] without accepting the
 //!   writes.
 //!
@@ -32,8 +33,8 @@
 //!    wrapped database and is visible to later transactions executed by the same [`Evm`].
 //! 2. **Transaction scratch**: writes, warm-access state, transient storage, journal entries,
 //!    touched accounts, selfdestruct markers, and logs for the currently executing transaction. It
-//!    is cleared after `commit`, `commit_to`, `commit_with`, `discard`, or `detach` while retaining
-//!    capacity where possible.
+//!    is cleared after `commit`, `commit_to`, `commit_with`, `discard`, `discard_with`, or `detach`
+//!    while retaining capacity where possible.
 //! 3. **Block accumulator**: optional block-level state output. It coalesces committed transaction
 //!    writes and keeps block-boundary originals.
 //!
@@ -79,6 +80,7 @@
 //! eth_call / simulation: transact -> discard
 //! serial block:          transact -> commit
 //! block output:          transact -> commit_to -> BlockStateAccumulator
+//! traced simulation:     transact -> discard_with -> Sink
 //! materialized tx diff:  transact -> detach -> TxResultWithState
 //! parallel worker:       transact -> detach -> send owned diff
 //! ```
@@ -670,7 +672,8 @@ impl<T: EvmTypes<Tx: Typed2718, Host = Self>> Evm<T> {
     ///
     /// The returned [`ExecutedTx`] keeps post-finalization writes in the transaction scratch layer.
     /// Callers must resolve it with [`ExecutedTx::commit`], [`ExecutedTx::commit_to`],
-    /// [`ExecutedTx::commit_with`], [`ExecutedTx::discard`], or [`ExecutedTx::detach`] before
+    /// [`ExecutedTx::commit_with`], [`ExecutedTx::discard`], [`ExecutedTx::discard_with`], or
+    /// [`ExecutedTx::detach`] before
     /// another transaction can be executed. Dropping the handle is equivalent to
     /// [`ExecutedTx::discard`].
     pub fn transact(&mut self, tx: &T::Tx) -> HandlerResult<ExecutedTx<'_, T>> {
@@ -1947,6 +1950,29 @@ mod tests {
 
         assert_eq!(outcome.gas_used(), 7);
         assert_eq!(outcome.logs.len(), 1);
+        assert_eq!(
+            evm.state.storage_ref(&LIFECYCLE_ACCOUNT, &LIFECYCLE_STORAGE_KEY),
+            Some(Word::from(1))
+        );
+    }
+
+    #[test]
+    fn executed_transaction_discard_with_streams_without_committing() {
+        let mut evm = lifecycle_evm();
+        let mut sink = BlockStateAccumulator::new();
+
+        let outcome = evm
+            .transact(&test_tx(7))
+            .expect("lifecycle transaction should execute")
+            .discard_with(&mut sink)
+            .expect("block accumulator is infallible");
+
+        assert_eq!(outcome.gas_used(), 7);
+        assert_eq!(outcome.logs.len(), 1);
+        let storage = sink.storage_sorted();
+        assert_eq!(storage.len(), 1);
+        assert_eq!(storage[0].1.original, Word::from(1));
+        assert_eq!(storage[0].1.current, Word::from(7));
         assert_eq!(
             evm.state.storage_ref(&LIFECYCLE_ACCOUNT, &LIFECYCLE_STORAGE_KEY),
             Some(Word::from(1))

--- a/crates/evm2/src/evm/tx.rs
+++ b/crates/evm2/src/evm/tx.rs
@@ -54,10 +54,11 @@ enum PendingState {
 /// transaction scratch:
 ///
 /// - [`Self::commit`] accepts the state into the internal accepted overlay;
-/// - [`Self::discard`] drops the state and keeps only the result;
-/// - [`Self::detach`] materializes an owned [`StateChanges`] value without committing it;
 /// - [`Self::commit_to`] accepts the state and records it in a block accumulator;
-/// - [`Self::commit_with`] accepts the state and first streams it to an external sink.
+/// - [`Self::commit_with`] accepts the state and first streams it to an external sink;
+/// - [`Self::discard`] drops the state and keeps only the result;
+/// - [`Self::discard_with`] streams the state to an external sink and then drops it;
+/// - [`Self::detach`] materializes an owned [`StateChanges`] value without committing it.
 ///
 /// Dropping `ExecutedTx` without calling one of those methods is equivalent to [`Self::discard`].
 #[must_use = "executed transaction state must be committed, discarded, or detached"]
@@ -180,6 +181,22 @@ impl<'evm, T: EvmTypes> ExecutedTx<'evm, T> {
     pub fn discard(mut self) -> TxResult<T> {
         self.clear_pending_state();
         self.take_result()
+    }
+
+    /// Streams transaction changes into `sink`, then discards the transaction state.
+    ///
+    /// This observes the same pending writes as [`Self::commit_with`], but does not mutate the
+    /// accepted overlay. If the sink returns an error, the executed handle is dropped, which
+    /// discards the transaction scratch.
+    pub fn discard_with<S: StateChangeSink>(
+        mut self,
+        sink: &mut S,
+    ) -> Result<TxResult<T>, S::Error> {
+        if self.has_pending_state() {
+            self.evm.state.visit_transaction_changes(sink)?;
+            self.clear_pending_state();
+        }
+        Ok(self.take_result())
     }
 
     /// Detaches the transaction into an owned state diff without committing it.


### PR DESCRIPTION
Adds `ExecutedTx::discard_with`, mirroring `commit_with` but streaming pending transaction changes to a `StateChangeSink` before discarding scratch instead of committing to the accepted overlay. Updates lifecycle docs and covers the discard-with-streaming path with a unit test.