### PR TITLE
fix: correct state output edges

### DIFF
--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -426,7 +426,7 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
     /// Returns account bytecode visible through the accepted state overlay.
     #[inline]
     pub fn account_code(&mut self, address: &Address) -> DbResult<Bytecode> {
-        self.state.account(address, false)?.load_code()
+        self.state.read_committed_code(address)
     }
 
     /// Applies borrowed changes to the accepted state overlay.
@@ -1613,7 +1613,7 @@ mod tests {
         BaseEvmConfigSelector, BaseEvmTypes, NoopInspector, Precompiles, SpecId, Version,
         bytecode::Bytecode,
         env::TxEnv,
-        ethereum::RecoveredTxEnvelope,
+        ethereum::{RecoveredTxEnvelope, ethereum_tx_registry},
         interpreter::{GasTracker, Interpreter, MessageKind, op},
         precompiles::{Precompile, PrecompileId, PrecompileMap},
         registry::TxRequest,
@@ -1621,7 +1621,7 @@ mod tests {
     };
     use alloc::{borrow::Cow, string::ToString, sync::Arc, vec, vec::Vec};
     use alloy_consensus::{TxLegacy, transaction::Recovered};
-    use alloy_primitives::{Address, Bytes, KECCAK256_EMPTY, U256};
+    use alloy_primitives::{Address, Bytes, KECCAK256_EMPTY, TxKind, U256};
     use core::{
         error::Error,
         fmt,
@@ -2234,6 +2234,45 @@ mod tests {
     }
 
     #[test]
+    fn create_tx_selfdestruct_does_not_stream_ephemeral_storage_wipe() {
+        let caller = Address::with_last_byte(0xaa);
+        let beneficiary = Address::with_last_byte(0xbb);
+        let created = caller.create(0);
+        let mut database = InMemoryDB::default();
+        database.insert_account_info(
+            &caller,
+            AccountInfo::default().with_balance(Word::from(1_000_000_000_u64)),
+        );
+        let mut initcode = vec![op::PUSH20];
+        initcode.extend_from_slice(beneficiary.as_slice());
+        initcode.push(op::SELFDESTRUCT);
+        let tx = RecoveredTxEnvelope::Legacy(Recovered::new_unchecked(
+            TxLegacy {
+                gas_limit: 100_000,
+                to: TxKind::Create,
+                input: Bytes::from(initcode),
+                ..TxLegacy::default()
+            },
+            caller,
+        ));
+        let mut evm = Evm::<BaseEvmTypes>::new(
+            SpecId::SPURIOUS_DRAGON,
+            BlockEnv::default(),
+            ethereum_tx_registry(SpecId::SPURIOUS_DRAGON),
+            database,
+            Precompiles::base(SpecId::SPURIOUS_DRAGON),
+        );
+        let mut block_state = BlockStateAccumulator::new();
+
+        let result =
+            evm.transact(&tx).expect("transaction should execute").commit_to(&mut block_state);
+
+        assert!(result.status, "{result:#?}");
+        assert_eq!(result.created_address, Some(created));
+        assert!(!block_state.storage_wipes_sorted().contains(&created), "{block_state:#?}");
+    }
+
+    #[test]
     fn dropped_executed_transaction_discards_state() {
         let mut evm = lifecycle_evm();
         drop(evm.transact(&test_tx(7)).expect("lifecycle transaction should execute"));
@@ -2265,6 +2304,57 @@ mod tests {
 
         let result = Host::execute_message(&mut evm, &TxEnv::default(), bytecode, &mut message);
         assert!(result.stop.is_success());
+    }
+
+    #[test]
+    fn account_code_read_does_not_shadow_later_committed_overlay_update() {
+        let account = Address::with_last_byte(0x55);
+        let code = Bytecode::new_legacy(Bytes::from_static(&[op::STOP]));
+        let original = AccountInfo::default().with_balance(Word::from(1)).with_code(code.clone());
+        let mut database = InMemoryDB::default();
+        database.insert_account_info(&account, original.clone());
+        let mut evm = Evm::<BaseEvmTypes>::new(
+            SpecId::OSAKA,
+            BlockEnv::default(),
+            TxRegistry::new(),
+            database,
+            Precompiles::base(SpecId::OSAKA),
+        );
+
+        assert_eq!(evm.account_code(&account).unwrap(), code);
+
+        let current = original.clone().with_balance(Word::from(2));
+        let mut changes = StateChanges::default();
+        changes.accounts.insert(
+            account,
+            AccountChange {
+                original: Some(original),
+                current: Some(current),
+                ..AccountChange::default()
+            },
+        );
+        evm.commit_source(&changes);
+
+        let visible = evm.read_account_info(&account).unwrap().unwrap();
+        assert_eq!(visible.balance, Word::from(2));
+    }
+
+    #[test]
+    fn build_state_changes_resolves_backing_account_for_storage_only_change() {
+        let contract = Address::from([0x33; 20]);
+        let mut database = InMemoryDB::default();
+        let info = AccountInfo::default()
+            .with_balance(Word::from(7))
+            .with_code(Bytecode::new_legacy(Bytes::from_static(&[op::STOP])));
+        database.insert_account_info(&contract, info);
+        let mut state = State::new(database);
+        state.storage_slot(&contract, Word::ZERO, false).unwrap().write(Word::from(1));
+        let changes = state.build_state_changes();
+        let change = changes.accounts.get(&contract).expect("storage change recorded");
+
+        assert_eq!(change.original.as_ref().map(|info| info.balance), Some(Word::from(7)));
+        assert_eq!(change.current.as_ref().map(|info| info.balance), Some(Word::from(7)));
+        assert_eq!(change.storage.get(&Word::ZERO).unwrap().current, Word::from(1));
     }
 
     #[test]

--- a/crates/evm2/src/evm/state/block.rs
+++ b/crates/evm2/src/evm/state/block.rs
@@ -21,6 +21,7 @@ use core::convert::Infallible;
 pub struct BlockStateAccumulator {
     accounts: AddressMap<Tracked<Option<AccountInfo>>>,
     storage_wipes: AddressSet,
+    deleted_accounts: AddressSet,
     storage: StorageKeyMap<Tracked<Word>>,
     code: B256Map<Bytecode>,
 }
@@ -88,6 +89,14 @@ impl BlockStateAccumulator {
         storage.sort_by_key(|(key, _)| (key.address(), key.key()));
         storage
     }
+
+    fn prune_unreachable_code(&mut self) {
+        self.code.retain(|code_hash, _| {
+            self.accounts.values().any(|delta| {
+                delta.current.as_ref().is_some_and(|info| info.code_hash == *code_hash)
+            })
+        });
+    }
 }
 
 impl StateChangeSink for BlockStateAccumulator {
@@ -103,6 +112,7 @@ impl StateChangeSink for BlockStateAccumulator {
         let original = change.original.map(AccountInfoRef::to_account_info_without_code);
         let current = change.current.map(AccountInfoRef::to_account_info_without_code);
         let deletes_account = current.is_none();
+        let deleted_existing_account = deletes_account && original.is_some();
 
         match self.accounts.entry(change.address) {
             hash_map::Entry::Occupied(mut entry) => {
@@ -122,9 +132,17 @@ impl StateChangeSink for BlockStateAccumulator {
         if deletes_account {
             self.storage_wipes.remove(&change.address);
             self.storage.retain(|key, _| key.address() != change.address);
+            if deleted_existing_account {
+                self.deleted_accounts.insert(change.address);
+            } else {
+                self.deleted_accounts.remove(&change.address);
+            }
+        } else if self.deleted_accounts.remove(&change.address) {
+            self.storage_wipes.insert(change.address);
         } else if self.accounts.get(&change.address).is_some_and(|delta| delta.original.is_none()) {
             self.storage_wipes.remove(&change.address);
         }
+        self.prune_unreachable_code();
         Ok(())
     }
 
@@ -218,8 +236,12 @@ mod tests {
         super::{AccountChange, AccountInfo, StateChangeSource, StateChanges, Tracked},
         BlockStateAccumulator,
     };
-    use crate::interpreter::Word;
-    use alloy_primitives::{Address, map::U256Map};
+    use crate::{
+        bytecode::Bytecode,
+        evm::{CacheDB, DynDatabase},
+        interpreter::Word,
+    };
+    use alloy_primitives::{Address, Bytes, map::U256Map};
 
     fn changes(address: Address, change: AccountChange) -> StateChanges {
         let mut changes = StateChanges::default();
@@ -265,6 +287,28 @@ mod tests {
     }
 
     #[test]
+    fn block_accumulator_drops_code_for_create_then_delete() {
+        let address = Address::from([0x57; 20]);
+        let code = Bytecode::new_legacy(Bytes::from_static(&[0x00]));
+        let created = AccountInfo::default().with_nonce(1).with_code(code.clone());
+        let mut accumulator = BlockStateAccumulator::new();
+
+        let mut create = changes(
+            address,
+            AccountChange { current: Some(created.clone()), ..AccountChange::default() },
+        );
+        create.code.insert(code.hash_slow(), code);
+        create.visit(&mut accumulator).expect("block accumulator is infallible");
+
+        let delete =
+            changes(address, AccountChange { original: Some(created), ..AccountChange::default() });
+        delete.visit(&mut accumulator).expect("block accumulator is infallible");
+
+        assert!(accumulator.accounts_sorted().is_empty());
+        assert_eq!(accumulator.code().count(), 0);
+    }
+
+    #[test]
     fn block_accumulator_preserves_original_for_delete_then_recreate() {
         let address = Address::from([0x51; 20]);
         let key = Word::from(1);
@@ -303,6 +347,44 @@ mod tests {
         assert_eq!(storage.len(), 1);
         assert_eq!(storage[0].0.key(), key);
         assert_eq!(storage[0].1.current, Word::from(7));
+    }
+
+    #[test]
+    fn block_accumulator_preserves_storage_wipe_for_delete_then_balance_recreate() {
+        let address = Address::from([0x55; 20]);
+        let key = Word::from(1);
+        let original = AccountInfo::default().with_balance(Word::from(3));
+        let recreated = AccountInfo::default().with_balance(Word::from(9));
+        let mut accumulator = BlockStateAccumulator::new();
+
+        let delete = changes(
+            address,
+            AccountChange {
+                original: Some(original.clone()),
+                wipe_storage: true,
+                ..AccountChange::default()
+            },
+        );
+        delete.visit(&mut accumulator).expect("block accumulator is infallible");
+
+        let balance_recreate = changes(
+            address,
+            AccountChange { current: Some(recreated.clone()), ..AccountChange::default() },
+        );
+        balance_recreate.visit(&mut accumulator).expect("block accumulator is infallible");
+
+        let accounts = accumulator.accounts_sorted();
+        assert_eq!(accounts.len(), 1);
+        assert_eq!(accounts[0].1.original.as_ref(), Some(&original));
+        assert_eq!(accounts[0].1.current.as_ref(), Some(&recreated));
+        assert_eq!(accumulator.storage_wipes_sorted(), [address]);
+
+        let mut db = CacheDB::default();
+        db.insert_account_info(&address, original);
+        db.insert_account_storage(&address, &key, &Word::from(7));
+        db.commit_source(&accumulator);
+
+        assert_eq!(db.get_storage(&address, &key).unwrap(), Word::ZERO);
     }
 
     #[test]

--- a/crates/evm2/src/evm/state/mod.rs
+++ b/crates/evm2/src/evm/state/mod.rs
@@ -192,6 +192,18 @@ impl State {
         self.inner.database.get_storage(address, key)
     }
 
+    /// Reads account bytecode from the committed state, ignoring the transaction overlay.
+    #[inline]
+    pub fn read_committed_code(&mut self, address: &Address) -> DbResult<Bytecode> {
+        let Some(info) = self.inner.database.get_account(address)? else {
+            return Ok(Bytecode::default());
+        };
+        if info.code_hash == KECCAK256_EMPTY || info.code_hash.is_zero() {
+            return Ok(Bytecode::default());
+        }
+        self.inner.database.get_code_by_hash(&info.code_hash)
+    }
+
     /// Takes logs emitted by the current in-flight transaction.
     #[inline]
     pub(crate) fn take_logs(&mut self) -> Vec<Log> {
@@ -694,6 +706,11 @@ impl State {
         slot.is_changed() && (!storage_wiped || !slot.current.is_zero())
     }
 
+    #[inline]
+    fn is_ephemeral_deleted_account(entry: Option<&Account>) -> bool {
+        entry.is_some_and(|entry| entry.original.is_none() && entry.present.is_none())
+    }
+
     /// Visits transaction state changes in database application order.
     ///
     /// This borrows changes directly from the transaction layer. It does not materialize
@@ -711,6 +728,9 @@ impl State {
         }
 
         for (&address, storage) in &self.storage {
+            if Self::is_ephemeral_deleted_account(self.accounts.get(&address)) {
+                continue;
+            }
             if storage.wiped {
                 sink.storage_wipe(address)?;
             }
@@ -771,12 +791,22 @@ impl State {
 
         // Fold per-account storage in, materializing an entry for any storage-only account whose
         // info is unchanged by resolving it from the backing database.
-        let database = &self.inner.database;
         for (&address, storage) in &self.storage {
-            let entry = changes.accounts.entry(address).or_insert_with(|| {
-                let info = database.account_info(&address).cloned();
-                AccountChange { original: info.clone(), current: info, ..AccountChange::default() }
-            });
+            if Self::is_ephemeral_deleted_account(self.accounts.get(&address)) {
+                continue;
+            }
+            if !changes.accounts.contains_key(&address) {
+                let info = self.inner.database.get_account(&address).ok().flatten();
+                changes.accounts.insert(
+                    address,
+                    AccountChange {
+                        original: info.clone(),
+                        current: info,
+                        ..AccountChange::default()
+                    },
+                );
+            }
+            let entry = changes.accounts.get_mut(&address).expect("account change inserted above");
             entry.wipe_storage = storage.wiped;
             entry.storage = storage.slots.iter().map(|(&key, slot)| (key, slot.value)).collect();
         }


### PR DESCRIPTION
Fixes EVM2-2026-121 by preserving the storage wipe required when an originally existing account is deleted and later recreated by an account-only update in the same block accumulator.

Fixes EVM2-2026-050 and EVM2-2026-115 by suppressing storage output for accounts created and deleted inside one transaction, and by pruning bytecode once account deltas collapse so block-level output does not retain unreachable code.

Fixes EVM2-2026-051 and EVM2-2026-113 by resolving storage-only materialized account metadata through committed state and by making public account code reads ignore transaction scratch.
