### PR TITLE
test: clean up evm2 test helpers

### DIFF
--- a/crates/evm2/src/evm/inspector.rs
+++ b/crates/evm2/src/evm/inspector.rs
@@ -139,80 +139,15 @@ mod tests {
         env::{BlockEnv, TxEnv},
         ethereum::{RecoveredTxEnvelope, ethereum_tx_registry},
         evm::{AccountInfo, InMemoryDB, SYSTEM_ADDRESS},
-        interpreter::{
-            GasTracker, Host, InstrStop, Interpreter, Message, MessageResult, Word,
-            instructions::tests::{TestHost, TestTypes, push},
-            op,
-        },
+        interpreter::{GasTracker, Host, InstrStop, Interpreter, Message, MessageResult, Word, op},
         registry::TxRegistry,
+        test_utils::{TestHost, TestTypes, legacy_bytecode, push, push_all},
         utils::address_to_word,
     };
     use alloc::{boxed::Box, vec::Vec};
     use alloy_consensus::{TxLegacy, transaction::Recovered};
     use alloy_primitives::{Address, Bytes, Log, TxKind, U256};
     use core::assert_matches;
-
-    #[derive(Default)]
-    struct StepInspector {
-        steps: usize,
-        step_ends: usize,
-    }
-
-    impl<T: EvmTypes> Inspector<T> for StepInspector {
-        fn step(&mut self, _interp: &mut Interpreter<'_, T>) {
-            self.steps += 1;
-        }
-
-        fn step_end(&mut self, _interp: &mut Interpreter<'_, T>) {
-            self.step_ends += 1;
-        }
-    }
-
-    #[derive(Default)]
-    struct StopOnStepInspector {
-        opcode: u8,
-        steps: usize,
-        step_ends: usize,
-        stack: Vec<Word>,
-    }
-
-    impl<T: EvmTypes> Inspector<T> for StopOnStepInspector {
-        fn step(&mut self, interp: &mut Interpreter<'_, T>) {
-            self.steps += 1;
-            if interp.opcode() == self.opcode {
-                self.stack = interp.stack().to_vec();
-                interp.set_stop(InstrStop::Revert);
-            }
-        }
-
-        fn step_end(&mut self, _interp: &mut Interpreter<'_, T>) {
-            self.step_ends += 1;
-        }
-    }
-
-    #[derive(Default)]
-    struct StopOnStepEndInspector {
-        opcode: u8,
-        last_opcode: Option<u8>,
-        steps: usize,
-        step_ends: usize,
-        stack: Vec<Word>,
-    }
-
-    impl<T: EvmTypes> Inspector<T> for StopOnStepEndInspector {
-        fn step(&mut self, interp: &mut Interpreter<'_, T>) {
-            self.steps += 1;
-            self.last_opcode = Some(interp.opcode());
-        }
-
-        fn step_end(&mut self, interp: &mut Interpreter<'_, T>) {
-            self.step_ends += 1;
-            if self.last_opcode == Some(self.opcode) {
-                self.stack = interp.stack().to_vec();
-                interp.set_stop(InstrStop::Revert);
-            }
-        }
-    }
 
     #[derive(Default)]
     struct SelfdestructInspector {
@@ -313,55 +248,6 @@ mod tests {
         }
     }
 
-    struct MutateCallInspector {
-        destination: Address,
-    }
-
-    impl Inspector<BaseEvmTypes> for MutateCallInspector {
-        fn call(
-            &mut self,
-            _interp: &mut Interpreter<'_, BaseEvmTypes>,
-            message: &mut Message<BaseEvmTypes>,
-        ) -> Option<MessageResult<BaseEvmTypes>> {
-            if message.depth > 0 {
-                message.destination = self.destination;
-                message.code_address = self.destination;
-            }
-            None
-        }
-    }
-
-    struct CallEndInspector;
-
-    impl Inspector<BaseEvmTypes> for CallEndInspector {
-        fn call(
-            &mut self,
-            _interp: &mut Interpreter<'_, BaseEvmTypes>,
-            message: &mut Message<BaseEvmTypes>,
-        ) -> Option<MessageResult<BaseEvmTypes>> {
-            if message.depth == 0 {
-                return None;
-            }
-            Some(MessageResult {
-                stop: InstrStop::Revert,
-                gas: GasTracker::new(message.gas_limit),
-                ..Default::default()
-            })
-        }
-
-        fn call_end(
-            &mut self,
-            _interp: &mut Interpreter<'_, BaseEvmTypes>,
-            message: &Message<BaseEvmTypes>,
-            result: &mut MessageResult<BaseEvmTypes>,
-        ) {
-            if message.depth > 0 {
-                result.stop = InstrStop::Return;
-                result.output = Bytes::from_static(&[0xaa, 0xbb]);
-            }
-        }
-    }
-
     struct OverrideCreateInspector {
         created: Address,
         create_depth: Option<u16>,
@@ -393,34 +279,6 @@ mod tests {
         }
     }
 
