### PR TITLE
feat(cli): add --verify flag to replay (state root + gas used)

### DIFF
--- a/crates/cli/src/args.rs
+++ b/crates/cli/src/args.rs
@@ -49,6 +49,10 @@ pub(crate) struct Replay {
     /// Print database method call counts after execution.
     #[arg(long)]
     pub(crate) db_stats: bool,
+    /// Verify each block's computed state root and gas used against its header
+    /// (blockchain tests). State tests always verify their post-state root.
+    #[arg(long)]
+    pub(crate) verify: bool,
     /// EEST fixture file, or a directory to replay every fixture within recursively.
     #[arg(value_name = "PATH")]
     pub(crate) path: PathBuf,

--- a/crates/cli/src/replay/mod.rs
+++ b/crates/cli/src/replay/mod.rs
@@ -21,13 +21,20 @@ use std::{
 
 pub(crate) fn run(command: Replay) -> Result<()> {
     let entrypoint = EntryPoint::new(command.entrypoint);
+    let options = ReplayOptions { db_stats: command.db_stats, verify: command.verify };
     if command.path.is_dir() {
-        return run_directory(&command.path, &entrypoint, command.db_stats);
+        return run_directory(&command.path, &entrypoint, options);
     }
-    replay_file(&command.path, &entrypoint, command.db_stats).map(|_| ())
+    replay_file(&command.path, &entrypoint, options).map(|_| ())
 }
 
-fn run_directory(path: &Path, entrypoint: &EntryPoint, db_stats: bool) -> Result<()> {
+#[derive(Clone, Copy)]
+struct ReplayOptions {
+    db_stats: bool,
+    verify: bool,
+}
+
+fn run_directory(path: &Path, entrypoint: &EntryPoint, options: ReplayOptions) -> Result<()> {
     let fixtures = collect_fixtures(path)?;
     if fixtures.is_empty() {
         return Err(Error::NoFixtures { path: path.to_path_buf() });
@@ -35,7 +42,7 @@ fn run_directory(path: &Path, entrypoint: &EntryPoint, db_stats: bool) -> Result
     let mut executed = 0;
     let mut skipped = 0;
     for fixture in &fixtures {
-        let summary = replay_file(fixture, entrypoint, db_stats)?;
+        let summary = replay_file(fixture, entrypoint, options)?;
         executed += summary.executed;
         skipped += summary.skipped;
     }
@@ -54,14 +61,19 @@ struct ReplaySummary {
     skipped: usize,
 }
 
-fn replay_file(path: &Path, entrypoint: &EntryPoint, db_stats: bool) -> Result<ReplaySummary> {
+fn replay_file(
+    path: &Path,
+    entrypoint: &EntryPoint,
+    options: ReplayOptions,
+) -> Result<ReplaySummary> {
+    let ReplayOptions { db_stats, verify } = options;
     if fixture::is_binary_path(path) {
         let suite = fixture::read_blockchain(path)?;
         let mut hook = ReplayProgressHook::default();
         let summary = execute_blockchain_tests_suite(
             path,
             &suite,
-            BlockchainTestExecuteConfig { db_stats, ..Default::default() },
+            BlockchainTestExecuteConfig { db_stats, verify, ..Default::default() },
             entrypoint,
             &mut hook,
         )
@@ -100,7 +112,7 @@ fn replay_file(path: &Path, entrypoint: &EntryPoint, db_stats: bool) -> Result<R
             let summary = execute_blockchain_tests_str(
                 path,
                 &input,
-                BlockchainTestExecuteConfig { db_stats, ..Default::default() },
+                BlockchainTestExecuteConfig { db_stats, verify, ..Default::default() },
                 entrypoint,
                 &mut hook,
             )

--- a/crates/eest/src/blockchaintest/error.rs
+++ b/crates/eest/src/blockchaintest/error.rs
@@ -64,6 +64,22 @@ pub(crate) enum TestErrorKind {
     /// A system call failed.
     #[error("system call failed: {0}")]
     SystemCall(&'static str),
+    /// The computed post-block state root did not match the block header.
+    #[error("state root mismatch: got {got}, expected {expected}")]
+    StateRootMismatch {
+        /// Computed state root.
+        got: alloy_primitives::B256,
+        /// Expected state root from the block header.
+        expected: alloy_primitives::B256,
+    },
+    /// The computed block gas used did not match the block header.
+    #[error("gas used mismatch: got {got}, expected {expected}")]
+    GasUsedMismatch {
+        /// Computed cumulative gas used by the block's transactions.
+        got: u64,
+        /// Expected gas used from the block header.
+        expected: u64,
+    },
 }
 
 impl From<TxBuildError> for TestErrorKind {

--- a/crates/eest/src/blockchaintest/execute.rs
+++ b/crates/eest/src/blockchaintest/execute.rs
@@ -13,7 +13,7 @@ use crate::{
     filter::EntryPoint,
     fixture_io,
     forks::is_fork_skipped,
-    state::{insert_account_with_storage, parse_bytecode},
+    state::{insert_account_with_storage, parse_bytecode, state_root_from_database},
     tx::{TxFields, build_recovered_tx, rpc_access_list, signed_authorizations},
 };
 use alloy_eips::eip7840::BlobParams;
@@ -43,11 +43,13 @@ pub struct ExecuteConfig {
     pub validate_post_state: bool,
     /// Whether to print database method call counts.
     pub db_stats: bool,
+    /// Whether to verify each block's computed state root and gas used against its header.
+    pub verify: bool,
 }
 
 impl Default for ExecuteConfig {
     fn default() -> Self {
-        Self { validate_post_state: true, db_stats: false }
+        Self { validate_post_state: true, db_stats: false, verify: false }
     }
 }
 
@@ -156,6 +158,7 @@ fn execute_case(
             &mut parent_excess_blob_gas,
             hook,
             if config.db_stats { Some(&mut db_stats_counts) } else { None },
+            config.verify,
         ) {
             Ok(()) => hook.block_finished(BlockFinished {
                 block_index,
@@ -219,9 +222,11 @@ fn execute_block(
     parent_excess_blob_gas: &mut u64,
     hook: &mut dyn Hook,
     db_stats_counts: Option<&mut DbStatsCounts>,
+    verify: bool,
 ) -> Result<(), TestError> {
     let db_stats = db_stats_counts.is_some();
     let should_fail = block.expect_exception.is_some();
+    let mut computed_gas_used: u64 = 0;
     let mut block_hash = None;
     let mut beacon_root = None;
     let mut this_excess_blob_gas = None;
@@ -293,7 +298,8 @@ fn execute_block(
             };
 
             match execute_tx(&mut evm, &mut block_state, &tx) {
-                Ok(_) => {
+                Ok(result) => {
+                    computed_gas_used = computed_gas_used.saturating_add(result.gas_used);
                     hook.transaction_finished(TransactionFinished {
                         block_index,
                         total_blocks,
@@ -373,6 +379,30 @@ fn execute_block(
             *parent_block_hash = block_hash;
             if let Some(excess_blob_gas) = this_excess_blob_gas {
                 *parent_excess_blob_gas = excess_blob_gas;
+            }
+            if verify && let Some(header) = block_header(block) {
+                let expected_gas = header.gas_used.saturating_to::<u64>();
+                if computed_gas_used != expected_gas {
+                    return Err(TestError::case(
+                        path,
+                        name,
+                        TestErrorKind::GasUsedMismatch {
+                            got: computed_gas_used,
+                            expected: expected_gas,
+                        },
+                    ));
+                }
+                let got_root = state_root_from_database(database);
+                if got_root != header.state_root {
+                    return Err(TestError::case(
+                        path,
+                        name,
+                        TestErrorKind::StateRootMismatch {
+                            got: got_root,
+                            expected: header.state_root,
+                        },
+                    ));
+                }
             }
             Ok(())
         }

--- a/crates/eest/src/execute.rs
+++ b/crates/eest/src/execute.rs
@@ -4,7 +4,8 @@ use crate::{
     fixture_io,
     forks::is_fork_skipped,
     state::{
-        insert_account_with_storage, parse_bytecode, storage_for_root, system_contract_has_code,
+        insert_account_with_storage, parse_bytecode, state_root_from_database,
+        system_contract_has_code,
     },
     tx::{TxFields, build_recovered_tx, recover_address, rpc_access_list, signed_authorizations},
     types::{AccountInfo, Env, Test, TestSuite, TestUnit, TransactionParts, TxPartIndices},
@@ -12,10 +13,6 @@ use crate::{
 use alloy_eips::{eip4844, eip7691};
 use alloy_primitives::{Address, B256, Bytes, Log, TxKind, U256, keccak256};
 use alloy_rpc_types_eth::AccessList as RpcAccessList;
-use alloy_trie::{
-    TrieAccount,
-    root::{state_root_unhashed, storage_root_unhashed},
-};
 use anstyle::{AnsiColor, Color, Style};
 use evm2::{
     BaseEvmTypes, Evm, EvmTypes, Precompiles, SpecId, TxResult,
@@ -367,24 +364,6 @@ fn logs_hash(logs: &[Log]) -> B256 {
     let mut out = Vec::with_capacity(alloy_rlp::list_length(logs));
     alloy_rlp::encode_list(logs, &mut out);
     keccak256(out)
-}
-
-fn state_root_from_database(state: &InMemoryDB) -> B256 {
-    let accounts = state.cache.accounts.iter().filter_map(|(&address, info)| {
-        let info = info.as_ref()?;
-        let storage = storage_for_root(state, address);
-        Some((
-            address,
-            TrieAccount {
-                nonce: info.nonce,
-                balance: info.balance,
-                storage_root: storage_root_unhashed(storage),
-                code_hash: info.code_hash,
-            },
-        ))
-    });
-
-    state_root_unhashed(accounts)
 }
 
 fn parse_state(pre: &BTreeMap<Address, AccountInfo>) -> Result<InMemoryDB, TestErrorKind> {

--- a/crates/eest/src/state.rs
+++ b/crates/eest/src/state.rs
@@ -1,4 +1,8 @@
 use alloy_primitives::{Address, B256};
+use alloy_trie::{
+    TrieAccount,
+    root::{state_root_unhashed, storage_root_unhashed},
+};
 use evm2::{
     bytecode::Bytecode,
     evm::{AccountInfo, InMemoryDB},
@@ -46,4 +50,23 @@ pub(crate) fn storage_for_root(
         .flat_map(|storage| storage.slots.iter())
         .filter_map(|(&key, &value)| (!value.is_zero()).then_some((B256::from(key), value)))
         .collect()
+}
+
+/// Computes the state root of all accounts currently cached in the database.
+pub(crate) fn state_root_from_database(state: &InMemoryDB) -> B256 {
+    let accounts = state.cache.accounts.iter().filter_map(|(&address, info)| {
+        let info = info.as_ref()?;
+        let storage = storage_for_root(state, address);
+        Some((
+            address,
+            TrieAccount {
+                nonce: info.nonce,
+                balance: info.balance,
+                storage_root: storage_root_unhashed(storage),
+                code_hash: info.code_hash,
+            },
+        ))
+    });
+
+    state_root_unhashed(accounts)
 }


### PR DESCRIPTION
Stacked on #227 (`improve-replay`).

## Summary

Adds a `--verify` flag to `replay`. For **blockchain tests** it checks each committed block's computed **state root** and cumulative **gas used** against the block header, failing with a typed mismatch error otherwise. The check is opt-in (default off), so the EEST nextest harness and all existing callers are unchanged.

- **State tests** already verify their post-state root unconditionally; `--verify` is a no-op for them since the fixture post carries no expected gas-used value.
- **BAL** is intentionally left out: evm2 does not build block access lists yet (`assert_block_access_list` is a `todo!()`), so there is nothing to compare against.

## Changes

- `eest/src/state.rs`: extract `state_root_from_database` into the shared `state` module (next to `storage_for_root`, which it uses).
- `eest/src/execute.rs`: state tests use the shared helper (removed the local copy + now-unused trie imports).
- `eest/src/blockchaintest/execute.rs`: add `verify: bool` to `ExecuteConfig` (default `false`); `execute_block` sums per-tx `gas_used` and, on commit when `verify` is set, compares it to `header.gas_used` and the post-commit state root to `header.state_root`.
- `eest/src/blockchaintest/error.rs`: add `StateRootMismatch` and `GasUsedMismatch` error kinds.
- `cli/src/args.rs`: add the `--verify` flag.
- `cli/src/replay/mod.rs`: thread `db_stats`/`verify` through a `ReplayOptions` struct into the blockchain config.

## Testing

- A directory of 29 fixtures / 107 cases passes `--verify` cleanly (computed roots and gas sums match the real headers).
- Corrupting a header `stateRoot` → `Error: state root mismatch: got 0x2d7b…, expected 0x0000…`.
- Corrupting a header `gasUsed` → `Error: gas used mismatch: got 26970, expected 9999`.
- `cargo cl`, `cargo docs`, and `cargo nextest run -p evm2-eest -p evm2-cli` all pass.