### PR TITLE
ci: disable rust-cache bin caching

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -10,7 +10,9 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  RUSTC_WRAPPER: "sccache"
   RUSTFLAGS: -Csymbol-mangling-version=v0
+  "INPUT_CACHE-BIN": "false"
 
 jobs:
   codspeed:
@@ -26,27 +28,18 @@ jobs:
         run: .github/scripts/install_llvm.sh ubuntu
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: mozilla-actions/sccache-action@v0.0.10
-      - name: Configure sccache
-        run: |
-          echo "RUSTC_WRAPPER=$SCCACHE_PATH" >> "$GITHUB_ENV"
-          "$SCCACHE_PATH" --zero-stats
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           cache-on-failure: true
-          cache-bin: false
       - name: Install cargo-codspeed
         uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2.82.0
         with:
           tool: cargo-codspeed
       - name: Build the benchmark target
         run: cargo codspeed build --profile profiling -p evm2-cli --features jit --bench evm
-      - name: Show sccache stats
-        if: always()
-        run: |
-          "$RUSTC_WRAPPER" --show-stats
       - name: Run the benchmarks
         uses: CodSpeedHQ/action@63f3e98b61959fe67f146a3ff022e4136fe9bb9c # v4.17.6
         with:
           run: cargo codspeed run -p evm2-cli --bench evm
-          mode: simulation
+          mode: instrumentation
           token: ${{ secrets.CODSPEED_TOKEN }}

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -10,7 +10,6 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  RUSTC_WRAPPER: "sccache"
   RUSTFLAGS: -Csymbol-mangling-version=v0
 
 jobs:
@@ -27,15 +26,39 @@ jobs:
         run: .github/scripts/install_llvm.sh ubuntu
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: mozilla-actions/sccache-action@v0.0.10
+      - name: Configure sccache
+        run: |
+          echo "RUSTC_WRAPPER=$SCCACHE_PATH" >> "$GITHUB_ENV"
+          echo "SCCACHE_ERROR_LOG=$RUNNER_TEMP/sccache.log" >> "$GITHUB_ENV"
+          "$SCCACHE_PATH" --zero-stats
+          "$SCCACHE_PATH" --version
+          which -a sccache
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           cache-on-failure: true
+          cache-bin: false
       - name: Install cargo-codspeed
         uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2.82.0
         with:
           tool: cargo-codspeed
+      - name: Inspect sccache
+        run: |
+          echo "PATH=$PATH"
+          echo "RUSTC_WRAPPER=$RUSTC_WRAPPER"
+          echo "SCCACHE_PATH=$SCCACHE_PATH"
+          which -a sccache
+          "$RUSTC_WRAPPER" --show-stats
       - name: Build the benchmark target
         run: cargo codspeed build --profile profiling -p evm2-cli --features jit --bench evm
+      - name: Show sccache stats
+        if: always()
+        run: |
+          "$RUSTC_WRAPPER" --show-stats
+          if [ -f "$SCCACHE_ERROR_LOG" ]; then
+            echo "::group::sccache log"
+            tail -200 "$SCCACHE_ERROR_LOG"
+            echo "::endgroup::"
+          fi
       - name: Run the benchmarks
         uses: CodSpeedHQ/action@63f3e98b61959fe67f146a3ff022e4136fe9bb9c # v4.17.6
         with:

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -29,10 +29,7 @@ jobs:
       - name: Configure sccache
         run: |
           echo "RUSTC_WRAPPER=$SCCACHE_PATH" >> "$GITHUB_ENV"
-          echo "SCCACHE_ERROR_LOG=$RUNNER_TEMP/sccache.log" >> "$GITHUB_ENV"
           "$SCCACHE_PATH" --zero-stats
-          "$SCCACHE_PATH" --version
-          which -a sccache
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           cache-on-failure: true
@@ -41,27 +38,15 @@ jobs:
         uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2.82.0
         with:
           tool: cargo-codspeed
-      - name: Inspect sccache
-        run: |
-          echo "PATH=$PATH"
-          echo "RUSTC_WRAPPER=$RUSTC_WRAPPER"
-          echo "SCCACHE_PATH=$SCCACHE_PATH"
-          which -a sccache
-          "$RUSTC_WRAPPER" --show-stats
       - name: Build the benchmark target
         run: cargo codspeed build --profile profiling -p evm2-cli --features jit --bench evm
       - name: Show sccache stats
         if: always()
         run: |
           "$RUSTC_WRAPPER" --show-stats
-          if [ -f "$SCCACHE_ERROR_LOG" ]; then
-            echo "::group::sccache log"
-            tail -200 "$SCCACHE_ERROR_LOG"
-            echo "::endgroup::"
-          fi
       - name: Run the benchmarks
         uses: CodSpeedHQ/action@63f3e98b61959fe67f146a3ff022e4136fe9bb9c # v4.17.6
         with:
           run: cargo codspeed run -p evm2-cli --bench evm
-          mode: instrumentation
+          mode: simulation
           token: ${{ secrets.CODSPEED_TOKEN }}

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -12,7 +12,6 @@ env:
   CARGO_TERM_COLOR: always
   RUSTC_WRAPPER: "sccache"
   RUSTFLAGS: -Csymbol-mangling-version=v0
-  "INPUT_CACHE-BIN": "false"
 
 jobs:
   codspeed:
@@ -31,6 +30,7 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           cache-on-failure: true
+          cache-bin: false
       - name: Install cargo-codspeed
         uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2.82.0
         with:


### PR DESCRIPTION
Disable `Swatinem/rust-cache` Cargo bin caching in the benchmark workflow with the explicit `cache-bin: false` action input.

The other workflow `rust-cache` uses already set this input; this makes the benchmark workflow consistent with them. The attempted global `INPUT_CACHE-BIN=false` env override did not work because GitHub still supplied the action default input and `rust-cache` logged `cache-bin: true`.
