### PR TITLE
chore(deps): bump all breaking deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,17 +104,17 @@ libc = "0.2"
 libtest-mimic = "0.8"
 once_cell = { version = "1.21", default-features = false }
 paste = { version = "1.0", default-features = false }
-phf = { version = "0.13", default-features = false }
+phf = { version = "0.14", default-features = false }
 quanta = "0.12"
 postcard = { version = "1.1.3", default-features = false }
 rand = "0.10"
 rayon = "1.10"
-revm = { version = "38", default-features = true, features = ["asm-keccak"] }
+revm = { version = "41", default-features = true, features = ["asm-keccak"] }
 rstest = "0.26.0"
 ruint = { version = "1.18", default-features = false }
 serde = { version = "1.0", default-features = false }
 serde_json = { version = "1.0", default-features = false }
-snapbox = "0.6"
+snapbox = "1.2"
 thiserror = { version = "2.0", default-features = false }
 tokio = { version = "1", default-features = false }
 tracing = "0.1"

--- a/crates/cli/src/fuzzer/normalize.rs
+++ b/crates/cli/src/fuzzer/normalize.rs
@@ -160,9 +160,9 @@ pub(crate) fn state_from_revm(
         let original = original_accounts.get(&address);
         let account_changed = original.map_or_else(
             || {
-                account.info.balance != account.original_info.balance
-                    || account.info.nonce != account.original_info.nonce
-                    || account.info.code_hash != account.original_info.code_hash
+                account.info.balance != account.original_info().balance
+                    || account.info.nonce != account.original_info().nonce
+                    || account.info.code_hash != account.original_info().code_hash
             },
             |original| {
                 account.info.balance != original.balance
@@ -171,7 +171,7 @@ pub(crate) fn state_from_revm(
             },
         );
         if account.is_selfdestructed() {
-            if original.is_some() || !account.original_info.is_empty() {
+            if original.is_some() || !account.original_info().is_empty() {
                 canonical.accounts.insert(address, None);
             }
             continue;


### PR DESCRIPTION
Updates the differential fuzzer normalization code for revm 41, where original account info is accessed through the public accessor instead of a field. This keeps the dependency bump compiling without changing the canonical-state comparison behavior.