### PR TITLE
chore: gitignore samply profile.json.gz

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ Cargo.lock
 /tests/BlockchainTests
 /test-fixtures
 /scripts/__pycache__
+# samply profiler output
+profile.json.gz


### PR DESCRIPTION
Adds `profile.json.gz` (samply profiler output) to `.gitignore`.