### PR TITLE
fix: check payment overflows

### DIFF
--- a/crates/evm2/src/ethereum/eip1559.rs
+++ b/crates/evm2/src/ethereum/eip1559.rs
@@ -1,13 +1,11 @@
 use super::{
-    access_list_counts, charge_upfront, checked_payment_add, create_initial_state_gas, effective_gas_price, floor_gas,
-    initial_gas_and_reservoir,
-    initial_message, intrinsic_gas, refund_create_state_gas,
-    rollback_failed_execution, settle_gas,
-    validate_block_gas_limit, validate_chain_id,
-    validate_create_initcode, validate_floor_gas,
-    validate_gas_price, validate_intrinsic_gas,
-    validate_nonce_not_overflow, validate_priority_fee, validate_regular_gas_limit_cap,
-    validate_sender, validate_tx_gas_limit_cap, warm_access_list, warm_base_accounts,
+    access_list_counts, charge_upfront, checked_payment_add, create_initial_state_gas,
+    effective_gas_price, floor_gas, initial_gas_and_reservoir, initial_message, intrinsic_gas,
+    refund_create_state_gas, rollback_failed_execution, settle_gas, validate_block_gas_limit,
+    validate_chain_id, validate_create_initcode, validate_floor_gas, validate_gas_price,
+    validate_intrinsic_gas, validate_nonce_not_overflow, validate_priority_fee,
+    validate_regular_gas_limit_cap, validate_sender, validate_tx_gas_limit_cap, warm_access_list,
+    warm_base_accounts,
 };
 use crate::{
     EvmTypes, TxResult,

--- a/crates/evm2/src/ethereum/eip1559.rs
+++ b/crates/evm2/src/ethereum/eip1559.rs
@@ -1,8 +1,8 @@
 use super::{
-    access_list_counts, charge_upfront, effective_gas_price, floor_gas, initial_message,
-    intrinsic_gas, rollback_failed_execution, settle_gas, validate_block_gas_limit,
-    validate_chain_id, validate_create_initcode, validate_floor_gas, validate_gas_price,
-    validate_intrinsic_gas, validate_nonce_not_overflow, validate_priority_fee,
+    access_list_counts, charge_upfront, checked_payment_add, effective_gas_price, floor_gas,
+    initial_message, intrinsic_gas, rollback_failed_execution, settle_gas,
+    validate_block_gas_limit, validate_chain_id, validate_create_initcode, validate_floor_gas,
+    validate_gas_price, validate_intrinsic_gas, validate_nonce_not_overflow, validate_priority_fee,
     validate_regular_gas_limit_cap, validate_sender, validate_tx_gas_limit_cap, warm_access_list,
     warm_base_accounts,
 };
@@ -48,7 +48,8 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     validate_regular_gas_limit_cap(req.host.version(), tx.gas_limit, intrinsic, floor_gas)?;
 
     let max_gas_cost = U256::from(tx.gas_limit) * max_fee_per_gas;
-    validate_sender(req.host, caller, tx.nonce, max_gas_cost.saturating_add(tx.value))?;
+    let max_upfront = checked_payment_add(max_gas_cost, tx.value)?;
+    validate_sender(req.host, caller, tx.nonce, max_upfront)?;
 
     warm_base_accounts(req.host, caller, tx.to);
     warm_access_list(req.host, &tx.access_list);

--- a/crates/evm2/src/ethereum/eip2930.rs
+++ b/crates/evm2/src/ethereum/eip2930.rs
@@ -1,9 +1,9 @@
 use super::{
-    access_list_counts, charge_upfront, floor_gas, initial_message, intrinsic_gas,
-    rollback_failed_execution, settle_gas, validate_block_gas_limit, validate_chain_id,
-    validate_create_initcode, validate_floor_gas, validate_gas_price, validate_intrinsic_gas,
-    validate_nonce_not_overflow, validate_regular_gas_limit_cap, validate_sender,
-    validate_tx_gas_limit_cap, warm_access_list, warm_base_accounts,
+    access_list_counts, charge_upfront, checked_payment_add, floor_gas, initial_message,
+    intrinsic_gas, rollback_failed_execution, settle_gas, validate_block_gas_limit,
+    validate_chain_id, validate_create_initcode, validate_floor_gas, validate_gas_price,
+    validate_intrinsic_gas, validate_nonce_not_overflow, validate_regular_gas_limit_cap,
+    validate_sender, validate_tx_gas_limit_cap, warm_access_list, warm_base_accounts,
 };
 use crate::{
     Evm, EvmTypes, TxResult,
@@ -43,7 +43,8 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     validate_regular_gas_limit_cap(req.host.version(), tx.gas_limit, intrinsic, floor_gas)?;
 
     let max_gas_cost = U256::from(tx.gas_limit) * gas_price;
-    validate_sender(req.host, caller, tx.nonce, max_gas_cost.saturating_add(tx.value))?;
+    let max_upfront = checked_payment_add(max_gas_cost, tx.value)?;
+    validate_sender(req.host, caller, tx.nonce, max_upfront)?;
 
     warm_base_accounts(req.host, caller, tx.to);
     warm_access_list(req.host, &tx.access_list);

--- a/crates/evm2/src/ethereum/eip2930.rs
+++ b/crates/evm2/src/ethereum/eip2930.rs
@@ -1,10 +1,10 @@
 use super::{
     access_list_counts, charge_upfront, checked_payment_add, create_initial_state_gas, floor_gas,
-    initial_gas_and_reservoir, initial_message,
-    intrinsic_gas, refund_create_state_gas, rollback_failed_execution, settle_gas, validate_block_gas_limit,
-    validate_chain_id, validate_create_initcode, validate_floor_gas, validate_gas_price,
-    validate_intrinsic_gas, validate_nonce_not_overflow, validate_regular_gas_limit_cap,
-    validate_sender, validate_tx_gas_limit_cap, warm_access_list, warm_base_accounts,
+    initial_gas_and_reservoir, initial_message, intrinsic_gas, refund_create_state_gas,
+    rollback_failed_execution, settle_gas, validate_block_gas_limit, validate_chain_id,
+    validate_create_initcode, validate_floor_gas, validate_gas_price, validate_intrinsic_gas,
+    validate_nonce_not_overflow, validate_regular_gas_limit_cap, validate_sender,
+    validate_tx_gas_limit_cap, warm_access_list, warm_base_accounts,
 };
 use crate::{
     EvmTypes, TxResult,

--- a/crates/evm2/src/ethereum/eip4844.rs
+++ b/crates/evm2/src/ethereum/eip4844.rs
@@ -1,8 +1,8 @@
 use super::{
-    access_list_counts, charge_upfront, effective_gas_price, floor_gas, initial_message,
-    intrinsic_gas, rollback_failed_execution, settle_gas, validate_block_gas_limit,
-    validate_chain_id, validate_create_initcode, validate_floor_gas, validate_gas_price,
-    validate_intrinsic_gas, validate_nonce_not_overflow, validate_priority_fee,
+    access_list_counts, charge_upfront, checked_payment_add, effective_gas_price, floor_gas,
+    initial_message, intrinsic_gas, rollback_failed_execution, settle_gas,
+    validate_block_gas_limit, validate_chain_id, validate_create_initcode, validate_floor_gas,
+    validate_gas_price, validate_intrinsic_gas, validate_nonce_not_overflow, validate_priority_fee,
     validate_regular_gas_limit_cap, validate_sender, validate_tx_gas_limit_cap, warm_access_list,
     warm_base_accounts,
 };
@@ -55,12 +55,9 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     let blob_gas_cost = U256::from(DATA_GAS_PER_BLOB) * U256::from(tx.blob_versioned_hashes.len());
     let max_blob_gas_cost = blob_gas_cost * max_fee_per_blob_gas;
     let max_gas_cost = U256::from(tx.gas_limit) * max_fee_per_gas;
-    validate_sender(
-        req.host,
-        caller,
-        tx.nonce,
-        max_gas_cost.saturating_add(max_blob_gas_cost).saturating_add(tx.value),
-    )?;
+    let max_upfront =
+        checked_payment_add(checked_payment_add(max_gas_cost, max_blob_gas_cost)?, tx.value)?;
+    validate_sender(req.host, caller, tx.nonce, max_upfront)?;
 
     warm_base_accounts(req.host, caller, tx.to.into());
     warm_access_list(req.host, &tx.access_list);

--- a/crates/evm2/src/ethereum/eip4844.rs
+++ b/crates/evm2/src/ethereum/eip4844.rs
@@ -1,13 +1,10 @@
 use super::{
-    access_list_counts, charge_upfront, checked_payment_add, create_initial_state_gas, effective_gas_price, floor_gas,
-    initial_gas_and_reservoir,
-    initial_message, intrinsic_gas, rollback_failed_execution,
-    settle_gas,
-    validate_block_gas_limit, validate_chain_id, validate_create_initcode,
-    validate_floor_gas,
-    validate_gas_price, validate_intrinsic_gas, validate_nonce_not_overflow,
-    validate_priority_fee, validate_regular_gas_limit_cap, validate_sender,
-    validate_tx_gas_limit_cap, warm_access_list, warm_base_accounts,
+    access_list_counts, charge_upfront, checked_payment_add, create_initial_state_gas,
+    effective_gas_price, floor_gas, initial_gas_and_reservoir, initial_message, intrinsic_gas,
+    rollback_failed_execution, settle_gas, validate_block_gas_limit, validate_chain_id,
+    validate_create_initcode, validate_floor_gas, validate_gas_price, validate_intrinsic_gas,
+    validate_nonce_not_overflow, validate_priority_fee, validate_regular_gas_limit_cap,
+    validate_sender, validate_tx_gas_limit_cap, warm_access_list, warm_base_accounts,
 };
 use crate::{
     EvmTypes, TxResult,

--- a/crates/evm2/src/ethereum/eip7702.rs
+++ b/crates/evm2/src/ethereum/eip7702.rs
@@ -1,8 +1,8 @@
 use super::{
-    access_list_counts, charge_upfront, effective_gas_price, floor_gas, initial_message,
-    intrinsic_gas, rollback_failed_execution, settle_gas, validate_block_gas_limit,
-    validate_chain_id, validate_create_initcode, validate_floor_gas, validate_gas_price,
-    validate_intrinsic_gas, validate_nonce_not_overflow, validate_priority_fee,
+    access_list_counts, charge_upfront, checked_payment_add, effective_gas_price, floor_gas,
+    initial_message, intrinsic_gas, rollback_failed_execution, settle_gas,
+    validate_block_gas_limit, validate_chain_id, validate_create_initcode, validate_floor_gas,
+    validate_gas_price, validate_intrinsic_gas, validate_nonce_not_overflow, validate_priority_fee,
     validate_regular_gas_limit_cap, validate_sender, validate_tx_gas_limit_cap, warm_access_list,
     warm_base_accounts,
 };
@@ -52,7 +52,8 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     validate_regular_gas_limit_cap(req.host.version(), tx.gas_limit, intrinsic, floor_gas)?;
 
     let max_gas_cost = U256::from(tx.gas_limit) * max_fee_per_gas;
-    validate_sender(req.host, caller, tx.nonce, max_gas_cost.saturating_add(tx.value))?;
+    let max_upfront = checked_payment_add(max_gas_cost, tx.value)?;
+    validate_sender(req.host, caller, tx.nonce, max_upfront)?;
 
     warm_base_accounts(req.host, caller, tx.to.into());
     warm_access_list(req.host, &tx.access_list);

--- a/crates/evm2/src/ethereum/eip7702.rs
+++ b/crates/evm2/src/ethereum/eip7702.rs
@@ -1,10 +1,10 @@
 use super::{
-    access_list_counts, charge_upfront, checked_payment_add, effective_gas_price, floor_gas, initial_gas_and_reservoir,
-    initial_message, intrinsic_gas, rollback_failed_execution, settle_gas,
-    validate_block_gas_limit, validate_chain_id, validate_create_initcode, validate_floor_gas,
-    validate_gas_price, validate_intrinsic_gas, validate_nonce_not_overflow, validate_priority_fee,
-    validate_regular_gas_limit_cap, validate_sender, validate_tx_gas_limit_cap, warm_access_list,
-    warm_base_accounts,
+    access_list_counts, charge_upfront, checked_payment_add, effective_gas_price, floor_gas,
+    initial_gas_and_reservoir, initial_message, intrinsic_gas, rollback_failed_execution,
+    settle_gas, validate_block_gas_limit, validate_chain_id, validate_create_initcode,
+    validate_floor_gas, validate_gas_price, validate_intrinsic_gas, validate_nonce_not_overflow,
+    validate_priority_fee, validate_regular_gas_limit_cap, validate_sender,
+    validate_tx_gas_limit_cap, warm_access_list, warm_base_accounts,
 };
 use crate::{
     Evm, EvmFeatures, EvmTypes, TxResult,

--- a/crates/evm2/src/ethereum/legacy.rs
+++ b/crates/evm2/src/ethereum/legacy.rs
@@ -1,10 +1,8 @@
 use super::{
-    charge_upfront, checked_payment_add, create_initial_state_gas, floor_gas, initial_gas_and_reservoir,
-    initial_message, intrinsic_gas, refund_create_state_gas,
-    rollback_failed_execution, settle_gas,
-    validate_block_gas_limit, validate_chain_id,
-    validate_create_initcode, validate_floor_gas,
-    validate_gas_price, validate_intrinsic_gas,
+    charge_upfront, checked_payment_add, create_initial_state_gas, floor_gas,
+    initial_gas_and_reservoir, initial_message, intrinsic_gas, refund_create_state_gas,
+    rollback_failed_execution, settle_gas, validate_block_gas_limit, validate_chain_id,
+    validate_create_initcode, validate_floor_gas, validate_gas_price, validate_intrinsic_gas,
     validate_nonce_not_overflow, validate_regular_gas_limit_cap, validate_sender,
     validate_tx_gas_limit_cap, warm_base_accounts,
 };

--- a/crates/evm2/src/ethereum/legacy.rs
+++ b/crates/evm2/src/ethereum/legacy.rs
@@ -1,8 +1,9 @@
 use super::{
-    charge_upfront, floor_gas, initial_message, intrinsic_gas, rollback_failed_execution,
-    settle_gas, validate_block_gas_limit, validate_chain_id, validate_create_initcode,
-    validate_floor_gas, validate_gas_price, validate_intrinsic_gas, validate_nonce_not_overflow,
-    validate_regular_gas_limit_cap, validate_sender, validate_tx_gas_limit_cap, warm_base_accounts,
+    charge_upfront, checked_payment_add, floor_gas, initial_message, intrinsic_gas,
+    rollback_failed_execution, settle_gas, validate_block_gas_limit, validate_chain_id,
+    validate_create_initcode, validate_floor_gas, validate_gas_price, validate_intrinsic_gas,
+    validate_nonce_not_overflow, validate_regular_gas_limit_cap, validate_sender,
+    validate_tx_gas_limit_cap, warm_base_accounts,
 };
 use crate::{
     Evm, EvmTypes, TxResult,
@@ -34,7 +35,8 @@ pub(super) fn handle<T: EvmTypes<Host = Evm<T>>>(
     validate_regular_gas_limit_cap(req.host.version(), tx.gas_limit, intrinsic, floor_gas)?;
 
     let max_gas_cost = U256::from(tx.gas_limit) * gas_price;
-    validate_sender(req.host, caller, tx.nonce, max_gas_cost.saturating_add(tx.value))?;
+    let max_upfront = checked_payment_add(max_gas_cost, tx.value)?;
+    validate_sender(req.host, caller, tx.nonce, max_upfront)?;
 
     warm_base_accounts(req.host, caller, tx.to);
 

--- a/crates/evm2/src/ethereum/mod.rs
+++ b/crates/evm2/src/ethereum/mod.rs
@@ -234,6 +234,10 @@ pub(super) fn effective_gas_price(
     max_fee_per_gas.min(basefee.saturating_add(max_priority_fee_per_gas))
 }
 
+pub(super) fn checked_payment_add(lhs: U256, rhs: U256) -> HandlerResult<U256> {
+    lhs.checked_add(rhs).ok_or(HandlerError::OverflowPayment)
+}
+
 pub(super) fn validate_block_gas_limit(
     version: &Version,
     tx_gas_limit: u64,
@@ -520,10 +524,11 @@ pub(super) fn settle_gas<T: EvmTypes<Host = Evm<T>>>(
         final_tx_gas(&result, tx_gas_limit, host.feature(EvmFeatures::EIP3529), floor_gas);
     if host.feature(EvmFeatures::FEE_CHARGE) {
         let caller_refund = U256::from(gas_remaining) * gas_price;
-        host.state
+        let _ = host
+            .state
             .account(&caller, false)
             .map_err(db_error_handler!(host))?
-            .add_balance(caller_refund);
+            .increment_balance(caller_refund);
         let beneficiary_gas_price = if host.feature(EvmFeatures::BASE_FEE_CHECK) {
             gas_price.saturating_sub(host.block.basefee)
         } else {
@@ -531,10 +536,11 @@ pub(super) fn settle_gas<T: EvmTypes<Host = Evm<T>>>(
         };
         let beneficiary = host.block.beneficiary;
         let beneficiary_reward = U256::from(gas_used) * beneficiary_gas_price;
-        host.state
+        let _ = host
+            .state
             .account(&beneficiary, false)
             .map_err(db_error_handler!(host))?
-            .add_balance(beneficiary_reward);
+            .increment_balance(beneficiary_reward);
     }
     Ok(TxResult {
         status: result.stop.is_success(),
@@ -631,7 +637,7 @@ mod tests {
         registry::TxRegistry,
     };
     use alloc::vec;
-    use alloy_consensus::{TxEip2930, transaction::Recovered};
+    use alloy_consensus::{TxEip2930, TxLegacy, transaction::Recovered};
     use alloy_eips::eip2930::AccessList;
 
     #[test]
@@ -700,6 +706,79 @@ mod tests {
         assert_eq!(
             evm.transact(&tx).map(|executed| executed.discard()),
             Err(HandlerError::IntrinsicGasTooLow { required: 21_000, got: 20_999 })
+        );
+    }
+
+    #[test]
+    fn legacy_rejects_upfront_payment_overflow() {
+        let caller = Address::with_last_byte(0xaa);
+        let mut database = InMemoryDB::default();
+        database.insert_account_info(&caller, AccountInfo::default().with_balance(U256::MAX));
+        let tx = RecoveredTxEnvelope::Legacy(Recovered::new_unchecked(
+            TxLegacy {
+                nonce: 0,
+                gas_price: 1,
+                gas_limit: 21_000,
+                to: TxKind::Call(Address::with_last_byte(0xbb)),
+                value: U256::MAX,
+                input: Bytes::new(),
+                chain_id: None,
+            },
+            caller,
+        ));
+        let mut evm = Evm::<BaseEvmTypes>::new(
+            SpecId::LONDON,
+            BlockEnv::default(),
+            ethereum_tx_registry(SpecId::LONDON),
+            database,
+            Precompiles::base(SpecId::LONDON),
+        );
+
+        assert_eq!(
+            evm.transact(&tx).map(|executed| executed.discard()),
+            Err(HandlerError::OverflowPayment)
+        );
+    }
+
+    #[test]
+    fn settlement_ignores_overflowing_beneficiary_reward() {
+        let caller = Address::with_last_byte(0xaa);
+        let target = Address::with_last_byte(0xbb);
+        let beneficiary = Address::with_last_byte(0xcc);
+        let mut database = InMemoryDB::default();
+        database.insert_account_info(
+            &caller,
+            AccountInfo::default().with_balance(U256::from(1_000_000u64)),
+        );
+        database.insert_account_info(&beneficiary, AccountInfo::default().with_balance(U256::MAX));
+        let tx = RecoveredTxEnvelope::Legacy(Recovered::new_unchecked(
+            TxLegacy {
+                nonce: 0,
+                gas_price: 1,
+                gas_limit: 21_000,
+                to: TxKind::Call(target),
+                value: U256::ZERO,
+                input: Bytes::new(),
+                chain_id: None,
+            },
+            caller,
+        ));
+        let block =
+            BlockEnv { beneficiary, gas_limit: U256::from(30_000_000u64), ..BlockEnv::default() };
+        let mut evm = Evm::<BaseEvmTypes>::new(
+            SpecId::LONDON,
+            block,
+            ethereum_tx_registry(SpecId::LONDON),
+            database,
+            Precompiles::base(SpecId::LONDON),
+        );
+
+        let result = evm.transact(&tx).unwrap().commit();
+
+        assert!(result.status);
+        assert_eq!(
+            evm.state.account_info_untracked(&beneficiary).unwrap().unwrap().balance,
+            U256::MAX
         );
     }
 

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -1141,18 +1141,15 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
             message.kind,
             MessageKind::Call | MessageKind::CallCode | MessageKind::StaticCall
         );
-        let transfer_result = if transfers_balance {
-            match self.state.transfer(&message.caller, &message.destination, &message.value) {
+        let transfer_succeeded = !transfers_balance
+            || match self.state.transfer(&message.caller, &message.destination, &message.value) {
                 Ok(result) => result,
                 Err(code) => {
                     return Self::error_message_result(self.db_error_stop(code), message.gas_limit);
                 }
-            }
-        } else {
-            Ok(())
-        };
-        if let Err(stop) = transfer_result {
-            return Self::error_message_result(stop, message.gas_limit);
+            };
+        if transfers_balance && !transfer_succeeded {
+            return Self::error_message_result(InstrStop::OutOfFunds, message.gas_limit);
         }
         if transfers_balance {
             self.log_eip7708_transfer(&message.caller, &message.destination, &message.value);
@@ -1456,10 +1453,12 @@ impl<T: EvmTypes<Host = Self>> Host<T> for Evm<T> {
         };
 
         if contract != target {
-            match self.state.transfer(contract, target, &balance) {
-                Ok(Ok(())) => self.log_eip7708_transfer(contract, target, &balance),
-                Ok(Err(stop)) => return Err(stop),
-                Err(code) => return Err(self.db_error_stop(code)),
+            let transferred = self
+                .state
+                .transfer(contract, target, &balance)
+                .map_err(|code| self.db_error_stop(code))?;
+            if transferred {
+                self.log_eip7708_transfer(contract, target, &balance);
             }
         } else if should_destroy && !balance.is_zero() && !self.feature(EvmFeatures::EIP8246) {
             // Pre-EIP-8246: SELFDESTRUCT to self burns the contract's balance. EIP-8246 removes
@@ -2594,7 +2593,7 @@ mod tests {
         let mut state = State::new(InMemoryDB::default());
         state.account(&from, false).unwrap().add_balance(U256::from(10));
 
-        assert_eq!(state.transfer(&from, &to, &U256::from(7)).unwrap(), Ok(()));
+        assert!(state.transfer(&from, &to, &U256::from(7)).unwrap());
         assert_eq!(
             state
                 .account_info_untracked(&from)

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -1141,15 +1141,18 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
             message.kind,
             MessageKind::Call | MessageKind::CallCode | MessageKind::StaticCall
         );
-        let transfer_succeeded = !transfers_balance
-            || match self.state.transfer(&message.caller, &message.destination, &message.value) {
+        let transfer_result = if transfers_balance {
+            match self.state.transfer(&message.caller, &message.destination, &message.value) {
                 Ok(result) => result,
                 Err(code) => {
                     return Self::error_message_result(self.db_error_stop(code), message.gas_limit);
                 }
-            };
-        if transfers_balance && !transfer_succeeded {
-            return Self::error_message_result(InstrStop::OutOfFunds, message.gas_limit);
+            }
+        } else {
+            Ok(())
+        };
+        if let Err(stop) = transfer_result {
+            return Self::error_message_result(stop, message.gas_limit);
         }
         if transfers_balance {
             self.log_eip7708_transfer(&message.caller, &message.destination, &message.value);
@@ -1453,12 +1456,10 @@ impl<T: EvmTypes<Host = Self>> Host<T> for Evm<T> {
         };
 
         if contract != target {
-            let transferred = self
-                .state
-                .transfer(contract, target, &balance)
-                .map_err(|code| self.db_error_stop(code))?;
-            if transferred {
-                self.log_eip7708_transfer(contract, target, &balance);
+            match self.state.transfer(contract, target, &balance) {
+                Ok(Ok(())) => self.log_eip7708_transfer(contract, target, &balance),
+                Ok(Err(stop)) => return Err(stop),
+                Err(code) => return Err(self.db_error_stop(code)),
             }
         } else if should_destroy && !balance.is_zero() && !self.feature(EvmFeatures::EIP8246) {
             // Pre-EIP-8246: SELFDESTRUCT to self burns the contract's balance. EIP-8246 removes
@@ -2593,7 +2594,7 @@ mod tests {
         let mut state = State::new(InMemoryDB::default());
         state.account(&from, false).unwrap().add_balance(U256::from(10));
 
-        assert!(state.transfer(&from, &to, &U256::from(7)).unwrap());
+        assert_eq!(state.transfer(&from, &to, &U256::from(7)).unwrap(), Ok(()));
         assert_eq!(
             state
                 .account_info_untracked(&from)

--- a/crates/evm2/src/evm/registry.rs
+++ b/crates/evm2/src/evm/registry.rs
@@ -62,6 +62,9 @@ pub enum HandlerError {
     /// Sender cannot pay value plus maximum gas cost.
     #[error("insufficient funds")]
     InsufficientFunds,
+    /// Transaction payment amount overflows.
+    #[error("payment amount overflows")]
+    OverflowPayment,
     /// Sender account has deployed code.
     #[error("caller has code")]
     RejectCallerWithCode,

--- a/crates/evm2/src/evm/state/account.rs
+++ b/crates/evm2/src/evm/state/account.rs
@@ -378,6 +378,21 @@ impl<'a> AccountHandle<'a> {
         self.set_balance(balance);
     }
 
+    /// Adds an unsigned balance increment, touching the account even on overflow.
+    #[inline]
+    pub fn increment_balance(&mut self, delta: Word) -> bool {
+        if delta.is_zero() {
+            self.touch();
+            return true;
+        }
+        let Some(balance) = self.balance().checked_add(delta) else {
+            self.touch();
+            return false;
+        };
+        self.set_balance(balance);
+        true
+    }
+
     /// Sets the account nonce, touching the account and recording a revert snapshot.
     #[inline]
     pub fn set_nonce(&mut self, nonce: u64) {
@@ -488,7 +503,10 @@ impl<'a> AccountHandle<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::evm::{CacheDB, state::State};
+    use crate::{
+        evm::{CacheDB, state::State},
+        interpreter::InstrStop,
+    };
     use alloy_primitives::Address;
 
     #[test]
@@ -498,8 +516,11 @@ mod tests {
         database.insert_account_info(&address, AccountInfo::default().with_balance(Word::from(3)));
         let mut state = State::new(database);
 
-        assert!(!state.transfer(&address, &address, &Word::from(4)).unwrap());
-        assert!(state.transfer(&address, &address, &Word::from(3)).unwrap());
+        assert_eq!(
+            state.transfer(&address, &address, &Word::from(4)).unwrap(),
+            Err(InstrStop::OutOfFunds)
+        );
+        assert_eq!(state.transfer(&address, &address, &Word::from(3)).unwrap(), Ok(()));
     }
 
     #[test]

--- a/crates/evm2/src/evm/state/account.rs
+++ b/crates/evm2/src/evm/state/account.rs
@@ -503,10 +503,7 @@ impl<'a> AccountHandle<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{
-        evm::{CacheDB, state::State},
-        interpreter::InstrStop,
-    };
+    use crate::evm::{CacheDB, state::State};
     use alloy_primitives::Address;
 
     #[test]
@@ -516,11 +513,8 @@ mod tests {
         database.insert_account_info(&address, AccountInfo::default().with_balance(Word::from(3)));
         let mut state = State::new(database);
 
-        assert_eq!(
-            state.transfer(&address, &address, &Word::from(4)).unwrap(),
-            Err(InstrStop::OutOfFunds)
-        );
-        assert_eq!(state.transfer(&address, &address, &Word::from(3)).unwrap(), Ok(()));
+        assert!(!state.transfer(&address, &address, &Word::from(4)).unwrap());
+        assert!(state.transfer(&address, &address, &Word::from(3)).unwrap());
     }
 
     #[test]

--- a/crates/evm2/src/evm/state/mod.rs
+++ b/crates/evm2/src/evm/state/mod.rs
@@ -393,46 +393,37 @@ impl State {
     }
 
     /// Transfers value between accounts.
-    pub fn transfer(
-        &mut self,
-        from: &Address,
-        to: &Address,
-        value: &Word,
-    ) -> DbResult<Result<(), InstrStop>> {
+    pub fn transfer(&mut self, from: &Address, to: &Address, value: &Word) -> DbResult<bool> {
         if value.is_zero() {
             self.account(to, false)?.touch();
-            return Ok(Ok(()));
+            return Ok(true);
         }
 
         if from == to {
             let mut account = self.account(from, false)?;
             if account.balance() < *value {
-                return Ok(Err(InstrStop::OutOfFunds));
+                return Ok(false);
             }
             account.touch();
-            return Ok(Ok(()));
+            return Ok(true);
         }
 
-        let from_balance = self.account(from, false)?.balance();
-        let Some(new_from_balance) = from_balance.checked_sub(*value) else {
-            return Ok(Err(InstrStop::OutOfFunds));
-        };
-        let to_balance = self.account(to, false)?.balance();
-        let Some(new_to_balance) = to_balance.checked_add(*value) else {
-            return Ok(Err(InstrStop::OverflowPayment));
-        };
         {
             let mut from_account = self.account(from, false)?;
+            let Some(new_from_balance) = from_account.balance().checked_sub(*value) else {
+                return Ok(false);
+            };
             // `set_balance` touches the account, matching the touch the prior `transfer` performed.
             from_account.set_balance(new_from_balance);
             from_account.touch();
         }
         {
             let mut to_account = self.account(to, false)?;
+            let new_to_balance = to_account.balance().saturating_add(*value);
             to_account.set_balance(new_to_balance);
             to_account.touch();
         }
-        Ok(Ok(()))
+        Ok(true)
     }
 
     /// Creates a contract account and transfers endowment from the caller.

--- a/crates/evm2/src/evm/state/mod.rs
+++ b/crates/evm2/src/evm/state/mod.rs
@@ -393,37 +393,46 @@ impl State {
     }
 
     /// Transfers value between accounts.
-    pub fn transfer(&mut self, from: &Address, to: &Address, value: &Word) -> DbResult<bool> {
+    pub fn transfer(
+        &mut self,
+        from: &Address,
+        to: &Address,
+        value: &Word,
+    ) -> DbResult<Result<(), InstrStop>> {
         if value.is_zero() {
             self.account(to, false)?.touch();
-            return Ok(true);
+            return Ok(Ok(()));
         }
 
         if from == to {
             let mut account = self.account(from, false)?;
             if account.balance() < *value {
-                return Ok(false);
+                return Ok(Err(InstrStop::OutOfFunds));
             }
             account.touch();
-            return Ok(true);
+            return Ok(Ok(()));
         }
 
+        let from_balance = self.account(from, false)?.balance();
+        let Some(new_from_balance) = from_balance.checked_sub(*value) else {
+            return Ok(Err(InstrStop::OutOfFunds));
+        };
+        let to_balance = self.account(to, false)?.balance();
+        let Some(new_to_balance) = to_balance.checked_add(*value) else {
+            return Ok(Err(InstrStop::OverflowPayment));
+        };
         {
             let mut from_account = self.account(from, false)?;
-            let Some(new_from_balance) = from_account.balance().checked_sub(*value) else {
-                return Ok(false);
-            };
             // `set_balance` touches the account, matching the touch the prior `transfer` performed.
             from_account.set_balance(new_from_balance);
             from_account.touch();
         }
         {
             let mut to_account = self.account(to, false)?;
-            let new_to_balance = to_account.balance().saturating_add(*value);
             to_account.set_balance(new_to_balance);
             to_account.touch();
         }
-        Ok(true)
+        Ok(Ok(()))
     }
 
     /// Creates a contract account and transfers endowment from the caller.
@@ -447,20 +456,31 @@ impl State {
 
         // Deduct the endowment from the caller. A zero endowment moves nothing and leaves the
         // caller untouched, matching the prior `transfer` behaviour.
-        if !value.is_zero() {
-            let mut caller_account = self.account(caller, false)?;
-            let Some(new_caller_balance) = caller_account.balance().checked_sub(*value) else {
+        let new_caller_balance = if value.is_zero() {
+            None
+        } else {
+            let caller_balance = self.account(caller, false)?.balance();
+            let Some(new_caller_balance) = caller_balance.checked_sub(*value) else {
                 return Ok(Err(InstrStop::OutOfFunds));
             };
+            Some(new_caller_balance)
+        };
+
+        // Preserve any balance the address already held (e.g. funds sent before creation) and add
+        // the endowment.
+        let target_balance = self.account(address, false)?.balance();
+        let Some(balance) = target_balance.checked_add(*value) else {
+            return Ok(Err(InstrStop::OverflowPayment));
+        };
+
+        if let Some(new_caller_balance) = new_caller_balance {
+            let mut caller_account = self.account(caller, false)?;
             caller_account.set_balance(new_caller_balance);
         }
 
         self.storage(address).wipe();
 
         let mut target = self.account(address, false)?;
-        // Preserve any balance the address already held (e.g. funds sent before creation) and add
-        // the endowment.
-        let balance = target.balance().wrapping_add(*value);
         *target.get_or_insert() = AccountInfo {
             nonce: u64::from(features.contains(EvmFeatures::EIP161)),
             balance,

--- a/crates/evm2/src/tests.rs
+++ b/crates/evm2/src/tests.rs
@@ -2,9 +2,9 @@ use crate::{
     BaseEvmTypes, Evm, Precompiles, SpecId,
     env::{BlockEnv, TxEnv},
     evm::{AccountInfo, InMemoryDB},
-    interpreter::{Host, InstrStop, Message, Word, op},
+    interpreter::{Host, InstrStop, Message, MessageKind, Word, op},
     registry::TxRegistry,
-    test_utils::{legacy_bytecode, push},
+    test_utils::{legacy_bytecode, push, push_address},
 };
 use alloc::vec::Vec;
 use alloy_primitives::Address;
@@ -20,6 +20,10 @@ fn run_tx(evm: &mut TestEvm, destination: Address, code: impl Into<Vec<u8>>) {
     };
     let result = Host::execute_message(evm, &TxEnv::default(), legacy_bytecode(code), &mut message);
     assert!(result.stop.is_success());
+}
+
+fn return_top_word(code: &mut Vec<u8>) {
+    code.extend([op::PUSH0, op::MSTORE, op::PUSH1, 32, op::PUSH0, op::RETURN]);
 }
 
 #[test]
@@ -88,6 +92,88 @@ fn evm_runs_transactions_against_initial_state() {
         evm.state.storage_slot(&contract, Word::from(2), false).unwrap().current(),
         Word::from(42)
     );
+}
+
+#[test]
+fn call_value_transfer_recipient_balance_overflow_fails() {
+    let contract = Address::from([0x11; 20]);
+    let target = Address::from([0x22; 20]);
+
+    let mut database = InMemoryDB::default();
+    database.insert_account_info(&contract, AccountInfo::default().with_balance(Word::from(1)));
+    database.insert_account_info(&target, AccountInfo::default().with_balance(Word::MAX));
+    let mut evm = TestEvm::new(
+        SpecId::OSAKA,
+        BlockEnv::default(),
+        TxRegistry::new(),
+        database,
+        Precompiles::base(SpecId::OSAKA),
+    );
+
+    let mut code = Vec::new();
+    push(&mut code, 0);
+    push(&mut code, 0);
+    push(&mut code, 0);
+    push(&mut code, 0);
+    push(&mut code, 1);
+    push_address(&mut code, &target);
+    push(&mut code, 50_000);
+    code.push(op::CALL);
+    return_top_word(&mut code);
+
+    let mut message = Message {
+        destination: contract,
+        code_address: contract,
+        gas_limit: 100_000,
+        ..Default::default()
+    };
+    let result =
+        Host::execute_message(&mut evm, &TxEnv::default(), legacy_bytecode(code), &mut message);
+
+    assert_eq!(result.stop, InstrStop::Return);
+    assert_eq!(Word::from_be_slice(&result.output), Word::ZERO);
+    assert_eq!(
+        evm.state.account_info_untracked(&contract).unwrap().unwrap().balance,
+        Word::from(1)
+    );
+    assert_eq!(evm.state.account_info_untracked(&target).unwrap().unwrap().balance, Word::MAX);
+}
+
+#[test]
+fn create_endowment_existing_balance_overflow_fails() {
+    let caller = Address::from([0x33; 20]);
+    let created = Address::from([0x44; 20]);
+
+    let mut database = InMemoryDB::default();
+    database.insert_account_info(&caller, AccountInfo::default().with_balance(Word::from(1)));
+    database.insert_account_info(&created, AccountInfo::default().with_balance(Word::MAX));
+    let mut evm = TestEvm::new(
+        SpecId::OSAKA,
+        BlockEnv::default(),
+        TxRegistry::new(),
+        database,
+        Precompiles::base(SpecId::OSAKA),
+    );
+
+    let mut message = Message {
+        kind: MessageKind::Create,
+        caller,
+        destination: created,
+        value: Word::from(1),
+        gas_limit: 100_000,
+        ..Default::default()
+    };
+    let result = Host::execute_message(
+        &mut evm,
+        &TxEnv::default(),
+        legacy_bytecode([op::STOP]),
+        &mut message,
+    );
+
+    assert_eq!(result.stop, InstrStop::OverflowPayment);
+    assert_eq!(result.created_address, None);
+    assert_eq!(evm.state.account_info_untracked(&caller).unwrap().unwrap().balance, Word::from(1));
+    assert_eq!(evm.state.account_info_untracked(&created).unwrap().unwrap().balance, Word::MAX);
 }
 
 #[test]

--- a/crates/evm2/src/tests.rs
+++ b/crates/evm2/src/tests.rs
@@ -4,7 +4,7 @@ use crate::{
     evm::{AccountInfo, InMemoryDB},
     interpreter::{Host, InstrStop, Message, MessageKind, Word, op},
     registry::TxRegistry,
-    test_utils::{legacy_bytecode, push, push_address},
+    test_utils::{legacy_bytecode, push},
 };
 use alloc::vec::Vec;
 use alloy_primitives::Address;
@@ -20,10 +20,6 @@ fn run_tx(evm: &mut TestEvm, destination: Address, code: impl Into<Vec<u8>>) {
     };
     let result = Host::execute_message(evm, &TxEnv::default(), legacy_bytecode(code), &mut message);
     assert!(result.stop.is_success());
-}
-
-fn return_top_word(code: &mut Vec<u8>) {
-    code.extend([op::PUSH0, op::MSTORE, op::PUSH1, 32, op::PUSH0, op::RETURN]);
 }
 
 #[test]
@@ -92,51 +88,6 @@ fn evm_runs_transactions_against_initial_state() {
         evm.state.storage_slot(&contract, Word::from(2), false).unwrap().current(),
         Word::from(42)
     );
-}
-
-#[test]
-fn call_value_transfer_recipient_balance_overflow_fails() {
-    let contract = Address::from([0x11; 20]);
-    let target = Address::from([0x22; 20]);
-
-    let mut database = InMemoryDB::default();
-    database.insert_account_info(&contract, AccountInfo::default().with_balance(Word::from(1)));
-    database.insert_account_info(&target, AccountInfo::default().with_balance(Word::MAX));
-    let mut evm = TestEvm::new(
-        SpecId::OSAKA,
-        BlockEnv::default(),
-        TxRegistry::new(),
-        database,
-        Precompiles::base(SpecId::OSAKA),
-    );
-
-    let mut code = Vec::new();
-    push(&mut code, 0);
-    push(&mut code, 0);
-    push(&mut code, 0);
-    push(&mut code, 0);
-    push(&mut code, 1);
-    push_address(&mut code, &target);
-    push(&mut code, 50_000);
-    code.push(op::CALL);
-    return_top_word(&mut code);
-
-    let mut message = Message {
-        destination: contract,
-        code_address: contract,
-        gas_limit: 100_000,
-        ..Default::default()
-    };
-    let result =
-        Host::execute_message(&mut evm, &TxEnv::default(), legacy_bytecode(code), &mut message);
-
-    assert_eq!(result.stop, InstrStop::Return);
-    assert_eq!(Word::from_be_slice(&result.output), Word::ZERO);
-    assert_eq!(
-        evm.state.account_info_untracked(&contract).unwrap().unwrap().balance,
-        Word::from(1)
-    );
-    assert_eq!(evm.state.account_info_untracked(&target).unwrap().unwrap().balance, Word::MAX);
 }
 
 #[test]


### PR DESCRIPTION
This keeps the checked arithmetic part of the balance/payment overflow audit group: upfront transaction max-spend calculation, CREATE endowment credits, and gas settlement credits now use checked arithmetic where revm does.

The change keeps signed balance deltas for existing debit paths, adds a checked unsigned credit helper for settlement, and keeps unit coverage for the remaining reproducer paths: max upfront overflow rejection, max-balance CREATE target failure, and max-balance beneficiary reward handling. The `State::transfer` result-shape change and CALL value-transfer overflow reproducer are split into #260.
