### PR TITLE
fix: harden async lifecycle

### DIFF
--- a/crates/evm2/src/evm/async.rs
+++ b/crates/evm2/src/evm/async.rs
@@ -69,6 +69,9 @@ pub enum AsyncError<E = core::convert::Infallible> {
     /// Blocking async I/O was requested outside a supported Tokio runtime.
     #[error("async host operation requires a Tokio multi-thread runtime")]
     Runtime,
+    /// Blocking async I/O was requested from a Tokio current-thread runtime.
+    #[error("async host operation cannot block on a Tokio current-thread runtime")]
+    CurrentThreadRuntime,
     /// Async fiber stack setup failed.
     #[error(transparent)]
     Io(io::Error),
@@ -83,6 +86,7 @@ impl AsyncError {
             Self::Cancelled => AsyncError::Cancelled,
             Self::NotOnFiber => AsyncError::NotOnFiber,
             Self::Runtime => AsyncError::Runtime,
+            Self::CurrentThreadRuntime => AsyncError::CurrentThreadRuntime,
             Self::Io(error) => AsyncError::Io(error),
             Self::Inner(error) => match error {},
         }
@@ -379,7 +383,7 @@ where
         Ok(current)
             if matches!(current.runtime_flavor(), tokio::runtime::RuntimeFlavor::CurrentThread) =>
         {
-            Err(AsyncError::Runtime)
+            Err(AsyncError::CurrentThreadRuntime)
         }
         Ok(_) => Ok(task::block_in_place(move || handle.block_on(future))),
         Err(_) => Ok(handle.block_on(future)),
@@ -914,7 +918,7 @@ mod tests {
             db.error(code).to_string()
         });
 
-        assert_eq!(result, "async host operation requires a Tokio multi-thread runtime");
+        assert_eq!(result, "async host operation cannot block on a Tokio current-thread runtime");
     }
 
     #[test]

--- a/crates/evm2/src/evm/async.rs
+++ b/crates/evm2/src/evm/async.rs
@@ -143,8 +143,8 @@ pub(crate) fn on_fiber_result<'a, R, E>(
     func: impl FnOnce() -> Result<R, E> + 'a,
 ) -> impl Future<Output = AsyncResult<R, E>> + Send + 'a
 where
-    R: Send + 'a,
-    E: Send + 'a,
+    R: 'a,
+    E: 'a,
 {
     OnFiber::new(func)
 }
@@ -160,8 +160,8 @@ pub(crate) unsafe fn on_fiber_result_with_stack<'a, R, E>(
     func: impl FnOnce() -> Result<R, E> + 'a,
 ) -> impl Future<Output = AsyncResult<R, E>> + Send + 'a
 where
-    R: Send + 'a,
-    E: Send + 'a,
+    R: 'a,
+    E: 'a,
 {
     OnFiber::with_stack(stack, func)
 }
@@ -171,7 +171,7 @@ pub(crate) fn on_fiber<'a, R>(
     func: impl FnOnce() -> R + 'a,
 ) -> impl Future<Output = AsyncResult<R>> + Send + 'a
 where
-    R: Send + 'a,
+    R: 'a,
 {
     on_fiber_result(move || Ok::<_, core::convert::Infallible>(func()))
 }
@@ -186,7 +186,7 @@ pub(crate) unsafe fn on_fiber_with_stack<'a, R>(
     func: impl FnOnce() -> R + 'a,
 ) -> impl Future<Output = AsyncResult<R>> + Send + 'a
 where
-    R: Send + 'a,
+    R: 'a,
 {
     unsafe { on_fiber_result_with_stack(stack, move || Ok::<_, core::convert::Infallible>(func())) }
 }
@@ -257,7 +257,7 @@ struct FiberFuture<'a, R> {
 // SAFETY: The future may move between polls, but the coroutine stack itself is heap allocated and
 // is only resumed through `poll` with a fresh task context. Values that can remain on the coroutine
 // stack across suspension are required to be `Send` by the blocking boundary.
