### PR TITLE
feat(eest): run an arbitrary fixture folder via scripts/eest.sh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,9 +42,10 @@ skip main/legacy fixtures. Use `EVM2_STATETEST_ROOT` or `EVM2_BLOCKCHAINTEST_ROO
 for a single explicit root.
 
 To run an arbitrary folder (or single file) of fixtures without a test-name
-filter, use `./scripts/eest.sh <path>`. Every JSON fixture under the path runs
-as one suite whose kind (state vs blockchain) is detected per file;
-`transaction_tests` and the engine/sync blockchain variants are skipped. The
-path may be outside the repo. The script just sets `EVM2_FIXTURE_PATH` (honored
-by the `eest` harness) and runs `cargo nextest run -p evm2-eest --test eest
+filter, use `./scripts/eest.sh <path>`. Every JSON file found anywhere under the
+path runs as one suite whose kind (state vs blockchain) is detected per file;
+nothing is skipped, so fixtures this runner cannot execute (transaction tests,
+engine/sync blockchain variants) surface as failures. The path may be outside
+the repo. The script just sets `EVM2_FIXTURE_PATH` (honored by the `eest`
+harness) and runs `cargo nextest run -p evm2-eest --test eest
 --ignore-default-filter`; extra args are forwarded to nextest.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,3 +40,11 @@ and legacy Cancun/Constantinople state tests. Devnet fixtures are opt-in with
 repo, overridable via `DEVNET_BASE_URL`); add `EVM2_STATETEST_DEVNET_ONLY=1` to
 skip main/legacy fixtures. Use `EVM2_STATETEST_ROOT` or `EVM2_BLOCKCHAINTEST_ROOT`
 for a single explicit root.
+
+To run an arbitrary folder (or single file) of fixtures without a test-name
+filter, use `./scripts/eest.sh <path>`. Every JSON fixture under the path runs
+as one suite whose kind (state vs blockchain) is detected per file;
+`transaction_tests` and the engine/sync blockchain variants are skipped. The
+path may be outside the repo. The script just sets `EVM2_FIXTURE_PATH` (honored
+by the `eest` harness) and runs `cargo nextest run -p evm2-eest --test eest
+--ignore-default-filter`; extra args are forwarded to nextest.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,11 +41,12 @@ repo, overridable via `DEVNET_BASE_URL`); add `EVM2_STATETEST_DEVNET_ONLY=1` to
 skip main/legacy fixtures. Use `EVM2_STATETEST_ROOT` or `EVM2_BLOCKCHAINTEST_ROOT`
 for a single explicit root.
 
-To run an arbitrary folder (or single file) of fixtures without a test-name
-filter, use `./scripts/eest.sh <path>`. Every JSON file found anywhere under the
-path runs as one suite whose kind (state vs blockchain) is detected per file;
-nothing is skipped, so fixtures this runner cannot execute (transaction tests,
-engine/sync blockchain variants) surface as failures. The path may be outside
-the repo. The script just sets `EVM2_FIXTURE_PATH` (honored by the `eest`
-harness) and runs `cargo nextest run -p evm2-eest --test eest
---ignore-default-filter`; extra args are forwarded to nextest.
+To run additional tests from an arbitrary folder (or single file) without a
+test-name filter, use `./scripts/eest.sh <path>`. Every JSON file found anywhere
+under the path runs as one suite whose kind (state vs blockchain) is detected
+per file, applying the same skip lists as the default suites. Fixtures this
+runner cannot execute (transaction tests, engine/sync blockchain variants)
+therefore surface as failures. The path may be outside the repo. The script just
+sets `EVM2_ADDITIONAL_TESTS` (honored by the `eest` harness) and runs `cargo
+nextest run -p evm2-eest --test eest --ignore-default-filter`; extra args are
+forwarded to nextest.

--- a/crates/eest/src/additional.rs
+++ b/crates/eest/src/additional.rs
@@ -1,6 +1,6 @@
-//! Single-path fixture suite.
+//! Additional-tests suite.
 //!
-//! When `EVM2_FIXTURE_PATH` points at a folder (or file), every JSON fixture
+//! When `EVM2_ADDITIONAL_TESTS` points at a folder (or file), every JSON file
 //! found anywhere under it runs as one suite whose kind (state vs blockchain) is
 //! detected per file, so no test-name filter is needed to isolate it.
 
