### PR TITLE
fix: memory expansion gas params

### DIFF
--- a/crates/evm2/src/interpreter/instructions/control.rs
+++ b/crates/evm2/src/interpreter/instructions/control.rs
@@ -2,7 +2,6 @@ use crate::{
     EvmTypes,
     interpreter::{
         InstrStop, Result, Word,
-        memory::resize_memory,
         private::{GasInstructionCx, InstructionCx},
     },
     utils::{word_to_usize, word_to_usize_saturated},
@@ -80,7 +79,7 @@ fn return_inner<T: EvmTypes>(
         if end > u32::MAX as usize {
             return Err(InstrStop::MemoryLimitOOG);
         }
-        resize_memory(cx.gas, cx.state.memory(), offset, len)?;
+        cx.state.resize_memory(cx.gas, offset, len)?;
         offset as u32..end as u32
     } else {
         0..0

--- a/crates/evm2/src/interpreter/instructions/crypto.rs
+++ b/crates/evm2/src/interpreter/instructions/crypto.rs
@@ -1,7 +1,4 @@
-use crate::{
-    interpreter::memory::resize_memory,
-    utils::{b256_to_word, word_to_usize},
-};
+use crate::utils::{b256_to_word, word_to_usize};
 use alloy_primitives::keccak256 as keccak256_hash;
 use evm2_macros::instruction;
 
@@ -13,7 +10,7 @@ pub(crate) fn keccak256(cx: _, [offset, len]: [Word]) -> Result<out> {
         keccak256_hash([])
     } else {
         let offset = word_to_usize(*offset)?;
-        resize_memory(cx.gas, cx.state.memory(), offset, len)?;
+        cx.state.resize_memory(cx.gas, offset, len)?;
         keccak256_hash(cx.state.memory().slice(offset, len))
     };
     *out = b256_to_word(hash);

--- a/crates/evm2/src/interpreter/instructions/env.rs
+++ b/crates/evm2/src/interpreter/instructions/env.rs
@@ -1,12 +1,11 @@
 use crate::{
     EvmTypes,
     evm::AccountLoad,
-    interpreter::{
-        Gas, Host, InstrStop, InterpreterState, Result, Word, private::GasInstructionCx,
-    },
+    interpreter::{Gas, Host, InstrStop, Memory, Result, Word, private::GasInstructionCx},
     utils::{
         address_to_word, b256_to_word, word_to_address, word_to_usize, word_to_usize_saturated,
     },
+    version::GasParams,
 };
 use alloy_primitives::B256;
 use evm2_macros::instruction;
@@ -27,15 +26,21 @@ fn load_account<T: EvmTypes>(
 }
 
 #[inline]
-fn resize_copy_memory<T: EvmTypes>(
+fn copy_data(
     gas: &mut Gas,
-    state: &mut InterpreterState<'_, T>,
+    memory: &mut Memory,
+    gas_params: &GasParams,
     memory_offset: &Word,
+    data_offset: &Word,
     len: usize,
-) -> Result<usize> {
-    let memory_offset = word_to_usize(*memory_offset)?;
-    state.resize_memory(gas, memory_offset, len)?;
-    Ok(memory_offset)
+    data: &[u8],
+) -> Result {
+    if len != 0 {
+        let memory_offset = word_to_usize(*memory_offset)?;
+        memory.resize_evm(gas, gas_params, memory_offset, len)?;
+        memory.set_data(memory_offset, word_to_usize_saturated(*data_offset), len, data);
+    }
+    Ok(())
 }
 
 #[instruction]
@@ -84,17 +89,9 @@ pub(crate) fn calldatasize(cx: _) -> out {
 pub(crate) fn calldatacopy(cx: _, [memory_offset, data_offset, len]: [Word]) -> Result {
     let len = word_to_usize(*len)?;
     cx.gas.spend(cx.state.gas_params().copy_cost(len))?;
-    if len != 0 {
-        let memory_offset = resize_copy_memory(cx.gas, cx.state, memory_offset, len)?;
-        let input = cx.state.message().input.as_ref();
-        cx.state.memory().set_data(
-            memory_offset,
-            word_to_usize_saturated(*data_offset),
-            len,
-            input,
-        );
-    }
-    Ok(())
+    let input = cx.state.message().input.as_ref();
+    let gas_params = cx.state.gas_params();
+    copy_data(cx.gas, &mut cx.state.0.memory, gas_params, memory_offset, data_offset, len, input)
 }
 
 #[instruction]
@@ -106,12 +103,9 @@ pub(crate) fn codesize(cx: _) -> out {
 pub(crate) fn codecopy(cx: _, [memory_offset, code_offset, len]: [Word]) -> Result {
     let len = word_to_usize(*len)?;
     cx.gas.spend(cx.state.gas_params().copy_cost(len))?;
-    if len != 0 {
-        let memory_offset = resize_copy_memory(cx.gas, cx.state, memory_offset, len)?;
-        let data = cx.state.0.bytecode.original_byte_slice();
-        cx.state.0.memory.set_data(memory_offset, word_to_usize_saturated(*code_offset), len, data);
-    }
-    Ok(())
+    let data = cx.state.0.bytecode.original_byte_slice();
+    let gas_params = cx.state.gas_params();
+    copy_data(cx.gas, &mut cx.state.0.memory, gas_params, memory_offset, code_offset, len, data)
 }
 
 #[instruction]
@@ -165,12 +159,10 @@ pub(crate) fn returndatacopy(cx: _, [memory_offset, data_offset, len]: [Word]) -
     }
 
     cx.gas.spend(cx.state.gas_params().copy_cost(len))?;
-    if len != 0 {
-        let memory_offset = resize_copy_memory(cx.gas, cx.state, memory_offset, len)?;
-        let data = &cx.state.0.return_data;
-        cx.state.0.memory.set_data(memory_offset, data_offset, len, data);
-    }
-    Ok(())
+    let data = &cx.state.0.return_data;
+    let data_offset = Word::from(data_offset);
+    let gas_params = cx.state.gas_params();
+    copy_data(cx.gas, &mut cx.state.0.memory, gas_params, memory_offset, &data_offset, len, data)
 }
 
 #[cfg(test)]

--- a/crates/evm2/src/interpreter/instructions/env.rs
+++ b/crates/evm2/src/interpreter/instructions/env.rs
@@ -2,8 +2,7 @@ use crate::{
     EvmTypes,
     evm::AccountLoad,
     interpreter::{
-        Gas, Host, InstrStop, Memory, Result, Word, memory::resize_memory,
-        private::GasInstructionCx,
+        Gas, Host, InstrStop, InterpreterState, Result, Word, private::GasInstructionCx,
     },
     utils::{
         address_to_word, b256_to_word, word_to_address, word_to_usize, word_to_usize_saturated,
@@ -28,20 +27,15 @@ fn load_account<T: EvmTypes>(
 }
 
 #[inline]
-fn copy_data(
+fn resize_copy_memory<T: EvmTypes>(
     gas: &mut Gas,
-    memory: &mut Memory,
+    state: &mut InterpreterState<'_, T>,
     memory_offset: &Word,
-    data_offset: &Word,
     len: usize,
-    data: &[u8],
-) -> Result {
-    if len != 0 {
-        let memory_offset = word_to_usize(*memory_offset)?;
-        resize_memory(gas, memory, memory_offset, len)?;
-        memory.set_data(memory_offset, word_to_usize_saturated(*data_offset), len, data);
-    }
-    Ok(())
+) -> Result<usize> {
+    let memory_offset = word_to_usize(*memory_offset)?;
+    state.resize_memory(gas, memory_offset, len)?;
+    Ok(memory_offset)
 }
 
 #[instruction]
@@ -90,8 +84,17 @@ pub(crate) fn calldatasize(cx: _) -> out {
 pub(crate) fn calldatacopy(cx: _, [memory_offset, data_offset, len]: [Word]) -> Result {
     let len = word_to_usize(*len)?;
     cx.gas.spend(cx.state.gas_params().copy_cost(len))?;
-    let input = cx.state.message().input.as_ref();
-    copy_data(cx.gas, &mut cx.state.0.memory, memory_offset, data_offset, len, input)
+    if len != 0 {
+        let memory_offset = resize_copy_memory(cx.gas, cx.state, memory_offset, len)?;
+        let input = cx.state.message().input.as_ref();
+        cx.state.memory().set_data(
+            memory_offset,
+            word_to_usize_saturated(*data_offset),
+            len,
+            input,
+        );
+    }
+    Ok(())
 }
 
 #[instruction]
@@ -103,8 +106,12 @@ pub(crate) fn codesize(cx: _) -> out {
 pub(crate) fn codecopy(cx: _, [memory_offset, code_offset, len]: [Word]) -> Result {
     let len = word_to_usize(*len)?;
     cx.gas.spend(cx.state.gas_params().copy_cost(len))?;
-    let data = cx.state.0.bytecode.original_byte_slice();
-    copy_data(cx.gas, &mut cx.state.0.memory, memory_offset, code_offset, len, data)
+    if len != 0 {
+        let memory_offset = resize_copy_memory(cx.gas, cx.state, memory_offset, len)?;
+        let data = cx.state.0.bytecode.original_byte_slice();
+        cx.state.0.memory.set_data(memory_offset, word_to_usize_saturated(*code_offset), len, data);
+    }
+    Ok(())
 }
 
 #[instruction]
@@ -129,7 +136,7 @@ pub(crate) fn extcodecopy(cx: _, [addr, memory_offset, code_offset, len]: [Word]
     cx.gas.spend(cx.state.gas_params().extcodecopy_cost(len))?;
     let memory_offset = if len != 0 {
         let memory_offset = word_to_usize(*memory_offset)?;
-        resize_memory(cx.gas, &mut cx.state.0.memory, memory_offset, len)?;
+        cx.state.resize_memory(cx.gas, memory_offset, len)?;
         memory_offset
     } else {
         0
@@ -158,9 +165,12 @@ pub(crate) fn returndatacopy(cx: _, [memory_offset, data_offset, len]: [Word]) -
     }
 
     cx.gas.spend(cx.state.gas_params().copy_cost(len))?;
-    let data = &cx.state.0.return_data;
-    let data_offset = Word::from(data_offset);
-    copy_data(cx.gas, &mut cx.state.0.memory, memory_offset, &data_offset, len, data)
+    if len != 0 {
+        let memory_offset = resize_copy_memory(cx.gas, cx.state, memory_offset, len)?;
+        let data = &cx.state.0.return_data;
+        cx.state.0.memory.set_data(memory_offset, data_offset, len, data);
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/evm2/src/interpreter/instructions/host.rs
+++ b/crates/evm2/src/interpreter/instructions/host.rs
@@ -1,9 +1,6 @@
 use crate::{
     EvmFeatures, EvmTypes,
-    interpreter::{
-        Host, InstrStop, InterpreterState, Result, StackMut, memory::resize_memory,
-        private::GasInstructionCx,
-    },
+    interpreter::{Host, InstrStop, InterpreterState, Result, StackMut, private::GasInstructionCx},
     utils::word_to_usize,
     version::GasId,
 };
@@ -109,7 +106,7 @@ fn log_common<T: EvmTypes>(
         Bytes::new()
     } else {
         let offset = word_to_usize(offset)?;
-        resize_memory(cx.gas, cx.state.memory(), offset, len)?;
+        cx.state.resize_memory(cx.gas, offset, len)?;
         Bytes::copy_from_slice(cx.state.memory().slice(offset, len))
     };
 

--- a/crates/evm2/src/interpreter/instructions/memory.rs
+++ b/crates/evm2/src/interpreter/instructions/memory.rs
@@ -1,27 +1,24 @@
-use crate::{
-    interpreter::{Word, memory::resize_memory},
-    utils::word_to_usize,
-};
+use crate::{interpreter::Word, utils::word_to_usize};
 use evm2_macros::instruction;
 
 #[instruction(dynamic_gas)]
 pub(crate) fn mload(cx: _, [offset]: [Word]) -> Result<out> {
     let offset = word_to_usize(*offset)?;
-    resize_memory(cx.gas, cx.state.memory(), offset, 32)?;
+    cx.state.resize_memory(cx.gas, offset, 32)?;
     *out = cx.state.memory().get_word(offset);
 }
 
 #[instruction(dynamic_gas)]
 pub(crate) fn mstore(cx: _, [offset, value]: [Word]) -> Result {
     let offset = word_to_usize(*offset)?;
-    resize_memory(cx.gas, cx.state.memory(), offset, 32)?;
+    cx.state.resize_memory(cx.gas, offset, 32)?;
     cx.state.memory().set(offset, &value.to_be_bytes::<32>());
 }
 
 #[instruction(dynamic_gas)]
 pub(crate) fn mstore8(cx: _, [offset, value]: [Word]) -> Result {
     let offset = word_to_usize(*offset)?;
-    resize_memory(cx.gas, cx.state.memory(), offset, 1)?;
+    cx.state.resize_memory(cx.gas, offset, 1)?;
     cx.state.memory().set(offset, &[value.byte(0)]);
 }
 
@@ -37,7 +34,7 @@ pub(crate) fn mcopy(cx: _, [dst, src, len]: [Word]) -> Result {
     if len != 0 {
         let dst = word_to_usize(*dst)?;
         let src = word_to_usize(*src)?;
-        resize_memory(cx.gas, cx.state.memory(), dst.max(src), len)?;
+        cx.state.resize_memory(cx.gas, dst.max(src), len)?;
         cx.state.memory().copy(dst, src, len);
     };
 }
@@ -53,6 +50,7 @@ mod tests {
             instructions::tests::{RunConfig, TestHost, TestTypes, push, run, run_stack},
             op,
         },
+        version::GasId,
     };
     use alloc::vec::Vec;
     use alloy_primitives::Bytes;
@@ -116,6 +114,28 @@ mod tests {
         let err = interp.run(&config, &mut host);
 
         assert_matches!(err, InstrStop::MemoryLimitOOG);
+        assert_eq!(interp.memory_len(), 0);
+    }
+
+    #[test]
+    fn mstore_respects_version_memory_gas_params() {
+        let mut version = Version::new(SpecId::OSAKA);
+        version.gas_params[GasId::MemoryLinearCost] = 9;
+        let config = ExecutionConfig::<TestTypes>::for_spec_and_version(SpecId::OSAKA, version);
+        let mut code = Vec::new();
+        push(&mut code, Word::ZERO);
+        push(&mut code, Word::ZERO);
+        code.push(op::MSTORE);
+        code.push(op::STOP);
+
+        let tx_env = TxEnv::default();
+        let message = Message { gas_limit: 17, ..Message::default() };
+        let bytecode = Bytecode::new_legacy(Bytes::from(code));
+        let mut interp = Interpreter::<TestTypes>::new(bytecode, &tx_env, &message);
+        let mut host = TestHost::default();
+        let err = interp.run(&config, &mut host);
+
+        assert_matches!(err, InstrStop::MemoryOOG);
         assert_eq!(interp.memory_len(), 0);
     }
 

--- a/crates/evm2/src/interpreter/instructions/system.rs
+++ b/crates/evm2/src/interpreter/instructions/system.rs
@@ -5,7 +5,6 @@ use crate::{
     bytecode::Bytecode,
     interpreter::{
         Gas, Host, InstrStop, InterpreterState, Message, MessageKind, Result, StackMut, Word,
-        memory::resize_memory,
     },
     utils::{word_to_address, word_to_usize},
     version::GasId,
@@ -40,7 +39,7 @@ fn resize_memory_range<T: EvmTypes>(
     let len = word_to_usize(len)?;
     let offset = if len != 0 {
         let offset = word_to_usize(offset)?;
-        resize_memory(gas, state.memory(), offset, len)?;
+        state.resize_memory(gas, offset, len)?;
         offset
     } else {
         usize::MAX

--- a/crates/evm2/src/interpreter/memory.rs
+++ b/crates/evm2/src/interpreter/memory.rs
@@ -65,6 +65,8 @@ impl Memory {
     }
 
     /// Resizes memory to cover `offset..offset + len`.
+    ///
+    /// Does not account for gas.
     #[inline]
     pub fn resize(&mut self, offset: usize, len: usize) -> Result {
         let Some(end) = offset.checked_add(len) else {

--- a/crates/evm2/src/interpreter/memory.rs
+++ b/crates/evm2/src/interpreter/memory.rs
@@ -1,5 +1,5 @@
 use super::{Gas, InstrStop, Result, Word};
-use crate::utils::num_words;
+use crate::{utils::num_words, version::GasParams};
 use alloc::vec::Vec;
 use core::{cmp::min, fmt, hint::cold_path, ops::Range};
 
@@ -193,21 +193,16 @@ unsafe fn set_data(dst: &mut [u8], src: &[u8], dst_offset: usize, src_offset: us
 }
 
 #[inline]
-pub(super) const fn memory_cost(len: usize) -> u64 {
-    let len = len as u64;
-    3_u64.saturating_mul(len).saturating_add(len.saturating_mul(len) / 512)
-}
-
-#[inline]
 pub(super) fn resize_memory(
     gas: &mut Gas,
     memory: &mut Memory,
+    gas_params: &GasParams,
     offset: usize,
     len: usize,
 ) -> Result {
     let new_num_words = num_words(offset.saturating_add(len));
     if new_num_words > gas.memory().words_num {
-        return resize_memory_cold(gas, memory, new_num_words);
+        return resize_memory_cold(gas, memory, gas_params, new_num_words);
     }
 
     Ok(())
@@ -215,7 +210,12 @@ pub(super) fn resize_memory(
 
 #[cold]
 #[inline(never)]
-fn resize_memory_cold(gas: &mut Gas, memory: &mut Memory, new_num_words: usize) -> Result {
+fn resize_memory_cold(
+    gas: &mut Gas,
+    memory: &mut Memory,
+    gas_params: &GasParams,
+    new_num_words: usize,
+) -> Result {
     let Some(new_size) = new_num_words.checked_mul(32) else {
         cold_path();
         return Err(InstrStop::MemoryOOG);
@@ -226,7 +226,7 @@ fn resize_memory_cold(gas: &mut Gas, memory: &mut Memory, new_num_words: usize) 
         return Err(InstrStop::MemoryLimitOOG);
     }
 
-    let cost = memory_cost(new_num_words);
+    let cost = gas_params.memory_cost(new_num_words);
     let cost = unsafe { gas.memory_mut().set_words_num(new_num_words, cost).unwrap_unchecked() };
 
     gas.spend(cost).map_err(|_| InstrStop::MemoryOOG)?;
@@ -237,6 +237,7 @@ fn resize_memory_cold(gas: &mut Gas, memory: &mut Memory, new_num_words: usize) 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{SpecId, Version};
     use core::assert_matches;
 
     #[test]
@@ -259,16 +260,19 @@ mod tests {
         let mut gas = Gas::new(100);
         let mut memory = Memory::new();
 
-        resize_memory(&mut gas, &mut memory, 0, 32).unwrap();
+        let gas_params = Version::new(SpecId::FRONTIER).gas_params;
+        resize_memory(&mut gas, &mut memory, &gas_params, 0, 32).unwrap();
         assert_eq!(gas.remaining(), 97);
         assert_eq!(gas.memory().words_num, 1);
         assert_eq!(memory.len(), 32);
 
-        resize_memory(&mut gas, &mut memory, 0, 1).unwrap();
+        let gas_params = Version::new(SpecId::FRONTIER).gas_params;
+        resize_memory(&mut gas, &mut memory, &gas_params, 0, 1).unwrap();
         assert_eq!(gas.remaining(), 97);
         assert_eq!(memory.len(), 32);
 
-        resize_memory(&mut gas, &mut memory, 0, 64).unwrap();
+        let gas_params = Version::new(SpecId::FRONTIER).gas_params;
+        resize_memory(&mut gas, &mut memory, &gas_params, 0, 64).unwrap();
         assert_eq!(gas.remaining(), 94);
         assert_eq!(gas.memory().words_num, 2);
         assert_eq!(memory.len(), 64);
@@ -280,14 +284,15 @@ mod tests {
         let mut memory = Memory::new();
         memory.set_memory_limit(64);
 
-        resize_memory(&mut gas, &mut memory, 0, 32).unwrap();
+        let gas_params = Version::new(SpecId::FRONTIER).gas_params;
+        resize_memory(&mut gas, &mut memory, &gas_params, 0, 32).unwrap();
         assert_eq!(memory.len(), 32);
 
-        resize_memory(&mut gas, &mut memory, 0, 64).unwrap();
+        resize_memory(&mut gas, &mut memory, &gas_params, 0, 64).unwrap();
         assert_eq!(memory.len(), 64);
 
         assert_matches!(
-            resize_memory(&mut gas, &mut memory, 0, 96),
+            resize_memory(&mut gas, &mut memory, &gas_params, 0, 96),
             Err(InstrStop::MemoryLimitOOG)
         );
         assert_eq!(memory.len(), 64);

--- a/crates/evm2/src/interpreter/memory.rs
+++ b/crates/evm2/src/interpreter/memory.rs
@@ -76,6 +76,50 @@ impl Memory {
         Ok(())
     }
 
+    /// Resizes memory to cover `offset..offset + len` and charges EVM expansion gas.
+    #[inline]
+    pub fn resize_evm(
+        &mut self,
+        gas: &mut Gas,
+        gas_params: &GasParams,
+        offset: usize,
+        len: usize,
+    ) -> Result {
+        let new_num_words = num_words(offset.saturating_add(len));
+        if new_num_words > gas.memory().words_num {
+            return self.resize_evm_cold(gas, gas_params, new_num_words);
+        }
+
+        Ok(())
+    }
+
+    #[cold]
+    #[inline(never)]
+    fn resize_evm_cold(
+        &mut self,
+        gas: &mut Gas,
+        gas_params: &GasParams,
+        new_num_words: usize,
+    ) -> Result {
+        let Some(new_size) = new_num_words.checked_mul(32) else {
+            cold_path();
+            return Err(InstrStop::MemoryOOG);
+        };
+
+        if self.limit_reached(new_num_words) {
+            cold_path();
+            return Err(InstrStop::MemoryLimitOOG);
+        }
+
+        let cost = gas_params.memory_cost(new_num_words);
+        let cost =
+            unsafe { gas.memory_mut().set_words_num(new_num_words, cost).unwrap_unchecked() };
+
+        gas.spend(cost).map_err(|_| InstrStop::MemoryOOG)?;
+        self.resize_to(new_size);
+        Ok(())
+    }
+
     /// Returns whether `new_words` exceeds the memory limit.
     #[inline]
     pub const fn limit_reached(&self, new_words: usize) -> bool {
@@ -192,48 +236,6 @@ unsafe fn set_data(dst: &mut [u8], src: &[u8], dst_offset: usize, src_offset: us
     unsafe { dst.get_unchecked_mut(dst_offset + src_len..dst_offset + len).fill(0) };
 }
 
-#[inline]
-pub(super) fn resize_memory(
-    gas: &mut Gas,
-    memory: &mut Memory,
-    gas_params: &GasParams,
-    offset: usize,
-    len: usize,
-) -> Result {
-    let new_num_words = num_words(offset.saturating_add(len));
-    if new_num_words > gas.memory().words_num {
-        return resize_memory_cold(gas, memory, gas_params, new_num_words);
-    }
-
-    Ok(())
-}
-
-#[cold]
-#[inline(never)]
-fn resize_memory_cold(
-    gas: &mut Gas,
-    memory: &mut Memory,
-    gas_params: &GasParams,
-    new_num_words: usize,
-) -> Result {
-    let Some(new_size) = new_num_words.checked_mul(32) else {
-        cold_path();
-        return Err(InstrStop::MemoryOOG);
-    };
-
-    if memory.limit_reached(new_num_words) {
-        cold_path();
-        return Err(InstrStop::MemoryLimitOOG);
-    }
-
-    let cost = gas_params.memory_cost(new_num_words);
-    let cost = unsafe { gas.memory_mut().set_words_num(new_num_words, cost).unwrap_unchecked() };
-
-    gas.spend(cost).map_err(|_| InstrStop::MemoryOOG)?;
-    memory.resize_to(new_size);
-    Ok(())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -256,43 +258,43 @@ mod tests {
     }
 
     #[test]
-    fn resize_memory_accounts_expansion_gas() {
+    fn resize_evm_accounts_expansion_gas() {
         let mut gas = Gas::new(100);
         let mut memory = Memory::new();
 
         let gas_params = Version::new(SpecId::FRONTIER).gas_params;
-        resize_memory(&mut gas, &mut memory, &gas_params, 0, 32).unwrap();
+        memory.resize_evm(&mut gas, &gas_params, 0, 32).unwrap();
         assert_eq!(gas.remaining(), 97);
         assert_eq!(gas.memory().words_num, 1);
         assert_eq!(memory.len(), 32);
 
         let gas_params = Version::new(SpecId::FRONTIER).gas_params;
-        resize_memory(&mut gas, &mut memory, &gas_params, 0, 1).unwrap();
+        memory.resize_evm(&mut gas, &gas_params, 0, 1).unwrap();
         assert_eq!(gas.remaining(), 97);
         assert_eq!(memory.len(), 32);
 
         let gas_params = Version::new(SpecId::FRONTIER).gas_params;
-        resize_memory(&mut gas, &mut memory, &gas_params, 0, 64).unwrap();
+        memory.resize_evm(&mut gas, &gas_params, 0, 64).unwrap();
         assert_eq!(gas.remaining(), 94);
         assert_eq!(gas.memory().words_num, 2);
         assert_eq!(memory.len(), 64);
     }
 
     #[test]
-    fn resize_memory_respects_memory_limit() {
+    fn resize_evm_respects_memory_limit() {
         let mut gas = Gas::new(100_000);
         let mut memory = Memory::new();
         memory.set_memory_limit(64);
 
         let gas_params = Version::new(SpecId::FRONTIER).gas_params;
-        resize_memory(&mut gas, &mut memory, &gas_params, 0, 32).unwrap();
+        memory.resize_evm(&mut gas, &gas_params, 0, 32).unwrap();
         assert_eq!(memory.len(), 32);
 
-        resize_memory(&mut gas, &mut memory, &gas_params, 0, 64).unwrap();
+        memory.resize_evm(&mut gas, &gas_params, 0, 64).unwrap();
         assert_eq!(memory.len(), 64);
 
         assert_matches!(
-            resize_memory(&mut gas, &mut memory, &gas_params, 0, 96),
+            memory.resize_evm(&mut gas, &gas_params, 0, 96),
             Err(InstrStop::MemoryLimitOOG)
         );
         assert_eq!(memory.len(), 64);

--- a/crates/evm2/src/interpreter/runtime.rs
+++ b/crates/evm2/src/interpreter/runtime.rs
@@ -389,6 +389,13 @@ impl<'frame, T: EvmTypes> InterpreterState<'frame, T> {
         &mut self.0.memory
     }
 
+    /// Resizes linear memory using the active runtime gas parameters.
+    #[inline]
+    pub(crate) fn resize_memory(&mut self, gas: &mut Gas, offset: usize, len: usize) -> Result {
+        let gas_params = *self.gas_params();
+        super::memory::resize_memory(gas, &mut self.0.memory, &gas_params, offset, len)
+    }
+
     /// Returns return data from the last call-like operation.
     #[inline]
     pub const fn return_data(&self) -> &Bytes {

--- a/crates/evm2/src/interpreter/runtime.rs
+++ b/crates/evm2/src/interpreter/runtime.rs
@@ -397,10 +397,8 @@ impl<'frame, T: EvmTypes> InterpreterState<'frame, T> {
 
     /// Resizes linear memory using the active runtime gas parameters.
     #[inline]
-    pub(crate) fn resize_memory(&mut self, gas: &mut Gas, offset: usize, len: usize) -> Result {
-        let version = self.0.version.expect("version is set during instruction execution");
-        let gas_params = &version.gas_params;
-        self.0.memory.resize_evm(gas, gas_params, offset, len)
+    pub fn resize_memory(&mut self, gas: &mut Gas, offset: usize, len: usize) -> Result {
+        self.0.memory.resize_evm(gas, self.gas_params(), offset, len)
     }
 
     /// Returns return data from the last call-like operation.

--- a/crates/evm2/src/interpreter/runtime.rs
+++ b/crates/evm2/src/interpreter/runtime.rs
@@ -31,7 +31,7 @@ pub struct Interpreter<'frame, T: EvmTypes> {
     message: Option<&'frame Message<T>>,
     host: Option<NonNull<T::Host>>,
     inspector: Option<NonNull<dyn Inspector<T>>>,
-    version: *const Version,
+    version: Option<&'frame Version>,
     pub(in crate::interpreter) stack_len: usize,
     #[derive_where(skip)]
     pub(in crate::interpreter) stack: Box<StackBacking>,
@@ -44,8 +44,8 @@ pub struct Interpreter<'frame, T: EvmTypes> {
 }
 
 // SAFETY: The interpreter's internal pointers are always valid. `pc` points into owned bytecode,
-// frame-local references are cleared before pooling, and host/inspector/version pointers are
-// installed for execution and not used after the owning execution context is gone.
+// frame-local references are cleared before pooling, and host/inspector pointers are installed for
+// execution and not used after the owning execution context is gone.
 unsafe impl<T: EvmTypes> Send for Interpreter<'_, T> {}
 
 impl<T: EvmTypes> Default for Interpreter<'_, T> {
@@ -65,7 +65,7 @@ impl<T: EvmTypes> Default for Interpreter<'_, T> {
             return_data: Bytes::new(),
             host: None,
             inspector: None,
-            version: core::ptr::null(),
+            version: None,
             spec: SpecId::DEFAULT,
             features: EvmFeatures::empty(),
             // SAFETY: `MaybeUninit<Word>` does not need initialization.
@@ -108,6 +108,7 @@ impl<'frame, T: EvmTypes> Interpreter<'frame, T> {
     pub(crate) const fn clear_frame_refs(&mut self) {
         self.tx_env = None;
         self.message = None;
+        self.version = None;
     }
 
     #[cfg(test)]
@@ -251,10 +252,12 @@ impl<'frame, T: EvmTypes> Interpreter<'frame, T> {
         instructions: &InstrTable<T>,
     ) -> InstrStop {
         self.memory.set_memory_limit(version.memory_limit);
+        // SAFETY: `version` remains alive for the duration of this interpreter run.
+        let version = unsafe { trustme::decouple_lt(version) };
 
         self.host = Some(NonNull::from(host));
         self.inspector = inspector;
-        self.version = version;
+        self.version = Some(version);
         self.spec = spec;
         self.features = version.features;
 
@@ -268,8 +271,11 @@ impl<'frame, T: EvmTypes> Interpreter<'frame, T> {
         version: &Version,
         host: &mut T::Host,
     ) {
+        // SAFETY: `version` remains alive for the duration of the inspection hook or run that
+        // installed it.
+        let version = unsafe { trustme::decouple_lt(version) };
         self.host = Some(NonNull::from(host));
-        self.version = version;
+        self.version = Some(version);
         self.spec = spec;
         self.features = version.features;
     }
@@ -351,10 +357,10 @@ impl<'frame, T: EvmTypes> InterpreterState<'frame, T> {
 
     /// Returns the active runtime version data.
     #[inline]
-    pub const fn version(&self) -> &Version {
-        // SAFETY: `version` is initialized at the beginning of `run` and points into the
-        // `Version` borrowed by the current run.
-        unsafe { &*self.0.version }
+    pub const fn version(&self) -> &'frame Version {
+        // SAFETY: `version` is initialized at the beginning of `run` and remains set for
+        // instruction execution.
+        unsafe { self.0.version.unwrap_unchecked() }
     }
 
     /// Returns the active frame-local call/create message.
@@ -379,7 +385,7 @@ impl<'frame, T: EvmTypes> InterpreterState<'frame, T> {
 
     /// Returns the active dynamic gas parameters.
     #[inline]
-    pub const fn gas_params(&self) -> &GasParams {
+    pub const fn gas_params(&self) -> &'frame GasParams {
         &self.version().gas_params
     }
 
@@ -392,8 +398,9 @@ impl<'frame, T: EvmTypes> InterpreterState<'frame, T> {
     /// Resizes linear memory using the active runtime gas parameters.
     #[inline]
     pub(crate) fn resize_memory(&mut self, gas: &mut Gas, offset: usize, len: usize) -> Result {
-        let gas_params = *self.gas_params();
-        super::memory::resize_memory(gas, &mut self.0.memory, &gas_params, offset, len)
+        let version = self.0.version.expect("version is set during instruction execution");
+        let gas_params = &version.gas_params;
+        self.0.memory.resize_evm(gas, gas_params, offset, len)
     }
 
     /// Returns return data from the last call-like operation.


### PR DESCRIPTION
## Summary
- Thread active `GasParams` into memory expansion.
- Charge memory expansion with `Version.gas_params.memory_cost(...)`.
- Add a custom-version test where default memory pricing would pass but overridden memory pricing OOGs.

## Bug
Memory expansion used a hard-coded Ethereum memory formula instead of the active runtime gas table. Custom `Version` gas overrides for memory linear/quadratic parameters were ignored.

## Revm mapping
- [revm `resize_memory`](https://github.com/bluealloy/revm/blob/ae95b77643504500cc11bfa47bfe6b4ec8e3d768/crates/interpreter/src/interpreter/shared_memory.rs?plain=1#L563-L575) receives the active `GasParams` table.
- [revm cold memory resize](https://github.com/bluealloy/revm/blob/ae95b77643504500cc11bfa47bfe6b4ec8e3d768/crates/interpreter/src/interpreter/shared_memory.rs?plain=1#L580-L598) computes expansion cost through `gas_table.memory_cost(new_num_words)`.
- [revm gas params](https://github.com/bluealloy/revm/blob/ae95b77643504500cc11bfa47bfe6b4ec8e3d768/crates/context/interface/src/cfg/gas_params.rs?plain=1#L594-L602) make memory linear and quadratic costs configurable through gas IDs.

## Tests
- `cargo +nightly test -p evm2 --no-default-features --features std,secp256k1 mstore_respects_version_memory_gas_params`
- `cargo +nightly fmt -p evm2 -- --check`
