### PR TITLE
perf: add mainnet block replay benchmark

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -28,10 +28,14 @@ jobs:
         with:
           tool: cargo-codspeed
       - name: Build the benchmark target
-        run: cargo codspeed build --profile profiling -p evm2 --bench evm
+        run: |
+          cargo codspeed build --profile profiling -p evm2 --bench evm
+          cargo codspeed build --profile profiling -p evm2-eest --bench mainnet
       - name: Run the benchmarks
         uses: CodSpeedHQ/action@v4
         with:
-          run: cargo codspeed run -p evm2 evm
+          run: |
+            cargo codspeed run -p evm2 evm
+            cargo codspeed run -p evm2-eest mainnet
           mode: instrumentation
           token: ${{ secrets.CODSPEED_TOKEN }}

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -28,14 +28,10 @@ jobs:
         with:
           tool: cargo-codspeed
       - name: Build the benchmark target
-        run: |
-          cargo codspeed build --profile profiling -p evm2 --bench evm
-          cargo codspeed build --profile profiling -p evm2-eest --bench mainnet
+        run: cargo codspeed build --profile profiling
       - name: Run the benchmarks
         uses: CodSpeedHQ/action@v4
         with:
-          run: |
-            cargo codspeed run -p evm2 evm
-            cargo codspeed run -p evm2-eest mainnet
+          run: cargo codspeed run
           mode: instrumentation
           token: ${{ secrets.CODSPEED_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ corosensei = { version = "0.3.4", default-features = false, features = [
     "unwind",
 ] }
 futures-util = { version = "0.3", default-features = false, features = ["std"] }
+flate2 = { version = "1", default-features = false, features = ["rust_backend"] }
 libtest-mimic = "0.8"
 once_cell = { version = "1.21", default-features = false }
 paste = { version = "1.0", default-features = false }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -41,6 +41,7 @@ alloy-rpc-client = { workspace = true, features = ["reqwest"] }
 alloy-rpc-types-eth = { workspace = true, features = ["serde", "std"] }
 alloy-rpc-types-trace.workspace = true
 clap.workspace = true
+flate2.workspace = true
 futures-util.workspace = true
 rand.workspace = true
 revm.workspace = true

--- a/crates/cli/src/capture/mod.rs
+++ b/crates/cli/src/capture/mod.rs
@@ -12,11 +12,13 @@ use crate::{args::Capture, error::Result, ethereum};
 use alloy_consensus::{
     Block as ConsensusBlock, EthereumTxEnvelope, TxEip4844, transaction::SignerRecoverable,
 };
+use flate2::{Compression, write::GzEncoder};
 use futures_util::{StreamExt, stream};
 use serde_json::{Value, value::RawValue};
 use std::{
     fs::File,
     io::BufWriter,
+    path::Path,
     time::{Duration, Instant},
 };
 
@@ -123,11 +125,7 @@ async fn capture(
     let base_storage_slots =
         capture.pre_state.accounts.iter().map(|account| account.storage.len()).sum();
     let suite = export::suite(&capture)?;
-    let file = File::create(&command.output).map_err(|source| CaptureError::WriteOutput {
-        path: command.output.display().to_string(),
-        source,
-    })?;
-    serde_json::to_writer(BufWriter::new(file), &suite).map_err(CaptureError::EncodeJson)?;
+    write_suite(&command.output, &suite)?;
 
     Ok(CaptureSummary {
         blocks: match &capture.input {
@@ -139,6 +137,30 @@ async fn capture(
         base_storage_slots,
         elapsed_sec: started_at.elapsed().as_secs_f64(),
     })
+}
+
+fn write_suite(
+    path: &Path,
+    suite: &evm2_eest::blockchaintest::BlockchainTest,
+) -> std::result::Result<(), CaptureError> {
+    let file = File::create(path)
+        .map_err(|source| CaptureError::WriteOutput { path: path.display().to_string(), source })?;
+    let writer = BufWriter::new(file);
+    if is_gzip_path(path) {
+        let mut encoder = GzEncoder::new(writer, Compression::default());
+        serde_json::to_writer(&mut encoder, suite).map_err(CaptureError::EncodeJson)?;
+        encoder.finish().map_err(|source| CaptureError::WriteOutput {
+            path: path.display().to_string(),
+            source,
+        })?;
+    } else {
+        serde_json::to_writer(writer, suite).map_err(CaptureError::EncodeJson)?;
+    }
+    Ok(())
+}
+
+fn is_gzip_path(path: &Path) -> bool {
+    path.extension().is_some_and(|extension| extension == "gz")
 }
 
 struct FetchedBlock {

--- a/crates/cli/src/capture/mod.rs
+++ b/crates/cli/src/capture/mod.rs
@@ -76,8 +76,14 @@ async fn capture(
 
     while let Some(block) = blocks.next().await {
         let block_started_at = Instant::now();
-        let PreparedBlock { number, consensus_block, pre_traces, diff_traces, transactions } =
-            block?;
+        let PreparedBlock {
+            number,
+            consensus_block,
+            pre_traces,
+            diff_traces,
+            transactions,
+            elapsed_sec,
+        } = block?;
 
         for (tx_index, ((pre_trace, diff_trace), tx)) in pre_traces
             .iter()
@@ -104,7 +110,7 @@ async fn capture(
         eprintln!(
             "captured block {number} ({} txs) in {:.2}s",
             block_transaction_count,
-            block_started_at.elapsed().as_secs_f64()
+            elapsed_sec + block_started_at.elapsed().as_secs_f64()
         );
     }
 
@@ -144,18 +150,23 @@ struct PreparedBlock {
     pre_traces: Vec<Value>,
     diff_traces: Vec<Value>,
     transactions: Vec<model::CapturedTransaction>,
+    elapsed_sec: f64,
 }
 
 async fn fetch_block(
     rpc: &rpc::RpcEndpoint,
     number: u64,
 ) -> std::result::Result<PreparedBlock, CaptureError> {
+    let started_at = Instant::now();
     let (consensus_block, pre_traces, diff_traces) = tokio::try_join!(
         rpc.block(number),
         rpc.trace_block(number, rpc::TraceMode::PreState),
         rpc.trace_block(number, rpc::TraceMode::Diff),
     )?;
-    prepare_block(FetchedBlock { number, consensus_block, pre_traces, diff_traces }).await
+    let mut block =
+        prepare_block(FetchedBlock { number, consensus_block, pre_traces, diff_traces }).await?;
+    block.elapsed_sec = started_at.elapsed().as_secs_f64();
+    Ok(block)
 }
 
 async fn prepare_block(block: FetchedBlock) -> std::result::Result<PreparedBlock, CaptureError> {
@@ -185,7 +196,14 @@ async fn prepare_block(block: FetchedBlock) -> std::result::Result<PreparedBlock
             })
             .collect::<std::result::Result<Vec<_>, CaptureError>>()?;
 
-        Ok(PreparedBlock { number, consensus_block, pre_traces, diff_traces, transactions })
+        Ok(PreparedBlock {
+            number,
+            consensus_block,
+            pre_traces,
+            diff_traces,
+            transactions,
+            elapsed_sec: 0.0,
+        })
     })
     .await
     .map_err(CaptureError::JoinBlockPreparation)?

--- a/crates/cli/src/capture/mod.rs
+++ b/crates/cli/src/capture/mod.rs
@@ -14,7 +14,11 @@ use alloy_consensus::{
 };
 use futures_util::{StreamExt, stream};
 use serde_json::{Value, value::RawValue};
-use std::{fs::File, io::BufWriter, time::Instant};
+use std::{
+    fs::File,
+    io::BufWriter,
+    time::{Duration, Instant},
+};
 
 type MainnetBlock = ConsensusBlock<EthereumTxEnvelope<TxEip4844>>;
 
@@ -82,7 +86,7 @@ async fn capture(
             pre_traces,
             diff_traces,
             transactions,
-            elapsed_sec,
+            elapsed,
         } = block?;
 
         for (tx_index, ((pre_trace, diff_trace), tx)) in pre_traces
@@ -110,7 +114,7 @@ async fn capture(
         eprintln!(
             "captured block {number} ({} txs) in {:.2}s",
             block_transaction_count,
-            elapsed_sec + block_started_at.elapsed().as_secs_f64()
+            (elapsed + block_started_at.elapsed()).as_secs_f64()
         );
     }
 
@@ -150,7 +154,7 @@ struct PreparedBlock {
     pre_traces: Vec<Value>,
     diff_traces: Vec<Value>,
     transactions: Vec<model::CapturedTransaction>,
-    elapsed_sec: f64,
+    elapsed: Duration,
 }
 
 async fn fetch_block(
@@ -165,7 +169,7 @@ async fn fetch_block(
     )?;
     let mut block =
         prepare_block(FetchedBlock { number, consensus_block, pre_traces, diff_traces }).await?;
-    block.elapsed_sec = started_at.elapsed().as_secs_f64();
+    block.elapsed = started_at.elapsed();
     Ok(block)
 }
 
@@ -202,7 +206,7 @@ async fn prepare_block(block: FetchedBlock) -> std::result::Result<PreparedBlock
             pre_traces,
             diff_traces,
             transactions,
-            elapsed_sec: 0.0,
+            elapsed: Duration::default(),
         })
     })
     .await