-unsafe impl<R: Send> Send for FiberFuture<'_, R> {}
+unsafe impl<R> Send for FiberFuture<'_, R> {}
 
 impl<'a, R> FiberFuture<'a, R> {
     fn new(
@@ -736,7 +736,7 @@ mod tests {
 
         let result = poll_ready(evm.transact_async(&tx)).unwrap();
 
-        assert_eq!(result.gas_used(), 42);
+        assert_eq!(result.result().gas_used(), 42);
     }
 
     #[test]
@@ -758,7 +758,7 @@ mod tests {
 
         let result = poll_ready(assert_send(evm.transact_async(&tx))).unwrap();
 
-        assert_eq!(result.gas_used(), 42);
+        assert_eq!(result.result().gas_used(), 42);
     }
 
     #[test]
@@ -781,7 +781,7 @@ mod tests {
 
         let result = poll_ready(assert_send(evm.transact_async(&tx))).unwrap();
 
-        assert_eq!(result.gas_used(), 42);
+        assert_eq!(result.result().gas_used(), 42);
     }
 
     #[test]
@@ -906,20 +906,15 @@ mod tests {
     fn current_thread_tokio_handle_does_not_panic_in_sync_adapter() {
         let runtime = tokio::runtime::Builder::new_current_thread().build().unwrap();
         let handle = runtime.handle().clone();
-        let result = std::panic::catch_unwind(move || {
-            runtime.block_on(async move {
-                let mut db = AsyncDb::with_tokio_handle(TokioDb, handle);
-                let address = Address::ZERO;
-                let key = Word::from(7);
-                let code = DynDatabase::get_storage(&mut db, &address, &key).unwrap_err();
-                db.error(code).to_string()
-            })
+        let result = runtime.block_on(async move {
+            let mut db = AsyncDb::with_tokio_handle(TokioDb, handle);
+            let address = Address::ZERO;
+            let key = Word::from(7);
+            let code = DynDatabase::get_storage(&mut db, &address, &key).unwrap_err();
+            db.error(code).to_string()
         });
 
-        assert_matches!(
-            result.as_deref(),
-            Ok("async host operation requires a Tokio multi-thread runtime")
-        );
+        assert_eq!(result, "async host operation requires a Tokio multi-thread runtime");
     }
 
     #[test]
@@ -967,7 +962,7 @@ mod tests {
         );
         evm.evm_is_send::<InMemoryDB, Precompiles<BaseEvmTypes>>();
 
-        let result = poll_ready(evm.system_call_async(contract, Bytes::new())).unwrap();
+        let result = poll_ready(evm.system_call_async(contract, Bytes::new())).unwrap().discard();
 
         assert!(result.status);
         assert_eq!(result.gas_used, 0);
@@ -992,7 +987,7 @@ mod tests {
         assert_matches!(evm.transact(&tx), Err(HandlerError::Database(_)));
         assert!(evm.db_error_code().is_some());
 
-        let result = poll_ready(evm.system_call_async(contract, Bytes::new())).unwrap();
+        let result = poll_ready(evm.system_call_async(contract, Bytes::new())).unwrap().discard();
 
         assert!(result.status);
         assert_eq!(result.db_error_code, None);

--- a/crates/evm2/src/evm/async.rs
+++ b/crates/evm2/src/evm/async.rs
@@ -92,6 +92,7 @@ impl AsyncError {
 struct CurrentFiber {
     suspend: NonNull<Yielder<Resume, Yield>>,
     future_cx: NonNull<Context<'static>>,
+    previous: Option<NonNull<Self>>,
     cancelled: bool,
 }
 
@@ -103,12 +104,16 @@ impl CurrentFiber {
 
     #[inline]
     fn suspend(&mut self) -> AsyncResult<()> {
+        let current = NonNull::from(&mut *self);
+        CURRENT.set(self.previous);
         match unsafe { self.suspend.as_ref() }.suspend(()) {
             Ok(cx) => {
+                CURRENT.set(Some(current));
                 self.future_cx = cx;
                 Ok(())
             }
             Err(error) => {
+                CURRENT.set(Some(current));
                 self.cancelled = true;
                 Err(error)
             }
@@ -265,10 +270,15 @@ impl<'a, R> FiberFuture<'a, R> {
         };
         let body = move |suspend: &Yielder<Resume, Yield>, resume| {
             let future_cx = resume?;
-            let mut current =
-                CurrentFiber { suspend: NonNull::from(suspend), future_cx, cancelled: false };
+            let previous = CURRENT.get();
+            let mut current = CurrentFiber {
+                suspend: NonNull::from(suspend),
+                future_cx,
+                previous,
+                cancelled: false,
+            };
             let current = NonNull::from(&mut current);
-            let previous = CURRENT.replace(Some(current));
+            CURRENT.set(Some(current));
             let _reset = ResetCurrentFiber(previous);
             Ok(func())
         };
@@ -361,21 +371,18 @@ fn current_tokio_handle() -> Option<Handle> {
     }
 }
 
-fn block_on_handle<F>(handle: &Handle, future: F) -> F::Output
+fn block_on_handle<F>(handle: &Handle, future: F) -> AsyncResult<F::Output>
 where
     F: Future,
 {
-    let should_use_block_in_place = Handle::try_current()
-        .ok()
-        .map(|current| {
-            !matches!(current.runtime_flavor(), tokio::runtime::RuntimeFlavor::CurrentThread)
-        })
-        .unwrap_or(false);
-
-    if should_use_block_in_place {
-        task::block_in_place(move || handle.block_on(future))
-    } else {
-        handle.block_on(future)
+    match Handle::try_current() {
+        Ok(current)
+            if matches!(current.runtime_flavor(), tokio::runtime::RuntimeFlavor::CurrentThread) =>
+        {
+            Err(AsyncError::Runtime)
+        }
+        Ok(_) => Ok(task::block_in_place(move || handle.block_on(future))),
+        Err(_) => Ok(handle.block_on(future)),
     }
 }
 
@@ -388,7 +395,7 @@ where
     }
 
     if let Some(runtime) = runtime {
-        return Ok(block_on_handle(runtime, future));
+        return block_on_handle(runtime, future);
     }
 
     Err(AsyncError::Runtime)
@@ -585,12 +592,12 @@ mod tests {
         bytecode::Bytecode,
         env::BlockEnv,
         evm::{Database, Db, DynDatabase, InMemoryDB, PrecompileProvider},
-        interpreter::{GasTracker, Message, Word},
+        interpreter::{GasTracker, Message, Word, op},
         precompile::PrecompileOutput,
         registry::{HandlerError, HandlerResult, TxRegistry, TxRequest},
     };
     use alloy_consensus::{TxLegacy, transaction::Recovered};
-    use alloy_primitives::{Address, B256, Bytes};
+    use alloy_primitives::{Address, B256, Bytes, TxKind};
     use core::{
         assert_matches, convert::Infallible, fmt, future::Future, pin::Pin, ptr::NonNull,
         task::Poll,
@@ -619,6 +626,18 @@ mod tests {
 
         assert_matches!(future.as_mut().poll(&mut cx), Poll::Pending);
         assert_matches!(future.as_mut().poll(&mut cx), Poll::Ready(Ok(3)));
+    }
+
+    #[test]
+    fn current_tls_is_cleared_while_fiber_is_pending() {
+        let mut future = core::pin::pin!(on_fiber(|| {
+            let _ = block_on_current(PendingForever);
+        }));
+        let waker = Waker::noop();
+        let mut cx = Context::from_waker(waker);
+
+        assert_matches!(future.as_mut().poll(&mut cx), Poll::Pending);
+        assert_matches!(block_on_current(core::future::ready(())), Err(AsyncError::NotOnFiber));
     }
 
     #[test]
@@ -884,6 +903,26 @@ mod tests {
     }
 
     #[test]
+    fn current_thread_tokio_handle_does_not_panic_in_sync_adapter() {
+        let runtime = tokio::runtime::Builder::new_current_thread().build().unwrap();
+        let handle = runtime.handle().clone();
+        let result = std::panic::catch_unwind(move || {
+            runtime.block_on(async move {
+                let mut db = AsyncDb::with_tokio_handle(TokioDb, handle);
+                let address = Address::ZERO;
+                let key = Word::from(7);
+                let code = DynDatabase::get_storage(&mut db, &address, &key).unwrap_err();
+                db.error(code).to_string()
+            })
+        });
+
+        assert_matches!(
+            result.as_deref(),
+            Ok("async host operation requires a Tokio multi-thread runtime")
+        );
+    }
+
+    #[test]
     fn synchronous_database_requires_runtime_handle() {
         let mut db = AsyncDb::new(TestDb);
         let address = Address::ZERO;
@@ -932,6 +971,61 @@ mod tests {
 
         assert!(result.status);
         assert_eq!(result.gas_used, 0);
+    }
+
+    #[test]
+    fn system_call_async_clears_stale_database_error_code() {
+        let contract = Address::from([0x42; 20]);
+        let mut evm = Evm::<BaseEvmTypes>::new(
+            SpecId::OSAKA,
+            BlockEnv::default(),
+            crate::ethereum::ethereum_tx_registry(SpecId::OSAKA),
+            Db::new(FailOnceAccountDb { fail_next_account: true }),
+            Precompiles::base(SpecId::OSAKA),
+        );
+        evm.evm_is_send::<Db<FailOnceAccountDb>, Precompiles<BaseEvmTypes>>();
+        let tx = crate::ethereum::RecoveredTxEnvelope::Legacy(Recovered::new_unchecked(
+            TxLegacy { gas_limit: 100_000, ..TxLegacy::default() },
+            Address::ZERO,
+        ));
+
+        assert_matches!(evm.transact(&tx), Err(HandlerError::Database(_)));
+        assert!(evm.db_error_code().is_some());
+
+        let result = poll_ready(evm.system_call_async(contract, Bytes::new())).unwrap();
+
+        assert!(result.status);
+        assert_eq!(result.db_error_code, None);
+    }
+
+    #[test]
+    fn dropping_transact_async_discards_nonce_after_cancelled_db_future() {
+        let caller = Address::ZERO;
+        let contract = Address::from([0x42; 20]);
+        let code = Bytecode::new_legacy(Bytes::from_static(&[op::PUSH1, 0, op::SLOAD, op::STOP]));
+        let mut evm = Evm::<BaseEvmTypes>::new(
+            SpecId::OSAKA,
+            BlockEnv::default(),
+            crate::ethereum::ethereum_tx_registry(SpecId::OSAKA),
+            AsyncDb::new(CancellingDb { contract, code }),
+            Precompiles::base(SpecId::OSAKA),
+        );
+        evm.evm_is_send::<AsyncDb<CancellingDb>, Precompiles<BaseEvmTypes>>();
+        let tx = crate::ethereum::RecoveredTxEnvelope::Legacy(Recovered::new_unchecked(
+            TxLegacy { to: TxKind::Call(contract), gas_limit: 100_000, ..TxLegacy::default() },
+            caller,
+        ));
+        {
+            let mut future = core::pin::pin!(evm.transact_async(&tx));
+            let waker = Waker::noop();
+            let mut cx = Context::from_waker(waker);
+
+            assert_matches!(future.as_mut().poll(&mut cx), Poll::Pending);
+        }
+
+        let nonce = evm.read_account_info(&caller).unwrap().map_or(0, |info| info.nonce);
+
+        assert_eq!(nonce, 0);
     }
 
     #[test]
@@ -1002,6 +1096,37 @@ mod tests {
         fn get_storage(&mut self, _address: &Address, _key: &Word) -> Result<Word, Self::Error> {
             let _ = Rc::strong_count(&self.marker);
             Ok(Word::from(9))
+        }
+
+        fn get_block_hash(&mut self, _number: &Word) -> Result<Option<B256>, Self::Error> {
+            Ok(None)
+        }
+    }
+
+    struct FailOnceAccountDb {
+        fail_next_account: bool,
+    }
+
+    impl Database for FailOnceAccountDb {
+        type Error = TestError;
+
+        fn get_account(
+            &mut self,
+            _address: &Address,
+        ) -> Result<Option<crate::evm::AccountInfo>, Self::Error> {
+            if self.fail_next_account {
+                self.fail_next_account = false;
+                return Err(TestError);
+            }
+            Ok(None)
+        }
+
+        fn get_code_by_hash(&mut self, _code_hash: &B256) -> Result<Bytecode, Self::Error> {
+            Ok(Bytecode::default())
+        }
+
+        fn get_storage(&mut self, _address: &Address, _key: &Word) -> Result<Word, Self::Error> {
+            Ok(Word::ZERO)
         }
 
         fn get_block_hash(&mut self, _number: &Word) -> Result<Option<B256>, Self::Error> {
@@ -1124,6 +1249,42 @@ mod tests {
         ) -> Result<Word, Self::Error> {
             PendingStorage { pending: &mut self.pending }.await;
             Ok(Word::from(9))
+        }
+
+        async fn get_block_hash(&mut self, _number: Word) -> Result<Option<B256>, Self::Error> {
+            Ok(None)
+        }
+    }
+
+    struct CancellingDb {
+        contract: Address,
+        code: Bytecode,
+    }
+
+    impl AsyncDatabase for CancellingDb {
+        type Error = Infallible;
+
+        async fn get_account(
+            &mut self,
+            address: Address,
+        ) -> Result<Option<crate::evm::AccountInfo>, Self::Error> {
+            if address == self.contract {
+                return Ok(Some(crate::evm::AccountInfo::default().with_code(self.code.clone())));
+            }
+            Ok(Some(crate::evm::AccountInfo::default()))
+        }
+
+        async fn get_code_by_hash(&mut self, _code_hash: B256) -> Result<Bytecode, Self::Error> {
+            Ok(self.code.clone())
+        }
+
+        async fn get_storage(
+            &mut self,
+            _address: Address,
+            _key: Word,
+        ) -> Result<Word, Self::Error> {
+            PendingForever.await;
+            Ok(Word::ZERO)
         }
 
         async fn get_block_hash(&mut self, _number: Word) -> Result<Option<B256>, Self::Error> {

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -766,7 +766,7 @@ impl<'a, T: EvmTypes> SendEvmRef<'a, T> {
 impl<T: EvmTypes<Tx: Typed2718, Host = Evm<T>>> SendEvmRef<'_, T> {
     #[inline]
     fn transact(&mut self, tx: &T::Tx) -> HandlerResult<TxResult<T>> {
-        self.evm.transact(tx).map(ExecutedTx::commit)
+        self.evm.transact(tx).map(ExecutedTx::commit_or_discard_database_error)
     }
 }
 

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -733,43 +733,6 @@ impl Drop for ExecutionGuard {
     }
 }
 
-#[cfg(feature = "async")]
-struct SendEvmRef<'a, T: EvmTypes> {
-    evm: &'a mut Evm<T>,
-}
-
-#[cfg(feature = "async")]
-// SAFETY: `SendEvmRef` is only constructed by async entrypoints after `Evm::evm_is_send` has
-// verified the concrete erased field types as `Send`.
-unsafe impl<T> Send for SendEvmRef<'_, T>
-where
-    T: EvmTypes,
-    T::SpecId: Send,
-    T::Tx: Send,
-    T::MessageExt: Send,
-    T::MessageResultExt: Send,
-    T::TxEnvExt: Send,
-    T::TxResultExt: Send,
-    T::BlockEnvExt: Send,
-{
-}
-
-#[cfg(feature = "async")]
-impl<'a, T: EvmTypes> SendEvmRef<'a, T> {
-    #[inline]
-    const fn new(evm: &'a mut Evm<T>) -> Self {
-        Self { evm }
-    }
-}
-
-#[cfg(feature = "async")]
-impl<T: EvmTypes<Tx: Typed2718, Host = Evm<T>>> SendEvmRef<'_, T> {
-    #[inline]
-    fn transact(&mut self, tx: &T::Tx) -> HandlerResult<TxResult<T>> {
-        self.evm.transact(tx).map(ExecutedTx::commit_or_discard_database_error)
-    }
-}
-
 impl<T: EvmTypes<Tx: Typed2718, Host = Self>> Evm<T> {
     /// Dispatches the transaction to its handler and returns an executed transaction handle.
     ///
@@ -823,9 +786,6 @@ impl<T: EvmTypes<Tx: Typed2718, Host = Self>> Evm<T> {
     /// advantage of yielding database I/O. With a synchronous database this is mostly equivalent to
     /// running the synchronous transaction on a fiber.
     ///
-    /// This commits the executed transaction on the fiber and returns the result-only
-    /// [`TxResult`].
-    ///
     /// This returns a `Send` future. Before calling it, the current erased database, precompile
     /// provider, and optional inspector must be verified with [`Self::evm_is_send`] or
     /// [`Self::evm_is_send_with_inspector`].
@@ -833,18 +793,16 @@ impl<T: EvmTypes<Tx: Typed2718, Host = Self>> Evm<T> {
     pub fn transact_async<'a>(
         &'a mut self,
         tx: &'a T::Tx,
-    ) -> impl Future<Output = r#async::AsyncResult<TxResult<T>, registry::HandlerError>> + Send + 'a
+    ) -> impl Future<Output = r#async::AsyncResult<ExecutedTx<'a, T>, registry::HandlerError>> + Send + 'a
     where
         T::Tx: Sync,
-        T::TxResultExt: Send,
     {
         self.assert_erased_send();
         let stack = self.async_stack();
-        let mut evm = SendEvmRef::new(self);
         // SAFETY: The returned future owns the exclusive `&mut self` borrow, so nothing else can
-        // access the EVM stack slot until that future is dropped. The send marker checked above
-        // requires all erased EVM fields to have been verified by `Evm::evm_is_send`.
-        unsafe { r#async::on_fiber_result_with_stack(stack, move || evm.transact(tx)) }
+        // access the EVM stack slot until that future is dropped. The assertion above requires all
+        // erased EVM fields to have been verified by `Evm::evm_is_send`.
+        unsafe { r#async::on_fiber_result_with_stack(stack, move || self.transact(tx)) }
     }
 
     /// Dispatches each transaction to its registered EIP-2718 handler and commits it.

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -733,6 +733,27 @@ impl Drop for ExecutionGuard {
     }
 }
 
+#[cfg(feature = "async")]
+struct SendEvmRef<'a, T: EvmTypes> {
+    evm: &'a mut Evm<T>,
+}
+
+#[cfg(feature = "async")]
+// SAFETY: `SendEvmRef` is only constructed by async entrypoints after `Evm::evm_is_send` has
+// verified the concrete erased field types as `Send`.
+unsafe impl<T> Send for SendEvmRef<'_, T>
+where
+    T: EvmTypes,
+    T::SpecId: Send,
+    T::Tx: Send,
+    T::MessageExt: Send,
+    T::MessageResultExt: Send,
+    T::TxEnvExt: Send,
+    T::TxResultExt: Send,
+    T::BlockEnvExt: Send,
+{
+}
+
 impl<T: EvmTypes<Tx: Typed2718, Host = Self>> Evm<T> {
     /// Dispatches the transaction to its handler and returns an executed transaction handle.
     ///
@@ -799,10 +820,16 @@ impl<T: EvmTypes<Tx: Typed2718, Host = Self>> Evm<T> {
     {
         self.assert_erased_send();
         let stack = self.async_stack();
+        let evm = SendEvmRef { evm: self };
         // SAFETY: The returned future owns the exclusive `&mut self` borrow, so nothing else can
-        // access the EVM stack slot until that future is dropped. The assertion above requires all
-        // erased EVM fields to have been verified by `Evm::evm_is_send`.
-        unsafe { r#async::on_fiber_result_with_stack(stack, move || self.transact(tx)) }
+        // access the EVM stack slot until that future is dropped. The send marker checked above
+        // requires all erased EVM fields to have been verified by `Evm::evm_is_send`.
+        unsafe {
+            r#async::on_fiber_result_with_stack(stack, move || {
+                let SendEvmRef { evm } = evm;
+                evm.transact(tx)
+            })
+        }
     }
 
     /// Dispatches each transaction to its registered EIP-2718 handler and commits it.

--- a/crates/evm2/src/evm/system.rs
+++ b/crates/evm2/src/evm/system.rs
@@ -7,8 +7,6 @@
 //! and produces no state changes.
 
 #[cfg(feature = "async")]
-use super::SendEvmRef;
-#[cfg(feature = "async")]
 use super::r#async;
 use super::{Evm, ExecutedTx, TxResult};
 use crate::{
@@ -70,19 +68,15 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
         &mut self,
         system_contract_address: Address,
         data: Bytes,
-    ) -> impl Future<Output = r#async::AsyncResult<TxResult<T>, Infallible>> + Send + '_
-    where
-        T::TxResultExt: Send,
-    {
+    ) -> impl Future<Output = r#async::AsyncResult<ExecutedTx<'_, T>, Infallible>> + Send + '_ {
         self.assert_erased_send();
         let stack = self.async_stack();
-        let mut evm = SendEvmRef::new(self);
         // SAFETY: The returned future owns the exclusive `&mut self` borrow, so nothing else can
-        // access the EVM stack slot until that future is dropped. The send marker checked above
-        // requires all erased EVM fields to have been verified by `Evm::evm_is_send`.
+        // access the EVM stack slot until that future is dropped. The assertion above requires all
+        // erased EVM fields to have been verified by `Evm::evm_is_send`.
         unsafe {
             r#async::on_fiber_with_stack(stack, move || {
-                evm.system_call(system_contract_address, data)
+                self.system_call(system_contract_address, data)
             })
         }
     }
@@ -177,41 +171,17 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
         caller: Address,
         system_contract_address: Address,
         data: Bytes,
-    ) -> impl Future<Output = r#async::AsyncResult<TxResult<T>, Infallible>> + Send + '_
-    where
-        T::TxResultExt: Send,
-    {
+    ) -> impl Future<Output = r#async::AsyncResult<ExecutedTx<'_, T>, Infallible>> + Send + '_ {
         self.assert_erased_send();
         let stack = self.async_stack();
-        let mut evm = SendEvmRef::new(self);
         // SAFETY: The returned future owns the exclusive `&mut self` borrow, so nothing else can
-        // access the EVM stack slot until that future is dropped. The send marker checked above
-        // requires all erased EVM fields to have been verified by `Evm::evm_is_send`.
+        // access the EVM stack slot until that future is dropped. The assertion above requires all
+        // erased EVM fields to have been verified by `Evm::evm_is_send`.
         unsafe {
             r#async::on_fiber_with_stack(stack, move || {
-                evm.system_call_with_caller(caller, system_contract_address, data)
+                self.system_call_with_caller(caller, system_contract_address, data)
             })
         }
-    }
-}
-
-#[cfg(feature = "async")]
-impl<T: EvmTypes<Host = Evm<T>>> SendEvmRef<'_, T> {
-    #[inline]
-    fn system_call(&mut self, system_contract_address: Address, data: Bytes) -> TxResult<T> {
-        self.evm.system_call(system_contract_address, data).commit_or_discard_database_error()
-    }
-
-    #[inline]
-    fn system_call_with_caller(
-        &mut self,
-        caller: Address,
-        system_contract_address: Address,
-        data: Bytes,
-    ) -> TxResult<T> {
-        self.evm
-            .system_call_with_caller(caller, system_contract_address, data)
-            .commit_or_discard_database_error()
     }
 }
 

--- a/crates/evm2/src/evm/system.rs
+++ b/crates/evm2/src/evm/system.rs
@@ -101,6 +101,7 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
         system_contract_address: Address,
         data: Bytes,
     ) -> ExecutedTx<'_, T> {
+        self.db_error_code = None;
         self.state.prewarm(&system_contract_address);
         let tx_env = TxEnv {
             origin: caller,
@@ -198,7 +199,7 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
 impl<T: EvmTypes<Host = Evm<T>>> SendEvmRef<'_, T> {
     #[inline]
     fn system_call(&mut self, system_contract_address: Address, data: Bytes) -> TxResult<T> {
-        self.evm.system_call(system_contract_address, data).commit()
+        self.evm.system_call(system_contract_address, data).commit_or_discard_database_error()
     }
 
     #[inline]
@@ -208,7 +209,9 @@ impl<T: EvmTypes<Host = Evm<T>>> SendEvmRef<'_, T> {
         system_contract_address: Address,
         data: Bytes,
     ) -> TxResult<T> {
-        self.evm.system_call_with_caller(caller, system_contract_address, data).commit()
+        self.evm
+            .system_call_with_caller(caller, system_contract_address, data)
+            .commit_or_discard_database_error()
     }
 }
 

--- a/crates/evm2/src/evm/system.rs
+++ b/crates/evm2/src/evm/system.rs
@@ -6,9 +6,9 @@
 //! before calling [`Evm::system_call`]. Calling an address without code succeeds as an empty call
 //! and produces no state changes.
 
-#[cfg(feature = "async")]
-use super::r#async;
 use super::{Evm, ExecutedTx, TxResult};
+#[cfg(feature = "async")]
+use super::{SendEvmRef, r#async};
 use crate::{
     EvmTypes,
     env::TxEnv,
@@ -71,12 +71,14 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
     ) -> impl Future<Output = r#async::AsyncResult<ExecutedTx<'_, T>, Infallible>> + Send + '_ {
         self.assert_erased_send();
         let stack = self.async_stack();
+        let evm = SendEvmRef { evm: self };
         // SAFETY: The returned future owns the exclusive `&mut self` borrow, so nothing else can
-        // access the EVM stack slot until that future is dropped. The assertion above requires all
-        // erased EVM fields to have been verified by `Evm::evm_is_send`.
+        // access the EVM stack slot until that future is dropped. The send marker checked above
+        // requires all erased EVM fields to have been verified by `Evm::evm_is_send`.
         unsafe {
             r#async::on_fiber_with_stack(stack, move || {
-                self.system_call(system_contract_address, data)
+                let SendEvmRef { evm } = evm;
+                evm.system_call(system_contract_address, data)
             })
         }
     }