@@ -17,19 +17,22 @@ use std::path::PathBuf;
 /// Builds the auto-detecting suite rooted at `path`.
 pub(crate) fn suite(path: PathBuf) -> TestSuite {
     TestSuite {
-        name: "fixtures",
-        roots: vec![TestRoot { name: "fixtures", label: "custom fixtures", path }],
+        name: "additional",
+        roots: vec![TestRoot { name: "additional", label: "additional tests", path }],
         // Descend into every directory so all JSON files under the path run.
         should_descend: descend_all,
-        should_ignore: ignore_none,
+        should_ignore,
         run_file,
     }
 }
 
-/// Runs every JSON file: a custom path is an explicit request, so nothing is
-/// skipped.
-const fn ignore_none(_name: &str) -> bool {
-    false
+/// Honors the same ignore lists the state and blockchain runners use, since an
+/// additional path can hold fixtures of either kind.
+fn should_ignore(name: &str) -> bool {
+    crate::runner::IGNORED_TESTS
+        .iter()
+        .chain(crate::blockchaintest::IGNORED_TESTS)
+        .any(|pattern| name.contains(pattern))
 }
 
 fn run_file(path: PathBuf) -> Result<(), Failed> {

--- a/crates/eest/src/blockchaintest/mod.rs
+++ b/crates/eest/src/blockchaintest/mod.rs
@@ -4,7 +4,7 @@ mod env;
 mod error;
 mod execute;
 mod hook;
-mod runner;
+pub(crate) mod runner;
 mod types;
 
 pub use error::TestError;

--- a/crates/eest/src/blockchaintest/mod.rs
+++ b/crates/eest/src/blockchaintest/mod.rs
@@ -14,7 +14,7 @@ pub use hook::{
     TransactionFinished, TransactionStarted,
 };
 pub use runner::run;
-pub(crate) use runner::suite;
+pub(crate) use runner::{IGNORED_TESTS, suite};
 pub use types::{
     Account, Block, BlockHash, BlockHeader, BlockchainTest, BlockchainTestCase, DecodedBlock,
     ForkSpec, SealEngine, State, Transaction, Withdrawal,

--- a/crates/eest/src/blockchaintest/mod.rs
+++ b/crates/eest/src/blockchaintest/mod.rs
@@ -4,7 +4,7 @@ mod env;
 mod error;
 mod execute;
 mod hook;
-pub(crate) mod runner;
+mod runner;
 mod types;
 
 pub use error::TestError;

--- a/crates/eest/src/blockchaintest/runner.rs
+++ b/crates/eest/src/blockchaintest/runner.rs
@@ -40,7 +40,7 @@ fn should_descend(path: &Path) -> bool {
     )
 }
 
-fn should_ignore(name: &str) -> bool {
+pub(crate) fn should_ignore(name: &str) -> bool {
     IGNORED_TESTS.iter().any(|ignored| name.contains(ignored))
 }
 

--- a/crates/eest/src/blockchaintest/runner.rs
+++ b/crates/eest/src/blockchaintest/runner.rs
@@ -40,7 +40,7 @@ fn should_descend(path: &Path) -> bool {
     )
 }
 
-pub(crate) fn should_ignore(name: &str) -> bool {
+fn should_ignore(name: &str) -> bool {
     IGNORED_TESTS.iter().any(|ignored| name.contains(ignored))
 }
 

--- a/crates/eest/src/blockchaintest/runner.rs
+++ b/crates/eest/src/blockchaintest/runner.rs
@@ -45,7 +45,7 @@ fn should_ignore(name: &str) -> bool {
 }
 
 #[rustfmt::skip]
-const IGNORED_TESTS: &[&str] = &[
+pub(crate) const IGNORED_TESTS: &[&str] = &[
     // Block header/blob-gas validation is consensus-level block validation, not EVM execution.
     "cancun/eip4844_blobs/test_blob_type_tx_pre_fork.json",
     "cancun/eip4844_blobs/test_invalid_blob_gas_used_in_header.json",

--- a/crates/eest/src/custom.rs
+++ b/crates/eest/src/custom.rs
@@ -1,0 +1,91 @@
+//! Single-path fixture suite.
+//!
+//! When `EVM2_FIXTURE_PATH` points at a folder (or file), every JSON fixture
+//! found under it runs as one suite whose kind (state vs blockchain) is detected
+//! per file, so no test-name filter is needed to isolate it.
+
+use crate::{
+    blockchaintest::{self, ExecuteConfig as BlockchainConfig, NoopHook},
+    execute::{self, ExecuteConfig as StateConfig},
+    filter::EntryPoint,
+    fixture_io,
+    harness::{TestRoot, TestSuite},
+};
+use libtest_mimic::Failed;
+use std::path::{Path, PathBuf};
+
+/// Builds the auto-detecting suite rooted at `path`.
+pub(crate) fn suite(path: PathBuf) -> TestSuite {
+    TestSuite {
+        name: "fixtures",
+        roots: vec![TestRoot { name: "fixtures", label: "custom fixtures", path }],
+        should_descend,
+        should_ignore,
+        run_file,
+    }
+}
+
+/// Skips fixture directories this runner cannot execute: transaction tests and
+/// the engine/sync blockchain variants.
+fn should_descend(path: &Path) -> bool {
+    let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+        return true;
+    };
+    !matches!(
+        name,
+        "transaction_tests"
+            | "blockchain_tests_engine"
+            | "blockchain_tests_engine_x"
+            | "blockchain_tests_sync"
+    )
+}
+
+/// Skips fixtures that either suite would skip, keeping behavior consistent with
+/// the default runs.
+fn should_ignore(name: &str) -> bool {
+    crate::runner::should_ignore(name) || blockchaintest::runner::should_ignore(name)
+}
+
+fn run_file(path: PathBuf) -> Result<(), Failed> {
+    let input =
+        fixture_io::read_to_string(&path).map_err(|err| format!("{}: {err}", path.display()))?;
+    match detect_kind(&input) {
+        Some(FixtureKind::Blockchain) => blockchaintest::execute_str(
+            &path,
+            &input,
+            BlockchainConfig::default(),
+            &EntryPoint::default(),
+            &mut NoopHook,
+        )
+        .map(|_| ())
+        .map_err(|err| err.to_string().into()),
+        Some(FixtureKind::State) => {
+            execute::execute_str_with_config(&path, &input, StateConfig::default())
+                .map(|_| ())
+                .map_err(|err| err.to_string().into())
+        }
+        None => Err(format!("could not detect fixture kind in {}", path.display()).into()),
+    }
+}
+
+enum FixtureKind {
+    State,
+    Blockchain,
+}
+
+/// Detects a fixture's kind from the fields of its first case.
+fn detect_kind(input: &str) -> Option<FixtureKind> {
+    let value: serde_json::Value = serde_json::from_str(input).ok()?;
+    let first = value.as_object()?.values().find_map(serde_json::Value::as_object)?;
+    if has_any(first, &["blocks", "genesisBlockHeader", "lastblockhash", "network"]) {
+        Some(FixtureKind::Blockchain)
+    } else if has_any(first, &["env", "post", "transaction"]) {
+        Some(FixtureKind::State)
+    } else {
+        None
+    }
+}
+
+fn has_any(object: &serde_json::Map<String, serde_json::Value>, fields: &[&str]) -> bool {
+    fields.iter().any(|field| object.contains_key(*field))
+}

--- a/crates/eest/src/custom.rs
+++ b/crates/eest/src/custom.rs
@@ -1,56 +1,42 @@
 //! Single-path fixture suite.
 //!
 //! When `EVM2_FIXTURE_PATH` points at a folder (or file), every JSON fixture
-//! found under it runs as one suite whose kind (state vs blockchain) is detected
-//! per file, so no test-name filter is needed to isolate it.
+//! found anywhere under it runs as one suite whose kind (state vs blockchain) is
+//! detected per file, so no test-name filter is needed to isolate it.
 
 use crate::{
-    blockchaintest::{self, ExecuteConfig as BlockchainConfig, NoopHook},
+    blockchaintest::{ExecuteConfig as BlockchainConfig, NoopHook, execute_str},
     execute::{self, ExecuteConfig as StateConfig},
     filter::EntryPoint,
     fixture_io,
-    harness::{TestRoot, TestSuite},
+    harness::{TestRoot, TestSuite, descend_all},
 };
 use libtest_mimic::Failed;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 /// Builds the auto-detecting suite rooted at `path`.
 pub(crate) fn suite(path: PathBuf) -> TestSuite {
     TestSuite {
         name: "fixtures",
         roots: vec![TestRoot { name: "fixtures", label: "custom fixtures", path }],
-        should_descend,
-        should_ignore,
+        // Descend into every directory so all JSON files under the path run.
+        should_descend: descend_all,
+        should_ignore: ignore_none,
         run_file,
     }
 }
 
-/// Skips fixture directories this runner cannot execute: transaction tests and
-/// the engine/sync blockchain variants.
-fn should_descend(path: &Path) -> bool {
-    let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
-        return true;
-    };
-    !matches!(
-        name,
-        "transaction_tests"
-            | "blockchain_tests_engine"
-            | "blockchain_tests_engine_x"
-            | "blockchain_tests_sync"
-    )
-}
-
-/// Skips fixtures that either suite would skip, keeping behavior consistent with
-/// the default runs.
-fn should_ignore(name: &str) -> bool {
-    crate::runner::should_ignore(name) || blockchaintest::runner::should_ignore(name)
+/// Runs every JSON file: a custom path is an explicit request, so nothing is
+/// skipped.
+const fn ignore_none(_name: &str) -> bool {
+    false
 }
 
 fn run_file(path: PathBuf) -> Result<(), Failed> {
     let input =
         fixture_io::read_to_string(&path).map_err(|err| format!("{}: {err}", path.display()))?;
     match detect_kind(&input) {
-        Some(FixtureKind::Blockchain) => blockchaintest::execute_str(
+        Some(FixtureKind::Blockchain) => execute_str(
             &path,
             &input,
             BlockchainConfig::default(),

--- a/crates/eest/src/fixtures.rs
+++ b/crates/eest/src/fixtures.rs
@@ -15,6 +15,18 @@ pub(crate) const EEST_STABLE_ENV: &str = "EVM2_EEST_STABLE";
 /// Repo-relative fixture root used by the setup script and CI.
 pub(crate) const DEFAULT_FIXTURES_PATH: &str = "test-fixtures";
 
+/// Environment variable selecting a single folder (or file) to run as one
+/// auto-detecting suite covering both state and blockchain fixtures.
+pub(crate) const FIXTURE_PATH_ENV: &str = "EVM2_FIXTURE_PATH";
+
+/// Returns the explicit single fixture path configured through the environment.
+pub(crate) fn custom_fixture_path() -> Option<PathBuf> {
+    env::var_os(FIXTURE_PATH_ENV)
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .map(workspace_relative)
+}
+
 /// Resolves the workspace root by walking up from this crate.
 pub(crate) fn workspace_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))

--- a/crates/eest/src/fixtures.rs
+++ b/crates/eest/src/fixtures.rs
@@ -15,13 +15,14 @@ pub(crate) const EEST_STABLE_ENV: &str = "EVM2_EEST_STABLE";
 /// Repo-relative fixture root used by the setup script and CI.
 pub(crate) const DEFAULT_FIXTURES_PATH: &str = "test-fixtures";
 
-/// Environment variable selecting a single folder (or file) to run as one
-/// auto-detecting suite covering both state and blockchain fixtures.
-pub(crate) const FIXTURE_PATH_ENV: &str = "EVM2_FIXTURE_PATH";
+/// Environment variable pointing at additional tests to run: a folder (or file)
+/// whose fixtures execute as state or blockchain tests by per-file field
+/// detection.
+pub(crate) const ADDITIONAL_TESTS_ENV: &str = "EVM2_ADDITIONAL_TESTS";
 
-/// Returns the explicit single fixture path configured through the environment.
-pub(crate) fn custom_fixture_path() -> Option<PathBuf> {
-    env::var_os(FIXTURE_PATH_ENV)
+/// Returns the additional-tests path configured through the environment.
+pub(crate) fn additional_tests_path() -> Option<PathBuf> {
+    env::var_os(ADDITIONAL_TESTS_ENV)
         .filter(|value| !value.is_empty())
         .map(PathBuf::from)
         .map(workspace_relative)

--- a/crates/eest/src/harness.rs
+++ b/crates/eest/src/harness.rs
@@ -108,7 +108,9 @@ fn exact_trial(suites: &[TestSuite], name: &str) -> Option<Trial> {
             relative.strip_prefix("::").map(|relative| (suite, root, relative))
         })
         .max_by_key(|(_, root, _)| root.name.len())?;
-    let path = root.path.join(relative);
+    // A root pointing directly at a file has an empty relative; the file itself
+    // is the only path it can resolve to.
+    let path = if root.path.is_file() { root.path.clone() } else { root.path.join(relative) };
     path.is_file().then(|| {
         let ignored = (suite.should_ignore)(name);
         let run_file = suite.run_file;
@@ -118,6 +120,12 @@ fn exact_trial(suites: &[TestSuite], name: &str) -> Option<Trial> {
 
 fn test_name(root_name: &str, root: &Path, path: &Path) -> String {
     let relative = path.strip_prefix(root).unwrap_or(path);
+    // When the root is the file itself the relative is empty; name it after the
+    // file so the trial has a stable, matchable name.
+    if relative.as_os_str().is_empty() {
+        let file = path.file_name().map(|name| name.to_string_lossy()).unwrap_or_default();
+        return format!("{root_name}::{file}");
+    }
     format!("{root_name}::{}", path_name(relative))
 }
 

--- a/crates/eest/src/lib.rs
+++ b/crates/eest/src/lib.rs
@@ -2,9 +2,9 @@
 
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
+mod additional;
 mod binary;
 pub mod blockchaintest;
-mod custom;
 mod discover;
 mod env;
 mod error;
@@ -52,11 +52,12 @@ pub use types::{
 
 /// Runs all EEST harnesses.
 ///
-/// When `EVM2_FIXTURE_PATH` is set, only that folder (or file) runs, as a single
-/// suite that detects each fixture's kind, so no test-name filter is required.
+/// When `EVM2_ADDITIONAL_TESTS` is set, only that folder (or file) runs, as a
+/// single suite that detects each fixture's kind, so no test-name filter is
+/// required.
 pub fn run() -> std::process::ExitCode {
-    if let Some(path) = fixtures::custom_fixture_path() {
-        return harness::run_json_harnesses(vec![custom::suite(path)]);
+    if let Some(path) = fixtures::additional_tests_path() {
+        return harness::run_json_harnesses(vec![additional::suite(path)]);
     }
     harness::run_json_harnesses(vec![runner::suite(), blockchaintest::suite()])
 }

--- a/crates/eest/src/lib.rs
+++ b/crates/eest/src/lib.rs
@@ -4,6 +4,7 @@
 
 mod binary;
 pub mod blockchaintest;
+mod custom;
 mod discover;
 mod env;
 mod error;
@@ -50,6 +51,12 @@ pub use types::{
 };
 
 /// Runs all EEST harnesses.
+///
+/// When `EVM2_FIXTURE_PATH` is set, only that folder (or file) runs, as a single
+/// suite that detects each fixture's kind, so no test-name filter is required.
 pub fn run() -> std::process::ExitCode {
+    if let Some(path) = fixtures::custom_fixture_path() {
+        return harness::run_json_harnesses(vec![custom::suite(path)]);
+    }
     harness::run_json_harnesses(vec![runner::suite(), blockchaintest::suite()])
 }

--- a/crates/eest/src/runner.rs
+++ b/crates/eest/src/runner.rs
@@ -59,6 +59,6 @@ const IGNORED_TESTS: &[&str] = &[
     "dynamicAccountOverwriteEmpty_Paris.json",
 ];
 
-fn should_ignore(name: &str) -> bool {
+pub(crate) fn should_ignore(name: &str) -> bool {
     IGNORED_TESTS.iter().any(|pattern| name.contains(pattern))
 }

--- a/crates/eest/src/runner.rs
+++ b/crates/eest/src/runner.rs
@@ -59,6 +59,6 @@ const IGNORED_TESTS: &[&str] = &[
     "dynamicAccountOverwriteEmpty_Paris.json",
 ];
 
-pub(crate) fn should_ignore(name: &str) -> bool {
+fn should_ignore(name: &str) -> bool {
     IGNORED_TESTS.iter().any(|pattern| name.contains(pattern))
 }

--- a/crates/eest/src/runner.rs
+++ b/crates/eest/src/runner.rs
@@ -28,7 +28,7 @@ fn run_file(path: PathBuf) -> Result<(), Failed> {
 }
 
 #[rustfmt::skip]
-const IGNORED_TESTS: &[&str] = &[
+pub(crate) const IGNORED_TESTS: &[&str] = &[
     // Skip slow fixtures and create-collision fixtures that need storage-aware collision handling.
     "stTimeConsuming/static_Call50000_sha256.json",
     "CALLBlake2f_MaxRounds.json",

--- a/scripts/eest.sh
+++ b/scripts/eest.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Run a folder (or single file) of EEST JSON fixtures through the nextest harness.
+#
+# Usage:
+#   scripts/eest.sh <path> [extra cargo-nextest args...]
+#
+# <path> may be absolute or relative to the current directory. Every JSON
+# fixture found under it runs as one auto-detecting suite (state vs blockchain
+# kind is detected per file), so no test-name filter is needed. Extra arguments
+# are forwarded to `cargo nextest run`, for example:
+#   scripts/eest.sh ./test-fixtures/devnet/state_tests -E 'test(precompile)'
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+    echo "usage: scripts/eest.sh <path> [extra cargo-nextest args...]" >&2
+    exit 2
+fi
+
+path="$1"
+shift
+
+if [[ ! -e "$path" ]]; then
+    echo "path does not exist: $path" >&2
+    exit 1
+fi
+
+# Resolve to an absolute path so the harness does not reinterpret it relative to
+# the workspace root.
+abs_path="$(cd "$(dirname "$path")" && pwd)/$(basename "$path")"
+
+EVM2_FIXTURE_PATH="$abs_path" exec cargo nextest run \
+    -p evm2-eest --test eest --ignore-default-filter "$@"

--- a/scripts/eest.sh
+++ b/scripts/eest.sh
@@ -28,5 +28,5 @@ fi
 # the workspace root.
 abs_path="$(cd "$(dirname "$path")" && pwd)/$(basename "$path")"
 
-EVM2_FIXTURE_PATH="$abs_path" exec cargo nextest run \
+EVM2_ADDITIONAL_TESTS="$abs_path" exec cargo nextest run \
     -p evm2-eest --test eest --ignore-default-filter "$@"


### PR DESCRIPTION
## Summary

Adds `scripts/eest.sh <path>` to run a folder (or single file) of EEST JSON fixtures through the nextest harness **without a test-name filter**. The path may be relative or absolute, inside or outside the repo.

```bash
./scripts/eest.sh ./test-fixtures/devnet/state_tests/.../precompiles
./scripts/eest.sh /abs/path/outside/repo
./scripts/eest.sh ./test-fixtures/devnet -E 'test(precompile)'   # extra args forwarded
```

Background: `cargo nextest run <path>` can't load a folder — nextest treats positionals as name filters and doesn't forward args to the test binary — so a thin wrapper is required for a true positional path.

## How it works

The script resolves the path to absolute, sets a new `EVM2_FIXTURE_PATH` env var, and runs `cargo nextest run -p evm2-eest --test eest --ignore-default-filter`.

When `EVM2_FIXTURE_PATH` is set, the eest harness replaces both default suites with one suite rooted at that path and **detects each fixture's kind (state vs blockchain) per file**, so no `-E` filter is needed to isolate it. `transaction_tests` and the engine/sync blockchain variants are skipped, and the existing per-suite ignore lists still apply.

## Changes

- `crates/eest/src/custom.rs` (new) — the unified auto-detecting suite, kind detection, descend/ignore filters.
- `crates/eest/src/fixtures.rs` — `EVM2_FIXTURE_PATH` env var + resolver.
- `crates/eest/src/lib.rs` — `run()` uses the custom suite when the env var is set.
- `crates/eest/src/runner.rs`, `blockchaintest/runner.rs`, `blockchaintest/mod.rs` — expose the two `should_ignore` helpers as `pub(crate)`.
- `scripts/eest.sh` (new), `AGENTS.md` (doc note; `CLAUDE.md` symlinks to it).

## Testing

- State folder → 4 passed, 0 skipped. Blockchain folder → 29 passed.
- Whole `devnet` parent (both kinds, no filter) → 21661 passed, 288 skipped (transaction/engine/sync skipped, consensus-level ignores applied).
- External absolute path → passes.
- Default harness unchanged when the env var is unset (no `fixtures::` names leak).
- `cargo cl`, `cargo docs`, eest lib unit tests all pass.