### PR TITLE
fix: selfdestruct skipped cold load

### DIFF
--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -1370,8 +1370,9 @@ impl<T: EvmTypes<Host = Self>> Host<T> for Evm<T> {
         skip_cold_load: bool,
     ) -> Result<SelfDestructResult, InstrStop> {
         let is_cold = if self.feature(EvmFeatures::EIP2929) {
-            match self.state.account(target, false).map(|mut a| a.warm()) {
+            match self.state.account(target, skip_cold_load).map(|mut a| a.warm()) {
                 Ok(is_cold) => is_cold,
+                Err(DbErrorCode::COLD_LOAD_SKIPPED) => return Err(InstrStop::OutOfGas),
                 Err(code) => return Err(self.db_error_stop(code)),
             }
         } else {
@@ -1569,10 +1570,14 @@ mod tests {
         interpreter::{GasTracker, Interpreter, MessageKind, op},
         registry::TxRequest,
     };
-    use alloc::{string::ToString, vec, vec::Vec};
+    use alloc::{string::ToString, sync::Arc, vec, vec::Vec};
     use alloy_consensus::{TxLegacy, transaction::Recovered};
     use alloy_primitives::{Address, Bytes, KECCAK256_EMPTY, U256};
-    use core::{error::Error, fmt};
+    use core::{
+        error::Error,
+        fmt,
+        sync::atomic::{AtomicUsize, Ordering},
+    };
 
     const TEST_TX_TYPE: u8 = 0x00;
 
@@ -1598,6 +1603,18 @@ mod tests {
             gas_used: req.host.version().tx_gas_limit_cap,
             ..TxResult::default()
         })
+    }
+
+    fn push_word(code: &mut Vec<u8>, value: Word) {
+        let bytes = value.to_be_bytes::<32>();
+        let first_nonzero = bytes.iter().position(|byte| *byte != 0).unwrap_or(31);
+        let data = &bytes[first_nonzero..];
+        code.push(op::PUSH1 + data.len() as u8 - 1);
+        code.extend_from_slice(data);
+    }
+
+    fn push_address(code: &mut Vec<u8>, address: &Address) {
+        push_word(code, Word::from_be_slice(address.as_slice()));
     }
 
     const LIFECYCLE_ACCOUNT: Address = Address::with_last_byte(0x7a);
@@ -2350,6 +2367,86 @@ mod tests {
 
         assert_eq!(result.stop, InstrStop::OutOfGas);
         assert!(!evm.state.storage(&contract).is_warm(&key));
+    }
+
+    #[derive(Clone, Debug)]
+    struct SelfdestructTargetLoadDb {
+        target: Address,
+        target_reads: Arc<AtomicUsize>,
+    }
+
+    #[derive(Clone, Debug, PartialEq, Eq)]
+    struct SelfdestructTargetLoadError;
+
+    impl fmt::Display for SelfdestructTargetLoadError {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.write_str("selfdestruct target account was loaded")
+        }
+    }
+
+    impl Error for SelfdestructTargetLoadError {}
+
+    impl Database for SelfdestructTargetLoadDb {
+        type Error = SelfdestructTargetLoadError;
+
+        fn get_account(&mut self, address: &Address) -> Result<Option<AccountInfo>, Self::Error> {
+            if *address == self.target {
+                self.target_reads.fetch_add(1, Ordering::SeqCst);
+                return Err(SelfdestructTargetLoadError);
+            }
+            Ok(Some(AccountInfo::default().with_balance(Word::from(1))))
+        }
+
+        fn get_code_by_hash(&mut self, _code_hash: &B256) -> Result<Bytecode, Self::Error> {
+            Ok(Bytecode::default())
+        }
+
+        fn get_storage(&mut self, _address: &Address, _key: &Word) -> Result<Word, Self::Error> {
+            Ok(Word::ZERO)
+        }
+
+        fn get_block_hash(&mut self, _number: &Word) -> Result<Option<B256>, Self::Error> {
+            Ok(None)
+        }
+    }
+
+    fn selfdestruct_to_code(target: &Address) -> Bytecode {
+        let mut code = Vec::new();
+        push_address(&mut code, target);
+        code.push(op::SELFDESTRUCT);
+        Bytecode::new_legacy(Bytes::from(code))
+    }
+
+    #[test]
+    fn unaffordable_cold_target_selfdestruct_does_not_load_target_account() {
+        let contract = Address::from([0xbb; 20]);
+        let target = Address::from([0xcc; 20]);
+        let target_reads = Arc::new(AtomicUsize::new(0));
+        let database = SelfdestructTargetLoadDb { target, target_reads: Arc::clone(&target_reads) };
+        let mut evm = Evm::<BaseEvmTypes>::new(
+            SpecId::BERLIN,
+            BlockEnv::default(),
+            TxRegistry::new(),
+            Db::new(database),
+            Precompiles::base(SpecId::BERLIN),
+        );
+        let mut message = Message {
+            kind: MessageKind::Call,
+            destination: contract,
+            code_address: contract,
+            gas_limit: 6_000,
+            ..Message::default()
+        };
+
+        let result = Host::execute_message(
+            &mut evm,
+            &TxEnv::default(),
+            selfdestruct_to_code(&target),
+            &mut message,
+        );
+
+        assert_eq!(result.stop, InstrStop::OutOfGas);
+        assert_eq!(target_reads.load(Ordering::SeqCst), 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Honor `skip_cold_load` when SELFDESTRUCT checks the beneficiary.
- Map skipped cold account loads to `OutOfGas`.
- Add a host-boundary regression test proving the unaffordable cold target is not loaded from DB.

## Bug
SELFDESTRUCT computed `skip_cold_load`, but `Evm::selfdestruct` loaded the beneficiary with `skip_cold_load = false`. With a healthy DB this can still later halt OOG, but it performs an underpriced/forbidden DB read and can turn deterministic OOG into a fatal DB error if that read fails.

This is not an EEST-style consensus fixture issue in the normal healthy-DB model; it is a host-boundary/load-order bug. The expected execution halt is OOG, and the regression host proves evm2 must not perform the cold DB load first.

## Revm mapping
- [revm SELFDESTRUCT computes `skip_cold_load`](https://github.com/bluealloy/revm/blob/ae95b77643504500cc11bfa47bfe6b4ec8e3d768/crates/interpreter/src/instructions/host.rs?plain=1#L374-L381) from remaining gas and passes it to `host.selfdestruct`.
- [revm journal SELFDESTRUCT](https://github.com/bluealloy/revm/blob/ae95b77643504500cc11bfa47bfe6b4ec8e3d768/crates/context/src/journal/inner.rs?plain=1#L628-L636) forwards `skip_cold_load` into account loading.
- [revm warm-address check](https://github.com/bluealloy/revm/blob/ae95b77643504500cc11bfa47bfe6b4ec8e3d768/crates/context/src/journal/warm_addresses.rs?plain=1#L162-L170) returns `ColdLoadSkipped` instead of loading a cold account when the skip flag is set.
- [revm interpreter load-error handling](https://github.com/bluealloy/revm/blob/ae95b77643504500cc11bfa47bfe6b4ec8e3d768/crates/interpreter/src/interpreter.rs?plain=1#L230-L234) maps `ColdLoadSkipped` to OOG and DB errors to fatal.

## Tests
- `cargo +nightly test -p evm2 --no-default-features --features std,secp256k1 unaffordable_cold_target_selfdestruct_does_not_load_target_account`
- `cargo +nightly fmt -p evm2 -- --check`
