### PR TITLE
fix(cli): include fetch time in capture log

### DIFF
--- a/crates/cli/src/capture/mod.rs
+++ b/crates/cli/src/capture/mod.rs
@@ -76,8 +76,14 @@ async fn capture(
 
     while let Some(block) = blocks.next().await {
         let block_started_at = Instant::now();
-        let PreparedBlock { number, consensus_block, pre_traces, diff_traces, transactions } =
-            block?;
+        let PreparedBlock {
+            number,
+            consensus_block,
+            pre_traces,
+            diff_traces,
+            transactions,
+            elapsed_sec,
+        } = block?;
 
         for (tx_index, ((pre_trace, diff_trace), tx)) in pre_traces
             .iter()
@@ -104,7 +110,7 @@ async fn capture(
         eprintln!(
             "captured block {number} ({} txs) in {:.2}s",
             block_transaction_count,
-            block_started_at.elapsed().as_secs_f64()
+            elapsed_sec + block_started_at.elapsed().as_secs_f64()
         );
     }
 
@@ -144,18 +150,23 @@ struct PreparedBlock {
     pre_traces: Vec<Value>,
     diff_traces: Vec<Value>,
     transactions: Vec<model::CapturedTransaction>,
+    elapsed_sec: f64,
 }
 
 async fn fetch_block(
     rpc: &rpc::RpcEndpoint,
     number: u64,
 ) -> std::result::Result<PreparedBlock, CaptureError> {
+    let started_at = Instant::now();
     let (consensus_block, pre_traces, diff_traces) = tokio::try_join!(
         rpc.block(number),
         rpc.trace_block(number, rpc::TraceMode::PreState),
         rpc.trace_block(number, rpc::TraceMode::Diff),
     )?;
-    prepare_block(FetchedBlock { number, consensus_block, pre_traces, diff_traces }).await
+    let mut block =
+        prepare_block(FetchedBlock { number, consensus_block, pre_traces, diff_traces }).await?;
+    block.elapsed_sec = started_at.elapsed().as_secs_f64();
+    Ok(block)
 }
 
 async fn prepare_block(block: FetchedBlock) -> std::result::Result<PreparedBlock, CaptureError> {
@@ -185,7 +196,14 @@ async fn prepare_block(block: FetchedBlock) -> std::result::Result<PreparedBlock
             })
             .collect::<std::result::Result<Vec<_>, CaptureError>>()?;
 
-        Ok(PreparedBlock { number, consensus_block, pre_traces, diff_traces, transactions })
+        Ok(PreparedBlock {
+            number,
+            consensus_block,
+            pre_traces,
+            diff_traces,
+            transactions,
+            elapsed_sec: 0.0,
+        })
     })
     .await
     .map_err(CaptureError::JoinBlockPreparation)?

--- a/crates/cli/src/capture/mod.rs
+++ b/crates/cli/src/capture/mod.rs
@@ -14,7 +14,11 @@ use alloy_consensus::{
 };
 use futures_util::{StreamExt, stream};
 use serde_json::{Value, value::RawValue};
-use std::{fs::File, io::BufWriter, time::Instant};
+use std::{
+    fs::File,
+    io::BufWriter,
+    time::{Duration, Instant},
+};
 
 type MainnetBlock = ConsensusBlock<EthereumTxEnvelope<TxEip4844>>;
 
@@ -82,7 +86,7 @@ async fn capture(
             pre_traces,
             diff_traces,
             transactions,
-            elapsed_sec,
+            elapsed,
         } = block?;
 
         for (tx_index, ((pre_trace, diff_trace), tx)) in pre_traces
@@ -110,7 +114,7 @@ async fn capture(
         eprintln!(
             "captured block {number} ({} txs) in {:.2}s",
             block_transaction_count,
-            elapsed_sec + block_started_at.elapsed().as_secs_f64()
+            (elapsed + block_started_at.elapsed()).as_secs_f64()
         );
     }
 
@@ -150,7 +154,7 @@ struct PreparedBlock {
     pre_traces: Vec<Value>,
     diff_traces: Vec<Value>,
     transactions: Vec<model::CapturedTransaction>,
-    elapsed_sec: f64,
+    elapsed: Duration,
 }
 
 async fn fetch_block(
@@ -165,7 +169,7 @@ async fn fetch_block(
     )?;
     let mut block =
         prepare_block(FetchedBlock { number, consensus_block, pre_traces, diff_traces }).await?;
-    block.elapsed_sec = started_at.elapsed().as_secs_f64();
+    block.elapsed = started_at.elapsed();
     Ok(block)
 }
 
@@ -202,7 +206,7 @@ async fn prepare_block(block: FetchedBlock) -> std::result::Result<PreparedBlock
             pre_traces,
             diff_traces,
             transactions,
-            elapsed_sec: 0.0,
+            elapsed: Duration::default(),
         })
     })
     .await


### PR DESCRIPTION
This fixes the per-block capture progress log so it includes the RPC block/trace fetch, trace decode, and signer recovery time instead of only timing the post-fetch local bookkeeping.

The fetched block now carries its elapsed fetch/prepare `Duration`, and the log combines that with the synchronous capture bookkeeping duration when formatting the per-block line.
