### PR TITLE
ci: use depot runners and sccache

### DIFF
--- a/.github/scripts/matrices.py
+++ b/.github/scripts/matrices.py
@@ -108,13 +108,13 @@ toolchains = ["stable", "nightly"]
 feature_sets = ["--no-default-features", "", "--all-features"]
 kinds = ["test", "eest"]
 
-t_linux_x86 = Target("ubuntu", "depot-ubuntu-latest-16", tier=1)
+t_linux_x86 = Target("ubuntu", "depot-ubuntu-latest-4", tier=1)
 t_macos_arm = Target("macos", "depot-macos-latest", tier=1)
-t_linux_arm = Target("ubuntu arm", "depot-ubuntu-latest-arm-16", cxx="clang++")
-t_windows = Target("windows", "depot-windows-latest-16", flags="--no-default-features")
+t_linux_arm = Target("ubuntu arm", "depot-ubuntu-latest-arm-4", cxx="clang++")
+t_windows = Target("windows", "depot-windows-latest-4", flags="--no-default-features")
 t_wasm_unknown = Target(
     "wasm",
-    "depot-ubuntu-latest-16",
+    "depot-ubuntu-latest-4",
     target="wasm32-unknown-unknown",
     command="build",
     kinds=["wasm"],
@@ -122,7 +122,7 @@ t_wasm_unknown = Target(
 )
 t_wasm_wasi = Target(
     "wasm wasi",
-    "depot-ubuntu-latest-16",
+    "depot-ubuntu-latest-4",
     target="wasm32-wasip1",
     command="wasm-test",
     kinds=["wasm"],
@@ -131,7 +131,7 @@ t_wasm_wasi = Target(
 )
 t_wasm_wasi_tail = Target(
     "wasm tail-call",
-    "depot-ubuntu-latest-16",
+    "depot-ubuntu-latest-4",
     target="wasm32-wasip1",
     command="wasm-test",
     kinds=["wasm"],
@@ -141,7 +141,7 @@ t_wasm_wasi_tail = Target(
 )
 t_linux_i686 = Target(
     "i686",
-    "depot-ubuntu-latest-16",
+    "depot-ubuntu-latest-4",
     target="i686-unknown-linux-gnu",
     command="cross-test",
     kinds=["test"],
@@ -149,7 +149,7 @@ t_linux_i686 = Target(
 )
 t_linux_armv7 = Target(
     "armv7",
-    "depot-ubuntu-latest-16",
+    "depot-ubuntu-latest-4",
     target="armv7-unknown-linux-gnueabihf",
     command="cross-test",
     kinds=["test"],

--- a/.github/scripts/matrices.py
+++ b/.github/scripts/matrices.py
@@ -108,13 +108,13 @@ toolchains = ["stable", "nightly"]
 feature_sets = ["--no-default-features", "", "--all-features"]
 kinds = ["test", "eest"]
 
-t_linux_x86 = Target("ubuntu", "ubuntu-latest", tier=1)
-t_macos_arm = Target("macos", "macos-latest", tier=1)
-t_linux_arm = Target("ubuntu arm", "ubuntu-24.04-arm", cxx="clang++")
-t_windows = Target("windows", "windows-latest", flags="--no-default-features")
+t_linux_x86 = Target("ubuntu", "depot-ubuntu-latest-16", tier=1)
+t_macos_arm = Target("macos", "depot-macos-latest", tier=1)
+t_linux_arm = Target("ubuntu arm", "depot-ubuntu-latest-arm-16", cxx="clang++")
+t_windows = Target("windows", "depot-windows-latest-16", flags="--no-default-features")
 t_wasm_unknown = Target(
     "wasm",
-    "ubuntu-latest",
+    "depot-ubuntu-latest-16",
     target="wasm32-unknown-unknown",
     command="build",
     kinds=["wasm"],
@@ -122,7 +122,7 @@ t_wasm_unknown = Target(
 )
 t_wasm_wasi = Target(
     "wasm wasi",
-    "ubuntu-latest",
+    "depot-ubuntu-latest-16",
     target="wasm32-wasip1",
     command="wasm-test",
     kinds=["wasm"],
@@ -131,7 +131,7 @@ t_wasm_wasi = Target(
 )
 t_wasm_wasi_tail = Target(
     "wasm tail-call",
-    "ubuntu-latest",
+    "depot-ubuntu-latest-16",
     target="wasm32-wasip1",
     command="wasm-test",
     kinds=["wasm"],
@@ -141,7 +141,7 @@ t_wasm_wasi_tail = Target(
 )
 t_linux_i686 = Target(
     "i686",
-    "ubuntu-latest",
+    "depot-ubuntu-latest-16",
     target="i686-unknown-linux-gnu",
     command="cross-test",
     kinds=["test"],
@@ -149,7 +149,7 @@ t_linux_i686 = Target(
 )
 t_linux_armv7 = Target(
     "armv7",
-    "ubuntu-latest",
+    "depot-ubuntu-latest-16",
     target="armv7-unknown-linux-gnueabihf",
     command="cross-test",
     kinds=["test"],

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -10,16 +10,18 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  RUSTC_WRAPPER: "sccache"
   RUSTFLAGS: -Csymbol-mangling-version=v0
 
 jobs:
   codspeed:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
+      - uses: mozilla-actions/sccache-action@v0.0.10
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,10 +177,10 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: rui314/setup-mold@v1
+      - uses: mozilla-actions/sccache-action@v0.0.10
       - uses: taiki-e/cache-cargo-install-action@v3
         with:
           tool: zepter
-      - uses: mozilla-actions/sccache-action@v0.0.10
       - name: Eagerly pull dependencies
         run: cargo generate-lockfile
       - run: zepter run check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  RUSTC_WRAPPER: "sccache"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -58,6 +59,7 @@ jobs:
           targets: ${{ matrix.target }}
       - uses: rui314/setup-mold@v1
         if: runner.os == 'Linux'
+      - uses: mozilla-actions/sccache-action@v0.0.10
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
@@ -128,7 +130,7 @@ jobs:
 
   no-std:
     name: no_std ${{ matrix.target }}
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -139,6 +141,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
+      - uses: mozilla-actions/sccache-action@v0.0.10
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
@@ -148,7 +151,7 @@ jobs:
 
   feature-checks:
     name: features ${{ matrix.flags }}
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -159,6 +162,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: rui314/setup-mold@v1
       - uses: taiki-e/install-action@cargo-hack
+      - uses: mozilla-actions/sccache-action@v0.0.10
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
@@ -167,7 +171,7 @@ jobs:
         run: cargo hack check --workspace --each-feature --skip nightly ${{ matrix.flags }}
 
   feature-propagation:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
@@ -176,16 +180,18 @@ jobs:
       - uses: taiki-e/cache-cargo-install-action@v3
         with:
           tool: zepter
+      - uses: mozilla-actions/sccache-action@v0.0.10
       - name: Eagerly pull dependencies
         run: cargo generate-lockfile
       - run: zepter run check
 
   examples:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
+      - uses: mozilla-actions/sccache-action@v0.0.10
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
@@ -201,7 +207,7 @@ jobs:
       - uses: crate-ci/typos@v1
 
   clippy:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
@@ -209,6 +215,7 @@ jobs:
         with:
           components: clippy
       - uses: rui314/setup-mold@v1
+      - uses: mozilla-actions/sccache-action@v0.0.10
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
@@ -216,12 +223,13 @@ jobs:
       - run: cargo clippy --workspace --all-targets --all-features
 
   docs:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@nightly
       - uses: rui314/setup-mold@v1
+      - uses: mozilla-actions/sccache-action@v0.0.10
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true

--- a/.github/workflows/fuzzer.yml
+++ b/.github/workflows/fuzzer.yml
@@ -15,11 +15,12 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  RUSTC_WRAPPER: "sccache"
 
 jobs:
   smoke:
     name: smoke (${{ matrix.dispatch_backend }})
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     timeout-minutes: 20
     permissions:
       contents: read
@@ -31,6 +32,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@nightly
       - uses: rui314/setup-mold@v1
+      - uses: mozilla-actions/sccache-action@v0.0.10
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true


### PR DESCRIPTION
Switch CI jobs that compile Rust onto Depot runners and enable sccache via `RUSTC_WRAPPER`, matching the setup used in Foundry. The generated test matrix now emits Depot runner labels, while the lightweight matrix and status aggregation jobs stay on standard GitHub-hosted runners.
