### PR TITLE
refactor(interpreter): carry caller_is_static on Message

### DIFF
--- a/crates/evm2/examples/custom_evm/tx.rs
+++ b/crates/evm2/examples/custom_evm/tx.rs
@@ -60,12 +60,8 @@ pub fn execute_code(
         ..Message::default()
     };
     let tx_env = TxEnv { ext: CustomTxEnvExt { label: "execute-code" }, ..TxEnv::default() };
-    let mut result = req.host.execute_message(
-        &tx_env,
-        Bytecode::new_legacy(req.tx.code.clone()),
-        &mut message,
-        false,
-    );
+    let mut result =
+        req.host.execute_message(&tx_env, Bytecode::new_legacy(req.tx.code.clone()), &mut message);
     result.ext = CustomMessageResultExt { handled_custom_message: true };
     Ok(evm2::TxResult::<CustomTypes> {
         status: result.stop.is_success(),

--- a/crates/evm2/src/ethereum/eip1559.rs
+++ b/crates/evm2/src/ethereum/eip1559.rs
@@ -67,7 +67,7 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     };
     let (bytecode, mut message) =
         initial_message(req.host, caller, tx.nonce, tx.to, &tx.input, tx.value, gas_limit)?;
-    let mut result = req.host.execute_message(&tx_env, bytecode, &mut message, false);
+    let mut result = req.host.execute_message(&tx_env, bytecode, &mut message);
     rollback_failed_execution(req.host, execution_checkpoint, &mut result);
 
     settle_gas(req.host, caller, gas_price, tx.gas_limit, floor_gas, result)

--- a/crates/evm2/src/ethereum/eip2930.rs
+++ b/crates/evm2/src/ethereum/eip2930.rs
@@ -61,7 +61,7 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     };
     let (bytecode, mut message) =
         initial_message(req.host, caller, tx.nonce, tx.to, &tx.input, tx.value, gas_limit)?;
-    let mut result = req.host.execute_message(&tx_env, bytecode, &mut message, false);
+    let mut result = req.host.execute_message(&tx_env, bytecode, &mut message);
     rollback_failed_execution(req.host, execution_checkpoint, &mut result);
 
     settle_gas(req.host, caller, gas_price, tx.gas_limit, floor_gas, result)

--- a/crates/evm2/src/ethereum/eip4844.rs
+++ b/crates/evm2/src/ethereum/eip4844.rs
@@ -82,7 +82,7 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     };
     let (bytecode, mut message) =
         initial_message(req.host, caller, tx.nonce, tx.to.into(), &tx.input, tx.value, gas_limit)?;
-    let mut result = req.host.execute_message(&tx_env, bytecode, &mut message, false);
+    let mut result = req.host.execute_message(&tx_env, bytecode, &mut message);
     rollback_failed_execution(req.host, execution_checkpoint, &mut result);
 
     settle_gas(req.host, caller, gas_price, tx.gas_limit, floor_gas, result)

--- a/crates/evm2/src/ethereum/eip7702.rs
+++ b/crates/evm2/src/ethereum/eip7702.rs
@@ -73,7 +73,7 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     };
     let (bytecode, mut message) =
         initial_message(req.host, caller, tx.nonce, tx.to.into(), &tx.input, tx.value, gas_limit)?;
-    let mut result = req.host.execute_message(&tx_env, bytecode, &mut message, false);
+    let mut result = req.host.execute_message(&tx_env, bytecode, &mut message);
     rollback_failed_execution(req.host, execution_checkpoint, &mut result);
     result.gas.set_refunded(
         result.gas.refunded().saturating_add(i64::try_from(eip7702_refund).unwrap_or(i64::MAX)),

--- a/crates/evm2/src/ethereum/legacy.rs
+++ b/crates/evm2/src/ethereum/legacy.rs
@@ -51,7 +51,7 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     };
     let (bytecode, mut message) =
         initial_message(req.host, caller, tx.nonce, tx.to, &tx.input, tx.value, gas_limit)?;
