### PR TITLE
ci: use v0 symbol mangling for codspeed

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -10,6 +10,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  RUSTFLAGS: -Csymbol-mangling-version=v0
 
 jobs:
   codspeed:


### PR DESCRIPTION
Configures the CodSpeed benchmark workflow to compile with Rust's v0 symbol mangling so instrumentation can resolve stable symbol names.