### PR TITLE
feat(cli): improve replay stats output

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -40,6 +40,7 @@ alloy-provider = { workspace = true, features = ["debug-api", "reqwest", "reqwes
 alloy-rpc-client = { workspace = true, features = ["reqwest"] }
 alloy-rpc-types-eth = { workspace = true, features = ["serde", "std"] }
 alloy-rpc-types-trace.workspace = true
+anstyle.workspace = true
 clap.workspace = true
 futures-util.workspace = true
 rand.workspace = true

--- a/crates/cli/src/capture/mod.rs
+++ b/crates/cli/src/capture/mod.rs
@@ -8,7 +8,7 @@ mod rpc;
 
 pub(crate) use error::CaptureError;
 
-use crate::{args::Capture, error::Result, ethereum};
+use crate::{args::Capture, error::Result, ethereum, style};
 use alloy_consensus::{
     Block as ConsensusBlock, EthereumTxEnvelope, TxEip4844, transaction::SignerRecoverable,
 };
@@ -39,8 +39,9 @@ pub(crate) fn run(command: Capture) -> Result<()> {
     let summary = runtime
         .block_on(capture(&command.rpc, from, to, &command))
         .map_err(|source| crate::error::Error::Capture { source })?;
+    let ok = style::OK;
     println!(
-        "captured EEST {}: {} blocks, {} txs, {} base accounts, {} base storage slots in {:.2}s",
+        "{ok}ok{ok:#}: captured EEST {}: {} blocks, {} txs, {} base accounts, {} base storage slots in {:.2}s",
         command.output.display(),
         summary.blocks,
         summary.transactions,
@@ -78,6 +79,7 @@ async fn capture(
         .buffer_unordered(rpc.max_concurrent_requests());
     let mut pending_blocks = BTreeMap::new();
     let mut next_block = from;
+    let total_blocks = (to - from + 1) as usize;
 
     while next_block <= to {
         let block = if let Some(block) = pending_blocks.remove(&next_block) {
@@ -126,11 +128,18 @@ async fn capture(
         transaction_count += block_transaction_count;
         block_inputs.push(model::CapturedBlock { block: consensus_block, transactions });
 
-        eprintln!(
-            "captured block {number} ({} txs) in {:.2}s",
-            block_transaction_count,
-            (elapsed + block_started_at.elapsed()).as_secs_f64()
-        );
+        let progress_index = (number - from + 1) as usize;
+        if style::should_print_progress(progress_index, total_blocks) {
+            let info = style::INFO;
+            eprintln!(
+                "{info}capture{info:#}: block {}/{} number={} ({} txs) in {:.2}s",
+                progress_index,
+                total_blocks,
+                number,
+                block_transaction_count,
+                (elapsed + block_started_at.elapsed()).as_secs_f64()
+            );
+        }
         next_block += 1;
     }
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -8,6 +8,7 @@ mod fixture;
 mod fuzzer;
 mod list;
 mod replay;
+mod style;
 
 use crate::{args::Args, error::Result};
 use clap::Parser;
@@ -15,10 +16,12 @@ use std::{error::Error as _, process::ExitCode};
 
 fn main() -> ExitCode {
     if let Err(error) = run() {
-        eprintln!("{error}");
+        let style = style::ERROR;
+        eprintln!("{style}error{style:#}: {error}");
         let mut source = error.source();
         while let Some(error) = source {
-            eprintln!("  caused by: {error}");
+            let muted = style::MUTED;
+            eprintln!("{muted}caused by{muted:#}: {error}");
             source = error.source();
         }
         return ExitCode::FAILURE;

--- a/crates/cli/src/replay/mod.rs
+++ b/crates/cli/src/replay/mod.rs
@@ -2,6 +2,7 @@ use crate::{
     args::Replay,
     error::{Error, Result},
     fixture::{self, FixtureKind},
+    style,
 };
 use alloy_primitives::U256;
 use evm2_eest::{
@@ -27,8 +28,9 @@ pub(crate) fn run(command: Replay) -> Result<()> {
             &mut hook,
         )
         .map_err(|source| Error::BlockchainTest { source })?;
+        let ok = style::OK;
         println!(
-            "replayed blockchain fixture {}: {} executed, {} skipped",
+            "{ok}ok{ok:#}: replayed blockchain fixture {}: {} executed, {} skipped",
             command.path.display(),
             summary.executed,
             summary.skipped
@@ -46,8 +48,9 @@ pub(crate) fn run(command: Replay) -> Result<()> {
                 &entrypoint,
             )
             .map_err(|source| Error::StateTest { source })?;
+            let ok = style::OK;
             println!(
-                "replayed state fixture {}: {} executed, {} skipped",
+                "{ok}ok{ok:#}: replayed state fixture {}: {} executed, {} skipped",
                 command.path.display(),
                 summary.executed,
                 summary.skipped
@@ -64,8 +67,9 @@ pub(crate) fn run(command: Replay) -> Result<()> {
                 &mut hook,
             )
             .map_err(|source| Error::BlockchainTest { source })?;
+            let ok = style::OK;
             println!(
-                "replayed blockchain fixture {}: {} executed, {} skipped",
+                "{ok}ok{ok:#}: replayed blockchain fixture {}: {} executed, {} skipped",
                 command.path.display(),
                 summary.executed,
                 summary.skipped
@@ -92,56 +96,57 @@ impl BlockchainTestHook for ReplayProgressHook {
         self.case_elapsed_sec = 0.0;
         self.case_gas_used = 0;
         self.case_blocks_with_gas = 0;
+        let info = style::INFO;
         eprintln!(
-            "replay case {}: {} blocks, network {:?}",
+            "{info}replay{info:#}: case {}: {} blocks, network {:?}",
             event.name, event.total_blocks, event.network
         );
     }
 
-    fn block_started(&mut self, event: BlockchainTestBlockStarted) {
+    fn block_started(&mut self, _event: BlockchainTestBlockStarted) {
         self.block_started_at = Some(Instant::now());
         self.printed_transaction_failure = false;
-        eprintln!(
-            "replay block {}/{} number={} started ({} txs)",
-            event.block_index + 1,
-            event.total_blocks,
-            display_block_number(event.block_number, event.block_index),
-            event.total_transactions
-        );
     }
 
     fn block_finished(&mut self, event: BlockchainTestBlockFinished) {
         let elapsed = self.take_block_elapsed();
         self.record_block(event.block_gas_used, elapsed);
-        if let Some(ggas_per_second) = ggas_per_second(event.block_gas_used, elapsed) {
+        let block_index = event.block_index + 1;
+        if !style::should_print_progress(block_index, event.total_blocks) {
+            if block_index == event.total_blocks {
+                self.print_case_summary(event.total_blocks);
+            }
+            return;
+        }
+        let ok = style::OK;
+        let block_width = decimal_width(event.total_blocks);
+        let total_blocks = event.total_blocks;
+        let block_number = display_block_number(event.block_number, event.block_index);
+        if let Some(block_gas_used) = event.block_gas_used
+            && let Some(ggas_per_second) =
+                ggas_per_second_from_gas(block_gas_used.saturating_to::<u128>(), elapsed)
+        {
+            let block_ggas = ggas(block_gas_used.saturating_to::<u128>());
             eprintln!(
-                "replay block {}/{} number={} done in {:.2}s ({:.3} Ggas/s)",
-                event.block_index + 1,
-                event.total_blocks,
-                display_block_number(event.block_number, event.block_index),
-                elapsed,
-                ggas_per_second
+                "{ok}done{ok:#}: block {block_index:block_width$}/{total_blocks} number={block_number} in {elapsed:.2}s ({block_ggas:.3} Ggas, {ggas_per_second:.3} Ggas/s)"
             );
         } else {
             eprintln!(
-                "replay block {}/{} number={} done in {:.2}s",
-                event.block_index + 1,
-                event.total_blocks,
-                display_block_number(event.block_number, event.block_index),
-                elapsed
+                "{ok}done{ok:#}: block {block_index:block_width$}/{total_blocks} number={block_number} in {elapsed:.2}s"
             );
         }
 
-        if event.block_index + 1 == event.total_blocks {
+        if block_index == event.total_blocks {
             self.print_case_summary(event.total_blocks);
         }
     }
 
     fn block_failed(&mut self, event: BlockchainTestBlockFailed<'_>) {
         let elapsed = self.take_block_elapsed();
+        let error = style::ERROR;
         if self.printed_transaction_failure {
             eprintln!(
-                "replay block {}/{} number={} failed in {:.2}s after transaction failure",
+                "{error}failed{error:#}: block {}/{} number={} in {:.2}s after transaction failure",
                 event.block_index + 1,
                 event.total_blocks,
                 display_block_number(event.block_number, event.block_index),
@@ -149,7 +154,7 @@ impl BlockchainTestHook for ReplayProgressHook {
             );
         } else {
             eprintln!(
-                "replay block {}/{} number={} failed in {:.2}s: {}",
+                "{error}failed{error:#}: block {}/{} number={} in {:.2}s: {}",
                 event.block_index + 1,
                 event.total_blocks,
                 display_block_number(event.block_number, event.block_index),
@@ -159,28 +164,16 @@ impl BlockchainTestHook for ReplayProgressHook {
         }
     }
 
-    fn transaction_started(&mut self, event: BlockchainTestTransactionStarted) {
-        if event.total_transactions >= 100
-            && (event.transaction_index == 0 || (event.transaction_index + 1).is_multiple_of(100))
-        {
-            eprintln!(
-                "replay tx {}/{} in block {}/{} number={} started",
-                event.transaction_index + 1,
-                event.total_transactions,
-                event.block_index + 1,
-                event.total_blocks,
-                display_block_number(event.block_number, event.block_index)
-            );
-        }
-    }
+    fn transaction_started(&mut self, _event: BlockchainTestTransactionStarted) {}
 
     fn transaction_finished(&mut self, event: BlockchainTestTransactionFinished) {
-        if event.total_transactions >= 100
-            && ((event.transaction_index + 1).is_multiple_of(100)
+        if event.total_transactions >= 1_000
+            && ((event.transaction_index + 1).is_multiple_of(500)
                 || event.transaction_index + 1 == event.total_transactions)
         {
+            let info = style::INFO;
             eprintln!(
-                "replay tx {}/{} in block {}/{} number={} done",
+                "{info}progress{info:#}: tx {}/{} in block {}/{} number={} done",
                 event.transaction_index + 1,
                 event.total_transactions,
                 event.block_index + 1,
@@ -192,8 +185,9 @@ impl BlockchainTestHook for ReplayProgressHook {
 
     fn transaction_failed(&mut self, event: BlockchainTestTransactionFailed<'_>) {
         self.printed_transaction_failure = true;
+        let error = style::ERROR;
         eprintln!(
-            "replay tx {}/{} in block {}/{} number={} failed: {}",
+            "{error}failed{error:#}: tx {}/{} in block {}/{} number={}: {}",
             event.transaction_index + 1,
             event.total_transactions,
             event.block_index + 1,
@@ -224,16 +218,18 @@ impl ReplayProgressHook {
         let Some(ggas_per_second) =
             ggas_per_second_from_gas(self.case_gas_used, self.case_elapsed_sec)
         else {
+            let ok = style::OK;
             eprintln!(
-                "replay case {}: {} blocks done in {:.2}s",
+                "{ok}done{ok:#}: case {}: {} blocks in {:.2}s",
                 case_name, total_blocks, self.case_elapsed_sec
             );
             return;
         };
 
+        let ok = style::OK;
         if self.case_blocks_with_gas == total_blocks {
             eprintln!(
-                "replay case {}: {} blocks done in {:.2}s ({:.3} Ggas/s aggregate, {:.3} Ggas total)",
+                "{ok}done{ok:#}: case {}: {} blocks in {:.2}s ({:.3} Ggas/s aggregate, {:.3} Ggas total)",
                 case_name,
                 total_blocks,
                 self.case_elapsed_sec,
@@ -241,8 +237,9 @@ impl ReplayProgressHook {
                 ggas(self.case_gas_used)
             );
         } else {
+            let warn = style::WARN;
             eprintln!(
-                "replay case {}: {} blocks done in {:.2}s ({:.3} Ggas/s aggregate, {:.3} Ggas total across {}/{} blocks with gasUsed)",
+                "{warn}done{warn:#}: case {}: {} blocks in {:.2}s ({:.3} Ggas/s aggregate, {:.3} Ggas total across {}/{} blocks with gasUsed)",
                 case_name,
                 total_blocks,
                 self.case_elapsed_sec,
@@ -259,8 +256,8 @@ fn display_block_number(block_number: Option<U256>, fallback: usize) -> String {
     block_number.map(|number| number.to_string()).unwrap_or_else(|| fallback.to_string())
 }
 
-fn ggas_per_second(block_gas_used: Option<U256>, elapsed: f64) -> Option<f64> {
-    ggas_per_second_from_gas(block_gas_used?.saturating_to::<u128>(), elapsed)
+fn decimal_width(value: usize) -> usize {
+    value.checked_ilog10().unwrap_or_default() as usize + 1
 }
 
 fn ggas_per_second_from_gas(gas_used: u128, elapsed: f64) -> Option<f64> {

--- a/crates/cli/src/style.rs
+++ b/crates/cli/src/style.rs
@@ -1,0 +1,16 @@
+use anstyle::{AnsiColor, Color, Style};
+
+pub(crate) const ERROR: Style =
+    Style::new().fg_color(Some(Color::Ansi(AnsiColor::BrightRed))).bold();
+pub(crate) const INFO: Style =
+    Style::new().fg_color(Some(Color::Ansi(AnsiColor::BrightCyan))).bold();
+pub(crate) const MUTED: Style = Style::new().fg_color(Some(Color::Ansi(AnsiColor::BrightBlack)));
+pub(crate) const OK: Style =
+    Style::new().fg_color(Some(Color::Ansi(AnsiColor::BrightGreen))).bold();
+pub(crate) const WARN: Style =
+    Style::new().fg_color(Some(Color::Ansi(AnsiColor::BrightYellow))).bold();
+
+#[inline]
+pub(crate) const fn should_print_progress(index: usize, total: usize) -> bool {
+    total <= 10 || index == 1 || index == total || index.is_multiple_of(10)
+}

--- a/crates/eest/Cargo.toml
+++ b/crates/eest/Cargo.toml
@@ -24,6 +24,7 @@ alloy-primitives = { workspace = true, features = ["std", "serde", "rlp"] }
 alloy-rlp = { workspace = true, features = ["std"] }
 alloy-rpc-types-eth = { workspace = true, features = ["std"] }
 alloy-trie = { workspace = true, features = ["ethereum"] }
+anstyle.workspace = true
 k256 = { workspace = true, features = ["ecdsa", "std"] }
 libtest-mimic.workspace = true
 postcard = { workspace = true, features = ["use-std"] }

--- a/crates/eest/src/blockchaintest/execute.rs
+++ b/crates/eest/src/blockchaintest/execute.rs
@@ -19,6 +19,7 @@ use crate::{
 use alloy_eips::eip7840::BlobParams;
 use alloy_primitives::{Address, B256, Bytes, KECCAK256_EMPTY, U256};
 use alloy_rpc_types_eth::AccessList as RpcAccessList;
+use anstyle::{AnsiColor, Color, Style};
 use evm2::{
     BaseEvmTypes, Evm, Precompiles, SpecId, TxResult,
     env::BlockEnv,
@@ -125,6 +126,7 @@ fn execute_case(
     let mut block_env =
         block_env_from_header(&test_case.genesis_block_header, parent_excess_blob_gas, spec);
     let total_blocks = test_case.blocks.len();
+    let mut db_stats_counts = DbStatsCounts::default();
 
     hook.case_started(CaseStarted { name, total_blocks, network: test_case.network });
 
@@ -153,7 +155,7 @@ fn execute_case(
             &mut parent_block_hash,
             &mut parent_excess_blob_gas,
             hook,
-            config.db_stats,
+            if config.db_stats { Some(&mut db_stats_counts) } else { None },
         ) {
             Ok(()) => hook.block_finished(BlockFinished {
                 block_index,
@@ -178,6 +180,9 @@ fn execute_case(
         && let Some(expected) = &test_case.post_state
     {
         validate_post_state(&database, expected).map_err(|err| TestError::case(path, name, err))?;
+    }
+    if config.db_stats {
+        print_db_stats(db_stats_counts);
     }
     Ok(())
 }
@@ -213,8 +218,9 @@ fn execute_block(
     parent_block_hash: &mut Option<B256>,
     parent_excess_blob_gas: &mut u64,
     hook: &mut dyn Hook,
-    db_stats: bool,
+    db_stats_counts: Option<&mut DbStatsCounts>,
 ) -> Result<(), TestError> {
+    let db_stats = db_stats_counts.is_some();
     let should_fail = block.expect_exception.is_some();
     let mut block_hash = None;
     let mut beacon_root = None;
@@ -337,7 +343,7 @@ fn execute_block(
 
     // The EVM was constructed with this concrete database above; recover it before returning so
     // invalid blocks leave the caller's state unchanged.
-    let (mut restored_database, db_stats_counts) = if db_stats {
+    let (mut restored_database, block_db_stats_counts) = if db_stats {
         let stats = evm
             .database_as_mut::<DbStats<InMemoryDB>>()
             .expect("block EVM database should be DbStats<InMemoryDB>");
@@ -351,8 +357,10 @@ fn execute_block(
             None,
         )
     };
-    if let Some(counts) = db_stats_counts {
-        print_db_stats(counts);
+    if let Some(counts) = db_stats_counts
+        && let Some(block_counts) = block_db_stats_counts
+    {
+        *counts += block_counts;
     }
 
     match result {
@@ -380,14 +388,25 @@ fn execute_block(
 }
 
 fn print_db_stats(counts: DbStatsCounts) {
+    let style = db_stats_style();
+    eprintln!("{style}db stats{style:#}: get_account={}", counts.get_account);
+    eprintln!("{style}db stats{style:#}: get_code_by_hash={}", counts.get_code_by_hash);
+    eprintln!("{style}db stats{style:#}: get_storage={}", counts.get_storage);
     eprintln!(
-        "db stats: get_account={} get_code_by_hash={} get_storage={} get_block_hash={} error={}",
-        counts.get_account,
-        counts.get_code_by_hash,
-        counts.get_storage,
-        counts.get_block_hash,
-        counts.error
+        "{style}db stats{style:#}: get_storage_same_address_repeats={}",
+        counts.get_storage_same_address_repeats
     );
+    eprintln!(
+        "{style}db stats{style:#}: get_storage_same_address_longest_streak={}",
+        counts.get_storage_same_address_longest_streak
+    );
+    eprintln!("{style}db stats{style:#}: get_block_hash={}", counts.get_block_hash);
+    eprintln!("{style}db stats{style:#}: error={}", counts.error);
+}
+
+#[inline]
+const fn db_stats_style() -> Style {
+    Style::new().fg_color(Some(Color::Ansi(AnsiColor::BrightCyan))).bold()
 }
 
 fn block_number(block: &Block) -> Option<U256> {

--- a/crates/eest/src/execute.rs
+++ b/crates/eest/src/execute.rs
@@ -16,6 +16,7 @@ use alloy_trie::{
     TrieAccount,
     root::{state_root_unhashed, storage_root_unhashed},
 };
+use anstyle::{AnsiColor, Color, Style};
 use evm2::{
     BaseEvmTypes, Evm, EvmTypes, Precompiles, SpecId, TxResult,
     env::BlockEnv,
@@ -88,13 +89,17 @@ pub fn execute_str_with_filter(
     let suite: TestSuite =
         serde_json::from_str(input).map_err(|err| TestError::unknown(path, err.into()))?;
     let mut summary = ExecuteSummary::default();
+    let mut db_stats_counts = DbStatsCounts::default();
     for (name, unit) in suite.0 {
         if !entrypoint.matches(&name) {
             summary.skipped += 1;
             continue;
         }
-        execute_unit(path, &name, unit, config)?;
+        execute_unit(path, &name, unit, config, &mut db_stats_counts)?;
         summary.executed += 1;
+    }
+    if config.db_stats {
+        print_db_stats(db_stats_counts);
     }
     Ok(summary)
 }
@@ -104,6 +109,7 @@ fn execute_unit(
     name: &str,
     unit: TestUnit,
     config: ExecuteConfig,
+    db_stats_counts: &mut DbStatsCounts,
 ) -> Result<(), TestError> {
     let state = parse_state(&unit.pre).map_err(|err| TestError::case(path, name, err))?;
     for (spec_name, posts) in &unit.post {
@@ -122,7 +128,14 @@ fn execute_unit(
                 }
                 Err(err) => return Err(TestError::case(path, name, err)),
             };
-            let result = execute_spec(spec, block, state.clone(), &tx, &unit.env, config.db_stats);
+            let result = execute_spec(
+                spec,
+                block,
+                state.clone(),
+                &tx,
+                &unit.env,
+                if config.db_stats { Some(&mut *db_stats_counts) } else { None },
+            );
             validate_result(path, name, &unit, post, result, spec, config)?;
         }
     }
@@ -242,8 +255,9 @@ fn execute_spec(
     database: InMemoryDB,
     tx: &RecoveredTxEnvelope,
     env: &Env,
-    db_stats: bool,
+    db_stats_counts: Option<&mut DbStatsCounts>,
 ) -> Result<SpecOutcome, HandlerError> {
+    let db_stats = db_stats_counts.is_some();
     let mut evm = if db_stats {
         Evm::<BaseEvmTypes>::new(
             spec,
@@ -264,21 +278,34 @@ fn execute_spec(
     let mut post = database;
     pre_block_system_calls(&mut evm, &mut post, spec, env);
     let Ok(result) = evm.transact(tx)?.commit_with(&mut post);
-    if db_stats && let Some(stats) = evm.database_as::<DbStats<InMemoryDB>>() {
-        print_db_stats(stats.counts());
+    if let Some(counts) = db_stats_counts
+        && let Some(stats) = evm.database_as::<DbStats<InMemoryDB>>()
+    {
+        *counts += stats.counts();
     }
     Ok(spec_outcome(post, result))
 }
 
 fn print_db_stats(counts: DbStatsCounts) {
+    let style = db_stats_style();
+    eprintln!("{style}db stats{style:#}: get_account={}", counts.get_account);
+    eprintln!("{style}db stats{style:#}: get_code_by_hash={}", counts.get_code_by_hash);
+    eprintln!("{style}db stats{style:#}: get_storage={}", counts.get_storage);
     eprintln!(
-        "db stats: get_account={} get_code_by_hash={} get_storage={} get_block_hash={} error={}",
-        counts.get_account,
-        counts.get_code_by_hash,
-        counts.get_storage,
-        counts.get_block_hash,
-        counts.error
+        "{style}db stats{style:#}: get_storage_same_address_repeats={}",
+        counts.get_storage_same_address_repeats
     );
+    eprintln!(
+        "{style}db stats{style:#}: get_storage_same_address_longest_streak={}",
+        counts.get_storage_same_address_longest_streak
+    );
+    eprintln!("{style}db stats{style:#}: get_block_hash={}", counts.get_block_hash);
+    eprintln!("{style}db stats{style:#}: error={}", counts.error);
+}
+
+#[inline]
+const fn db_stats_style() -> Style {
+    Style::new().fg_color(Some(Color::Ansi(AnsiColor::BrightCyan))).bold()
 }
 
 fn spec_outcome(post: InMemoryDB, result: TxResult) -> SpecOutcome {

--- a/crates/evm2/src/evm/db.rs
+++ b/crates/evm2/src/evm/db.rs
@@ -196,10 +196,29 @@ pub struct DbStatsCounts {
     pub get_code_by_hash: u64,
     /// Number of storage slot loads.
     pub get_storage: u64,
+    /// Number of storage loads whose address matched the previous storage load.
+    pub get_storage_same_address_repeats: u64,
+    /// Longest run of storage loads for the same address.
+    pub get_storage_same_address_longest_streak: u64,
     /// Number of block hash loads.
     pub get_block_hash: u64,
     /// Number of error lookups.
     pub error: u64,
+}
+
+impl core::ops::AddAssign for DbStatsCounts {
+    #[inline]
+    fn add_assign(&mut self, rhs: Self) {
+        self.get_account += rhs.get_account;
+        self.get_code_by_hash += rhs.get_code_by_hash;
+        self.get_storage += rhs.get_storage;
+        self.get_storage_same_address_repeats += rhs.get_storage_same_address_repeats;
+        self.get_storage_same_address_longest_streak = self
+            .get_storage_same_address_longest_streak
+            .max(rhs.get_storage_same_address_longest_streak);
+        self.get_block_hash += rhs.get_block_hash;
+        self.error += rhs.error;
+    }
 }
 
 /// Database wrapper that records method call counts.
@@ -207,6 +226,8 @@ pub struct DbStatsCounts {
 pub struct DbStats<D> {
     db: D,
     counts: DbStatsCounts,
+    last_storage_address: Option<Address>,
+    storage_address_streak: u64,
 }
 
 impl<D> DbStats<D> {
@@ -219,9 +240,13 @@ impl<D> DbStats<D> {
                 get_account: 0,
                 get_code_by_hash: 0,
                 get_storage: 0,
+                get_storage_same_address_repeats: 0,
+                get_storage_same_address_longest_streak: 0,
                 get_block_hash: 0,
                 error: 0,
             },
+            last_storage_address: None,
+            storage_address_streak: 0,
         }
     }
 
@@ -248,6 +273,20 @@ impl<D> DbStats<D> {
     pub const fn counts(&self) -> DbStatsCounts {
         self.counts
     }
+
+    #[inline]
+    fn record_storage_load(&mut self, address: &Address) {
+        self.counts.get_storage += 1;
+        if self.last_storage_address.as_ref() == Some(address) {
+            self.counts.get_storage_same_address_repeats += 1;
+            self.storage_address_streak += 1;
+        } else {
+            self.last_storage_address = Some(*address);
+            self.storage_address_streak = 1;
+        }
+        self.counts.get_storage_same_address_longest_streak =
+            self.counts.get_storage_same_address_longest_streak.max(self.storage_address_streak);
+    }
 }
 
 impl<D: DynDatabase> DynDatabase for DbStats<D> {
@@ -265,7 +304,7 @@ impl<D: DynDatabase> DynDatabase for DbStats<D> {
 
     #[inline]
     fn get_storage(&mut self, address: &Address, key: &Word) -> DbResult<Word> {
-        self.counts.get_storage += 1;
+        self.record_storage_load(address);
         self.db.get_storage(address, key)
     }
 


### PR DESCRIPTION
This adds aggregate database stats for full EEST fixture execution instead of printing per inner run. Storage stats now include adjacent same-address storage query repeats and the longest same-address storage query streak.

It also refreshes replay and capture progress output with anstyle colors, reduces normal progress spam, pads printed block indexes for scanability, and includes per-block total gas alongside throughput when gasUsed is available.
