### PR TITLE
feat(eest): add ability to skip full hardforks

### DIFF
--- a/crates/eest/README.md
+++ b/crates/eest/README.md
@@ -101,3 +101,8 @@ For local experiments, `EVM2_STATETEST_ROOT`, `EVM2_BLOCKCHAINTEST_ROOT`,
 `EVM2_STATETEST_STABLE`, `EVM2_BLOCKCHAINTEST_STABLE`, `EVM2_EEST_STABLE`,
 `ETHEREUM_TESTS`, `ETHTESTS`, `EVM2_TEST_FIXTURES`, `REVMC_TEST_FIXTURES`, and
 `SUBDIR` are supported as optional filters.
+
+Test cases for unsupported hardforks (currently Amsterdam) are skipped
+automatically. Set `EVM2_SKIP_FORKS` to a comma-separated list of hardfork
+names (for example `EVM2_SKIP_FORKS=osaka,prague`) to skip additional full
+hardforks.

--- a/crates/eest/src/blockchaintest/execute.rs
+++ b/crates/eest/src/blockchaintest/execute.rs
@@ -11,6 +11,7 @@ use super::{
 };
 use crate::{
     filter::EntryPoint,
+    forks::is_fork_skipped,
     state::{insert_account_with_storage, parse_bytecode},
     tx::{TxFields, build_recovered_tx, rpc_access_list, signed_authorizations},
 };
@@ -78,7 +79,10 @@ pub fn execute_str(
         serde_json::from_str(input).map_err(|err| TestError::unknown(path, err.into()))?;
     let mut summary = ExecuteSummary::default();
     for (name, test_case) in suite.0 {
-        if !entrypoint.matches(&name) || test_case.network.is_transition() {
+        if !entrypoint.matches(&name)
+            || test_case.network.is_transition()
+            || is_fork_skipped(fork_to_spec_id(test_case.network))
+        {
             summary.skipped += 1;
             continue;
         }

--- a/crates/eest/src/execute.rs
+++ b/crates/eest/src/execute.rs
@@ -1,6 +1,7 @@
 use crate::{
     error::{TestError, TestErrorKind},
     filter::EntryPoint,
+    forks::is_fork_skipped,
     state::{
         insert_account_with_storage, parse_bytecode, storage_for_root, system_contract_has_code,
     },
@@ -104,6 +105,9 @@ fn execute_unit(
         let Some(spec) = spec_name.to_spec_id() else {
             continue;
         };
+        if is_fork_skipped(spec) {
+            continue;
+        }
         let block = parse_block(&unit.env, spec);
         for post in posts {
             let tx = match build_tx(&unit.transaction, &post.indexes, unit.env.current_chain_id) {

--- a/crates/eest/src/forks.rs
+++ b/crates/eest/src/forks.rs
@@ -1,0 +1,65 @@
+use evm2::SpecId;
+use std::{env, sync::OnceLock};
+
+/// Environment variable listing extra hardforks to skip, comma-separated by name.
+pub(crate) const SKIP_FORKS_ENV: &str = "EVM2_SKIP_FORKS";
+
+/// Hardforks skipped by default because evm2 does not support them yet.
+const UNSUPPORTED_FORKS: &[SpecId] = &[SpecId::AMSTERDAM];
+
+/// Returns whether all test cases targeting `spec` should be skipped.
+#[inline]
+pub(crate) fn is_fork_skipped(spec: SpecId) -> bool {
+    skipped_forks().contains(&spec)
+}
+
+/// Returns the skipped hardforks, combining [`UNSUPPORTED_FORKS`] with any
+/// forks named in [`SKIP_FORKS_ENV`].
+fn skipped_forks() -> &'static [SpecId] {
+    static SKIPPED: OnceLock<Vec<SpecId>> = OnceLock::new();
+    SKIPPED.get_or_init(|| {
+        let mut forks = UNSUPPORTED_FORKS.to_vec();
+        if let Ok(names) = env::var(SKIP_FORKS_ENV) {
+            for name in names.split(',').map(str::trim).filter(|name| !name.is_empty()) {
+                let Some(spec) = parse_fork(name) else {
+                    panic!("{SKIP_FORKS_ENV}: unknown hardfork name `{name}`");
+                };
+                forks.push(spec);
+            }
+        }
+        forks
+    })
+}
+
+/// Parses a case-insensitive hardfork name into a spec ID.
+fn parse_fork(name: &str) -> Option<SpecId> {
+    macro_rules! parse {
+        ([$name:ident] $($spec:ident $lower:ident,)*) => {
+            match $name.to_ascii_lowercase().as_str() {
+                $(stringify!($lower) => Some(SpecId::$spec),)*
+                _ => None,
+            }
+        };
+    }
+    evm2::for_each_spec!([name] parse)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_fork_names() {
+        assert_eq!(parse_fork("amsterdam"), Some(SpecId::AMSTERDAM));
+        assert_eq!(parse_fork("Osaka"), Some(SpecId::OSAKA));
+        assert_eq!(parse_fork("SPURIOUS_DRAGON"), Some(SpecId::SPURIOUS_DRAGON));
+        assert_eq!(parse_fork("atlantis"), None);
+    }
+
+    #[test]
+    fn unsupported_forks_are_skipped() {
+        assert!(is_fork_skipped(SpecId::AMSTERDAM));
+        assert!(!is_fork_skipped(SpecId::OSAKA));
+        assert!(!is_fork_skipped(SpecId::FRONTIER));
+    }
+}

--- a/crates/eest/src/lib.rs
+++ b/crates/eest/src/lib.rs
@@ -9,6 +9,7 @@ mod error;
 mod execute;
 mod filter;
 mod fixtures;
+mod forks;
 mod harness;
 mod runner;
 mod state;


### PR DESCRIPTION
## Motivation

Amsterdam is not supported yet, so its EEST fixtures fail. Instead of ignoring fixtures path by path, skip entire hardforks at the fork level.

## Solution

Adds `crates/eest/src/forks.rs`, shared by both runners:

- `UNSUPPORTED_FORKS` — forks skipped by default (currently `AMSTERDAM`). Enabling a fork later is a one-line removal.
- `EVM2_SKIP_FORKS` — comma-separated, case-insensitive hardfork names (e.g. `EVM2_SKIP_FORKS=osaka,prague`) to skip additional full forks at runtime. Names are parsed via `evm2::for_each_spec!`, so new `SpecId` variants are picked up automatically; unknown names panic with a clear message.

Wiring:
- State tests: `execute_unit` skips posts whose spec is in the skip set (`SpecName::to_spec_id` stays a pure mapping).
- Blockchain tests: `execute_str` skips cases whose network resolves to a skipped spec, after the existing transition-fork skip.

## Verification

Against EEST fixtures:
- All 5208 `amsterdam/` tests pass as skipped; previously they failed. Other forks (spot-checked osaka) still execute and pass.
- With the default list temporarily emptied: `EVM2_SKIP_FORKS=amsterdam` makes the Amsterdam set pass, omitting it makes it fail again, and a bogus name fails fast with `EVM2_SKIP_FORKS: unknown hardfork name \`atlantis\``.