### PR TITLE
fix: balance credit overflow

### DIFF
--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -167,7 +167,7 @@ pub use state::{
     AccountChange, AccountChangeRef, AccountHandle, AccountInfo, AccountInfoRef,
     BlockStateAccumulator, JournalEntry, NoopChangeSink, State, StateChangeSink, StateChangeSource,
     StateChanges, StateCheckpoint, StateInner, StorageChange, StorageHandle, StorageOverlay,
-    StorageSlot, StorageSlotHandle, Tee, Tracked,
+    StorageSlot, StorageSlotHandle, Tee, Tracked, TransferError,
 };
 
 mod prewarm_set;
@@ -661,6 +661,15 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
         InstrStop::FatalExternalError
     }
 
+    #[inline]
+    const fn transfer_error_stop(error: TransferError) -> InstrStop {
+        match error {
+            TransferError::OutOfFunds => InstrStop::OutOfFunds,
+            TransferError::OverflowPayment => InstrStop::OverflowPayment,
+            TransferError::CreateCollision => InstrStop::CreateCollision,
+        }
+    }
+
     /// Returns the active base specification ID.
     #[inline]
     pub fn spec_id(&self) -> SpecId {
@@ -954,38 +963,38 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
         bytecode: &Bytecode,
         message: &mut Message<T>,
     ) -> Result<(), InstrStop> {
-        let info = if message.value > 0 || message.depth > 0 {
-            self.state
-                .account_info_untracked(&message.caller)
-                .map_err(|code| self.db_error_stop(code))?
+        let caller_nonce = if message.value > 0 || message.depth > 0 {
+            let mut caller = match self.state.account(&message.caller, false) {
+                Ok(caller) => caller,
+                Err(code) => return Err(db_error_stop!(self, code)),
+            };
+
+            if message.value > 0 && caller.balance() < message.value {
+                return Err(InstrStop::OutOfFunds);
+            }
+
+            let nonce = caller.nonce();
+            // EIP-2681 caps account nonces at u64::MAX; CREATE/CREATE2 return zero instead of
+            // wrapping or saturating the creator nonce.
+            if message.depth > 0 && !caller.bump_nonce() {
+                return Err(InstrStop::Return);
+            }
+            nonce
         } else {
-            None
+            0
         };
-
-        if message.value > 0 && info.as_ref().is_none_or(|info| info.balance < message.value) {
-            return Err(InstrStop::OutOfFunds);
-        }
-
-        // EIP-2681 caps account nonces at u64::MAX; CREATE/CREATE2 return zero instead of
-        // wrapping or saturating the creator nonce.
-        if message.depth > 0 && info.as_ref().is_some_and(|info| info.nonce == u64::MAX) {
-            return Err(InstrStop::Return);
-        }
 
         // When an inspector is installed, the destination is already derived for the create hook,
         // and inspector mutations of it are respected.
         if self.inspector.is_none() {
-            message.destination =
-                Self::derive_create_address(bytecode, message, info.map_or(0, |info| info.nonce));
+            message.destination = Self::derive_create_address(bytecode, message, caller_nonce);
         }
 
-        let _ = self.state.account(&message.destination, false).map(|mut a| a.warm());
-
-        if message.depth > 0
-            && let Err(code) =
-                self.state.account(&message.caller, false).map(|mut a| a.bump_nonce())
-        {
-            return Err(self.db_error_stop(code));
+        match self.state.account(&message.destination, false) {
+            Ok(mut account) => {
+                account.warm();
+            }
+            Err(code) => return Err(db_error_stop!(self, code)),
         }
 
         Ok(())
@@ -995,7 +1004,7 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
     fn create_message_account(&mut self, message: &Message<T>) -> Result<(), InstrStop> {
         self.state
             .create_account(&message.caller, &message.destination, &message.value, self.features)
-            .map_err(|code| self.db_error_stop(code))??;
+            .map_err(Self::transfer_error_stop)?;
 
         self.log_eip7708_transfer(&message.caller, &message.destination, &message.value);
         Ok(())
@@ -1098,17 +1107,21 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
             message.kind,
             MessageKind::Call | MessageKind::CallCode | MessageKind::StaticCall
         );
-        let transfer_succeeded = !transfers_balance
-            || match self.state.transfer(&message.caller, &message.destination, &message.value) {
-                Ok(result) => result,
+        if transfers_balance {
+            match self.state.transfer(&message.caller, &message.destination, &message.value) {
+                Ok(None) => {}
+                Ok(Some(error)) => {
+                    self.state.rollback(checkpoint, self.features);
+                    return Self::error_message_result(
+                        Self::transfer_error_stop(error),
+                        message.gas_limit,
+                    );
+                }
                 Err(code) => {
+                    self.state.rollback(checkpoint, self.features);
                     return Self::error_message_result(self.db_error_stop(code), message.gas_limit);
                 }
-            };
-        if transfers_balance && !transfer_succeeded {
-            return Self::error_message_result(InstrStop::OutOfFunds, message.gas_limit);
-        }
-        if transfers_balance {
+            }
             self.log_eip7708_transfer(&message.caller, &message.destination, &message.value);
         }
 
@@ -1405,13 +1418,14 @@ impl<T: EvmTypes<Host = Self>> Host<T> for Evm<T> {
         };
 
         if contract != target {
-            let transferred = self
+            if let Some(error) = self
                 .state
                 .transfer(contract, target, &balance)
-                .map_err(|code| self.db_error_stop(code))?;
-            if transferred {
-                self.log_eip7708_transfer(contract, target, &balance);
+                .map_err(|code| self.db_error_stop(code))?
+            {
+                return Err(Self::transfer_error_stop(error));
             }
+            self.log_eip7708_transfer(contract, target, &balance);
         } else if should_destroy && !balance.is_zero() && !self.feature(EvmFeatures::EIP8246) {
             // Pre-EIP-8246: SELFDESTRUCT to self burns the contract's balance. EIP-8246 removes
             // this burn, leaving the balance untouched; finalization resets the account
@@ -2497,7 +2511,7 @@ mod tests {
         let mut state = State::new(InMemoryDB::default());
         state.account(&from, false).unwrap().add_balance(U256::from(10));
 
-        assert!(state.transfer(&from, &to, &U256::from(7)).unwrap());
+        assert_eq!(state.transfer(&from, &to, &U256::from(7)).unwrap(), None);
         assert_eq!(
             state
                 .account_info_untracked(&from)
@@ -2514,6 +2528,95 @@ mod tests {
                 .balance,
             U256::from(7)
         );
+    }
+
+    #[test]
+    fn transfer_recipient_overflow_returns_overflow_payment() {
+        let from = Address::from([0x01; 20]);
+        let to = Address::from([0x02; 20]);
+        let mut state = State::new(InMemoryDB::default());
+        state.account(&from, false).unwrap().add_balance(U256::from(1));
+        state.account(&to, false).unwrap().add_balance(U256::MAX);
+
+        assert_eq!(
+            state.transfer(&from, &to, &U256::from(1)).unwrap(),
+            Some(TransferError::OverflowPayment)
+        );
+        assert_eq!(state.account_info_untracked(&from).unwrap().unwrap().balance, U256::from(1));
+        assert_eq!(state.account_info_untracked(&to).unwrap().unwrap().balance, U256::MAX);
+    }
+
+    #[test]
+    fn call_value_transfer_recipient_overflow_halts() {
+        let caller = Address::from([0x01; 20]);
+        let target = Address::from([0x02; 20]);
+        let mut database = InMemoryDB::default();
+        database.insert_account_info(&caller, AccountInfo::default().with_balance(U256::from(1)));
+        database.insert_account_info(&target, AccountInfo::default().with_balance(U256::MAX));
+        let mut evm = Evm::<BaseEvmTypes>::new(
+            SpecId::OSAKA,
+            BlockEnv::default(),
+            TxRegistry::new(),
+            database,
+            Precompiles::base(SpecId::OSAKA),
+        );
+        let mut message = Message {
+            kind: MessageKind::Call,
+            caller,
+            destination: target,
+            code_address: target,
+            value: U256::from(1),
+            gas_limit: 50_000,
+            ..Message::default()
+        };
+
+        let result =
+            Host::execute_message(&mut evm, &TxEnv::default(), Bytecode::default(), &mut message);
+
+        assert_eq!(result.stop, InstrStop::OverflowPayment);
+        assert_eq!(
+            evm.state.account_info_untracked(&caller).unwrap().unwrap().balance,
+            U256::from(1)
+        );
+        assert_eq!(evm.state.account_info_untracked(&target).unwrap().unwrap().balance, U256::MAX);
+    }
+
+    #[test]
+    fn create_prefunded_target_endowment_overflow_halts() {
+        let caller = Address::from([0x01; 20]);
+        let created = Address::from([0x02; 20]);
+        let mut database = InMemoryDB::default();
+        database.insert_account_info(&caller, AccountInfo::default().with_balance(U256::from(1)));
+        database.insert_account_info(&created, AccountInfo::default().with_balance(U256::MAX));
+        let mut evm = Evm::<BaseEvmTypes>::new(
+            SpecId::OSAKA,
+            BlockEnv::default(),
+            TxRegistry::new(),
+            database,
+            Precompiles::base(SpecId::OSAKA),
+        );
+        let mut message = Message {
+            kind: MessageKind::Create,
+            caller,
+            destination: created,
+            value: U256::from(1),
+            gas_limit: 50_000,
+            ..Message::default()
+        };
+
+        let result = Host::execute_message(
+            &mut evm,
+            &TxEnv::default(),
+            Bytecode::new_legacy(Bytes::from_static(&[op::STOP])),
+            &mut message,
+        );
+
+        assert_eq!(result.stop, InstrStop::OverflowPayment);
+        assert_eq!(
+            evm.state.account_info_untracked(&caller).unwrap().unwrap().balance,
+            U256::from(1)
+        );
+        assert_eq!(evm.state.account_info_untracked(&created).unwrap().unwrap().balance, U256::MAX);
     }
 
     #[test]

--- a/crates/evm2/src/evm/state/account.rs
+++ b/crates/evm2/src/evm/state/account.rs
@@ -488,7 +488,7 @@ impl<'a> AccountHandle<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::evm::{CacheDB, state::State};
+    use crate::evm::{CacheDB, TransferError, state::State};
     use alloy_primitives::Address;
 
     #[test]
@@ -498,8 +498,11 @@ mod tests {
         database.insert_account_info(&address, AccountInfo::default().with_balance(Word::from(3)));
         let mut state = State::new(database);
 
-        assert!(!state.transfer(&address, &address, &Word::from(4)).unwrap());
-        assert!(state.transfer(&address, &address, &Word::from(3)).unwrap());
+        assert_eq!(
+            state.transfer(&address, &address, &Word::from(4)).unwrap(),
+            Some(TransferError::OutOfFunds)
+        );
+        assert_eq!(state.transfer(&address, &address, &Word::from(3)).unwrap(), None);
     }
 
     #[test]

--- a/crates/evm2/src/evm/state/mod.rs
+++ b/crates/evm2/src/evm/state/mod.rs
@@ -27,7 +27,7 @@ use super::{
 use crate::{
     EvmFeatures, Version,
     bytecode::Bytecode,
-    interpreter::{InstrStop, Word},
+    interpreter::Word,
     storage_key::{StorageKey, StorageKeyMap},
 };
 use alloc::{boxed::Box, vec::Vec};
@@ -53,6 +53,17 @@ pub struct State {
     transient_storage: StorageKeyMap<Word>,
     /// Inner state.
     inner: StateInner,
+}
+
+/// Transfer and account creation semantic errors.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TransferError {
+    /// Caller does not have enough funds.
+    OutOfFunds,
+    /// Overflow in target account balance.
+    OverflowPayment,
+    /// Create target already has nonce or code.
+    CreateCollision,
 }
 
 impl Deref for State {
@@ -330,6 +341,11 @@ impl State {
             .map(|tracked| AccountHandle::new(*address, tracked, &mut self.inner))
     }
 
+    fn account_loaded(&mut self, address: &Address) -> AccountHandle<'_> {
+        let tracked = self.accounts.get_mut(address).expect("account must be loaded");
+        AccountHandle::new(*address, tracked, &mut self.inner)
+    }
+
     /// Returns a journaled mutation handle to `address`'s persistent storage overlay.
     ///
     /// The returned [`StorageHandle`] ties the account's storage slots to the revert journal, so
@@ -393,37 +409,46 @@ impl State {
     }
 
     /// Transfers value between accounts.
-    pub fn transfer(&mut self, from: &Address, to: &Address, value: &Word) -> DbResult<bool> {
+    pub fn transfer(
+        &mut self,
+        from: &Address,
+        to: &Address,
+        value: &Word,
+    ) -> DbResult<Option<TransferError>> {
         if value.is_zero() {
             self.account(to, false)?.touch();
-            return Ok(true);
+            return Ok(None);
         }
 
         if from == to {
             let mut account = self.account(from, false)?;
             if account.balance() < *value {
-                return Ok(false);
+                return Ok(Some(TransferError::OutOfFunds));
             }
             account.touch();
-            return Ok(true);
+            return Ok(None);
         }
+
+        let Some(new_from_balance) = self.account(from, false)?.balance().checked_sub(*value)
+        else {
+            return Ok(Some(TransferError::OutOfFunds));
+        };
+        let Some(new_to_balance) = self.account(to, false)?.balance().checked_add(*value) else {
+            return Ok(Some(TransferError::OverflowPayment));
+        };
 
         {
             let mut from_account = self.account(from, false)?;
-            let Some(new_from_balance) = from_account.balance().checked_sub(*value) else {
-                return Ok(false);
-            };
             // `set_balance` touches the account, matching the touch the prior `transfer` performed.
             from_account.set_balance(new_from_balance);
             from_account.touch();
         }
         {
             let mut to_account = self.account(to, false)?;
-            let new_to_balance = to_account.balance().saturating_add(*value);
             to_account.set_balance(new_to_balance);
             to_account.touch();
         }
-        Ok(true)
+        Ok(None)
     }
 
     /// Creates a contract account and transfers endowment from the caller.
@@ -434,33 +459,42 @@ impl State {
         address: &Address,
         value: &Word,
         features: EvmFeatures,
-    ) -> DbResult<Result<(), InstrStop>> {
+    ) -> Result<(), TransferError> {
         // TODO check order of operations, we could potentially simplify it and do a lot more with
         // only one hashmap lookup.
         if self
-            .account(address, false)?
+            .account_loaded(address)
             .get()
             .is_some_and(|account| account.nonce != 0 || account.code_hash != KECCAK256_EMPTY)
         {
-            return Ok(Err(InstrStop::CreateCollision));
+            return Err(TransferError::CreateCollision);
         }
 
-        // Deduct the endowment from the caller. A zero endowment moves nothing and leaves the
-        // caller untouched, matching the prior `transfer` behaviour.
-        if !value.is_zero() {
-            let mut caller_account = self.account(caller, false)?;
-            let Some(new_caller_balance) = caller_account.balance().checked_sub(*value) else {
-                return Ok(Err(InstrStop::OutOfFunds));
+        // Check the caller balance before mutating either side. A zero endowment moves nothing and
+        // leaves the caller untouched, matching the prior `transfer` behaviour.
+        let new_caller_balance = if !value.is_zero() {
+            let caller_account = self.account_loaded(caller);
+            let Some(balance) = caller_account.balance().checked_sub(*value) else {
+                return Err(TransferError::OutOfFunds);
             };
-            caller_account.set_balance(new_caller_balance);
+            Some(balance)
+        } else {
+            None
+        };
+
+        // Preserve any balance the address already held (e.g. funds sent before creation) and add
+        // the endowment.
+        let Some(balance) = self.account_loaded(address).balance().checked_add(*value) else {
+            return Err(TransferError::OverflowPayment);
+        };
+
+        if let Some(new_caller_balance) = new_caller_balance {
+            self.account_loaded(caller).set_balance(new_caller_balance);
         }
 
         self.storage(address).wipe();
 
-        let mut target = self.account(address, false)?;
-        // Preserve any balance the address already held (e.g. funds sent before creation) and add
-        // the endowment.
-        let balance = target.balance().wrapping_add(*value);
+        let mut target = self.account_loaded(address);
         *target.get_or_insert() = AccountInfo {
             nonce: u64::from(features.contains(EvmFeatures::EIP161)),
             balance,
@@ -470,7 +504,7 @@ impl State {
         };
         target.mark_created();
         target.touch();
-        Ok(Ok(()))
+        Ok(())
     }
 
     /// Loads transient (EIP-1153) storage.

--- a/fixtures/eest/balance_overflow/call_value_recipient_overflow.json
+++ b/fixtures/eest/balance_overflow/call_value_recipient_overflow.json
@@ -1,0 +1,57 @@
+{
+  "call_value_recipient_overflow": {
+    "_info": {
+      "comment": "CALL value transfer to an account at U256::MAX balance must fail with OverflowPayment instead of saturating the recipient balance."
+    },
+    "env": {
+      "currentCoinbase": "0x0000000000000000000000000000000000000000",
+      "currentDifficulty": "0x00",
+      "currentGasLimit": "0x0f4240",
+      "currentNumber": "0x01",
+      "currentTimestamp": "0x01"
+    },
+    "pre": {
+      "0x1000000000000000000000000000000000000000": {
+        "balance": "0x01",
+        "code": "0x",
+        "nonce": "0x00",
+        "storage": {}
+      },
+      "0x2000000000000000000000000000000000000000": {
+        "balance": "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        "code": "0x",
+        "nonce": "0x00",
+        "storage": {}
+      }
+    },
+    "transaction": {
+      "data": [
+        "0x"
+      ],
+      "gasLimit": [
+        "0x5208"
+      ],
+      "gasPrice": "0x00",
+      "nonce": "0x00",
+      "sender": "0x1000000000000000000000000000000000000000",
+      "to": "0x2000000000000000000000000000000000000000",
+      "value": [
+        "0x01"
+      ]
+    },
+    "post": {
+      "Osaka": [
+        {
+          "expectException": null,
+          "hash": "0x5e60a4c32203f4790ac27130c586b9f613ba8d74d4482d15fff7ce023605fe2c",
+          "indexes": {
+            "data": 0,
+            "gas": 0,
+            "value": 0
+          },
+          "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Replace recipient transfer `saturating_add` and CREATE target `wrapping_add` with checked addition.
- Mirror revm's transfer boundary: state returns semantic `TransferError`s separately from DB errors, and the EVM maps those errors to `InstrStop`.
- Add unit tests for transfer, CALL, and CREATE overflow.
- Add a local EEST fixture demonstrating the CALL value-transfer consensus divergence.

## Bug
If a recipient or prefunded CREATE target was near `U256::MAX`, evm2 silently saturated/wrapped the credited balance and allowed execution to continue. Revm returns `OverflowPayment`, so this can diverge on valid arbitrary prestates.

## Revm mapping
- [revm `TransferError`](https://github.com/bluealloy/revm/blob/ae95b77643504500cc11bfa47bfe6b4ec8e3d768/crates/context/interface/src/journaled_state.rs?plain=1#L427-L433) keeps semantic transfer/create failures distinct from DB errors.
- [revm CALL/value transfer](https://github.com/bluealloy/revm/blob/ae95b77643504500cc11bfa47bfe6b4ec8e3d768/crates/context/src/journal/inner.rs?plain=1#L432-L489) returns `Result<Option<TransferError>, DB::Error>` and uses `checked_add` for the recipient balance.
- [revm CREATE frame handling](https://github.com/bluealloy/revm/blob/ae95b77643504500cc11bfa47bfe6b4ec8e3d768/crates/handler/src/frame.rs?plain=1#L290-L322) loads the caller and created account before calling `create_account_checkpoint`.
- [revm CREATE endowment](https://github.com/bluealloy/revm/blob/ae95b77643504500cc11bfa47bfe6b4ec8e3d768/crates/context/src/journal/inner.rs?plain=1#L511-L565) operates on loaded accounts, uses `checked_add` for the created account balance, and reverts the checkpoint on overflow.
- [revm frame result mapping](https://github.com/bluealloy/revm/blob/ae95b77643504500cc11bfa47bfe6b4ec8e3d768/crates/interpreter/src/instruction_result.rs?plain=1#L97-L103) converts `TransferError` into the externally observed instruction result.

## Tests
- `cargo +nightly test -p evm2 --no-default-features --features std,secp256k1`
- `cargo +nightly fmt -p evm2 -- --check`
- `env NEXTEST=1 EVM2_ADDITIONAL_TESTS=/private/tmp/evm2-balance-overflow/fixtures/eest/balance_overflow cargo +nightly run --manifest-path /private/tmp/eest-runner/Cargo.toml -- --nocapture`

## EEST
- Fixture: `fixtures/eest/balance_overflow/call_value_recipient_overflow.json`
- Result: `additional::call_value_recipient_overflow.json ... ok`