-    struct CreateEndInspector {
-        created: Address,
-    }
-
-    impl Inspector<BaseEvmTypes> for CreateEndInspector {
-        fn create(
-            &mut self,
-            _interp: &mut Interpreter<'_, BaseEvmTypes>,
-            message: &mut Message<BaseEvmTypes>,
-        ) -> Option<MessageResult<BaseEvmTypes>> {
-            Some(MessageResult {
-                stop: InstrStop::Revert,
-                gas: GasTracker::new(message.gas_limit),
-                ..Default::default()
-            })
-        }
-
-        fn create_end(
-            &mut self,
-            _interp: &mut Interpreter<'_, BaseEvmTypes>,
-            _message: &Message<BaseEvmTypes>,
-            result: &mut MessageResult<BaseEvmTypes>,
-        ) {
-            result.stop = InstrStop::Return;
-            result.created_address = Some(self.created);
-        }
-    }
-
     #[derive(Default)]
     struct LogInspector {
         logs: Vec<Log>,
@@ -429,23 +287,6 @@ mod tests {
     impl<T: EvmTypes> Inspector<T> for LogInspector {
         fn log(&mut self, log: &Log, _host: &mut T::Host) {
             self.logs.push(log.clone());
-        }
-    }
-
-    #[derive(Default)]
-    struct FailingStepInspector {
-        steps: usize,
-        step_ends: usize,
-    }
-
-    impl<T: EvmTypes> Inspector<T> for FailingStepInspector {
-        fn step(&mut self, _interp: &mut Interpreter<'_, T>) {
-            self.steps += 1;
-        }
-
-        fn step_end(&mut self, interp: &mut Interpreter<'_, T>) {
-            let _ = interp;
-            self.step_ends += 1;
         }
     }
 
@@ -500,12 +341,6 @@ mod tests {
         }
     }
 
-    fn push_all<const N: usize>(code: &mut Vec<u8>, values: [Word; N]) {
-        for value in values {
-            push(code, value);
-        }
-    }
-
     fn run_evm_with_inspector<I: Inspector<BaseEvmTypes> + 'static>(
         code: Vec<u8>,
         message: &Message<BaseEvmTypes>,
@@ -531,7 +366,7 @@ mod tests {
         );
         evm.set_inspector(inspector);
         let tx_env = TxEnv::default();
-        let bytecode = Bytecode::new_legacy(Bytes::from(code));
+        let bytecode = legacy_bytecode(code);
         let mut message = message.clone();
         message.gas_limit = gas_limit;
         let result = Host::execute_message(&mut evm, &tx_env, bytecode, &mut message);
@@ -569,6 +404,22 @@ mod tests {
 
     #[test]
     fn inspect_run_steps() {
+        #[derive(Default)]
+        struct StepInspector {
+            steps: usize,
+            step_ends: usize,
+        }
+
+        impl<T: EvmTypes> Inspector<T> for StepInspector {
+            fn step(&mut self, _interp: &mut Interpreter<'_, T>) {
+                self.steps += 1;
+            }
+
+            fn step_end(&mut self, _interp: &mut Interpreter<'_, T>) {
+                self.step_ends += 1;
+            }
+        }
+
         let (result, inspector, _) = run_evm_with_inspector(
             Vec::from([op::STOP]),
             &Message::default(),
@@ -583,6 +434,28 @@ mod tests {
 
     #[test]
     fn step_can_stop_before_current_opcode_executes() {
+        #[derive(Default)]
+        struct StopOnStepInspector {
+            opcode: u8,
+            steps: usize,
+            step_ends: usize,
+            stack: Vec<Word>,
+        }
+
+        impl<T: EvmTypes> Inspector<T> for StopOnStepInspector {
+            fn step(&mut self, interp: &mut Interpreter<'_, T>) {
+                self.steps += 1;
+                if interp.opcode() == self.opcode {
+                    self.stack = interp.stack().to_vec();
+                    interp.set_stop(InstrStop::Revert);
+                }
+            }
+
+            fn step_end(&mut self, _interp: &mut Interpreter<'_, T>) {
+                self.step_ends += 1;
+            }
+        }
+
         let (result, inspector, _) = run_evm_with_inspector(
             Vec::from([op::PUSH1, 1, op::PUSH1, 2, op::ADD, op::STOP]),
             &Message::default(),
@@ -598,6 +471,30 @@ mod tests {
 
     #[test]
     fn step_end_can_stop_before_next_opcode_executes() {
+        #[derive(Default)]
+        struct StopOnStepEndInspector {
+            opcode: u8,
+            last_opcode: Option<u8>,
+            steps: usize,
+            step_ends: usize,
+            stack: Vec<Word>,
+        }
+
+        impl<T: EvmTypes> Inspector<T> for StopOnStepEndInspector {
+            fn step(&mut self, interp: &mut Interpreter<'_, T>) {
+                self.steps += 1;
+                self.last_opcode = Some(interp.opcode());
+            }
+
+            fn step_end(&mut self, interp: &mut Interpreter<'_, T>) {
+                self.step_ends += 1;
+                if self.last_opcode == Some(self.opcode) {
+                    self.stack = interp.stack().to_vec();
+                    interp.set_stop(InstrStop::Revert);
+                }
+            }
+        }
+
         let (result, inspector, _) = run_evm_with_inspector(
             Vec::from([op::PUSH1, 1, op::PUSH1, 2, op::ADD, op::STOP]),
             &Message::default(),
@@ -685,6 +582,24 @@ mod tests {
 
     #[test]
     fn call_inspector_can_mutate_message_before_execution() {
+        struct MutateCallInspector {
+            destination: Address,
+        }
+
+        impl Inspector<BaseEvmTypes> for MutateCallInspector {
+            fn call(
+                &mut self,
+                _interp: &mut Interpreter<'_, BaseEvmTypes>,
+                message: &mut Message<BaseEvmTypes>,
+            ) -> Option<MessageResult<BaseEvmTypes>> {
+                if message.depth > 0 {
+                    message.destination = self.destination;
+                    message.code_address = self.destination;
+                }
+                None
+            }
+        }
+
         let target = Address::from([0x22; 20]);
         let replacement = Address::from([0x33; 20]);
         let mut db = InMemoryDB::default();
@@ -716,7 +631,7 @@ mod tests {
         );
         evm.set_inspector(MutateCallInspector { destination: replacement });
         let tx_env = TxEnv::default();
-        let bytecode = Bytecode::new_legacy(Bytes::from(code));
+        let bytecode = legacy_bytecode(code);
         let mut message = Message { gas_limit: 100_000, ..Default::default() };
         let result = Host::execute_message(&mut evm, &tx_env, bytecode, &mut message);
 
@@ -734,6 +649,37 @@ mod tests {
 
     #[test]
     fn call_end_can_mutate_result_before_caller_observes_it() {
+        struct CallEndInspector;
+
+        impl Inspector<BaseEvmTypes> for CallEndInspector {
+            fn call(
+                &mut self,
+                _interp: &mut Interpreter<'_, BaseEvmTypes>,
+                message: &mut Message<BaseEvmTypes>,
+            ) -> Option<MessageResult<BaseEvmTypes>> {
+                if message.depth == 0 {
+                    return None;
+                }
+                Some(MessageResult {
+                    stop: InstrStop::Revert,
+                    gas: GasTracker::new(message.gas_limit),
+                    ..Default::default()
+                })
+            }
+
+            fn call_end(
+                &mut self,
+                _interp: &mut Interpreter<'_, BaseEvmTypes>,
+                message: &Message<BaseEvmTypes>,
+                result: &mut MessageResult<BaseEvmTypes>,
+            ) {
+                if message.depth > 0 {
+                    result.stop = InstrStop::Return;
+                    result.output = Bytes::from_static(&[0xaa, 0xbb]);
+                }
+            }
+        }
+
         let target = Address::from([0x22; 20]);
         let mut code = call_code(target);
         code.extend([op::CALL, op::POP, op::RETURNDATASIZE]);
@@ -824,6 +770,34 @@ mod tests {
 
     #[test]
     fn create_end_can_mutate_result_before_caller_observes_it() {
+        struct CreateEndInspector {
+            created: Address,
+        }
+
+        impl Inspector<BaseEvmTypes> for CreateEndInspector {
+            fn create(
+                &mut self,
+                _interp: &mut Interpreter<'_, BaseEvmTypes>,
+                message: &mut Message<BaseEvmTypes>,
+            ) -> Option<MessageResult<BaseEvmTypes>> {
+                Some(MessageResult {
+                    stop: InstrStop::Revert,
+                    gas: GasTracker::new(message.gas_limit),
+                    ..Default::default()
+                })
+            }
+
+            fn create_end(
+                &mut self,
+                _interp: &mut Interpreter<'_, BaseEvmTypes>,
+                _message: &Message<BaseEvmTypes>,
+                result: &mut MessageResult<BaseEvmTypes>,
+            ) {
+                result.stop = InstrStop::Return;
+                result.created_address = Some(self.created);
+            }
+        }
+
         let created = Address::from([0x88; 20]);
         let mut code = create_code();
         code.extend([op::CREATE]);
@@ -872,6 +846,23 @@ mod tests {
 
     #[test]
     fn step_end_runs_for_failing_opcode_with_result_set() {
+        #[derive(Default)]
+        struct FailingStepInspector {
+            steps: usize,
+            step_ends: usize,
+        }
+
+        impl<T: EvmTypes> Inspector<T> for FailingStepInspector {
+            fn step(&mut self, _interp: &mut Interpreter<'_, T>) {
+                self.steps += 1;
+            }
+
+            fn step_end(&mut self, interp: &mut Interpreter<'_, T>) {
+                let _ = interp;
+                self.step_ends += 1;
+            }
+        }
+
         let (result, inspector, _) = run_evm_with_inspector(
             Vec::from([op::INVALID]),
             &Message::default(),
@@ -933,15 +924,17 @@ mod tests {
     fn selfdestruct_host_error_is_not_inspected() {
         // Host failures are injected through the mock host; this intentionally uses [`TestHost`].
         let target = Address::from([0x99; 20]);
-        let mut host = TestHost::default();
-        host.selfdestruct_error = Some(InstrStop::FatalExternalError);
+        let mut host = TestHost {
+            selfdestruct_error: Some(InstrStop::FatalExternalError),
+            ..Default::default()
+        };
         let mut inspector = SelfdestructInspector::default();
         let mut code = Vec::new();
         push(&mut code, address_to_word(&target));
         code.push(op::SELFDESTRUCT);
 
         let tx_env = TxEnv::default();
-        let bytecode = Bytecode::new_legacy(Bytes::from(code));
+        let bytecode = legacy_bytecode(code);
         let message = Message::<TestTypes> { gas_limit: 10_000, ..Default::default() };
         let mut interp = Interpreter::<TestTypes>::new(bytecode, &tx_env, &message);
         let config = ExecutionConfig::for_base_spec::<BaseEvmConfigSelector>(SpecId::OSAKA);

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -1569,6 +1569,7 @@ mod tests {
         ethereum::RecoveredTxEnvelope,
         interpreter::{GasTracker, Interpreter, MessageKind, op},
         registry::TxRequest,
+        test_utils::{legacy_bytecode, push_address},
     };
     use alloc::{string::ToString, sync::Arc, vec, vec::Vec};
     use alloy_consensus::{TxLegacy, transaction::Recovered};
@@ -1595,49 +1596,27 @@ mod tests {
         Ok(TxResult { status: true, gas_used: req.tx.nonce + 1, ..TxResult::default() })
     }
 
-    fn handle_test_tx_version(
-        req: TxRequest<'_, BaseEvmTypes, Recovered<TxLegacy>>,
-    ) -> HandlerResult<TxResult> {
-        Ok(TxResult {
-            status: true,
-            gas_used: req.host.version().tx_gas_limit_cap,
-            ..TxResult::default()
-        })
-    }
-
-    fn push_word(code: &mut Vec<u8>, value: Word) {
-        let bytes = value.to_be_bytes::<32>();
-        let first_nonzero = bytes.iter().position(|byte| *byte != 0).unwrap_or(31);
-        let data = &bytes[first_nonzero..];
-        code.push(op::PUSH1 + data.len() as u8 - 1);
-        code.extend_from_slice(data);
-    }
-
-    fn push_address(code: &mut Vec<u8>, address: &Address) {
-        push_word(code, Word::from_be_slice(address.as_slice()));
-    }
-
     const LIFECYCLE_ACCOUNT: Address = Address::with_last_byte(0x7a);
     const LIFECYCLE_STORAGE_KEY: Word = Word::from_limbs([1, 0, 0, 0]);
 
-    fn handle_lifecycle_tx(
-        req: TxRequest<'_, BaseEvmTypes, Recovered<TxLegacy>>,
-    ) -> HandlerResult<TxResult> {
-        let value = Word::from(req.tx.nonce);
-        req.host
-            .state
-            .storage(&LIFECYCLE_ACCOUNT)
-            .into_slot(LIFECYCLE_STORAGE_KEY, false)
-            .map_err(registry::HandlerError::Database)?
-            .write(value);
-        req.host.state.log(Log {
-            address: LIFECYCLE_ACCOUNT,
-            data: LogData::new_unchecked(vec![], Bytes::new()),
-        });
-        Ok(TxResult { status: true, gas_used: req.tx.nonce, ..TxResult::default() })
-    }
-
     fn lifecycle_evm() -> Evm<BaseEvmTypes> {
+        fn handle_lifecycle_tx(
+            req: TxRequest<'_, BaseEvmTypes, Recovered<TxLegacy>>,
+        ) -> HandlerResult<TxResult> {
+            let value = Word::from(req.tx.nonce);
+            req.host
+                .state
+                .storage(&LIFECYCLE_ACCOUNT)
+                .into_slot(LIFECYCLE_STORAGE_KEY, false)
+                .map_err(registry::HandlerError::Database)?
+                .write(value);
+            req.host.state.log(Log {
+                address: LIFECYCLE_ACCOUNT,
+                data: LogData::new_unchecked(vec![], Bytes::new()),
+            });
+            Ok(TxResult { status: true, gas_used: req.tx.nonce, ..TxResult::default() })
+        }
+
         let registry = TxRegistry::new().with_handler(
             TEST_TX_TYPE,
             RecoveredTxEnvelope::as_legacy,
@@ -2084,6 +2063,16 @@ mod tests {
 
     #[test]
     fn dispatches_transaction_with_dynamic_version() {
+        fn handle_test_tx_version(
+            req: TxRequest<'_, BaseEvmTypes, Recovered<TxLegacy>>,
+        ) -> HandlerResult<TxResult> {
+            Ok(TxResult {
+                status: true,
+                gas_used: req.host.version().tx_gas_limit_cap,
+                ..TxResult::default()
+            })
+        }
+
         let registry = TxRegistry::new().with_handler(
             TEST_TX_TYPE,
             RecoveredTxEnvelope::as_legacy,
@@ -2282,42 +2271,49 @@ mod tests {
         assert!(result.stop.is_success());
     }
 
-    #[derive(Debug)]
-    struct FailingDbError;
-
-    impl fmt::Display for FailingDbError {
-        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            f.write_str("storage read failed")
-        }
-    }
-
-    impl Error for FailingDbError {}
-
-    #[derive(Debug, Default)]
-    struct FailingStorageDb;
-
-    impl Database for FailingStorageDb {
-        type Error = FailingDbError;
-
-        fn get_account(&mut self, _address: &Address) -> Result<Option<AccountInfo>, Self::Error> {
-            Ok(Some(AccountInfo::default()))
-        }
-
-        fn get_code_by_hash(&mut self, _code_hash: &B256) -> Result<Bytecode, Self::Error> {
-            Ok(Bytecode::default())
-        }
-
-        fn get_storage(&mut self, _address: &Address, _key: &Word) -> Result<Word, Self::Error> {
-            Err(FailingDbError)
-        }
-
-        fn get_block_hash(&mut self, _number: &Word) -> Result<Option<B256>, Self::Error> {
-            Ok(None)
-        }
-    }
-
     #[test]
     fn host_records_database_error_code() {
+        #[derive(Debug)]
+        struct FailingDbError;
+
+        impl fmt::Display for FailingDbError {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.write_str("storage read failed")
+            }
+        }
+
+        impl Error for FailingDbError {}
+
+        #[derive(Debug, Default)]
+        struct FailingStorageDb;
+
+        impl Database for FailingStorageDb {
+            type Error = FailingDbError;
+
+            fn get_account(
+                &mut self,
+                _address: &Address,
+            ) -> Result<Option<AccountInfo>, Self::Error> {
+                Ok(Some(AccountInfo::default()))
+            }
+
+            fn get_code_by_hash(&mut self, _code_hash: &B256) -> Result<Bytecode, Self::Error> {
+                Ok(Bytecode::default())
+            }
+
+            fn get_storage(
+                &mut self,
+                _address: &Address,
+                _key: &Word,
+            ) -> Result<Word, Self::Error> {
+                Err(FailingDbError)
+            }
+
+            fn get_block_hash(&mut self, _number: &Word) -> Result<Option<B256>, Self::Error> {
+                Ok(None)
+            }
+        }
+
         let mut evm = Evm::<BaseEvmTypes>::new(
             SpecId::OSAKA,
             BlockEnv::default(),
@@ -2369,56 +2365,63 @@ mod tests {
         assert!(!evm.state.storage(&contract).is_warm(&key));
     }
 
-    #[derive(Clone, Debug)]
-    struct SelfdestructTargetLoadDb {
-        target: Address,
-        target_reads: Arc<AtomicUsize>,
-    }
-
-    #[derive(Clone, Debug, PartialEq, Eq)]
-    struct SelfdestructTargetLoadError;
-
-    impl fmt::Display for SelfdestructTargetLoadError {
-        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            f.write_str("selfdestruct target account was loaded")
-        }
-    }
-
-    impl Error for SelfdestructTargetLoadError {}
-
-    impl Database for SelfdestructTargetLoadDb {
-        type Error = SelfdestructTargetLoadError;
-
-        fn get_account(&mut self, address: &Address) -> Result<Option<AccountInfo>, Self::Error> {
-            if *address == self.target {
-                self.target_reads.fetch_add(1, Ordering::SeqCst);
-                return Err(SelfdestructTargetLoadError);
-            }
-            Ok(Some(AccountInfo::default().with_balance(Word::from(1))))
-        }
-
-        fn get_code_by_hash(&mut self, _code_hash: &B256) -> Result<Bytecode, Self::Error> {
-            Ok(Bytecode::default())
-        }
-
-        fn get_storage(&mut self, _address: &Address, _key: &Word) -> Result<Word, Self::Error> {
-            Ok(Word::ZERO)
-        }
-
-        fn get_block_hash(&mut self, _number: &Word) -> Result<Option<B256>, Self::Error> {
-            Ok(None)
-        }
-    }
-
-    fn selfdestruct_to_code(target: &Address) -> Bytecode {
-        let mut code = Vec::new();
-        push_address(&mut code, target);
-        code.push(op::SELFDESTRUCT);
-        Bytecode::new_legacy(Bytes::from(code))
-    }
-
     #[test]
     fn unaffordable_cold_target_selfdestruct_does_not_load_target_account() {
+        #[derive(Clone, Debug)]
+        struct SelfdestructTargetLoadDb {
+            target: Address,
+            target_reads: Arc<AtomicUsize>,
+        }
+
+        #[derive(Clone, Debug, PartialEq, Eq)]
+        struct SelfdestructTargetLoadError;
+
+        impl fmt::Display for SelfdestructTargetLoadError {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.write_str("selfdestruct target account was loaded")
+            }
+        }
+
+        impl Error for SelfdestructTargetLoadError {}
+
+        impl Database for SelfdestructTargetLoadDb {
+            type Error = SelfdestructTargetLoadError;
+
+            fn get_account(
+                &mut self,
+                address: &Address,
+            ) -> Result<Option<AccountInfo>, Self::Error> {
+                if *address == self.target {
+                    self.target_reads.fetch_add(1, Ordering::SeqCst);
+                    return Err(SelfdestructTargetLoadError);
+                }
+                Ok(Some(AccountInfo::default().with_balance(Word::from(1))))
+            }
+
+            fn get_code_by_hash(&mut self, _code_hash: &B256) -> Result<Bytecode, Self::Error> {
+                Ok(Bytecode::default())
+            }
+
+            fn get_storage(
+                &mut self,
+                _address: &Address,
+                _key: &Word,
+            ) -> Result<Word, Self::Error> {
+                Ok(Word::ZERO)
+            }
+
+            fn get_block_hash(&mut self, _number: &Word) -> Result<Option<B256>, Self::Error> {
+                Ok(None)
+            }
+        }
+
+        fn selfdestruct_to_code(target: &Address) -> Bytecode {
+            let mut code = Vec::new();
+            push_address(&mut code, target);
+            code.push(op::SELFDESTRUCT);
+            legacy_bytecode(code)
+        }
+
         let contract = Address::from([0xbb; 20]);
         let target = Address::from([0xcc; 20]);
         let target_reads = Arc::new(AtomicUsize::new(0));

--- a/crates/evm2/src/interpreter/instructions/arithmetic.rs
+++ b/crates/evm2/src/interpreter/instructions/arithmetic.rs
@@ -64,14 +64,13 @@ pub(crate) fn signextend([ext, value]: [Word]) -> out {
 
 #[cfg(test)]
 mod tests {
-    use alloc::vec::Vec;
-    use core::assert_matches;
-
     use crate::{
         SpecId,
         interpreter::{InstrStop, Word, op},
         test_utils::{RunConfig, assert_stack, neg, push, run},
     };
+    use alloc::vec::Vec;
+    use core::assert_matches;
 
     #[test]
     fn add_opcode() {

--- a/crates/evm2/src/interpreter/instructions/arithmetic.rs
+++ b/crates/evm2/src/interpreter/instructions/arithmetic.rs
@@ -69,16 +69,9 @@ mod tests {
 
     use crate::{
         SpecId,
-        interpreter::{
-            InstrStop, Word,
-            instructions::tests::{RunConfig, assert_stack, push, run},
-            op,
-        },
+        interpreter::{InstrStop, Word, op},
+        test_utils::{RunConfig, assert_stack, neg, push, run},
     };
-
-    fn neg(value: u64) -> Word {
-        Word::from(0).wrapping_sub(Word::from(value))
-    }
 
     #[test]
     fn add_opcode() {

--- a/crates/evm2/src/interpreter/instructions/bitwise.rs
+++ b/crates/evm2/src/interpreter/instructions/bitwise.rs
@@ -90,11 +90,10 @@ pub(crate) fn clz([value]: [Word]) -> out {
 
 #[cfg(test)]
 mod tests {
-    use crate::interpreter::{Word, instructions::tests::assert_stack};
-
-    fn neg(value: u64) -> Word {
-        Word::from(0).wrapping_sub(Word::from(value))
-    }
+    use crate::{
+        interpreter::Word,
+        test_utils::{assert_stack, neg},
+    };
 
     #[test]
     fn lt_opcode() {

--- a/crates/evm2/src/interpreter/instructions/block.rs
+++ b/crates/evm2/src/interpreter/instructions/block.rs
@@ -89,11 +89,8 @@ mod tests {
     use crate::{
         SpecId,
         env::{BlockEnv, TxEnv},
-        interpreter::{
-            InstrStop, Message, Word,
-            instructions::tests::{RunConfig, TestHost, TestTypes, push, run},
-            op,
-        },
+        interpreter::{InstrStop, Message, Word, op},
+        test_utils::{RunConfig, TestHost, TestTypes, push, run},
         utils::{address_to_word, b256_to_word},
     };
     use alloc::vec::Vec;

--- a/crates/evm2/src/interpreter/instructions/control.rs
+++ b/crates/evm2/src/interpreter/instructions/control.rs
@@ -97,10 +97,9 @@ pub(crate) fn invalid() -> Result {
 
 #[cfg(test)]
 mod tests {
-    use crate::interpreter::{
-        InstrStop, Word,
-        instructions::tests::{RunConfig, push, run, run_stack},
-        op,
+    use crate::{
+        interpreter::{InstrStop, Word, op},
+        test_utils::{RunConfig, push, run, run_stack},
     };
     use alloc::vec::Vec;
     use core::assert_matches;

--- a/crates/evm2/src/interpreter/instructions/crypto.rs
+++ b/crates/evm2/src/interpreter/instructions/crypto.rs
@@ -22,11 +22,8 @@ pub(crate) fn keccak256(cx: _, [offset, len]: [Word]) -> Result<out> {
 #[cfg(test)]
 mod tests {
     use crate::{
-        interpreter::{
-            InstrStop, Word,
-            instructions::tests::{RunConfig, push, run, run_stack},
-            op,
-        },
+        interpreter::{InstrStop, Word, op},
+        test_utils::{RunConfig, push, run, run_stack},
         utils::b256_to_word,
     };
     use alloc::vec::Vec;

--- a/crates/evm2/src/interpreter/instructions/env.rs
+++ b/crates/evm2/src/interpreter/instructions/env.rs
@@ -168,12 +168,9 @@ mod tests {
     use crate::{
         SpecId,
         env::TxEnv,
-        interpreter::{
-            InstrStop, Message, Word,
-            instructions::tests::{
-                RunConfig, TestHost, TestTypes, assert_stack, push, run, run_stack,
-            },
-            op,
+        interpreter::{InstrStop, Message, Word, op},
+        test_utils::{
+            RunConfig, TestHost, TestTypes, assert_stack, neg, push, run, run_stack, stack_code,
         },
         utils::{address_to_word, b256_to_word},
     };
@@ -181,21 +178,8 @@ mod tests {
     use alloy_primitives::{Address, B256, Bytes};
     use core::assert_matches;
 
-    fn neg(value: u64) -> Word {
-        Word::from(0).wrapping_sub(Word::from(value))
-    }
-
     fn test_message() -> Message<TestTypes> {
         Message { gas_limit: 10_000, ..Message::default() }
-    }
-
-    fn stack_code<const N: usize>(inputs: [Word; N], opcode: u8) -> Vec<u8> {
-        let mut code = Vec::new();
-        for input in inputs.into_iter().rev() {
-            push(&mut code, input);
-        }
-        code.extend([opcode, op::STOP]);
-        code
     }
 
     #[test]

--- a/crates/evm2/src/interpreter/instructions/host.rs
+++ b/crates/evm2/src/interpreter/instructions/host.rs
@@ -129,12 +129,9 @@ fn log_common<T: EvmTypes>(
 mod tests {
     use crate::{
         SpecId,
-        interpreter::{
-            InstrStop, Message, MessageKind, Word,
-            instructions::tests::{RunConfig, TestHost, push, run},
-            op,
-        },
+        interpreter::{InstrStop, Message, MessageKind, Word, op},
         storage_key::StorageKey,
+        test_utils::{RunConfig, TestHost, push, run},
     };
     use alloc::vec::Vec;
     use alloy_primitives::{Address, B256, Bytes};

--- a/crates/evm2/src/interpreter/instructions/macro_tests.rs
+++ b/crates/evm2/src/interpreter/instructions/macro_tests.rs
@@ -1,13 +1,11 @@
-use super::tests::{RunConfig, TestHost, TestInterpreter, TestTypes, push};
 use crate::{
     BaseEvmConfig, EvmConfig, ExecutionConfig, SpecId,
-    bytecode::Bytecode,
     env::BlockEnv,
     interpreter::{Host, InstrStop, Interpreter, Word, op},
+    test_utils::{RunConfig, TestHost, TestInterpreter, TestTypes, legacy_bytecode, push},
     version::OpcodeConfig,
 };
 use alloc::vec::Vec;
-use alloy_primitives::Bytes;
 use evm2_macros::instruction;
 
 const ADD_OPCODE: u8 = 0x0c;
@@ -81,7 +79,7 @@ const fn macro_opcode_config() -> OpcodeConfig<TestTypes> {
 fn run(config: RunConfig<'_>) -> TestInterpreter {
     let execution_config = ExecutionConfig::<TestTypes>::for_config::<MacroConfig>();
     let RunConfig { code, host, spec_id, tx_env, mut message, gas_limit, return_data } = config;
-    let bytecode = Bytecode::new_legacy(Bytes::from(code));
+    let bytecode = legacy_bytecode(code);
     message.gas_limit = gas_limit;
     let mut inner = Interpreter::<TestTypes>::new(bytecode, &tx_env, &message);
     inner.set_return_data(return_data);

--- a/crates/evm2/src/interpreter/instructions/memory.rs
+++ b/crates/evm2/src/interpreter/instructions/memory.rs
@@ -46,16 +46,11 @@ pub(crate) fn mcopy(cx: _, [dst, src, len]: [Word]) -> Result {
 mod tests {
     use crate::{
         ExecutionConfig, SpecId, Version,
-        bytecode::Bytecode,
         env::TxEnv,
-        interpreter::{
-            InstrStop, Interpreter, Message, Word,
-            instructions::tests::{RunConfig, TestHost, TestTypes, push, run, run_stack},
-            op,
-        },
+        interpreter::{InstrStop, Interpreter, Message, Word, op},
+        test_utils::{RunConfig, TestHost, TestTypes, legacy_bytecode, push, run, run_stack},
     };
     use alloc::vec::Vec;
-    use alloy_primitives::Bytes;
     use core::assert_matches;
 
     #[test]
@@ -110,7 +105,7 @@ mod tests {
 
         let tx_env = TxEnv::default();
         let message = Message { gas_limit: 10_000, ..Message::default() };
-        let bytecode = Bytecode::new_legacy(Bytes::from(code));
+        let bytecode = legacy_bytecode(code);
         let mut interp = Interpreter::<TestTypes>::new(bytecode, &tx_env, &message);
         let mut host = TestHost::default();
         let err = interp.run(&config, &mut host);

--- a/crates/evm2/src/interpreter/instructions/memory.rs
+++ b/crates/evm2/src/interpreter/instructions/memory.rs
@@ -125,7 +125,7 @@ mod tests {
 
         let tx_env = TxEnv::default();
         let message = Message { gas_limit: 17, ..Message::default() };
-        let bytecode = Bytecode::new_legacy(Bytes::from(code));
+        let bytecode = legacy_bytecode(code);
         let mut interp = Interpreter::<TestTypes>::new(bytecode, &tx_env, &message);
         let mut host = TestHost::default();
         let err = interp.run(&config, &mut host);

--- a/crates/evm2/src/interpreter/instructions/mod.rs
+++ b/crates/evm2/src/interpreter/instructions/mod.rs
@@ -32,6 +32,3 @@ mod i256;
 
 #[cfg(test)]
 mod macro_tests;
-
-#[cfg(test)]
-pub(crate) mod tests;

--- a/crates/evm2/src/interpreter/instructions/stack.rs
+++ b/crates/evm2/src/interpreter/instructions/stack.rs
@@ -62,11 +62,8 @@ const fn decode_pair(x: u8) -> Option<(usize, usize)> {
 mod tests {
     use crate::{
         SpecId,
-        interpreter::{
-            InstrStop, StackMut, Word,
-            instructions::tests::{RunConfig, push, run, run_stack},
-            op,
-        },
+        interpreter::{InstrStop, StackMut, Word, op},
+        test_utils::{RunConfig, push, run, run_stack},
     };
     use alloc::{vec, vec::Vec};
     use core::assert_matches;

--- a/crates/evm2/src/interpreter/instructions/system.rs
+++ b/crates/evm2/src/interpreter/instructions/system.rs
@@ -368,22 +368,13 @@ mod tests {
     use crate::{
         SpecId,
         constants::{CALL_DEPTH_LIMIT, MAX_INITCODE_SIZE},
-        interpreter::{
-            InstrStop, Message, MessageKind, MessageResult, Word,
-            instructions::tests::{RunConfig, TestHost, push, run},
-            op,
-        },
+        interpreter::{InstrStop, Message, MessageKind, MessageResult, Word, op},
+        test_utils::{RunConfig, TestHost, push, push_all, run},
         utils::address_to_word,
     };
     use alloc::vec::Vec;
     use alloy_primitives::{Address, Bytes};
     use core::assert_matches;
-
-    fn push_all<const N: usize>(code: &mut Vec<u8>, values: [Word; N]) {
-        for value in values {
-            push(code, value);
-        }
-    }
 
     #[test]
     fn call_opcode() {

--- a/crates/evm2/src/lib.rs
+++ b/crates/evm2/src/lib.rs
@@ -32,6 +32,9 @@ pub use precompiles::{
 
 pub(crate) mod trustme;
 
+#[cfg(test)]
+pub(crate) mod test_utils;
+
 pub mod version;
 pub use version::{EvmFeatures, OpcodeConfig, Version};
 

--- a/crates/evm2/src/test_utils.rs
+++ b/crates/evm2/src/test_utils.rs
@@ -31,24 +31,24 @@ impl EvmTypes for TestTypes {
 
 #[derive(Debug)]
 pub(crate) struct TestHost {
-    pub(super) spec_id: SpecId,
-    pub(super) block: BlockEnv<TestTypes>,
-    pub(super) code_hash: B256,
-    pub(super) code: Bytes,
-    pub(super) exists: bool,
-    pub(super) is_empty: bool,
-    pub(super) is_cold: bool,
-    pub(super) is_touched: bool,
-    pub(super) storage: StorageKeyMap<Word>,
-    pub(super) original_storage: StorageKeyMap<Word>,
-    pub(super) transient_storage: StorageKeyMap<Word>,
+    pub(crate) spec_id: SpecId,
+    pub(crate) block: BlockEnv<TestTypes>,
+    pub(crate) code_hash: B256,
+    pub(crate) code: Bytes,
+    pub(crate) exists: bool,
+    pub(crate) is_empty: bool,
+    pub(crate) is_cold: bool,
+    pub(crate) is_touched: bool,
+    pub(crate) storage: StorageKeyMap<Word>,
+    pub(crate) original_storage: StorageKeyMap<Word>,
+    pub(crate) transient_storage: StorageKeyMap<Word>,
     pub(crate) logs: Vec<Log>,
-    pub(super) execute_result: MessageResult<TestTypes>,
+    pub(crate) execute_result: MessageResult<TestTypes>,
     pub(crate) selfdestruct_result: SelfDestructResult,
     pub(crate) selfdestruct_error: Option<InstrStop>,
     pub(crate) calls: Vec<Message<TestTypes>>,
-    pub(super) call_static_flags: Vec<bool>,
-    pub(super) selfdestructs: Vec<(Address, Address, bool)>,
+    pub(crate) call_static_flags: Vec<bool>,
+    pub(crate) selfdestructs: Vec<(Address, Address, bool)>,
 }
 
 impl Default for TestHost {
@@ -213,87 +213,87 @@ impl Host<TestTypes> for TestHost {
     }
 }
 
-pub(super) struct TestInterpreter {
-    pub(super) stack: Box<StackBacking>,
-    pub(super) stack_len: usize,
-    pub(super) gas: Gas,
-    pub(super) memory: Memory,
-    pub(super) output: Range<u32>,
-    pub(super) err: InstrStop,
+pub(crate) struct TestInterpreter {
+    pub(crate) stack: Box<StackBacking>,
+    pub(crate) stack_len: usize,
+    pub(crate) gas: Gas,
+    pub(crate) memory: Memory,
+    pub(crate) output: Range<u32>,
+    pub(crate) err: InstrStop,
 }
 
 impl TestInterpreter {
-    pub(super) fn stack(&self) -> &[Word] {
+    pub(crate) fn stack(&self) -> &[Word] {
         unsafe { core::slice::from_raw_parts(self.stack.as_ptr().cast(), self.stack_len) }
     }
 
-    pub(super) fn memory(&mut self, offset: usize, len: usize) -> &[u8] {
+    pub(crate) fn memory(&mut self, offset: usize, len: usize) -> &[u8] {
         self.memory.slice(offset, len)
     }
 
-    pub(super) fn gas_remaining(&self) -> u64 {
+    pub(crate) fn gas_remaining(&self) -> u64 {
         self.gas.remaining()
     }
 
-    pub(super) fn gas_refunded(&self) -> i64 {
+    pub(crate) fn gas_refunded(&self) -> i64 {
         self.gas.refunded()
     }
 
-    pub(super) fn state_gas_spent(&self) -> u64 {
+    pub(crate) fn state_gas_spent(&self) -> u64 {
         self.gas.state_gas_spent()
     }
 
-    pub(super) fn output(&self) -> &[u8] {
+    pub(crate) fn output(&self) -> &[u8] {
         self.memory.slice(self.output.start as usize, self.output.len())
     }
 }
 
-pub(super) struct RunConfig<'a> {
-    pub(super) code: Vec<u8>,
-    pub(super) host: Option<&'a mut TestHost>,
-    pub(super) spec_id: SpecId,
-    pub(super) tx_env: TxEnv<TestTypes>,
-    pub(super) message: Message<TestTypes>,
-    pub(super) gas_limit: u64,
-    pub(super) return_data: Bytes,
+pub(crate) struct RunConfig<'a> {
+    pub(crate) code: Vec<u8>,
+    pub(crate) host: Option<&'a mut TestHost>,
+    pub(crate) spec_id: SpecId,
+    pub(crate) tx_env: TxEnv<TestTypes>,
+    pub(crate) message: Message<TestTypes>,
+    pub(crate) gas_limit: u64,
+    pub(crate) return_data: Bytes,
 }
 
 impl<'a> RunConfig<'a> {
-    pub(super) fn new(code: impl Into<Vec<u8>>) -> Self {
+    pub(crate) fn new(code: impl Into<Vec<u8>>) -> Self {
         Self { code: code.into(), ..Self::default() }
     }
 
-    pub(super) fn host(mut self, host: &'a mut TestHost) -> Self {
+    pub(crate) fn host(mut self, host: &'a mut TestHost) -> Self {
         self.host = Some(host);
         self
     }
 
-    pub(super) const fn spec(mut self, spec_id: SpecId) -> Self {
+    pub(crate) const fn spec(mut self, spec_id: SpecId) -> Self {
         self.spec_id = spec_id;
         self
     }
 
-    pub(super) fn tx_env(mut self, tx_env: TxEnv<TestTypes>) -> Self {
+    pub(crate) fn tx_env(mut self, tx_env: TxEnv<TestTypes>) -> Self {
         self.tx_env = tx_env;
         self
     }
 
-    pub(super) fn message(mut self, message: Message<TestTypes>) -> Self {
+    pub(crate) fn message(mut self, message: Message<TestTypes>) -> Self {
         self.message = message;
         self
     }
 
-    pub(super) fn staticcall(mut self) -> Self {
+    pub(crate) fn staticcall(mut self) -> Self {
         self.message.kind = MessageKind::StaticCall;
         self
     }
 
-    pub(super) const fn gas_limit(mut self, gas_limit: u64) -> Self {
+    pub(crate) const fn gas_limit(mut self, gas_limit: u64) -> Self {
         self.gas_limit = gas_limit;
         self
     }
 
-    pub(super) fn return_data(mut self, return_data: Bytes) -> Self {
+    pub(crate) fn return_data(mut self, return_data: Bytes) -> Self {
         self.return_data = return_data;
         self
     }
@@ -313,9 +313,9 @@ impl Default for RunConfig<'_> {
     }
 }
 
-pub(super) fn run(config: RunConfig<'_>) -> TestInterpreter {
+pub(crate) fn run(config: RunConfig<'_>) -> TestInterpreter {
     let RunConfig { code, host, spec_id, tx_env, mut message, gas_limit, return_data } = config;
-    let bytecode = Bytecode::new_legacy(Bytes::from(code));
+    let bytecode = legacy_bytecode(code);
     message.gas_limit = gas_limit;
     let mut inner = Interpreter::<TestTypes>::new(bytecode, &tx_env, &message);
     inner.set_return_data(return_data);
@@ -356,16 +356,20 @@ impl ToWord for usize {
     }
 }
 
-pub(super) fn run_stack<T: ToWord, const N: usize>(inputs: [T; N], opcode: u8) -> TestInterpreter {
+pub(crate) fn stack_code<T: ToWord, const N: usize>(inputs: [T; N], opcode: u8) -> Vec<u8> {
     let mut code = Vec::new();
     for input in inputs.into_iter().rev() {
         push(&mut code, input);
     }
     code.extend([opcode, op::STOP]);
-    run(RunConfig::new(code))
+    code
 }
 
-pub(super) fn assert_stack_words(inputs: &[Word], opcode: u8, expected: &[Word]) {
+pub(crate) fn run_stack<T: ToWord, const N: usize>(inputs: [T; N], opcode: u8) -> TestInterpreter {
+    run(RunConfig::new(stack_code(inputs, opcode)))
+}
+
+pub(crate) fn assert_stack_words(inputs: &[Word], opcode: u8, expected: &[Word]) {
     let mut code = Vec::new();
     for input in inputs.iter().rev() {
         push(&mut code, *input);
@@ -380,7 +384,7 @@ macro_rules! assert_stack {
     ($op:ident($($input:expr),* $(,)?), $expected:expr $(,)?) => {{
         let inputs = [$($crate::interpreter::Word::from($input)),*];
         let expected = [$crate::interpreter::Word::from($expected)];
-        $crate::interpreter::instructions::tests::assert_stack_words(
+        $crate::test_utils::assert_stack_words(
             &inputs,
             $crate::interpreter::op::$op,
             &expected,
@@ -401,4 +405,22 @@ pub(crate) fn push(code: &mut Vec<u8>, value: impl ToWord) {
     let len = bytes.len() - start;
     code.push(op::PUSH1 + len as u8 - 1);
     code.extend_from_slice(&bytes[start..]);
+}
+
+pub(crate) fn push_all<T: ToWord, const N: usize>(code: &mut Vec<u8>, values: [T; N]) {
+    for value in values {
+        push(code, value);
+    }
+}
+
+pub(crate) fn push_address(code: &mut Vec<u8>, address: &Address) {
+    push(code, Word::from_be_slice(address.as_slice()));
+}
+
+pub(crate) fn neg(value: u64) -> Word {
+    Word::ZERO.wrapping_sub(Word::from(value))
+}
+
+pub(crate) fn legacy_bytecode(code: impl Into<Vec<u8>>) -> Bytecode {
+    Bytecode::new_legacy(Bytes::from(code.into()))
 }

--- a/crates/evm2/src/tests.rs
+++ b/crates/evm2/src/tests.rs
@@ -1,13 +1,13 @@
 use crate::{
     BaseEvmTypes, Evm, Precompiles, SpecId,
-    bytecode::Bytecode,
     env::{BlockEnv, TxEnv},
     evm::{AccountInfo, InMemoryDB},
-    interpreter::{Host, InstrStop, Message, Word, instructions::tests::push, op},
+    interpreter::{Host, InstrStop, Message, Word, op},
     registry::TxRegistry,
+    test_utils::{legacy_bytecode, push},
 };
 use alloc::vec::Vec;
-use alloy_primitives::{Address, Bytes};
+use alloy_primitives::Address;
 
 type TestEvm = Evm<BaseEvmTypes>;
 
@@ -18,12 +18,7 @@ fn run_tx(evm: &mut TestEvm, destination: Address, code: impl Into<Vec<u8>>) {
         gas_limit: 100_000,
         ..Default::default()
     };
-    let result = Host::execute_message(
-        evm,
-        &TxEnv::default(),
-        Bytecode::new_legacy(Bytes::from(code.into())),
-        &mut message,
-    );
+    let result = Host::execute_message(evm, &TxEnv::default(), legacy_bytecode(code), &mut message);
     assert!(result.stop.is_success());
 }
 
@@ -106,11 +101,7 @@ fn evm_propagates_child_sstore_negative_refund() {
     let mut database = InMemoryDB::default();
     database.insert_account_info(
         &contract,
-        AccountInfo {
-            nonce: 1,
-            code: Some(Bytecode::new_legacy(Bytes::from(child_code))),
-            ..Default::default()
-        },
+        AccountInfo { nonce: 1, code: Some(legacy_bytecode(child_code)), ..Default::default() },
     );
     database.insert_account_storage(&contract, &Word::from(0), &Word::from(5));
     let mut evm = TestEvm::new(
@@ -143,7 +134,7 @@ fn evm_propagates_child_sstore_negative_refund() {
     let result = Host::execute_message(
         &mut evm,
         &TxEnv::default(),
-        Bytecode::new_legacy(Bytes::from(parent_code)),
+        legacy_bytecode(parent_code),
         &mut message,
     );
 
@@ -170,7 +161,7 @@ fn evm_reports_invalid_transaction_execution() {
     let result = Host::execute_message(
         &mut evm,
         &TxEnv::default(),
-        Bytecode::new_legacy(Bytes::from_static(&[op::PUSH1, 0x01, op::SSTORE])),
+        legacy_bytecode([op::PUSH1, 0x01, op::SSTORE]),
         &mut message,
     );
 


### PR DESCRIPTION
Moves the shared EVM test harness and bytecode builders into a crate-level test_utils module so unit tests do not depend on the instruction test namespace. This also folds duplicate bytecode and word helpers into that module while keeping single-use inspector and database test implementations local to the tests that need them.
