### PR TITLE
perf(ethereum): cache EIP-7702 auth recovery

### DIFF
--- a/crates/cli/src/fuzzer/case.rs
+++ b/crates/cli/src/fuzzer/case.rs
@@ -625,7 +625,7 @@ impl CaseTx {
                 }),
                 self.caller,
             )),
-            TxKindCase::Eip7702 => RecoveredTxEnvelope::Eip7702(Recovered::new_unchecked(
+            TxKindCase::Eip7702 => RecoveredTxEnvelope::from(Recovered::new_unchecked(
                 TxEip7702 {
                     chain_id: 1,
                     nonce: self.nonce,

--- a/crates/eest/src/tx.rs
+++ b/crates/eest/src/tx.rs
@@ -208,7 +208,7 @@ fn recovered_envelope(tx: TypedTransaction, caller: Address) -> RecoveredTxEnvel
             RecoveredTxEnvelope::Eip4844(Recovered::new_unchecked(tx, caller))
         }
         TypedTransaction::Eip7702(tx) => {
-            RecoveredTxEnvelope::Eip7702(Recovered::new_unchecked(tx, caller))
+            RecoveredTxEnvelope::from(Recovered::new_unchecked(tx, caller))
         }
     }
 }

--- a/crates/evm2/src/ethereum/eip7702.rs
+++ b/crates/evm2/src/ethereum/eip7702.rs
@@ -14,12 +14,11 @@ use crate::{
     registry::{HandlerError, HandlerResult, TxRequest},
     version::GasId,
 };
-use alloy_consensus::{TxEip7702, transaction::Recovered};
-use alloy_eips::eip7702::SignedAuthorization;
+use alloy_consensus::transaction::Recovered;
 use alloy_primitives::{Address, U256};
 
 pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
-    req: TxRequest<'_, T, Recovered<TxEip7702>>,
+    req: TxRequest<'_, T, Recovered<super::LazyTxEip7702>>,
 ) -> HandlerResult<TxResult<T>> {
     let caller = req.tx.signer();
     let tx = req.tx.inner();
@@ -94,7 +93,7 @@ fn eip7702_authorization_gas<T: EvmTypes<Host = Evm<T>>>(
 fn apply_auth_list<T: EvmTypes<Host = Evm<T>>>(
     host: &mut Evm<T>,
     chain_id: u64,
-    authorizations: &[SignedAuthorization],
+    authorizations: &[super::LazyAuthorization],
 ) -> HandlerResult<u64> {
     let mut refunded_accounts = 0u64;
     for authorization in authorizations {
@@ -106,7 +105,7 @@ fn apply_auth_list<T: EvmTypes<Host = Evm<T>>>(
             continue;
         }
 
-        let Ok(authority) = authorization.recover_authority() else {
+        let Some(authority) = authorization.authority() else {
             continue;
         };
         host.state.warm_account_non_revertible(&authority);

--- a/crates/evm2/src/ethereum/lazy_eip7702.rs
+++ b/crates/evm2/src/ethereum/lazy_eip7702.rs
@@ -1,0 +1,224 @@
+use alloc::vec::Vec;
+use alloy_consensus::{TxEip7702, TxType};
+use alloy_eips::{
+    Typed2718,
+    eip2930::AccessList,
+    eip7702::{Authorization, RecoveredAuthorization, SignedAuthorization},
+};
+use alloy_primitives::{Address, Bytes, ChainId, U256};
+
+/// EIP-7702 authorization that may already have its authority recovered.
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+pub enum LazyAuthorization {
+    /// Signed authorization whose authority is recovered on demand.
+    Signed(SignedAuthorization),
+    /// Authorization with a cached recovery result.
+    Recovered(RecoveredAuthorization),
+}
+
+impl LazyAuthorization {
+    /// Returns the inner unsigned authorization.
+    pub fn inner(&self) -> &Authorization {
+        match self {
+            Self::Signed(authorization) => authorization.inner(),
+            Self::Recovered(authorization) => authorization,
+        }
+    }
+
+    /// Returns the authorization chain ID.
+    pub fn chain_id(&self) -> &U256 {
+        self.inner().chain_id()
+    }
+
+    /// Returns the delegated address.
+    pub fn address(&self) -> &Address {
+        self.inner().address()
+    }
+
+    /// Returns the authorization nonce.
+    pub fn nonce(&self) -> u64 {
+        self.inner().nonce()
+    }
+
+    /// Returns the recovered authority address, if the authorization signature is valid.
+    ///
+    /// Signed authorizations perform recovery on demand. Recovered authorizations return their
+    /// cached result without doing secp256k1 recovery.
+    pub fn authority(&self) -> Option<Address> {
+        match self {
+            Self::Signed(authorization) => authorization.recover_authority().ok(),
+            Self::Recovered(authorization) => authorization.authority(),
+        }
+    }
+
+    /// Returns the signed authorization if this authorization has not been recovered yet.
+    pub const fn as_signed(&self) -> Option<&SignedAuthorization> {
+        match self {
+            Self::Signed(authorization) => Some(authorization),
+            Self::Recovered(_) => None,
+        }
+    }
+
+    /// Returns the recovered authorization if this authorization has a cached recovery result.
+    pub const fn as_recovered(&self) -> Option<&RecoveredAuthorization> {
+        match self {
+            Self::Recovered(authorization) => Some(authorization),
+            Self::Signed(_) => None,
+        }
+    }
+}
+
+impl From<SignedAuthorization> for LazyAuthorization {
+    fn from(value: SignedAuthorization) -> Self {
+        Self::Signed(value)
+    }
+}
+
+impl From<RecoveredAuthorization> for LazyAuthorization {
+    fn from(value: RecoveredAuthorization) -> Self {
+        Self::Recovered(value)
+    }
+}
+
+/// EIP-7702 transaction used by the executable Ethereum transaction model.
+///
+/// This preserves the consensus [`TxEip7702`] fields but stores authorization list entries as
+/// signed-or-recovered values so callers can supply cached EIP-7702 authority recovery results.
+#[derive(Clone, Debug, Default, Eq, PartialEq, Hash)]
+pub struct LazyTxEip7702 {
+    /// EIP-155 replay protection chain ID.
+    pub chain_id: ChainId,
+    /// Sender nonce.
+    pub nonce: u64,
+    /// Maximum gas that may be used by the transaction.
+    pub gas_limit: u64,
+    /// Maximum total fee per gas.
+    pub max_fee_per_gas: u128,
+    /// Maximum priority fee per gas.
+    pub max_priority_fee_per_gas: u128,
+    /// Message-call recipient.
+    pub to: Address,
+    /// Wei value transferred to the recipient.
+    pub value: U256,
+    /// EIP-2930 access list.
+    pub access_list: AccessList,
+    /// EIP-7702 authorizations, either signed or with cached recovery results.
+    pub authorization_list: Vec<LazyAuthorization>,
+    /// Transaction input calldata.
+    pub input: Bytes,
+}
+
+impl LazyTxEip7702 {
+    /// Converts a consensus transaction while keeping signed authorizations unresolved.
+    pub fn from_signed_authorizations(tx: TxEip7702) -> Self {
+        tx.map_authorizations(Into::into)
+    }
+
+    /// Converts a consensus transaction and eagerly recovers all authorization authorities.
+    ///
+    /// Invalid authorization signatures are cached as invalid recovered authorizations so execution
+    /// skips them in the same way as a failed on-demand recovery.
+    pub fn from_recovered_authorizations(tx: TxEip7702) -> Self {
+        tx.map_authorizations(|authorization| authorization.into_recovered().into())
+    }
+
+    /// Converts a consensus transaction using an externally supplied authorization list.
+    ///
+    /// The caller is responsible for ensuring that `authorization_list` corresponds to `tx`.
+    pub fn from_authorizations(tx: TxEip7702, authorization_list: Vec<LazyAuthorization>) -> Self {
+        let TxEip7702 {
+            chain_id,
+            nonce,
+            gas_limit,
+            max_fee_per_gas,
+            max_priority_fee_per_gas,
+            to,
+            value,
+            access_list,
+            authorization_list: _,
+            input,
+        } = tx;
+        Self {
+            chain_id,
+            nonce,
+            gas_limit,
+            max_fee_per_gas,
+            max_priority_fee_per_gas,
+            to,
+            value,
+            access_list,
+            authorization_list,
+            input,
+        }
+    }
+
+    /// Converts a consensus transaction using externally supplied recovered authorizations.
+    ///
+    /// The caller is responsible for ensuring that `authorization_list` corresponds to `tx`.
+    pub fn from_cached_recovered_authorizations(
+        tx: TxEip7702,
+        authorization_list: Vec<RecoveredAuthorization>,
+    ) -> Self {
+        Self::from_authorizations(tx, authorization_list.into_iter().map(Into::into).collect())
+    }
+
+    /// Calculates a heuristic for the in-memory size of the transaction.
+    #[inline]
+    pub fn size(&self) -> usize {
+        size_of::<Self>()
+            + self.access_list.size()
+            + self.input.len()
+            + self.authorization_list.capacity() * size_of::<LazyAuthorization>()
+    }
+}
+
+trait MapAuthorizationList {
+    fn map_authorizations(
+        self,
+        f: impl FnMut(SignedAuthorization) -> LazyAuthorization,
+    ) -> LazyTxEip7702;
+}
+
+impl MapAuthorizationList for TxEip7702 {
+    fn map_authorizations(
+        self,
+        f: impl FnMut(SignedAuthorization) -> LazyAuthorization,
+    ) -> LazyTxEip7702 {
+        let Self {
+            chain_id,
+            nonce,
+            gas_limit,
+            max_fee_per_gas,
+            max_priority_fee_per_gas,
+            to,
+            value,
+            access_list,
+            authorization_list,
+            input,
+        } = self;
+        LazyTxEip7702 {
+            chain_id,
+            nonce,
+            gas_limit,
+            max_fee_per_gas,
+            max_priority_fee_per_gas,
+            to,
+            value,
+            access_list,
+            authorization_list: authorization_list.into_iter().map(f).collect(),
+            input,
+        }
+    }
+}
+
+impl From<TxEip7702> for LazyTxEip7702 {
+    fn from(value: TxEip7702) -> Self {
+        Self::from_signed_authorizations(value)
+    }
+}
+
+impl Typed2718 for LazyTxEip7702 {
+    fn ty(&self) -> u8 {
+        TxType::Eip7702 as u8
+    }
+}

--- a/crates/evm2/src/ethereum/mod.rs
+++ b/crates/evm2/src/ethereum/mod.rs
@@ -4,7 +4,10 @@ mod eip1559;
 mod eip2930;
 mod eip4844;
 mod eip7702;
+mod lazy_eip7702;
 mod legacy;
+
+pub use lazy_eip7702::{LazyAuthorization, LazyTxEip7702};
 
 use crate::{
     Evm, EvmFeatures, EvmTypes, SpecId, TxResult, Version,
@@ -34,7 +37,7 @@ pub enum RecoveredTxEnvelope {
     /// EIP-4844 blob transaction.
     Eip4844(Recovered<TxEip4844Variant>),
     /// EIP-7702 set-code transaction.
-    Eip7702(Recovered<TxEip7702>),
+    Eip7702(Recovered<LazyTxEip7702>),
 }
 
 impl RecoveredTxEnvelope {
@@ -71,7 +74,7 @@ impl RecoveredTxEnvelope {
     }
 
     /// Returns the contained EIP-7702 transaction, if this is EIP-7702.
-    pub const fn as_eip7702(&self) -> Option<&Recovered<TxEip7702>> {
+    pub const fn as_eip7702(&self) -> Option<&Recovered<LazyTxEip7702>> {
         match self {
             Self::Eip7702(tx) => Some(tx),
             Self::Legacy(_) | Self::Eip2930(_) | Self::Eip1559(_) | Self::Eip4844(_) => None,
@@ -96,7 +99,7 @@ impl RecoveredTxEnvelope {
             Self::Eip2930(tx) => tx.gas_limit(),
             Self::Eip1559(tx) => tx.gas_limit(),
             Self::Eip4844(tx) => tx.gas_limit(),
-            Self::Eip7702(tx) => tx.gas_limit(),
+            Self::Eip7702(tx) => tx.gas_limit,
         }
     }
 
@@ -107,7 +110,7 @@ impl RecoveredTxEnvelope {
             Self::Eip2930(tx) => tx.kind(),
             Self::Eip1559(tx) => tx.kind(),
             Self::Eip4844(tx) => tx.kind(),
-            Self::Eip7702(tx) => tx.kind(),
+            Self::Eip7702(tx) => tx.to.into(),
         }
     }
 
@@ -118,7 +121,7 @@ impl RecoveredTxEnvelope {
             Self::Eip2930(tx) => tx.input(),
             Self::Eip1559(tx) => tx.input(),
             Self::Eip4844(tx) => tx.input(),
-            Self::Eip7702(tx) => tx.input(),
+            Self::Eip7702(tx) => &tx.input,
         }
     }
 
@@ -129,7 +132,11 @@ impl RecoveredTxEnvelope {
             Self::Eip2930(tx) => tx.effective_gas_price(base_fee),
             Self::Eip1559(tx) => tx.effective_gas_price(base_fee),
             Self::Eip4844(tx) => tx.effective_gas_price(base_fee),
-            Self::Eip7702(tx) => tx.effective_gas_price(base_fee),
+            Self::Eip7702(tx) => alloy_eips::eip1559::calc_effective_gas_price(
+                tx.max_fee_per_gas,
+                tx.max_priority_fee_per_gas,
+                base_fee,
+            ),
         }
     }
 
@@ -140,8 +147,20 @@ impl RecoveredTxEnvelope {
             Self::Eip2930(tx) => tx.value(),
             Self::Eip1559(tx) => tx.value(),
             Self::Eip4844(tx) => tx.value(),
-            Self::Eip7702(tx) => tx.value(),
+            Self::Eip7702(tx) => tx.value,
         }
+    }
+}
+
+impl From<Recovered<TxEip7702>> for RecoveredTxEnvelope {
+    fn from(tx: Recovered<TxEip7702>) -> Self {
+        Self::Eip7702(tx.convert())
+    }
+}
+
+impl From<Recovered<LazyTxEip7702>> for RecoveredTxEnvelope {
+    fn from(tx: Recovered<LazyTxEip7702>) -> Self {
+        Self::Eip7702(tx)
     }
 }
 

--- a/crates/inspectors/src/access_list.rs
+++ b/crates/inspectors/src/access_list.rs
@@ -59,7 +59,7 @@ impl AccessListInspector {
             .as_eip7702()
             .into_iter()
             .flat_map(|tx| &tx.inner().authorization_list)
-            .filter_map(|authorization| authorization.recover_authority().ok());
+            .filter_map(|authorization| authorization.authority());
         self.with_excluded(authorities)
     }
 


### PR DESCRIPTION
Adds lazy/cached EIP-7702 authorization recovery so recovered authorities can be reused instead of recomputed during execution. Updates transaction envelope handling, tests, and access-list exclusions for lazy authorizations.

Ideally this, or some version of it, is upstreamed to Alloy.