### PR TITLE
feat(cli): add db stats flag

### DIFF
--- a/crates/cli/src/args.rs
+++ b/crates/cli/src/args.rs
@@ -46,6 +46,9 @@ pub(crate) struct Replay {
     /// Logical EEST test or case name glob to run.
     #[arg(long)]
     pub(crate) entrypoint: Option<String>,
+    /// Print database method call counts after execution.
+    #[arg(long)]
+    pub(crate) db_stats: bool,
     /// EEST JSON fixture to replay.
     #[arg(value_name = "PATH")]
     pub(crate) path: PathBuf,

--- a/crates/cli/src/replay/mod.rs
+++ b/crates/cli/src/replay/mod.rs
@@ -21,7 +21,7 @@ pub(crate) fn run(command: Replay) -> Result<()> {
             let summary = execute_state_tests_str_with_filter(
                 &command.path,
                 &input,
-                StateTestExecuteConfig::default(),
+                StateTestExecuteConfig { db_stats: command.db_stats, ..Default::default() },
                 &entrypoint,
             )
             .map_err(|source| Error::StateTest { source })?;
@@ -38,7 +38,7 @@ pub(crate) fn run(command: Replay) -> Result<()> {
             let summary = execute_blockchain_tests_str(
                 &command.path,
                 &input,
-                BlockchainTestExecuteConfig::default(),
+                BlockchainTestExecuteConfig { db_stats: command.db_stats, ..Default::default() },
                 &entrypoint,
                 &mut hook,
             )

--- a/crates/eest/src/blockchaintest/execute.rs
+++ b/crates/eest/src/blockchaintest/execute.rs
@@ -24,8 +24,8 @@ use evm2::{
     ethereum::{RecoveredTxEnvelope, ethereum_tx_registry},
     evm::{
         AccountChangeRef, AccountInfo as EvmAccountInfo, AccountInfoRef, BEACON_ROOTS_ADDRESS,
-        BlockStateAccumulator, DbErrorCode, HISTORY_STORAGE_ADDRESS, InMemoryDB, StateChangeSink,
-        StateChangeSource, Tee, WITHDRAWAL_REQUEST_ADDRESS,
+        BlockStateAccumulator, DbErrorCode, DbStats, DbStatsCounts, HISTORY_STORAGE_ADDRESS,
+        InMemoryDB, StateChangeSink, StateChangeSource, Tee, WITHDRAWAL_REQUEST_ADDRESS,
     },
     registry::HandlerError,
 };
@@ -39,11 +39,13 @@ const ONE_ETHER: u128 = 1_000_000_000_000_000_000;
 pub struct ExecuteConfig {
     /// Whether to validate final post-state when fixtures contain it.
     pub validate_post_state: bool,
+    /// Whether to print database method call counts.
+    pub db_stats: bool,
 }
 
 impl Default for ExecuteConfig {
     fn default() -> Self {
-        Self { validate_post_state: true }
+        Self { validate_post_state: true, db_stats: false }
     }
 }
 
@@ -138,6 +140,7 @@ fn execute_case(
             &mut parent_block_hash,
             &mut parent_excess_blob_gas,
             hook,
+            config.db_stats,
         ) {
             Ok(()) => hook.block_finished(BlockFinished {
                 block_index,
@@ -197,6 +200,7 @@ fn execute_block(
     parent_block_hash: &mut Option<B256>,
     parent_excess_blob_gas: &mut u64,
     hook: &mut dyn Hook,
+    db_stats: bool,
 ) -> Result<(), TestError> {
     let should_fail = block.expect_exception.is_some();
     let mut block_hash = None;
@@ -212,13 +216,23 @@ fn execute_block(
     }
 
     let initial_database = mem::take(database);
-    let mut evm = Evm::<BaseEvmTypes>::new(
-        spec,
-        next_block_env,
-        ethereum_tx_registry(spec),
-        initial_database,
-        Precompiles::base(spec),
-    );
+    let mut evm = if db_stats {
+        Evm::<BaseEvmTypes>::new(
+            spec,
+            next_block_env,
+            ethereum_tx_registry(spec),
+            DbStats::new(initial_database),
+            Precompiles::base(spec),
+        )
+    } else {
+        Evm::<BaseEvmTypes>::new(
+            spec,
+            next_block_env,
+            ethereum_tx_registry(spec),
+            initial_database,
+            Precompiles::base(spec),
+        )
+    };
     let mut block_state = BlockStateAccumulator::new();
 
     let result = (|| -> Result<BlockResolution, TestError> {
@@ -310,9 +324,23 @@ fn execute_block(
 
     // The EVM was constructed with this concrete database above; recover it before returning so
     // invalid blocks leave the caller's state unchanged.
-    let mut restored_database = mem::take(
-        evm.database_as_mut::<InMemoryDB>().expect("block EVM database should be InMemoryDB"),
-    );
+    let (mut restored_database, db_stats_counts) = if db_stats {
+        let stats = evm
+            .database_as_mut::<DbStats<InMemoryDB>>()
+            .expect("block EVM database should be DbStats<InMemoryDB>");
+        (mem::take(stats.inner_mut()), Some(stats.counts()))
+    } else {
+        (
+            mem::take(
+                evm.database_as_mut::<InMemoryDB>()
+                    .expect("block EVM database should be InMemoryDB"),
+            ),
+            None,
+        )
+    };
+    if let Some(counts) = db_stats_counts {
+        print_db_stats(counts);
+    }
 
     match result {
         Ok(BlockResolution::Commit) => {
@@ -336,6 +364,17 @@ fn execute_block(
             Err(err)
         }
     }
+}
+
+fn print_db_stats(counts: DbStatsCounts) {
+    eprintln!(
+        "db stats: get_account={} get_code_by_hash={} get_storage={} get_block_hash={} error={}",
+        counts.get_account,
+        counts.get_code_by_hash,
+        counts.get_storage,
+        counts.get_block_hash,
+        counts.error
+    );
 }
 
 fn block_number(block: &Block) -> Option<U256> {

--- a/crates/eest/src/execute.rs
+++ b/crates/eest/src/execute.rs
@@ -20,7 +20,8 @@ use evm2::{
     env::BlockEnv,
     ethereum::{RecoveredTxEnvelope, ethereum_tx_registry},
     evm::{
-        AccountInfo as EvmAccountInfo, BEACON_ROOTS_ADDRESS, HISTORY_STORAGE_ADDRESS, InMemoryDB,
+        AccountInfo as EvmAccountInfo, BEACON_ROOTS_ADDRESS, DbStats, DbStatsCounts,
+        HISTORY_STORAGE_ADDRESS, InMemoryDB,
     },
     registry::HandlerError,
 };
@@ -47,6 +48,8 @@ pub(crate) struct SpecOutcome {
 pub struct ExecuteConfig {
     /// Whether to print revm-style JSON outcome records.
     pub print_json_outcome: bool,
+    /// Whether to print database method call counts.
+    pub db_stats: bool,
 }
 
 /// Per-file execution summary.
@@ -117,7 +120,7 @@ fn execute_unit(
                 }
                 Err(err) => return Err(TestError::case(path, name, err)),
             };
-            let result = execute_spec(spec, block, state.clone(), &tx, &unit.env);
+            let result = execute_spec(spec, block, state.clone(), &tx, &unit.env, config.db_stats);
             validate_result(path, name, &unit, post, result, spec, config)?;
         }
     }
@@ -237,18 +240,43 @@ fn execute_spec(
     database: InMemoryDB,
     tx: &RecoveredTxEnvelope,
     env: &Env,
+    db_stats: bool,
 ) -> Result<SpecOutcome, HandlerError> {
-    let mut evm = Evm::<BaseEvmTypes>::new(
-        spec,
-        block,
-        ethereum_tx_registry(spec),
-        database.clone(),
-        Precompiles::base(spec),
-    );
+    let mut evm = if db_stats {
+        Evm::<BaseEvmTypes>::new(
+            spec,
+            block,
+            ethereum_tx_registry(spec),
+            DbStats::new(database.clone()),
+            Precompiles::base(spec),
+        )
+    } else {
+        Evm::<BaseEvmTypes>::new(
+            spec,
+            block,
+            ethereum_tx_registry(spec),
+            database.clone(),
+            Precompiles::base(spec),
+        )
+    };
     let mut post = database;
     pre_block_system_calls(&mut evm, &mut post, spec, env);
     let Ok(result) = evm.transact(tx)?.commit_with(&mut post);
+    if db_stats && let Some(stats) = evm.database_as::<DbStats<InMemoryDB>>() {
+        print_db_stats(stats.counts());
+    }
     Ok(spec_outcome(post, result))
+}
+
+fn print_db_stats(counts: DbStatsCounts) {
+    eprintln!(
+        "db stats: get_account={} get_code_by_hash={} get_storage={} get_block_hash={} error={}",
+        counts.get_account,
+        counts.get_code_by_hash,
+        counts.get_storage,
+        counts.get_block_hash,
+        counts.error
+    );
 }
 
 fn spec_outcome(post: InMemoryDB, result: TxResult) -> SpecOutcome {

--- a/crates/evm2/src/evm/db.rs
+++ b/crates/evm2/src/evm/db.rs
@@ -187,6 +187,101 @@ pub trait DynDatabase: Any {
     }
 }
 
+/// Counts calls made through a [`DynDatabase`].
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct DbStatsCounts {
+    /// Number of account loads.
+    pub get_account: u64,
+    /// Number of bytecode loads by hash.
+    pub get_code_by_hash: u64,
+    /// Number of storage slot loads.
+    pub get_storage: u64,
+    /// Number of block hash loads.
+    pub get_block_hash: u64,
+    /// Number of error lookups.
+    pub error: u64,
+}
+
+/// Database wrapper that records method call counts.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct DbStats<D> {
+    db: D,
+    counts: DbStatsCounts,
+}
+
+impl<D> DbStats<D> {
+    /// Creates a stats wrapper around `db`.
+    #[inline]
+    pub const fn new(db: D) -> Self {
+        Self {
+            db,
+            counts: DbStatsCounts {
+                get_account: 0,
+                get_code_by_hash: 0,
+                get_storage: 0,
+                get_block_hash: 0,
+                error: 0,
+            },
+        }
+    }
+
+    /// Returns the wrapped database.
+    #[inline]
+    pub const fn inner(&self) -> &D {
+        &self.db
+    }
+
+    /// Returns the wrapped database mutably.
+    #[inline]
+    pub const fn inner_mut(&mut self) -> &mut D {
+        &mut self.db
+    }
+
+    /// Consumes the wrapper and returns the wrapped database.
+    #[inline]
+    pub fn into_inner(self) -> D {
+        self.db
+    }
+
+    /// Returns recorded method call counts.
+    #[inline]
+    pub const fn counts(&self) -> DbStatsCounts {
+        self.counts
+    }
+}
+
+impl<D: DynDatabase> DynDatabase for DbStats<D> {
+    #[inline]
+    fn get_account(&mut self, address: &Address) -> DbResult<Option<AccountInfo>> {
+        self.counts.get_account += 1;
+        self.db.get_account(address)
+    }
+
+    #[inline]
+    fn get_code_by_hash(&mut self, code_hash: &B256) -> DbResult<Bytecode> {
+        self.counts.get_code_by_hash += 1;
+        self.db.get_code_by_hash(code_hash)
+    }
+
+    #[inline]
+    fn get_storage(&mut self, address: &Address, key: &Word) -> DbResult<Word> {
+        self.counts.get_storage += 1;
+        self.db.get_storage(address, key)
+    }
+
+    #[inline]
+    fn get_block_hash(&mut self, number: &Word) -> DbResult<Option<B256>> {
+        self.counts.get_block_hash += 1;
+        self.db.get_block_hash(number)
+    }
+
+    #[inline]
+    fn error(&mut self, code: DbErrorCode) -> Box<dyn Error> {
+        self.counts.error += 1;
+        self.db.error(code)
+    }
+}
+
 impl core::ops::Deref for dyn DynDatabase + '_ {
     type Target = dyn Any;
 

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -153,8 +153,8 @@ pub use system::{
 
 mod db;
 pub use db::{
-    AccountStorageCache, Cache, CacheDB, Database, Db, DbErrorCode, DbResult, DynDatabase, EmptyDB,
-    InMemoryDB,
+    AccountStorageCache, Cache, CacheDB, Database, Db, DbErrorCode, DbResult, DbStats,
+    DbStatsCounts, DynDatabase, EmptyDB, InMemoryDB,
 };
 #[cfg(feature = "async")]
 pub(crate) use db::{db_error_unavailable, stored_error_code};


### PR DESCRIPTION
Adds a `--db-stats` flag to replay execution paths. When enabled, EEST state and blockchain replay wrap the EVM database in a `DbStats` dyn database wrapper and print per-method call counts after execution.

Prompted by: @DaniPopes

Verification:
- `cargo fmt`
- `cargo check -p evm2 --no-default-features`
- `cargo check -p evm2-eest --no-default-features`

Note: full/default CLI checking is blocked in this sandbox because `mcl_rust` cannot find GMP (`GMP_INCLUDE_DIR`, `GMP_LIBRARY`, `GMP_GMPXX_INCLUDE_DIR`, `GMP_GMPXX_LIBRARY`).