@@ -174,12 +176,14 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
     ) -> impl Future<Output = r#async::AsyncResult<ExecutedTx<'_, T>, Infallible>> + Send + '_ {
         self.assert_erased_send();
         let stack = self.async_stack();
+        let evm = SendEvmRef { evm: self };
         // SAFETY: The returned future owns the exclusive `&mut self` borrow, so nothing else can
-        // access the EVM stack slot until that future is dropped. The assertion above requires all
-        // erased EVM fields to have been verified by `Evm::evm_is_send`.
+        // access the EVM stack slot until that future is dropped. The send marker checked above
+        // requires all erased EVM fields to have been verified by `Evm::evm_is_send`.
         unsafe {
             r#async::on_fiber_with_stack(stack, move || {
-                self.system_call_with_caller(caller, system_contract_address, data)
+                let SendEvmRef { evm } = evm;
+                evm.system_call_with_caller(caller, system_contract_address, data)
             })
         }
     }

--- a/crates/evm2/src/evm/tx.rs
+++ b/crates/evm2/src/evm/tx.rs
@@ -152,12 +152,6 @@ impl<'evm, T: EvmTypes> ExecutedTx<'evm, T> {
         self.take_result()
     }
 
-    #[cfg(feature = "async")]
-    #[inline]
-    pub(crate) fn commit_or_discard_database_error(self) -> TxResult<T> {
-        if self.result().db_error_code.is_some() { self.discard() } else { self.commit() }
-    }
-
     /// Accepts the transaction state and records its changes in a block accumulator.
     ///
     /// This streams transaction changes into `block_state`, commits them to the accepted overlay,