--- a/crates/cli/src/fixture.rs
+++ b/crates/cli/src/fixture.rs
@@ -1,7 +1,7 @@
 use crate::error::{Error, Result};
 use serde::de::{DeserializeSeed, Deserializer, IgnoredAny, MapAccess, Visitor};
 use serde_json::Value;
-use std::{fmt, fs, path::Path};
+use std::{fmt, path::Path};
 
 pub(crate) struct FixtureInput {
     pub(crate) json: Value,
@@ -21,7 +21,8 @@ pub(crate) fn read(path: &Path) -> Result<FixtureInput> {
 }
 
 pub(crate) fn read_text(path: &Path) -> Result<String> {
-    fs::read_to_string(path).map_err(|source| Error::ReadInput { path: path.to_path_buf(), source })
+    evm2_eest::read_fixture_text(path)
+        .map_err(|source| Error::ReadInput { path: path.to_path_buf(), source })
 }
 
 pub(crate) fn detect_str(path: &Path, input: &str) -> Result<Option<FixtureKind>> {

--- a/crates/eest/Cargo.toml
+++ b/crates/eest/Cargo.toml
@@ -31,7 +31,14 @@ serde_json = { workspace = true, features = ["preserve_order", "std"] }
 thiserror = { workspace = true, features = ["std"] }
 walkdir.workspace = true
 
+[dev-dependencies]
+criterion.workspace = true
+
 [[test]]
 name = "eest"
 path = "tests/eest.rs"
+harness = false
+
+[[bench]]
+name = "mainnet"
 harness = false

--- a/crates/eest/Cargo.toml
+++ b/crates/eest/Cargo.toml
@@ -24,6 +24,7 @@ alloy-primitives = { workspace = true, features = ["std", "serde", "rlp"] }
 alloy-rlp = { workspace = true, features = ["std"] }
 alloy-rpc-types-eth = { workspace = true, features = ["std"] }
 alloy-trie = { workspace = true, features = ["ethereum"] }
+flate2.workspace = true
 k256 = { workspace = true, features = ["ecdsa", "std"] }
 libtest-mimic.workspace = true
 serde = { workspace = true, features = ["derive", "std"] }

--- a/crates/eest/benches/mainnet.rs
+++ b/crates/eest/benches/mainnet.rs
@@ -5,15 +5,15 @@ use evm2_eest::{
     BlockchainTestExecuteConfig, BlockchainTestNoopHook, EntryPoint,
     blockchaintest::BlockchainTest, execute_blockchain_tests_suite,
 };
-use std::{fs, path::Path, time::Duration};
+use std::{path::Path, time::Duration};
 
-const MAINNET_100_BLOCKS: &str =
-    concat!(env!("CARGO_MANIFEST_DIR"), "/../../data/mainnet-17000000-17000099.json");
+const MAINNET_BLOCKS: &str =
+    concat!(env!("CARGO_MANIFEST_DIR"), "/../../data/mainnet-25346511-25346520.json.gz");
 
 fn mainnet(c: &mut Criterion) {
-    let path = Path::new(MAINNET_100_BLOCKS);
-    let input =
-        fs::read_to_string(path).unwrap_or_else(|err| panic!("failed to read fixture: {err}"));
+    let path = Path::new(MAINNET_BLOCKS);
+    let input = evm2_eest::read_fixture_text(path)
+        .unwrap_or_else(|err| panic!("failed to read fixture: {err}"));
     let suite: BlockchainTest =
         serde_json::from_str(&input).unwrap_or_else(|err| panic!("failed to parse fixture: {err}"));
     let entrypoint = EntryPoint::default();
@@ -35,7 +35,7 @@ fn mainnet(c: &mut Criterion) {
     group.measurement_time(Duration::from_secs(2));
     group.sample_size(10);
 
-    group.bench_function("17000000_17000099/replay", |b| {
+    group.bench_function("25346511_25346520/replay", |b| {
         b.iter(|| {
             let mut hook = BlockchainTestNoopHook;
             black_box(

--- a/crates/eest/benches/mainnet.rs
+++ b/crates/eest/benches/mainnet.rs
@@ -1,0 +1,58 @@
+#![allow(missing_docs)]
+
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use evm2_eest::{
+    BlockchainTestExecuteConfig, BlockchainTestNoopHook, EntryPoint,
+    blockchaintest::BlockchainTest, execute_blockchain_tests_suite,
+};
+use std::{fs, path::Path, time::Duration};
+
+const MAINNET_100_BLOCKS: &str =
+    concat!(env!("CARGO_MANIFEST_DIR"), "/../../data/mainnet-17000000-17000099.json");
+
+fn mainnet(c: &mut Criterion) {
+    let path = Path::new(MAINNET_100_BLOCKS);
+    let input =
+        fs::read_to_string(path).unwrap_or_else(|err| panic!("failed to read fixture: {err}"));
+    let suite: BlockchainTest =
+        serde_json::from_str(&input).unwrap_or_else(|err| panic!("failed to parse fixture: {err}"));
+    let entrypoint = EntryPoint::default();
+
+    let mut hook = BlockchainTestNoopHook;
+    let summary = execute_blockchain_tests_suite(
+        path,
+        &suite,
+        BlockchainTestExecuteConfig::default(),
+        &entrypoint,
+        &mut hook,
+    )
+    .unwrap_or_else(|err| panic!("mainnet fixture sanity check failed: {err}"));
+    assert_eq!(summary.executed, 1);
+    assert_eq!(summary.skipped, 0);
+
+    let mut group = c.benchmark_group("mainnet");
+    group.warm_up_time(Duration::from_secs(1));
+    group.measurement_time(Duration::from_secs(2));
+    group.sample_size(10);
+
+    group.bench_function("17000000_17000099/replay", |b| {
+        b.iter(|| {
+            let mut hook = BlockchainTestNoopHook;
+            black_box(
+                execute_blockchain_tests_suite(
+                    path,
+                    &suite,
+                    BlockchainTestExecuteConfig { validate_post_state: false },
+                    &entrypoint,
+                    &mut hook,
+                )
+                .unwrap_or_else(|err| panic!("mainnet fixture replay failed: {err}")),
+            )
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, mainnet);
+criterion_main!(benches);

--- a/crates/eest/src/blockchaintest/execute.rs
+++ b/crates/eest/src/blockchaintest/execute.rs
@@ -77,16 +77,27 @@ pub fn execute_str(
 ) -> Result<ExecuteSummary, TestError> {
     let suite: BlockchainTest =
         serde_json::from_str(input).map_err(|err| TestError::unknown(path, err.into()))?;
+    execute_suite(path, &suite, config, entrypoint, hook)
+}
+
+/// Executes a parsed blockchain test suite.
+pub fn execute_suite(
+    path: &Path,
+    suite: &BlockchainTest,
+    config: ExecuteConfig,
+    entrypoint: &EntryPoint,
+    hook: &mut dyn Hook,
+) -> Result<ExecuteSummary, TestError> {
     let mut summary = ExecuteSummary::default();
-    for (name, test_case) in suite.0 {
-        if !entrypoint.matches(&name)
+    for (name, test_case) in &suite.0 {
+        if !entrypoint.matches(name)
             || test_case.network.is_transition()
             || is_fork_skipped(fork_to_spec_id(test_case.network))
         {
             summary.skipped += 1;
             continue;
         }
-        execute_case(path, &name, &test_case, config, hook)?;
+        execute_case(path, name, test_case, config, hook)?;
         summary.executed += 1;
     }
     Ok(summary)

--- a/crates/eest/src/blockchaintest/execute.rs
+++ b/crates/eest/src/blockchaintest/execute.rs
@@ -11,6 +11,7 @@ use super::{
 };
 use crate::{
     filter::EntryPoint,
+    fixture_io,
     forks::is_fork_skipped,
     state::{insert_account_with_storage, parse_bytecode},
     tx::{TxFields, build_recovered_tx, rpc_access_list, signed_authorizations},
@@ -29,7 +30,7 @@ use evm2::{
     },
     registry::HandlerError,
 };
-use std::{fs, mem, path::Path};
+use std::{mem, path::Path};
 
 const ONE_GWEI: u64 = 1_000_000_000;
 const ONE_ETHER: u128 = 1_000_000_000_000_000_000;
@@ -61,7 +62,8 @@ pub(crate) fn execute_test_suite(
     path: &Path,
     config: ExecuteConfig,
 ) -> Result<ExecuteSummary, TestError> {
-    let input = fs::read_to_string(path).map_err(|err| TestError::unknown(path, err.into()))?;
+    let input =
+        fixture_io::read_to_string(path).map_err(|err| TestError::unknown(path, err.into()))?;
     let entrypoint = EntryPoint::default();
     let mut hook = NoopHook;
     execute_str(path, &input, config, &entrypoint, &mut hook)

--- a/crates/eest/src/blockchaintest/mod.rs
+++ b/crates/eest/src/blockchaintest/mod.rs
@@ -8,7 +8,7 @@ mod runner;
 mod types;
 
 pub use error::TestError;
-pub use execute::{ExecuteConfig, ExecuteSummary, execute_str};
+pub use execute::{ExecuteConfig, ExecuteSummary, execute_str, execute_suite};
 pub use hook::{
     BlockFailed, BlockFinished, BlockStarted, CaseStarted, Hook, NoopHook, TransactionFailed,
     TransactionFinished, TransactionStarted,

--- a/crates/eest/src/execute.rs
+++ b/crates/eest/src/execute.rs
@@ -1,6 +1,7 @@
 use crate::{
     error::{TestError, TestErrorKind},
     filter::EntryPoint,
+    fixture_io,
     forks::is_fork_skipped,
     state::{
         insert_account_with_storage, parse_bytecode, storage_for_root, system_contract_has_code,
@@ -25,7 +26,7 @@ use evm2::{
     registry::HandlerError,
 };
 use serde_json::json;
-use std::{collections::BTreeMap, fs, path::Path};
+use std::{collections::BTreeMap, path::Path};
 
 /// Per-spec execution outcome.
 #[derive(Clone, Debug)]
@@ -60,7 +61,8 @@ pub struct ExecuteSummary {
 
 /// Executes a single state test JSON file using explicit execution options.
 pub(crate) fn execute_test_suite(path: &Path, config: ExecuteConfig) -> Result<(), TestError> {
-    let input = fs::read_to_string(path).map_err(|err| TestError::unknown(path, err.into()))?;
+    let input =
+        fixture_io::read_to_string(path).map_err(|err| TestError::unknown(path, err.into()))?;
     execute_str_with_config(path, &input, config).map(|_| ())
 }
 

--- a/crates/eest/src/fixture_io.rs
+++ b/crates/eest/src/fixture_io.rs
@@ -1,0 +1,20 @@
+use flate2::read::GzDecoder;
+use std::{
+    fs::File,
+    io::{self, Read},
+    path::Path,
+};
+
+/// Reads a plain JSON fixture or gzip-compressed JSON fixture.
+pub fn read_to_string(path: &Path) -> io::Result<String> {
+    let file = File::open(path)?;
+    let mut reader: Box<dyn Read> =
+        if is_gzip_path(path) { Box::new(GzDecoder::new(file)) } else { Box::new(file) };
+    let mut input = String::new();
+    reader.read_to_string(&mut input)?;
+    Ok(input)
+}
+
+fn is_gzip_path(path: &Path) -> bool {
+    path.extension().is_some_and(|extension| extension == "gz")
+}

--- a/crates/eest/src/lib.rs
+++ b/crates/eest/src/lib.rs
@@ -8,6 +8,7 @@ mod env;
 mod error;
 mod execute;
 mod filter;
+mod fixture_io;
 mod fixtures;
 mod forks;
 mod harness;
@@ -34,6 +35,7 @@ pub use execute::{
     execute_str_with_filter as execute_state_tests_str_with_filter,
 };
 pub use filter::EntryPoint;
+pub use fixture_io::read_to_string as read_fixture_text;
 pub use runner::run as run_statetests;
 pub use tx::{AccessListItem, TestAuthorization};
 

--- a/crates/eest/src/lib.rs
+++ b/crates/eest/src/lib.rs
@@ -24,7 +24,8 @@ pub use blockchaintest::{
     TestError as BlockchainTestError, TransactionFailed as BlockchainTestTransactionFailed,
     TransactionFinished as BlockchainTestTransactionFinished,
     TransactionStarted as BlockchainTestTransactionStarted,
-    execute_str as execute_blockchain_tests_str, run as run_blockchaintests,
+    execute_str as execute_blockchain_tests_str, execute_suite as execute_blockchain_tests_suite,
+    run as run_blockchaintests,
 };
 pub use error::TestError as StateTestError;
 pub use execute::{


### PR DESCRIPTION
This adds a captured 100-block Ethereum mainnet blockchain-test fixture and wires it into a new `evm2-eest` Criterion/CodSpeed benchmark. The benchmark reuses the parsed blockchain suite so the measured path focuses on replaying the captured blocks rather than reparsing the large JSON fixture each iteration.

The benchmark workflow now builds and runs both the existing `evm2` EVM microbenchmarks and the new EEST mainnet replay benchmark, giving CI coverage for a larger real-block execution workload.
