### PR TITLE
feat(cli): replay a directory of fixtures recursively

### DIFF
--- a/crates/cli/src/args.rs
+++ b/crates/cli/src/args.rs
@@ -49,7 +49,7 @@ pub(crate) struct Replay {
     /// Print database method call counts after execution.
     #[arg(long)]
     pub(crate) db_stats: bool,
-    /// EEST JSON fixture to replay.
+    /// EEST fixture file, or a directory to replay every fixture within recursively.
     #[arg(value_name = "PATH")]
     pub(crate) path: PathBuf,
 }

--- a/crates/cli/src/error.rs
+++ b/crates/cli/src/error.rs
@@ -39,4 +39,6 @@ pub(crate) enum Error {
     Fuzzer(String),
     #[error("could not detect EEST fixture kind in {path}")]
     UnknownFixtureKind { path: std::path::PathBuf },
+    #[error("no replayable fixtures found in {path}")]
+    NoFixtures { path: std::path::PathBuf },
 }

--- a/crates/cli/src/fixture.rs
+++ b/crates/cli/src/fixture.rs
@@ -34,6 +34,21 @@ pub(crate) fn is_binary_path(path: &Path) -> bool {
     evm2_eest::is_binary_fixture_path(path)
 }
 
+/// Returns true when the path looks like a replayable fixture: a binary fixture
+/// (`*.bin` / `*.bin.zst`) or a JSON fixture (`*.json` / `*.json.zst`).
+pub(crate) fn is_fixture_path(path: &Path) -> bool {
+    is_binary_path(path) || has_extension(path, "json") || is_zstd_json_path(path)
+}
+
+fn is_zstd_json_path(path: &Path) -> bool {
+    has_extension(path, "zst")
+        && path.file_stem().is_some_and(|stem| has_extension(Path::new(stem), "json"))
+}
+
+fn has_extension(path: &Path, extension: &str) -> bool {
+    path.extension().is_some_and(|candidate| candidate == extension)
+}
+
 pub(crate) fn detect_str(path: &Path, input: &str) -> Result<Option<FixtureKind>> {
     struct FixtureKindVisitor;
 

--- a/crates/cli/src/replay/mod.rs
+++ b/crates/cli/src/replay/mod.rs
@@ -13,71 +13,133 @@ use evm2_eest::{
     execute_blockchain_tests_str, execute_blockchain_tests_suite,
     execute_state_tests_str_with_filter,
 };
-use std::time::Instant;
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    time::Instant,
+};
 
 pub(crate) fn run(command: Replay) -> Result<()> {
     let entrypoint = EntryPoint::new(command.entrypoint);
-    if fixture::is_binary_path(&command.path) {
-        let suite = fixture::read_blockchain(&command.path)?;
+    if command.path.is_dir() {
+        return run_directory(&command.path, &entrypoint, command.db_stats);
+    }
+    replay_file(&command.path, &entrypoint, command.db_stats).map(|_| ())
+}
+
+fn run_directory(path: &Path, entrypoint: &EntryPoint, db_stats: bool) -> Result<()> {
+    let fixtures = collect_fixtures(path)?;
+    if fixtures.is_empty() {
+        return Err(Error::NoFixtures { path: path.to_path_buf() });
+    }
+    let mut executed = 0;
+    let mut skipped = 0;
+    for fixture in &fixtures {
+        let summary = replay_file(fixture, entrypoint, db_stats)?;
+        executed += summary.executed;
+        skipped += summary.skipped;
+    }
+    let ok = style::OK;
+    println!(
+        "{ok}ok{ok:#}: replayed {} fixtures in {}: {executed} executed, {skipped} skipped",
+        fixtures.len(),
+        path.display(),
+    );
+    Ok(())
+}
+
+#[derive(Clone, Copy, Default)]
+struct ReplaySummary {
+    executed: usize,
+    skipped: usize,
+}
+
+fn replay_file(path: &Path, entrypoint: &EntryPoint, db_stats: bool) -> Result<ReplaySummary> {
+    if fixture::is_binary_path(path) {
+        let suite = fixture::read_blockchain(path)?;
         let mut hook = ReplayProgressHook::default();
         let summary = execute_blockchain_tests_suite(
-            &command.path,
+            path,
             &suite,
-            BlockchainTestExecuteConfig { db_stats: command.db_stats, ..Default::default() },
-            &entrypoint,
+            BlockchainTestExecuteConfig { db_stats, ..Default::default() },
+            entrypoint,
             &mut hook,
         )
         .map_err(|source| Error::BlockchainTest { source })?;
         let ok = style::OK;
         println!(
             "{ok}ok{ok:#}: replayed blockchain fixture {}: {} executed, {} skipped",
-            command.path.display(),
+            path.display(),
             summary.executed,
             summary.skipped
         );
-        return Ok(());
+        return Ok(ReplaySummary { executed: summary.executed, skipped: summary.skipped });
     }
 
-    let input = fixture::read_text(&command.path)?;
-    match fixture::detect_str(&command.path, &input)? {
+    let input = fixture::read_text(path)?;
+    match fixture::detect_str(path, &input)? {
         Some(FixtureKind::StateTest) => {
             let summary = execute_state_tests_str_with_filter(
-                &command.path,
+                path,
                 &input,
-                StateTestExecuteConfig { db_stats: command.db_stats, ..Default::default() },
-                &entrypoint,
+                StateTestExecuteConfig { db_stats, ..Default::default() },
+                entrypoint,
             )
             .map_err(|source| Error::StateTest { source })?;
             let ok = style::OK;
             println!(
                 "{ok}ok{ok:#}: replayed state fixture {}: {} executed, {} skipped",
-                command.path.display(),
+                path.display(),
                 summary.executed,
                 summary.skipped
             );
-            Ok(())
+            Ok(ReplaySummary { executed: summary.executed, skipped: summary.skipped })
         }
         Some(FixtureKind::BlockchainTest) => {
             let mut hook = ReplayProgressHook::default();
             let summary = execute_blockchain_tests_str(
-                &command.path,
+                path,
                 &input,
-                BlockchainTestExecuteConfig { db_stats: command.db_stats, ..Default::default() },
-                &entrypoint,
+                BlockchainTestExecuteConfig { db_stats, ..Default::default() },
+                entrypoint,
                 &mut hook,
             )
             .map_err(|source| Error::BlockchainTest { source })?;
             let ok = style::OK;
             println!(
                 "{ok}ok{ok:#}: replayed blockchain fixture {}: {} executed, {} skipped",
-                command.path.display(),
+                path.display(),
                 summary.executed,
                 summary.skipped
             );
-            Ok(())
+            Ok(ReplaySummary { executed: summary.executed, skipped: summary.skipped })
         }
-        None => Err(Error::UnknownFixtureKind { path: command.path }),
+        None => Err(Error::UnknownFixtureKind { path: path.to_path_buf() }),
     }
+}
+
+/// Recursively collects replayable fixture files under `path`, sorted by path.
+fn collect_fixtures(path: &Path) -> Result<Vec<PathBuf>> {
+    let mut fixtures = Vec::new();
+    collect_fixtures_into(path, &mut fixtures)?;
+    fixtures.sort_unstable();
+    Ok(fixtures)
+}
+
+fn collect_fixtures_into(path: &Path, fixtures: &mut Vec<PathBuf>) -> Result<()> {
+    let entries = fs::read_dir(path)
+        .map_err(|source| Error::ReadInput { path: path.to_path_buf(), source })?;
+    for entry in entries {
+        let entry =
+            entry.map_err(|source| Error::ReadInput { path: path.to_path_buf(), source })?;
+        let entry_path = entry.path();
+        if entry_path.is_dir() {
+            collect_fixtures_into(&entry_path, fixtures)?;
+        } else if fixture::is_fixture_path(&entry_path) {
+            fixtures.push(entry_path);
+        }
+    }
+    Ok(())
 }
 
 #[derive(Default)]


### PR DESCRIPTION
## Summary

`replay` now accepts a **directory** and replays every fixture within it recursively, in addition to single files. Previously passing a directory errored when the CLI tried to read it as a file.

## Changes

- **`replay/mod.rs`**: `run` branches on `path.is_dir()`. Directories go through a new `run_directory` that recursively collects fixture files (`collect_fixtures`), replays each via the extracted `replay_file` helper, aggregates executed/skipped totals, and prints a final summary line. Single-file behavior is unchanged; per-file `ok:` lines and the blockchain progress hook still print.
- **`fixture.rs`**: added `is_fixture_path` to match binary (`*.bin` / `*.bin.zst`) and JSON (`*.json` / `*.json.zst`) fixtures so the walker skips non-fixture files.
- **`error.rs`**: added `Error::NoFixtures` for directories with no replayable fixtures.
- **`args.rs`**: updated the `path` help text to mention directory support.

The `--entrypoint` glob and `--db_stats` flags apply across all files in a directory.

## Testing

- `cargo cl` clean, `cargo fmt` applied, all 13 CLI tests pass.
- Single-file replay: unchanged.
- Directory with one fixture: `replayed 1 fixtures … 3 executed`.
- Recursive directory: `replayed 4 fixtures … 92 executed`.
- Empty directory: `error: no replayable fixtures found in …`.