-    let mut result = req.host.execute_message(&tx_env, bytecode, &mut message, false);
+    let mut result = req.host.execute_message(&tx_env, bytecode, &mut message);
     rollback_failed_execution(req.host, execution_checkpoint, &mut result);
 
     settle_gas(req.host, caller, gas_price, tx.gas_limit, floor_gas, result)

--- a/crates/evm2/src/ethereum/mod.rs
+++ b/crates/evm2/src/ethereum/mod.rs
@@ -431,6 +431,7 @@ pub(crate) fn initial_message<T: EvmTypes<Host = Evm<T>>>(
                 value,
                 code_address: initial_code.code_address,
                 disable_precompiles: initial_code.disable_precompiles,
+                caller_is_static: false,
                 salt: B256::ZERO,
                 ext: T::MessageExt::default(),
                 _non_exhaustive: (),
@@ -449,6 +450,7 @@ pub(crate) fn initial_message<T: EvmTypes<Host = Evm<T>>>(
                 value,
                 code_address: address,
                 disable_precompiles: false,
+                caller_is_static: false,
                 salt: B256::ZERO,
                 ext: T::MessageExt::default(),
                 _non_exhaustive: (),
@@ -863,8 +865,7 @@ mod tests {
         assert_eq!(message.code_address, delegated);
         assert!(message.disable_precompiles);
 
-        let result =
-            Host::execute_message(&mut evm, &TxEnv::default(), bytecode, &mut message, false);
+        let result = Host::execute_message(&mut evm, &TxEnv::default(), bytecode, &mut message);
 
         assert_eq!(result.stop, InstrStop::Return);
         assert_eq!(result.output.len(), 32);

--- a/crates/evm2/src/evm/inspector.rs
+++ b/crates/evm2/src/evm/inspector.rs
@@ -534,7 +534,7 @@ mod tests {
         let bytecode = Bytecode::new_legacy(Bytes::from(code));
         let mut message = message.clone();
         message.gas_limit = gas_limit;
-        let result = Host::execute_message(&mut evm, &tx_env, bytecode, &mut message, false);
+        let result = Host::execute_message(&mut evm, &tx_env, bytecode, &mut message);
         let inspector = evm.clear_inspector_as::<I>().unwrap();
         (result, inspector, evm)
     }
@@ -718,7 +718,7 @@ mod tests {
         let tx_env = TxEnv::default();
         let bytecode = Bytecode::new_legacy(Bytes::from(code));
         let mut message = Message { gas_limit: 100_000, ..Default::default() };
-        let result = Host::execute_message(&mut evm, &tx_env, bytecode, &mut message, false);
+        let result = Host::execute_message(&mut evm, &tx_env, bytecode, &mut message);
 
         assert_matches!(result.stop, InstrStop::Stop);
         // The redirected call transferred the value to the replacement, not the target.
@@ -921,7 +921,7 @@ mod tests {
         let tx_env = TxEnv::default();
         let bytecode = Bytecode::new_legacy(Bytes::from(code));
         let message = Message::<TestTypes> { gas_limit: 10_000, ..Default::default() };
-        let mut interp = Interpreter::<TestTypes>::new(bytecode, &tx_env, &message, false);
+        let mut interp = Interpreter::<TestTypes>::new(bytecode, &tx_env, &message);
         let config = ExecutionConfig::for_base_spec::<BaseEvmConfigSelector>(SpecId::OSAKA);
         let stop = interp.run_inspect(&config, &mut host, &mut inspector);
 

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -829,18 +829,15 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
         tx_env: &TxEnv<T>,
         bytecode: Bytecode,
         message: &mut Message<T>,
-        caller_is_static: bool,
     ) -> MessageResult<T> {
         match message.kind {
             MessageKind::Create | MessageKind::Create2 => {
-                self.execute_create_message(tx_env, bytecode, message, caller_is_static)
+                self.execute_create_message(tx_env, bytecode, message)
             }
             MessageKind::Call
             | MessageKind::CallCode
             | MessageKind::DelegateCall
-            | MessageKind::StaticCall => {
-                self.execute_call_message(tx_env, bytecode, message, caller_is_static)
-            }
+            | MessageKind::StaticCall => self.execute_call_message(tx_env, bytecode, message),
         }
     }
 
@@ -854,10 +851,9 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
         tx_env: &TxEnv<T>,
         bytecode: Bytecode,
         message: &mut Message<T>,
-        caller_is_static: bool,
     ) -> MessageResult<T> {
         let Some(inspector) = self.inspector.as_deref_mut() else {
-            return self.execute_message_impl(tx_env, bytecode, message, caller_is_static);
+            return self.execute_message_impl(tx_env, bytecode, message);
         };
         // SAFETY: The inspector is stored in `self` and remains alive for the duration of the
         // message execution.
@@ -890,7 +886,7 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
                 let frame = top_frame.insert(self.interpreter_pool.pop());
                 // SAFETY: The message outlives the frame, which is returned to the pool below.
                 let frame_message = unsafe { trustme::decouple_lt(&*message) };
-                frame.init(bytecode.clone(), tx_env, frame_message, caller_is_static);
+                frame.init(bytecode.clone(), tx_env, frame_message);
                 // SAFETY: `execution_config` points to a private field that host execution does
                 // not replace or mutate, so the pointee remains valid for the lifetime of the
                 // frame.
@@ -908,9 +904,8 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
             inspector.call(frame, message)
         };
 
-        let mut result = inspected.unwrap_or_else(|| {
-            self.execute_message_impl(tx_env, bytecode, message, caller_is_static)
-        });
+        let mut result =
+            inspected.unwrap_or_else(|| self.execute_message_impl(tx_env, bytecode, message));
 
         if is_create {
             inspector.create_end(frame, message, &mut result);
@@ -931,7 +926,6 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
         tx_env: &TxEnv<T>,
         bytecode: Bytecode,
         message: &mut Message<T>,
-        caller_is_static: bool,
     ) -> MessageResult<T> {
         if message.depth > CALL_DEPTH_LIMIT {
             return Self::error_message_result(InstrStop::CallTooDeep, message.gas_limit);
@@ -948,7 +942,7 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
         message.disable_precompiles = false;
         let input = core::mem::take(&mut message.input);
 
-        let stop = self.run_interpreter(bytecode, tx_env, message, caller_is_static);
+        let stop = self.run_interpreter(bytecode, tx_env, message);
         message.input = input;
 
         self.finish_create_message_run(checkpoint, &message.destination, message.gas_limit, stop)
@@ -1094,7 +1088,6 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
         tx_env: &TxEnv<T>,
         bytecode: Bytecode,
         message: &mut Message<T>,
-        caller_is_static: bool,
     ) -> MessageResult<T> {
         if message.depth > CALL_DEPTH_LIMIT {
             return Self::error_message_result(InstrStop::CallTooDeep, message.gas_limit);
@@ -1123,7 +1116,7 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
             return self.execute_call_precompile(checkpoint, message);
         }
 
-        let stop = self.run_interpreter(bytecode, tx_env, message, caller_is_static);
+        let stop = self.run_interpreter(bytecode, tx_env, message);
 
         self.finish_call_message_run(checkpoint, stop)
     }
@@ -1204,12 +1197,11 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
         bytecode: Bytecode,
         tx_env: &'frame TxEnv<T>,
         message: &'frame Message<T>,
-        caller_is_static: bool,
     ) -> InstrStop {
         let mut interp = self.interpreter_pool.pop();
         let _guard = self.enter_execution();
         let interp_ref = interp.as_mut();
-        interp_ref.init(bytecode, tx_env, message, caller_is_static);
+        interp_ref.init(bytecode, tx_env, message);
         // SAFETY: `execution_config` points to a private field that host execution does not
         // replace or mutate, so the pointee remains valid here.
         let execution_config = unsafe { trustme::decouple_lt(&self.execution_config) };
@@ -1364,12 +1356,11 @@ impl<T: EvmTypes<Host = Self>> Host<T> for Evm<T> {
         tx_env: &TxEnv<T>,
         bytecode: Bytecode,
         message: &mut Message<T>,
-        caller_is_static: bool,
     ) -> MessageResult<T> {
         if self.inspector.is_some() {
-            return self.execute_message_inspected(tx_env, bytecode, message, caller_is_static);
+            return self.execute_message_inspected(tx_env, bytecode, message);
         }
-        self.execute_message_impl(tx_env, bytecode, message, caller_is_static)
+        self.execute_message_impl(tx_env, bytecode, message)
     }
 
     fn selfdestruct(
@@ -1714,6 +1705,7 @@ mod tests {
             value: U256::ZERO,
             code_address: AccessingPrecompile::ADDRESS,
             disable_precompiles: false,
+            caller_is_static: false,
             salt: B256::ZERO,
             ext: (),
             _non_exhaustive: (),
@@ -1762,6 +1754,7 @@ mod tests {
             value: U256::ZERO,
             code_address: AccessingPrecompile::ADDRESS,
             disable_precompiles: false,
+            caller_is_static: false,
             salt: B256::ZERO,
             ext: (),
             _non_exhaustive: (),
@@ -1830,7 +1823,7 @@ mod tests {
         let message = Message::default();
         let tx_env = TxEnv::default();
         let bytecode = Bytecode::new_legacy(Bytes::from_static(&[op::STOP]));
-        let _ = evm.run_interpreter(bytecode, &tx_env, &message, false);
+        let _ = evm.run_interpreter(bytecode, &tx_env, &message);
     }
 
     #[test]
@@ -1855,7 +1848,7 @@ mod tests {
         let tx_env = TxEnv::default();
         let bytecode = Bytecode::new_legacy(Bytes::from_static(&[op::STOP]));
 
-        let _ = evm.run_interpreter(bytecode, &tx_env, &message, false);
+        let _ = evm.run_interpreter(bytecode, &tx_env, &message);
     }
 
     #[test]
@@ -1929,6 +1922,7 @@ mod tests {
             value: U256::from(99),
             code_address: address,
             disable_precompiles: false,
+            caller_is_static: false,
             salt: B256::ZERO,
             ext: (),
             _non_exhaustive: (),
@@ -1990,6 +1984,7 @@ mod tests {
                     value: U256::ZERO,
                     code_address: Self::INNER,
                     disable_precompiles: false,
+                    caller_is_static: false,
                     salt: B256::ZERO,
                     ext: (),
                     _non_exhaustive: (),
@@ -2015,6 +2010,7 @@ mod tests {
             value: U256::ZERO,
             code_address: NestedPrecompile::OUTER,
             disable_precompiles: false,
+            caller_is_static: false,
             salt: B256::ZERO,
             ext: (),
             _non_exhaustive: (),
@@ -2265,8 +2261,7 @@ mod tests {
             ..Message::default()
         };
 
-        let result =
-            Host::execute_message(&mut evm, &TxEnv::default(), bytecode, &mut message, false);
+        let result = Host::execute_message(&mut evm, &TxEnv::default(), bytecode, &mut message);
         assert!(result.stop.is_success());
     }
 
@@ -2323,8 +2318,7 @@ mod tests {
             ..Message::default()
         };
 
-        let result =
-            Host::execute_message(&mut evm, &TxEnv::default(), bytecode, &mut message, false);
+        let result = Host::execute_message(&mut evm, &TxEnv::default(), bytecode, &mut message);
 
         assert_eq!(result.stop, InstrStop::FatalExternalError);
         let error_code = evm.db_error_code().unwrap();
@@ -2352,8 +2346,7 @@ mod tests {
             ..Message::default()
         };
 
-        let result =
-            Host::execute_message(&mut evm, &TxEnv::default(), bytecode, &mut message, false);
+        let result = Host::execute_message(&mut evm, &TxEnv::default(), bytecode, &mut message);
 
         assert_eq!(result.stop, InstrStop::OutOfGas);
         assert!(!evm.state.storage(&contract).is_warm(&key));
@@ -2382,7 +2375,7 @@ mod tests {
         let code =
             Bytecode::new_legacy(Bytes::from_static(&[op::PUSH1, 1, op::PUSH1, 0, op::RETURN]));
 
-        let result = Host::execute_message(&mut evm, &TxEnv::default(), code, &mut message, false);
+        let result = Host::execute_message(&mut evm, &TxEnv::default(), code, &mut message);
         assert!(result.stop.is_success());
 
         evm.state.finalize_transaction_(Version::base(SpecId::FRONTIER));
@@ -2415,7 +2408,7 @@ mod tests {
         let code =
             Bytecode::new_legacy(Bytes::from_static(&[op::PUSH1, 1, op::PUSH1, 0, op::RETURN]));
 
-        let result = Host::execute_message(&mut evm, &TxEnv::default(), code, &mut message, false);
+        let result = Host::execute_message(&mut evm, &TxEnv::default(), code, &mut message);
         assert_eq!(result.stop, InstrStop::OutOfGas);
 
         evm.state.finalize_transaction_(Version::base(SpecId::HOMESTEAD));
@@ -2444,13 +2437,8 @@ mod tests {
             ..Message::default()
         };
 
-        let result = Host::execute_message(
-            &mut evm,
-            &TxEnv::default(),
-            Bytecode::default(),
-            &mut message,
-            false,
-        );
+        let result =
+            Host::execute_message(&mut evm, &TxEnv::default(), Bytecode::default(), &mut message);
         assert!(result.stop.is_success());
 
         evm.state.finalize_transaction_(Version::base(SpecId::SPURIOUS_DRAGON));
@@ -2485,13 +2473,8 @@ mod tests {
             ..Message::default()
         };
 
-        let result = Host::execute_message(
-            &mut evm,
-            &TxEnv::default(),
-            Bytecode::default(),
-            &mut message,
-            false,
-        );
+        let result =
+            Host::execute_message(&mut evm, &TxEnv::default(), Bytecode::default(), &mut message);
         assert!(result.stop.is_success());
 
         evm.state.finalize_transaction_(Version::base(SpecId::SPURIOUS_DRAGON));
@@ -2555,13 +2538,8 @@ mod tests {
             ..Message::default()
         };
 
-        let result = Host::execute_message(
-            &mut evm,
-            &TxEnv::default(),
-            Bytecode::default(),
-            &mut message,
-            false,
-        );
+        let result =
+            Host::execute_message(&mut evm, &TxEnv::default(), Bytecode::default(), &mut message);
         assert!(result.stop.is_success());
 
         let version = *evm.version();

--- a/crates/evm2/src/evm/registry.rs
+++ b/crates/evm2/src/evm/registry.rs
@@ -397,7 +397,6 @@ mod tests {
             _tx_env: &TxEnv<TestTypes>,
             _bytecode: Bytecode,
             _message: &mut Message<TestTypes>,
-            _caller_is_static: bool,
         ) -> MessageResult<TestTypes> {
             unimplemented!()
         }

--- a/crates/evm2/src/evm/system.rs
+++ b/crates/evm2/src/evm/system.rs
@@ -127,7 +127,7 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
         };
         // System calls are not inspected.
         let inspector = self.inspector.take();
-        let result = Host::execute_message(self, &tx_env, bytecode, &mut message, false);
+        let result = Host::execute_message(self, &tx_env, bytecode, &mut message);
         self.inspector = inspector;
         let gas_spent = SYSTEM_CALL_GAS_LIMIT.saturating_sub(result.gas.remaining());
         let gas_refunded = if result.stop.is_success() && result.gas.refunded() > 0 {

--- a/crates/evm2/src/interpreter/host.rs
+++ b/crates/evm2/src/interpreter/host.rs
@@ -137,12 +137,13 @@ pub trait Host<T: EvmTypes> {
     fn log(&mut self, log: Log);
 
     /// Executes a message inside this host.
+    ///
+    /// The static context is carried by [`Message::caller_is_static`].
     fn execute_message(
         &mut self,
         tx_env: &TxEnv<T>,
         bytecode: Bytecode,
         message: &mut Message<T>,
-        caller_is_static: bool,
     ) -> MessageResult<T>;
 
     /// Registers the current contract for self-destruction.

--- a/crates/evm2/src/interpreter/host.rs
+++ b/crates/evm2/src/interpreter/host.rs
@@ -137,8 +137,6 @@ pub trait Host<T: EvmTypes> {
     fn log(&mut self, log: Log);
 
     /// Executes a message inside this host.
-    ///
-    /// The static context is carried by [`Message::caller_is_static`].
     fn execute_message(
         &mut self,
         tx_env: &TxEnv<T>,

--- a/crates/evm2/src/interpreter/instructions/macro_tests.rs
+++ b/crates/evm2/src/interpreter/instructions/macro_tests.rs
@@ -83,7 +83,7 @@ fn run(config: RunConfig<'_>) -> TestInterpreter {
     let RunConfig { code, host, spec_id, tx_env, mut message, gas_limit, return_data } = config;
     let bytecode = Bytecode::new_legacy(Bytes::from(code));
     message.gas_limit = gas_limit;
-    let mut inner = Interpreter::<TestTypes>::new(bytecode, &tx_env, &message, false);
+    let mut inner = Interpreter::<TestTypes>::new(bytecode, &tx_env, &message);
     inner.set_return_data(return_data);
     let mut default_host = TestHost::default();
     let host = host.unwrap_or(&mut default_host);

--- a/crates/evm2/src/interpreter/instructions/memory.rs
+++ b/crates/evm2/src/interpreter/instructions/memory.rs
@@ -111,7 +111,7 @@ mod tests {
         let tx_env = TxEnv::default();
         let message = Message { gas_limit: 10_000, ..Message::default() };
         let bytecode = Bytecode::new_legacy(Bytes::from(code));
-        let mut interp = Interpreter::<TestTypes>::new(bytecode, &tx_env, &message, false);
+        let mut interp = Interpreter::<TestTypes>::new(bytecode, &tx_env, &message);
         let mut host = TestHost::default();
         let err = interp.run(&config, &mut host);
 

--- a/crates/evm2/src/interpreter/instructions/system.rs
+++ b/crates/evm2/src/interpreter/instructions/system.rs
@@ -146,7 +146,7 @@ fn prepare_call<T: EvmTypes>(
     message: &mut Message<T>,
     code: &mut Bytecode,
     return_memory_range: &mut Range<usize>,
-) -> Result<bool> {
+) -> Result {
     let has_value = match kind {
         MessageKind::Call | MessageKind::CallCode => true,
         MessageKind::DelegateCall | MessageKind::StaticCall => false,
@@ -203,15 +203,15 @@ fn prepare_call<T: EvmTypes>(
         value: call_value,
         code_address,
         disable_precompiles,
+        caller_is_static: state.is_static(),
         salt: B256::ZERO,
         ext: T::MessageExt::default(),
         _non_exhaustive: (),
     };
     *code = loaded_code;
     *return_memory_range = prepared_return_memory_range;
-    let caller_is_static = state.is_static();
 
-    Ok(caller_is_static)
+    Ok(())
 }
 
 #[inline(never)]
@@ -224,7 +224,7 @@ fn call_inner<T: EvmTypes>(
     let mut message = Message::<T>::default();
     let mut code = Bytecode::default();
     let mut return_memory_range = 0..0;
-    let caller_is_static = prepare_call(
+    prepare_call(
         stack.reborrow(),
         gas,
         state,
@@ -235,7 +235,7 @@ fn call_inner<T: EvmTypes>(
     )?;
 
     let tx_env = state.tx();
-    let mut result = state.host().execute_message(tx_env, code, &mut message, caller_is_static);
+    let mut result = state.host().execute_message(tx_env, code, &mut message);
     gas.erase_cost(result.gas_returned_to_parent());
     gas.record_refund(result.refund_propagated_to_parent());
     let copy_len = min(return_memory_range.len(), result.output.len());
@@ -317,13 +317,15 @@ fn create_inner<T: EvmTypes>(
         value,
         code_address: current.destination,
         disable_precompiles: false,
+        // CREATE is rejected in a static context (see `require_non_staticcall`).
+        caller_is_static: false,
         salt: salt.map(|salt| B256::from(salt.to_be_bytes())).unwrap_or_default(),
         ext: T::MessageExt::default(),
         _non_exhaustive: (),
     };
     let bytecode = crate::bytecode::Bytecode::new_legacy(message.input.clone());
     let tx_env = state.tx();
-    let result = state.host().execute_message(tx_env, bytecode, &mut message, false);
+    let result = state.host().execute_message(tx_env, bytecode, &mut message);
     gas.erase_cost(result.gas_returned_to_parent());
     gas.record_refund(result.refund_propagated_to_parent());
     // EIP-211 exposes CREATE failure data only for REVERT; other failures clear returndata.

--- a/crates/evm2/src/interpreter/instructions/tests.rs
+++ b/crates/evm2/src/interpreter/instructions/tests.rs
@@ -184,7 +184,6 @@ impl Host<TestTypes> for TestHost {
         _tx_env: &TxEnv<TestTypes>,
         _bytecode: Bytecode,
         message: &mut Message<TestTypes>,
-        caller_is_static: bool,
     ) -> MessageResult<TestTypes> {
         // Mimics the depth limit enforced by the real host.
         if message.depth > CALL_DEPTH_LIMIT {
@@ -194,7 +193,8 @@ impl Host<TestTypes> for TestHost {
                 ..Default::default()
             };
         }
-        self.call_static_flags.push(caller_is_static || message.kind == MessageKind::StaticCall);
+        self.call_static_flags
+            .push(message.caller_is_static || message.kind == MessageKind::StaticCall);
         self.calls.push(message.clone());
         self.execute_result.clone()
     }
@@ -317,7 +317,7 @@ pub(super) fn run(config: RunConfig<'_>) -> TestInterpreter {
     let RunConfig { code, host, spec_id, tx_env, mut message, gas_limit, return_data } = config;
     let bytecode = Bytecode::new_legacy(Bytes::from(code));
     message.gas_limit = gas_limit;
-    let mut inner = Interpreter::<TestTypes>::new(bytecode, &tx_env, &message, false);
+    let mut inner = Interpreter::<TestTypes>::new(bytecode, &tx_env, &message);
     inner.set_return_data(return_data);
     let mut default_host = TestHost::default();
     let host = host.unwrap_or(&mut default_host);

--- a/crates/evm2/src/interpreter/message.rs
+++ b/crates/evm2/src/interpreter/message.rs
@@ -52,6 +52,9 @@ pub struct Message<T: EvmTypes = BaseEvmTypes> {
     /// Whether native precompile dispatch is disabled for this frame because its bytecode was
     /// loaded through an EIP-7702 delegation designation.
     pub disable_precompiles: bool,
+    /// Whether the immediate caller frame is executing in a static context. Combined with a
+    /// `STATICCALL` kind, this determines whether the new frame is static.
+    pub caller_is_static: bool,
     /// CREATE2 salt. Ignored for other message kinds.
     pub salt: B256,
     /// EVM type-specific extension data.

--- a/crates/evm2/src/interpreter/runtime.rs
+++ b/crates/evm2/src/interpreter/runtime.rs
@@ -77,14 +77,9 @@ impl<T: EvmTypes> Default for Interpreter<'_, T> {
 impl<'frame, T: EvmTypes> Interpreter<'frame, T> {
     /// Creates an interpreter from analyzed bytecode, a transaction-global environment, and a
     /// frame-local message.
-    pub fn new(
-        bytecode: Bytecode,
-        tx_env: &'frame TxEnv<T>,
-        message: &'frame Message<T>,
-        caller_is_static: bool,
-    ) -> Self {
+    pub fn new(bytecode: Bytecode, tx_env: &'frame TxEnv<T>, message: &'frame Message<T>) -> Self {
         let mut interp = Self::default();
-        interp.init(bytecode, tx_env, message, caller_is_static);
+        interp.init(bytecode, tx_env, message);
         interp
     }
 
@@ -94,10 +89,9 @@ impl<'frame, T: EvmTypes> Interpreter<'frame, T> {
         bytecode: Bytecode,
         tx_env: &'frame TxEnv<T>,
         message: &'frame Message<T>,
-        caller_is_static: bool,
     ) {
         let gas_limit = message.gas_limit;
-        let is_static = caller_is_static || matches!(message.kind, MessageKind::StaticCall);
+        let is_static = message.caller_is_static || matches!(message.kind, MessageKind::StaticCall);
         self.pc = bytecode.original_byte_slice().as_ptr();
         self.bytecode = bytecode;
         self.stack_len = 0;

--- a/crates/evm2/src/tests.rs
+++ b/crates/evm2/src/tests.rs
@@ -23,7 +23,6 @@ fn run_tx(evm: &mut TestEvm, destination: Address, code: impl Into<Vec<u8>>) {
         &TxEnv::default(),
         Bytecode::new_legacy(Bytes::from(code.into())),
         &mut message,
-        false,
     );
     assert!(result.stop.is_success());
 }
@@ -146,7 +145,6 @@ fn evm_propagates_child_sstore_negative_refund() {
         &TxEnv::default(),
         Bytecode::new_legacy(Bytes::from(parent_code)),
         &mut message,
-        false,
     );
 
     assert!(result.stop.is_success());
@@ -174,7 +172,6 @@ fn evm_reports_invalid_transaction_execution() {
         &TxEnv::default(),
         Bytecode::new_legacy(Bytes::from_static(&[op::PUSH1, 0x01, op::SSTORE])),
         &mut message,
-        false,
     );
 
     assert_eq!(result.stop, InstrStop::StackUnderflow);

--- a/crates/inspectors/src/opcode.rs
+++ b/crates/inspectors/src/opcode.rs
@@ -157,7 +157,7 @@ mod tests {
         let bytecode = Bytecode::new_legacy(Bytes::from(opcodes));
         let tx_env = TxEnv::<BaseEvmTypes>::default();
         let message = Message::default();
-        let mut interp = Interpreter::new(bytecode, &tx_env, &message, false);
+        let mut interp = Interpreter::new(bytecode, &tx_env, &message);
 
         for _ in &opcodes {
             opcode_counter.step(&mut interp);
@@ -173,7 +173,7 @@ mod tests {
         let bytecode = Bytecode::new_legacy(Bytes::from(opcodes));
         let tx_env = TxEnv::<BaseEvmTypes>::default();
         let message = Message::default();
-        let mut interp = Interpreter::new(bytecode, &tx_env, &message, false);
+        let mut interp = Interpreter::new(bytecode, &tx_env, &message);
 
         for _ in &opcodes {
             opcode_counter.step(&mut interp);


### PR DESCRIPTION
## Summary

Moves the `caller_is_static` flag onto `Message` instead of threading it as a separate parameter next to the message through the whole execution chain.

- `Message` gains a `caller_is_static: bool` field.
- `Host::execute_message`, `Evm::{execute_message, execute_message_impl, execute_message_inspected, execute_create_message, execute_call_message, run_interpreter}`, and `Interpreter::{init, new}` all drop the `caller_is_static` parameter and read it from the message.
- Producers set the flag where the message is built:
  - call instructions (`prepare_call`): `state.is_static()` — `prepare_call` now returns `Result` instead of `Result<bool>`.
  - `CREATE`/`CREATE2`: `false` (CREATE is rejected in a static context via `require_non_staticcall`).
  - top-level transaction messages: `false`.

Behavior is unchanged — `is_static` is still derived as `caller_is_static || kind == StaticCall`; the flag is just stored on the message rather than propagated alongside it.

## Test plan

- `cargo nextest run` — full workspace green (465 tests)
- `cargo cl` / `cargo docs` clean
- Static-propagation coverage (`call_static_flags`) unchanged