### PR TITLE
test(eest): bump devnet fixtures to glamsterdam-devnet@v6.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,8 +75,8 @@ jobs:
         shell: bash
         run: |
           if [[ "${{ matrix.fixture }}" == "devnet" ]]; then
-            export DEVNET_VERSION="snobal-devnet-6%40v1.1.0"
-            export DEVNET_TAR="fixtures_snobal-devnet-6.tar.gz"
+            export DEVNET_VERSION="tests-glamsterdam-devnet%40v6.0.0"
+            export DEVNET_TAR="fixtures_glamsterdam-devnet.tar.gz"
             export EVM2_STATETEST_DEVNET_ONLY=1
           fi
           ./scripts/setup_test_fixtures.py

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,7 @@ If fixtures are already available in another worktree, symlink `test-fixtures`
 to that directory instead of re-downloading them.
 By default it downloads EEST develop (or stable with `EVM2_STATETEST_STABLE=1`)
 and legacy Cancun/Constantinople state tests. Devnet fixtures are opt-in with
-`DEVNET_VERSION` and `DEVNET_TAR`; add `EVM2_STATETEST_DEVNET_ONLY=1` to skip
-main/legacy fixtures. Use `EVM2_STATETEST_ROOT` or `EVM2_BLOCKCHAINTEST_ROOT`
+`DEVNET_VERSION` and `DEVNET_TAR` (downloaded from the `ethereum/execution-specs`
+repo, overridable via `DEVNET_BASE_URL`); add `EVM2_STATETEST_DEVNET_ONLY=1` to
+skip main/legacy fixtures. Use `EVM2_STATETEST_ROOT` or `EVM2_BLOCKCHAINTEST_ROOT`
 for a single explicit root.

--- a/crates/eest/src/blockchaintest/runner.rs
+++ b/crates/eest/src/blockchaintest/runner.rs
@@ -109,6 +109,8 @@ const IGNORED_TESTS: &[&str] = &[
 
     // These validate block header fields/roots and belong to consensus-level block validation.
     "frontier/validation/header/gas_limit_below_minimum.json",
+    // The same test was renamed with a `block_` prefix on glamsterdam-devnet releases.
+    "frontier/validation/header/block_gas_limit_below_minimum.json",
     "london/validation/header/invalid_header.json",
     "shanghai/eip4895_withdrawals/withdrawals/withdrawals_root.json",
 

--- a/crates/eest/src/blockchaintest/types.rs
+++ b/crates/eest/src/blockchaintest/types.rs
@@ -252,9 +252,11 @@ pub enum ForkSpec {
     HomesteadToDaoAt5,
     /// Homestead to EIP-150 transition.
     HomesteadToEIP150At5,
-    /// EIP-150.
+    /// EIP-150 aka Tangerine Whistle.
+    #[serde(alias = "TangerineWhistle")]
     EIP150,
-    /// EIP-158.
+    /// EIP-158 aka Spurious Dragon.
+    #[serde(alias = "SpuriousDragon")]
     EIP158,
     /// EIP-158 to Byzantium transition.
     EIP158ToByzantiumAt5,

--- a/crates/eest/src/types.rs
+++ b/crates/eest/src/types.rs
@@ -136,9 +136,11 @@ pub enum SpecName {
     HomesteadToDaoAt5,
     /// Homestead to EIP-150 transition.
     HomesteadToEIP150At5,
-    /// EIP-150.
+    /// EIP-150 aka Tangerine Whistle.
+    #[serde(alias = "TangerineWhistle")]
     EIP150,
-    /// EIP-158.
+    /// EIP-158 aka Spurious Dragon.
+    #[serde(alias = "SpuriousDragon")]
     EIP158,
     /// EIP-158 to Byzantium transition.
     EIP158ToByzantiumAt5,

--- a/scripts/setup_test_fixtures.py
+++ b/scripts/setup_test_fixtures.py
@@ -36,6 +36,11 @@ from rich.text import Text
 MAIN_VERSION = os.environ.get("MAIN_VERSION", "v5.3.0")
 LEGACY_VERSION = os.environ.get("LEGACY_VERSION", "v17.2")
 BASE_URL = "https://github.com/ethereum/execution-spec-tests/releases/download"
+# Fork-specific devnet fixtures are published from the execution-specs repo.
+DEVNET_BASE_URL = os.environ.get(
+    "DEVNET_BASE_URL",
+    "https://github.com/ethereum/execution-specs/releases/download",
+)
 LEGACY_URL = (
     f"https://github.com/ethereum/tests/archive/refs/tags/{LEGACY_VERSION}.tar.gz"
 )
@@ -121,7 +126,7 @@ def devnet_fixture() -> Fixture | None:
 
     return Fixture(
         label="devnet",
-        url=f"{BASE_URL}/{version}/{tar_name}",
+        url=f"{DEVNET_BASE_URL}/{version}/{tar_name}",
         dest=DEVNET_DIR,
         exists_paths=(DEVNET_DIR / "state_tests", DEVNET_DIR / "blockchain_tests"),
     )


### PR DESCRIPTION
Bumps the EEST devnet fixtures to [`tests-glamsterdam-devnet@v6.0.0`](https://github.com/ethereum/execution-specs/releases/tag/tests-glamsterdam-devnet@v6.0.0).

## What changed

- **Devnet fixtures moved repos.** Fork-specific devnet fixtures are now published from `ethereum/execution-specs` (asset `fixtures_glamsterdam-devnet.tar.gz`) instead of `ethereum/execution-spec-tests`. Added a `DEVNET_BASE_URL` knob (defaulting to execution-specs) to `setup_test_fixtures.py` and updated the CI devnet pin. Main develop/stable fixtures are unaffected — they still ship from execution-spec-tests.
- **Fork label rename.** The new fixtures rename `EIP150`/`EIP158` to `TangerineWhistle`/`SpuriousDragon`. Added serde aliases on both the blockchain-test `ForkSpec` and the state-test `SpecName` enums (mirroring the existing `Merge`→`Paris` alias). The state-test enum previously swallowed these as `Unknown` and *silently skipped* those forks, so this also recovers lost coverage.
- **Header test rename.** The consensus-level `gas_limit_below_minimum.json` header-validation test was renamed with a `block_` prefix. Kept both skip entries, following the existing convention for renamed fixtures.
- Documented the new devnet source repo / `DEVNET_BASE_URL` in `AGENTS.md`.

Amsterdam ("Glamsterdam") stays in `UNSUPPORTED_FORKS` and is skipped, as before.

## Verification

Downloaded the real fixtures and ran the full devnet suite locally:

```
Summary 21678 tests run: 21678 passed, 281 skipped, 0 failed
```

`cargo fmt` + `cargo clippy -p evm2-eest` clean.

> [!NOTE]
> `MAIN_VERSION` is left at `v5.3.0` (latest is `v5.4.0`) — this PR scopes only to the devnet bump that was requested.