### PR TITLE
perf(evm): add selfbalance fast path

### DIFF
--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -1250,6 +1250,10 @@ impl<T: EvmTypes<Host = Self>> Host<T> for Evm<T> {
         })
     }
 
+    fn selfbalance(&mut self, address: &Address) -> Result<Word, InstrStop> {
+        self.state.read_balance(address).map_err(|code| self.db_error_stop(code))
+    }
+
     fn target_is_empty_for_new_account_gas(
         &mut self,
         address: &Address,

--- a/crates/evm2/src/evm/state/mod.rs
+++ b/crates/evm2/src/evm/state/mod.rs
@@ -268,6 +268,21 @@ impl State {
         self.database.get_account(address)
     }
 
+    /// Returns account balance without recording an account load in transaction state.
+    #[inline]
+    pub(crate) fn read_balance(&mut self, address: &Address) -> DbResult<Word> {
+        if let Some(account) = self.scratch.accounts.get(address) {
+            return Ok(account.as_ref().map_or(Word::ZERO, |account| account.balance));
+        }
+        if self.database.account_absent(address) {
+            return Ok(Word::ZERO);
+        }
+        if let Some(info) = self.database.account_info(address) {
+            return Ok(info.balance);
+        }
+        Ok(self.database.get_account(address)?.map_or(Word::ZERO, |info| info.balance))
+    }
+
     /// Loads account info and records the account in transaction state.
     ///
     /// This is the EVM-semantic account load: the loaded account becomes part of the transaction

--- a/crates/evm2/src/interpreter/host.rs
+++ b/crates/evm2/src/interpreter/host.rs
@@ -100,6 +100,12 @@ pub trait Host<T: EvmTypes> {
         skip_cold_load: bool,
     ) -> Result<AccountLoad, InstrStop>;
 
+    /// Returns the current account balance for `SELFBALANCE`.
+    #[inline]
+    fn selfbalance(&mut self, address: &Address) -> Result<Word, InstrStop> {
+        Ok(self.load_account(address, false, false)?.balance)
+    }
+
     /// Returns whether an account is empty/non-existent for new-account gas checks.
     fn target_is_empty_for_new_account_gas(
         &mut self,

--- a/crates/evm2/src/interpreter/instructions/block.rs
+++ b/crates/evm2/src/interpreter/instructions/block.rs
@@ -60,7 +60,7 @@ pub(crate) fn chainid(cx: _) -> Result<out> {
 #[instruction]
 pub(crate) fn selfbalance(cx: _) -> Result<out> {
     let destination = &cx.state.message().destination;
-    *out = cx.state.host().load_account(destination, false, false)?.balance;
+    *out = cx.state.host().selfbalance(destination)?;
 }
 
 #[instruction]


### PR DESCRIPTION
Routes SELFBALANCE through a dedicated host/state balance read instead of generic account loading. This avoids account warmth and AccountLoad construction for the current account balance path.