### PR TITLE
ci: bump github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,11 @@ updates:
     open-pull-requests-limit: 2
     cooldown:
       default-days: 7
+    ignore:
+      # These refs intentionally point at tool-specific tags or toolchain branches.
+      # Dependabot rewrites them to generic release refs and breaks CI.
+      - dependency-name: "dtolnay/rust-toolchain"
+      - dependency-name: "taiki-e/install-action"
     groups:
       github-actions:
         patterns:

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           cache-on-failure: true
       - name: Install cargo-codspeed
-        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2.82.0
+        uses: taiki-e/install-action@8b3c737da4b541bf0fb5a3e0488ff20535badac9 # v2.82.1
         with:
           tool: cargo-codspeed
       - name: Build the benchmark target

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,11 +77,11 @@ jobs:
         with:
           cache-on-failure: true
           cache-bin: false
-      - uses: taiki-e/install-action@16a76bb73558798e4218983c40c25fee9f2f99a8 # nextest
+      - uses: taiki-e/install-action@96c7780c1d8a2b8723e12031def873a434d39d8d # nextest
         if: ${{ !matrix.command || matrix.command == 'nextest' }}
-      - uses: taiki-e/install-action@867989a7645cb8230b1c87a12c07c4bfaf9a7d8c # cross
+      - uses: taiki-e/install-action@019ff5fd0f8eae341c18fae38f5dcf1ad6dced0b # cross
         if: ${{ matrix.command == 'cross-test' }}
-      - uses: taiki-e/install-action@f8f9a96a3ddf6d0f5787449860fc7d72ae41f4b4 # wasmtime
+      - uses: taiki-e/install-action@55b64938ebc43fea1373a940406514e0937f1471 # wasmtime
         if: ${{ matrix.command == 'wasm-test' }}
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         if: ${{ matrix.kind == 'eest' }}
@@ -172,7 +172,7 @@ jobs:
             subset: ci-smoke
             filter: test(statetests::jit)
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Install LLVM
@@ -190,7 +190,7 @@ jobs:
           cache-on-failure: true
           cache-bin: false
       - uses: taiki-e/install-action@nextest # zizmor: ignore[unpinned-uses] Keep the tool-specific install-action ref.
-      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       - name: Download EEST fixtures
         run: ./scripts/setup_test_fixtures.py
       - name: eest ${{ matrix.mode }}
@@ -243,7 +243,7 @@ jobs:
         run: .github/scripts/install_llvm.sh ubuntu
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
-      - uses: taiki-e/install-action@dbb49279d79bb6825e754b75c8278b7619be13d2 # cargo-hack
+      - uses: taiki-e/install-action@c8fac77ad14033d073e5c8e4f5a25fffd79d4e75 # cargo-hack
       - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:

--- a/.github/workflows/cyclops-audit.yml
+++ b/.github/workflows/cyclops-audit.yml
@@ -49,7 +49,7 @@ jobs:
       pull-requests: read
     steps:
       - name: Check commenter permission
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ github.token }}
           script: |
@@ -71,7 +71,7 @@ jobs:
 
       - name: Parse arguments
         id: args
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ github.token }}
           script: |
@@ -211,7 +211,7 @@ jobs:
 
       - name: Acknowledge request
         id: ack
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           ACTOR: ${{ steps.args.outputs.actor }}
           SUMMARY: ${{ steps.args.outputs.summary }}
@@ -259,7 +259,7 @@ jobs:
 
       - name: Update status
         if: ${{ always() && steps.ack.outcome == 'success' && steps.ack.outputs['comment-id'] != '' }}
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           COMMENT_ID: ${{ steps.ack.outputs['comment-id'] }}
           PUBLISH_OUTCOME: ${{ steps.publish.outcome }}


### PR DESCRIPTION
This reworks the failed Dependabot bump from #249 by updating the safe action pins while preserving the refs that encode behavior.

The generic release refs move forward for checkout, setup-uv, github-script, and the cargo-codspeed install-action step. The install-action refs for nextest, cross, wasmtime, and cargo-hack stay tool-specific and are refreshed to the current tag SHAs, so the jobs still install the expected cargo tools. The rust-toolchain stable/master/nightly branch refs are left with their intended channel semantics.

Dependabot now ignores dtolnay/rust-toolchain and taiki-e/install-action for GitHub Actions updates because grouped bumps rewrite those special refs to generic release refs and break CI.