--- a/crates/evm2/src/evm/tx.rs
+++ b/crates/evm2/src/evm/tx.rs
@@ -152,6 +152,12 @@ impl<'evm, T: EvmTypes> ExecutedTx<'evm, T> {
         self.take_result()
     }
 
+    #[cfg(feature = "async")]
+    #[inline]
+    pub(crate) fn commit_or_discard_database_error(self) -> TxResult<T> {
+        if self.result().db_error_code.is_some() { self.discard() } else { self.commit() }
+    }
+
     /// Accepts the transaction state and records its changes in a block accumulator.
     ///
     /// This streams transaction changes into `block_state`, commits them to the accepted overlay,


### PR DESCRIPTION
Fixes EVM2-2026-003 and EVM2-2026-022 by tightening async fiber lifecycle handling. The current fiber TLS is restored while a fiber is pending, and async transaction entrypoints now return `ExecutedTx` directly so callers make the same explicit commit or discard decision as the synchronous API. The `SendEvmRef` send marker wrapper is retained; the old inherent wrapper method impls that hid commit/discard behavior are removed.

Fixes EVM2-2026-001 by clearing stale database error state when entering system calls, matching the transaction entrypoint bookkeeping. Async system calls also return `ExecutedTx` directly instead of hiding commit/discard handling behind an internal wrapper.

Fixes EVM2-2026-002 by returning a specific `AsyncError::CurrentThreadRuntime` through the sync adapter path when a stored Tokio handle is used from a current-thread runtime, instead of letting Tokio panic or folding that case into the generic missing-runtime error.
