### PR TITLE
fix: avoid truncated push pointer advance

### DIFF
--- a/crates/evm2/src/bytecode/analysis.rs
+++ b/crates/evm2/src/bytecode/analysis.rs
@@ -26,8 +26,9 @@ pub(super) fn analyze_legacy(bytecode: Bytes) -> (JumpTable, Bytes) {
         } else {
             let push_offset = last_byte.wrapping_sub(op::PUSH1);
             if push_offset < 32 {
-                // SAFETY: Iterator access range is checked in the while loop.
-                iterator = unsafe { iterator.add(push_offset as usize + 2) };
+                // A trailing PUSH can advance past the bytecode allocation.
+                // `wrapping_add` keeps that offset computation defined.
+                iterator = iterator.wrapping_add(push_offset as usize + 2);
             } else {
                 // SAFETY: Iterator access range is checked in the while loop.
                 iterator = unsafe { iterator.add(1) };
@@ -126,6 +127,16 @@ mod tests {
         let bytecode = vec![op::PUSH32];
         let (_, padded_bytecode) = analyze_legacy(bytecode.clone().into());
         assert_eq!(padded_bytecode.len(), bytecode.len() + 33); // PUSH32 + 32 bytes + STOP
+    }
+
+    #[test]
+    fn test_truncated_pushes_are_padded_without_inbounds_pointer_advance() {
+        for push in op::PUSH1..=op::PUSH32 {
+            let bytecode = vec![push];
+            let (_, padded_bytecode) = analyze_legacy(bytecode.clone().into());
+            let push_immediate_len = (push - op::PUSH1 + 1) as usize;
+            assert_eq!(padded_bytecode.len(), bytecode.len() + push_immediate_len + 1);
+        }
     }
 
     #[test]

--- a/crates/evm2/src/bytecode/serde_impl.rs
+++ b/crates/evm2/src/bytecode/serde_impl.rs
@@ -1,43 +1,43 @@
-use super::Bytecode;
+use super::{Bytecode, BytecodeKind};
 use alloy_primitives::{Address, Bytes};
 use serde::{Deserialize, Serialize};
 
-// TODO: eventually remove `BytecodeSerdeOld`.
-
-#[derive(Deserialize)]
-#[serde(untagged)]
+#[derive(Serialize, Deserialize)]
 enum BytecodeSerde {
-    New(Bytes),
-    Old(BytecodeSerdeOld),
+    LegacyAnalyzed { bytecode: Bytes, original_len: usize },
+    Eip7702 { delegated_address: Address },
 }
 
 #[derive(Deserialize)]
-enum BytecodeSerdeOld {
-    LegacyAnalyzed {
-        bytecode: Bytes,
-        original_len: usize,
-        #[allow(dead_code)]
-        jump_table: serde::de::IgnoredAny,
-    },
-    Eip7702 {
-        delegated_address: Address,
-    },
+#[serde(untagged)]
+enum BytecodeDeserialize {
+    New(Bytes),
+    Old(BytecodeSerde),
 }
 
 impl Serialize for Bytecode {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        self.original_bytes().serialize(serializer)
+        let repr = match self.kind() {
+            BytecodeKind::Legacy => BytecodeSerde::LegacyAnalyzed {
+                bytecode: self.bytes().clone(),
+                original_len: self.len(),
+            },
+            BytecodeKind::Eip7702 => BytecodeSerde::Eip7702 {
+                delegated_address: self.eip7702_address().expect("EIP-7702 bytecode has address"),
+            },
+        };
+        repr.serialize(serializer)
     }
 }
 
 impl<'de> Deserialize<'de> for Bytecode {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        match BytecodeSerde::deserialize(deserializer)? {
-            BytecodeSerde::New(bytes) => {
+        match BytecodeDeserialize::deserialize(deserializer)? {
+            BytecodeDeserialize::New(bytes) => {
                 Self::new_raw_checked(bytes).map_err(serde::de::Error::custom)
             }
-            BytecodeSerde::Old(bytecode_serde_old) => match bytecode_serde_old {
-                BytecodeSerdeOld::LegacyAnalyzed { bytecode, original_len, jump_table: _ } => {
+            BytecodeDeserialize::Old(bytecode_serde) => match bytecode_serde {
+                BytecodeSerde::LegacyAnalyzed { bytecode, original_len } => {
                     if original_len > bytecode.len() {
                         return Err(serde::de::Error::custom(
                             "original_len is greater than bytecode length",
@@ -45,10 +45,45 @@ impl<'de> Deserialize<'de> for Bytecode {
                     }
                     Ok(Self::new_legacy(bytecode.slice(..original_len)))
                 }
-                BytecodeSerdeOld::Eip7702 { delegated_address } => {
+                BytecodeSerde::Eip7702 { delegated_address } => {
                     Ok(Self::new_eip7702(delegated_address))
                 }
             },
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::constants::{EIP7702_BYTECODE_LEN, EIP7702_MAGIC_BYTES, EIP7702_VERSION};
+
+    #[test]
+    fn serde_roundtrip_preserves_legacy_eip7702_prefix() {
+        let mut raw = [0u8; EIP7702_BYTECODE_LEN];
+        raw[..2].copy_from_slice(EIP7702_MAGIC_BYTES);
+        raw[2] = EIP7702_VERSION;
+        raw[3..].copy_from_slice(Address::with_last_byte(0x7a).as_slice());
+
+        let bytecode = Bytecode::new_legacy(Bytes::copy_from_slice(&raw));
+        assert_eq!(bytecode.kind(), BytecodeKind::Legacy);
+
+        let json = serde_json::to_string(&bytecode).unwrap();
+        let deserialized: Bytecode = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(deserialized.kind(), BytecodeKind::Legacy);
+        assert_eq!(deserialized.original_byte_slice(), raw);
+    }
+
+    #[test]
+    fn serde_roundtrip_preserves_eip7702_kind() {
+        let delegated_address = Address::with_last_byte(0x42);
+        let bytecode = Bytecode::new_eip7702(delegated_address);
+
+        let json = serde_json::to_string(&bytecode).unwrap();
+        let deserialized: Bytecode = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(deserialized.kind(), BytecodeKind::Eip7702);
+        assert_eq!(deserialized.eip7702_address(), Some(delegated_address));
     }
 }

--- a/crates/evm2/src/bytecode/serde_impl.rs
+++ b/crates/evm2/src/bytecode/serde_impl.rs
@@ -1,43 +1,43 @@
-use super::{Bytecode, BytecodeKind};
+use super::Bytecode;
 use alloy_primitives::{Address, Bytes};
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize)]
-enum BytecodeSerde {
-    LegacyAnalyzed { bytecode: Bytes, original_len: usize },
-    Eip7702 { delegated_address: Address },
-}
+// TODO: eventually remove `BytecodeSerdeOld`.
 
 #[derive(Deserialize)]
 #[serde(untagged)]
-enum BytecodeDeserialize {
+enum BytecodeSerde {
     New(Bytes),
-    Old(BytecodeSerde),
+    Old(BytecodeSerdeOld),
+}
+
+#[derive(Deserialize)]
+enum BytecodeSerdeOld {
+    LegacyAnalyzed {
+        bytecode: Bytes,
+        original_len: usize,
+        #[allow(dead_code)]
+        jump_table: serde::de::IgnoredAny,
+    },
+    Eip7702 {
+        delegated_address: Address,
+    },
 }
 
 impl Serialize for Bytecode {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let repr = match self.kind() {
-            BytecodeKind::Legacy => BytecodeSerde::LegacyAnalyzed {
-                bytecode: self.bytes().clone(),
-                original_len: self.len(),
-            },
-            BytecodeKind::Eip7702 => BytecodeSerde::Eip7702 {
-                delegated_address: self.eip7702_address().expect("EIP-7702 bytecode has address"),
-            },
-        };
-        repr.serialize(serializer)
+        self.original_bytes().serialize(serializer)
     }
 }
 
 impl<'de> Deserialize<'de> for Bytecode {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        match BytecodeDeserialize::deserialize(deserializer)? {
-            BytecodeDeserialize::New(bytes) => {
+        match BytecodeSerde::deserialize(deserializer)? {
+            BytecodeSerde::New(bytes) => {
                 Self::new_raw_checked(bytes).map_err(serde::de::Error::custom)
             }
-            BytecodeDeserialize::Old(bytecode_serde) => match bytecode_serde {
-                BytecodeSerde::LegacyAnalyzed { bytecode, original_len } => {
+            BytecodeSerde::Old(bytecode_serde_old) => match bytecode_serde_old {
+                BytecodeSerdeOld::LegacyAnalyzed { bytecode, original_len, jump_table: _ } => {
                     if original_len > bytecode.len() {
                         return Err(serde::de::Error::custom(
                             "original_len is greater than bytecode length",
@@ -45,45 +45,10 @@ impl<'de> Deserialize<'de> for Bytecode {
                     }
                     Ok(Self::new_legacy(bytecode.slice(..original_len)))
                 }
-                BytecodeSerde::Eip7702 { delegated_address } => {
+                BytecodeSerdeOld::Eip7702 { delegated_address } => {
                     Ok(Self::new_eip7702(delegated_address))
                 }
             },
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::constants::{EIP7702_BYTECODE_LEN, EIP7702_MAGIC_BYTES, EIP7702_VERSION};
-
-    #[test]
-    fn serde_roundtrip_preserves_legacy_eip7702_prefix() {
-        let mut raw = [0u8; EIP7702_BYTECODE_LEN];
-        raw[..2].copy_from_slice(EIP7702_MAGIC_BYTES);
-        raw[2] = EIP7702_VERSION;
-        raw[3..].copy_from_slice(Address::with_last_byte(0x7a).as_slice());
-
-        let bytecode = Bytecode::new_legacy(Bytes::copy_from_slice(&raw));
-        assert_eq!(bytecode.kind(), BytecodeKind::Legacy);
-
-        let json = serde_json::to_string(&bytecode).unwrap();
-        let deserialized: Bytecode = serde_json::from_str(&json).unwrap();
-
-        assert_eq!(deserialized.kind(), BytecodeKind::Legacy);
-        assert_eq!(deserialized.original_byte_slice(), raw);
-    }
-
-    #[test]
-    fn serde_roundtrip_preserves_eip7702_kind() {
-        let delegated_address = Address::with_last_byte(0x42);
-        let bytecode = Bytecode::new_eip7702(delegated_address);
-
-        let json = serde_json::to_string(&bytecode).unwrap();
-        let deserialized: Bytecode = serde_json::from_str(&json).unwrap();
-
-        assert_eq!(deserialized.kind(), BytecodeKind::Eip7702);
-        assert_eq!(deserialized.eip7702_address(), Some(delegated_address));
     }
 }


### PR DESCRIPTION
Fixes EVM2-2026-112 by matching revm's analyzer behavior for truncated PUSH opcodes: the scanner no longer performs an in-bounds pointer advance when the PUSH immediate extends beyond the bytecode allocation, while preserving the existing padding semantics.

The bytecode serialization kind-tagging fix that was previously in this branch is now split into #261.
