### PR TITLE
fix: selfdestruct trace after gas charge

### DIFF
--- a/crates/evm2/src/evm/inspector.rs
+++ b/crates/evm2/src/evm/inspector.rs
@@ -908,6 +908,28 @@ mod tests {
     }
 
     #[test]
+    fn selfdestruct_dynamic_gas_oog_is_not_inspected() {
+        let contract = Address::from([0x11; 20]);
+        let target = Address::from([0x99; 20]);
+        let mut db = InMemoryDB::default();
+        db.insert_account_info(&contract, AccountInfo::default());
+        let mut code = Vec::new();
+        push(&mut code, address_to_word(&target));
+        code.push(op::SELFDESTRUCT);
+
+        let (result, inspector, _) = run_evm_with_inspector_db(
+            db,
+            code,
+            &Message { destination: contract, ..Default::default() },
+            7_000,
+            SelfdestructInspector::default(),
+        );
+
+        assert_eq!(result.stop, InstrStop::OutOfGas);
+        assert_eq!(inspector.selfdestruct, None);
+    }
+
+    #[test]
     fn selfdestruct_host_error_is_not_inspected() {
         // Host failures are injected through the mock host; this intentionally uses [`TestHost`].
         let target = Address::from([0x99; 20]);

--- a/crates/evm2/src/interpreter/instructions/system.rs
+++ b/crates/evm2/src/interpreter/instructions/system.rs
@@ -350,7 +350,6 @@ pub(crate) fn selfdestruct(cx: _, [target]: [Word]) -> Result {
     let skip_cold_load = cx.gas.remaining() < cold_load_gas;
     let destination = &cx.state.message().destination;
     let res = cx.state.host().selfdestruct(destination, &target, skip_cold_load)?;
-    cx.state.inspect_selfdestruct(destination, &target, &res.value);
     let should_charge_topup = should_charge_new_account_gas(
         cx.state.feature(EvmFeatures::EIP161),
         res.had_value,
@@ -360,6 +359,7 @@ pub(crate) fn selfdestruct(cx: _, [target]: [Word]) -> Result {
     if !res.previously_destroyed {
         cx.gas.record_refund(cx.state.gas_params().get(GasId::SelfdestructRefund) as i64);
     }
+    cx.state.inspect_selfdestruct(destination, &target, &res.value);
     Err(InstrStop::SelfDestruct)
 }
 


### PR DESCRIPTION
## Summary
- Move SELFDESTRUCT inspector notification after the final dynamic gas charge succeeds.
- Add a regression test for OOG after host SELFDESTRUCT but before committed instruction success.

## Bug
The inspector was notified immediately after the host selfdestruct call. If the later selfdestruct gas charge failed, state rolled back but trace metadata still recorded a selfdestruct.

## Revm mapping
- [revm SELFDESTRUCT charges dynamic gas](https://github.com/bluealloy/revm/blob/ae95b77643504500cc11bfa47bfe6b4ec8e3d768/crates/interpreter/src/instructions/host.rs?plain=1#L390-L403) after the host call and before the instruction reports success.
- [revm SELFDESTRUCT returns the instruction action](https://github.com/bluealloy/revm/blob/ae95b77643504500cc11bfa47bfe6b4ec8e3d768/crates/interpreter/src/instructions/host.rs?plain=1#L406-L413) only after those charges complete.
- [revm inspector handling](https://github.com/bluealloy/revm/blob/ae95b77643504500cc11bfa47bfe6b4ec8e3d768/crates/inspector/src/handler.rs?plain=1#L264-L270) emits the selfdestruct callback only from the interpreter return action whose result is `SelfDestruct`.

## Tests
- `cargo +nightly test -p evm2 --no-default-features --features std,secp256k1 selfdestruct_dynamic_gas_oog_is_not_inspected`
- `cargo +nightly fmt -p evm2 -- --check`
