### PR TITLE
chore: fix clippy warnings

### DIFF
--- a/crates/evm2/src/interpreter/stack.rs
+++ b/crates/evm2/src/interpreter/stack.rs
@@ -441,8 +441,7 @@ impl<'a> StackMut<'a> {
 
             let mut i = 0;
 
-            let words = slice.chunks_exact(32);
-            let partial_last_word = words.remainder();
+            let (words, partial_last_word) = slice.as_chunks::<32>();
             for word in words {
                 for l in word.rchunks_exact(8) {
                     dst.add(i).write(u64::from_be_bytes(l.try_into().unwrap()));

--- a/crates/evm2/src/precompiles/blake2/mod.rs
+++ b/crates/evm2/src/precompiles/blake2/mod.rs
@@ -99,14 +99,14 @@ pub fn run(input: &[u8], gas: &mut GasTracker) -> PrecompileResult {
 
     // Parse state vector h (8 × u64)
     let mut h = [0u64; 8];
-    input[4..68].chunks_exact(8).enumerate().for_each(|(i, chunk)| {
-        h[i] = u64::from_le_bytes(chunk.try_into().unwrap());
+    input[4..68].as_chunks::<8>().0.iter().enumerate().for_each(|(i, chunk)| {
+        h[i] = u64::from_le_bytes(*chunk);
     });
 
     // Parse message block m (16 × u64)
     let mut m = [0u64; 16];
-    input[68..196].chunks_exact(8).enumerate().for_each(|(i, chunk)| {
-        m[i] = u64::from_le_bytes(chunk.try_into().unwrap());
+    input[68..196].as_chunks::<8>().0.iter().enumerate().for_each(|(i, chunk)| {
+        m[i] = u64::from_le_bytes(*chunk);
     });
 
     // Parse offset counters

--- a/crates/inspectors/src/tracing/utils.rs
+++ b/crates/inspectors/src/tracing/utils.rs
@@ -73,8 +73,7 @@ pub(crate) fn fmt_error_msg(res: InstrStop, kind: TraceStyle) -> Option<String> 
 /// See: <https://github.com/ethereum/go-ethereum/blob/366d2169fbc0e0f803b68c042b77b6b480836dbc/eth/tracers/logger/logger.go#L450-L452>
 pub(crate) fn convert_memory(data: &[u8]) -> Vec<String> {
     let mut memory = Vec::with_capacity(data.len().div_ceil(32));
-    let chunks = data.chunks_exact(32);
-    let remainder = chunks.remainder();
+    let (chunks, remainder) = data.as_chunks::<32>();
     for chunk in chunks {
         memory.push(hex::encode_prefixed(chunk));
     }


### PR DESCRIPTION
This fixes the current clippy warnings by replacing constant-size `chunks_exact` calls with `as_chunks` in stack byte parsing, BLAKE2 input parsing, and trace memory formatting.
