### PR TITLE
perf(state): trim redundant loops and dead journaling in finalize/commit

### DIFF
--- a/crates/evm2/src/evm/state/account.rs
+++ b/crates/evm2/src/evm/state/account.rs
@@ -459,28 +459,27 @@ impl<'a> AccountHandle<'a> {
         self.present_mut()
     }
 
-    /// Deletes the account at transaction finalization, recording a revert snapshot.
+    /// Deletes the account at transaction finalization.
     ///
     /// Used for self-destructed accounts (pre-EIP-8246, and zero-balance accounts under EIP-8246)
     /// and EIP-161 dead-account cleanup. The caller is responsible for wiping the account's
-    /// storage.
+    /// storage. Finalization runs after the last revertible scope, so the mutation is not
+    /// journaled: the entry would never be replayed before [`State`](super::State) clears it.
     #[inline]
     pub(crate) fn delete_for_finalization(&mut self) {
-        self.record_change();
         self.tracked.present = None;
     }
 
-    /// Resets a self-destructed account to a balance-only account for EIP-8246 finalization,
-    /// recording a revert snapshot.
+    /// Resets a self-destructed account to a balance-only account for EIP-8246 finalization.
     ///
     /// The balance is preserved while the nonce is reset to 0 and the code is cleared. The caller
     /// is responsible for wiping the account's storage. This is only called for accounts that
     /// still hold a balance; zero-balance self-destructed accounts are removed via
-    /// [`Self::delete_for_finalization`] instead.
+    /// [`Self::delete_for_finalization`] instead. Like [`Self::delete_for_finalization`], the
+    /// mutation is not journaled because finalization runs after the last revertible scope.
     #[inline]
     pub(crate) fn reset_selfdestructed_for_finalization(&mut self) {
         let balance = self.balance();
-        self.record_change();
         self.tracked.is_destroyed = false;
         self.tracked.present = Some(AccountInfo::default().with_balance(balance));
     }

--- a/crates/evm2/src/evm/state/mod.rs
+++ b/crates/evm2/src/evm/state/mod.rs
@@ -593,15 +593,8 @@ impl State {
         // so its existence is read from the same source rather than via a separate database read.
         let entry = Self::account_raw(&mut self.inner, &mut self.accounts, address, false)?;
         if entry.original.is_none() && entry.present.is_none() {
-            self.inner.journal.push(JournalEntry::AccountChange {
-                address: *address,
-                previous: None,
-                previous_is_warm: entry.is_warm,
-                previous_is_touched: entry.is_touched,
-                previous_is_destroyed: entry.is_destroyed,
-                previous_just_created: entry.just_created,
-                previous_code_changed: entry.code_changed,
-            });
+            // Finalization runs after the last revertible scope, so this is not journaled: the
+            // entry would never be replayed before `clear_transaction_state` clears it.
             entry.present = Some(AccountInfo::default());
         }
         Ok(())
@@ -646,8 +639,10 @@ impl State {
         if version.feature(EvmFeatures::EIP161) {
             for address in &touched {
                 // EIP-161 deletes touched dead accounts at transaction finalization.
-                if self.account(address, false)?.is_existing_dead() {
-                    self.account(address, false)?.delete_for_finalization();
+                let mut account = self.account(address, false)?;
+                if account.is_existing_dead() {
+                    account.delete_for_finalization();
+                    drop(account);
                     self.storage(address).wipe();
                 }
             }
@@ -795,14 +790,6 @@ impl State {
     /// transaction account/storage layers. It does not materialize [`StateChanges`], take logs, or
     /// write to the wrapped backing database.
     pub(crate) fn commit_transaction(&mut self) {
-        for entry in self.accounts.values() {
-            if let Some(account) = entry.present.as_ref()
-                && let Some((code_hash, code)) = Self::changed_code(entry.code_changed, account)
-            {
-                self.inner.database.cache.contracts.insert(code_hash, code.clone());
-            }
-        }
-
         for (&address, storage) in &self.storage {
             if storage.wiped {
                 self.inner.database.cache.storage.entry(address).or_default().wipe();
@@ -823,7 +810,15 @@ impl State {
             }
         }
 
+        // Code and account-info commits are fused into a single pass over `accounts`. They write to
+        // independent cache maps (`contracts` vs `accounts`), and the storage pass above already
+        // ran, so the delete branch's `storage` wipe still lands after any committed slots.
         for (&address, entry) in self.accounts.iter() {
+            if let Some(account) = entry.present.as_ref()
+                && let Some((code_hash, code)) = Self::changed_code(entry.code_changed, account)
+            {
+                self.inner.database.cache.contracts.insert(code_hash, code.clone());
+            }
             if !Self::account_changed(entry.original.as_ref(), entry.present.as_ref()) {
                 continue;
             }

--- a/crates/evm2/src/evm/state/mod.rs
+++ b/crates/evm2/src/evm/state/mod.rs
@@ -810,9 +810,6 @@ impl State {
             }
         }
 
-        // Code and account-info commits are fused into a single pass over `accounts`. They write to
-        // independent cache maps (`contracts` vs `accounts`), and the storage pass above already
-        // ran, so the delete branch's `storage` wipe still lands after any committed slots.
         for (&address, entry) in self.accounts.iter() {
             if let Some(account) = entry.present.as_ref()
                 && let Some((code_hash, code)) = Self::changed_code(entry.code_changed, account)


### PR DESCRIPTION
## Summary

Three **behavior-preserving** optimizations on the post-execution state path (finalization → CacheDB commit). All write-sets, changesets, and gas are identical; this only removes redundant iteration and dead bookkeeping.

1. **`commit_transaction` — fuse the two `accounts` passes.** The code-insert pass (→ `cache.contracts`) and the account-info pass (→ `cache.accounts`) now run in a single iteration. They write independent cache maps, and the storage pass is kept *before* the fused loop so the delete branch's `cache.storage` re-wipe still lands after any committed slots — preserving the exact write order for selfdestructed accounts.

2. **`finalize_transaction` — drop the double lookup in the EIP-161 branch.** `is_existing_dead()` and `delete_for_finalization()` now share one `AccountHandle` instead of two hash lookups + two handle constructions per dead account.

3. **Finalization mutations no longer journal.** `delete_for_finalization`, `reset_selfdestructed_for_finalization`, and `materialize_empty_account_for_finalization` dropped their journal entries. Finalization runs after the last revertible scope: both `finalize_transaction` callers (`evm/mod.rs`, `evm/system.rs`) call `clear_transaction_state()` on error rather than rolling back, and `clear_transaction_state` only clears the journal — so these entries were never replayed. Removing them saves a `JournalEntry` alloc + `present.clone()` + push per selfdestruct / EIP-161 deletion / pre-161 materialization.

## Deliberately not changed (would not preserve behavior)

- Draining the overlay in `build_state_changes` — a test asserts the account stays loaded/warm after it, with warmth cleared only by `clear_transaction_state`.
- Filtering unchanged accounts out of `build_state_changes` — it intentionally includes read-loaded accounts; needs a consumer audit.
- Fusing `visit_transaction_changes` passes — the sink relies on bytecode → storage → accounts ordering.

## Test plan

- `cargo nextest run` — full workspace green (465 tests), incl. finalize / selfdestruct / EIP-161 / EIP-8246 / wipe / commit coverage.
- `cargo cl` and `cargo docs` clean.
- ⚠️ EEST fixtures are not present in this worktree, so the EEST suite was not run; validated against unit tests only.