### PR TITLE
ci: add codspeed benchmarks

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,36 @@
+name: Benchmark
+
+permissions: {}
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  codspeed:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+      - name: Install cargo-codspeed
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-codspeed
+      - name: Build the benchmark target
+        run: cargo codspeed build --profile profiling -p evm2 --bench evm
+      - name: Run the benchmarks
+        uses: CodSpeedHQ/action@v4
+        with:
+          run: cargo codspeed run -p evm2 evm
+          mode: instrumentation
+          token: ${{ secrets.CODSPEED_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,31 +215,6 @@ jobs:
           cache-bin: false
       - run: cargo clippy --workspace --all-targets --all-features
 
-  codspeed:
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
-          cache-bin: false
-      - name: Install cargo-codspeed
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-codspeed
-      - name: Build the benchmark target
-        run: cargo codspeed build --profile profiling -p evm2 --bench evm
-      - name: Run the benchmarks
-        uses: CodSpeedHQ/action@v4
-        with:
-          run: cargo codspeed run -p evm2 evm
-          mode: instrumentation
-          token: ${{ secrets.CODSPEED_TOKEN }}
-
   docs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -280,7 +255,6 @@ jobs:
       - examples
       - typos
       - clippy
-      - codspeed
       - docs
       - fmt
       - deny

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,6 +215,31 @@ jobs:
           cache-bin: false
       - run: cargo clippy --workspace --all-targets --all-features
 
+  codspeed:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+          cache-bin: false
+      - name: Install cargo-codspeed
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-codspeed
+      - name: Build the benchmark target
+        run: cargo codspeed build --profile profiling -p evm2 --bench evm
+      - name: Run the benchmarks
+        uses: CodSpeedHQ/action@v4
+        with:
+          run: cargo codspeed run -p evm2 evm
+          mode: instrumentation
+          token: ${{ secrets.CODSPEED_TOKEN }}
+
   docs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -255,6 +280,7 @@ jobs:
       - examples
       - typos
       - clippy
+      - codspeed
       - docs
       - fmt
       - deny

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,6 +108,11 @@ proc-macro2 = "1.0"
 quote = "1.0"
 syn = "2.0"
 
+# testing
+criterion = { package = "codspeed-criterion-compat", version = "4", default-features = false, features = [
+    "cargo_bench_support",
+] }
+
 [profile.dev]
 opt-level = 3
 

--- a/crates/evm2/Cargo.toml
+++ b/crates/evm2/Cargo.toml
@@ -82,7 +82,7 @@ aws-lc-rs = { workspace = true, optional = true }
 
 [dev-dependencies]
 alloy-primitives = { workspace = true, features = ["serde", "std"] }
-criterion = { package = "codspeed-criterion-compat", version = "4", default-features = false, features = ["cargo_bench_support"] }
+criterion.workspace = true
 serde = { workspace = true, features = ["derive", "std"] }
 serde_json = { workspace = true, features = ["std"] }
 rand = { workspace = true, features = ["std"] }


### PR DESCRIPTION
Adds CodSpeed benchmark integration for the existing `evm2` Criterion benchmark target. The benchmark workflow is split into `.github/workflows/bench.yml`, matching the Solar setup: it installs `cargo-codspeed`, builds the `evm` bench with the profiling profile, and runs it through `CodSpeedHQ/action` in instrumentation mode.

The `criterion` dev dependency is now a workspace dependency backed by `codspeed-criterion-compat`, and `evm2` uses `criterion.workspace = true` for the bench target.
