### PR TITLE
fix: preserve host error semantics

### DIFF
--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -130,7 +130,7 @@ use crate::{
     trustme,
     version::{EvmFeatures, GasId},
 };
-use alloc::{boxed::Box, sync::Arc, vec};
+use alloc::{boxed::Box, string::ToString, sync::Arc, vec};
 use alloy_eips::eip2718::Typed2718;
 use alloy_primitives::{Address, B256, Bytes, Log, LogData};
 #[cfg(feature = "async")]
@@ -1178,9 +1178,15 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
             Err(PrecompileError::Halt(PrecompileHalt::OutOfGas)) => {
                 (InstrStop::PrecompileOOG, Bytes::new())
             }
-            Err(PrecompileError::Halt(_) | PrecompileError::Fatal(_)) => {
-                (InstrStop::PrecompileError, Bytes::new())
+            Err(PrecompileError::Halt(halt)) => {
+                let output = if message.depth == 0 {
+                    Bytes::from(halt.to_string().into_bytes())
+                } else {
+                    Bytes::new()
+                };
+                (InstrStop::PrecompileError, output)
             }
+            Err(PrecompileError::Fatal(_)) => (InstrStop::FatalExternalError, Bytes::new()),
         };
         if !stop.is_success() {
             self.state.rollback(checkpoint, self.features);
@@ -1613,7 +1619,7 @@ mod tests {
         BaseEvmConfigSelector, BaseEvmTypes, NoopInspector, Precompiles, SpecId, Version,
         bytecode::Bytecode,
         env::TxEnv,
-        ethereum::RecoveredTxEnvelope,
+        ethereum::{RecoveredTxEnvelope, ethereum_tx_registry},
         interpreter::{GasTracker, Interpreter, MessageKind, op},
         precompiles::{Precompile, PrecompileId, PrecompileMap},
         registry::TxRequest,
@@ -1621,7 +1627,7 @@ mod tests {
     };
     use alloc::{borrow::Cow, string::ToString, sync::Arc, vec, vec::Vec};
     use alloy_consensus::{TxLegacy, transaction::Recovered};
-    use alloy_primitives::{Address, Bytes, KECCAK256_EMPTY, U256};
+    use alloy_primitives::{Address, Bytes, KECCAK256_EMPTY, TxKind, U256};
     use core::{
         error::Error,
         fmt,
@@ -2003,6 +2009,84 @@ mod tests {
             .expect("precompile succeeds");
 
         assert_eq!(output.bytes(), b"inner");
+    }
+
+    #[test]
+    fn precompile_fatal_error_stops_frame_fatally() {
+        let precompiles = precompiles_with([test_precompile(TEST_PRECOMPILE, |_, _, _| {
+            Err(PrecompileError::from("fatal precompile failure"))
+        })]);
+        let mut evm = Evm::<BaseEvmTypes>::new(
+            SpecId::OSAKA,
+            BlockEnv::default(),
+            TxRegistry::new(),
+            InMemoryDB::default(),
+            precompiles,
+        );
+        let mut message = precompile_message(TEST_PRECOMPILE);
+
+        let result =
+            Host::execute_message(&mut evm, &TxEnv::default(), Bytecode::default(), &mut message);
+
+        assert_eq!(result.stop, InstrStop::FatalExternalError);
+        assert!(result.output.is_empty());
+    }
+
+    #[test]
+    fn top_level_precompile_halt_preserves_context() {
+        let caller = Address::with_last_byte(0xaa);
+        let mut database = InMemoryDB::default();
+        database.insert_account_info(
+            &caller,
+            AccountInfo::default().with_balance(U256::from(1_000_000u64)),
+        );
+        let tx = RecoveredTxEnvelope::Legacy(Recovered::new_unchecked(
+            TxLegacy {
+                nonce: 0,
+                gas_price: 0,
+                gas_limit: 50_000,
+                to: TxKind::Call(Address::with_last_byte(0x09)),
+                value: U256::ZERO,
+                input: Bytes::new(),
+                chain_id: Some(1),
+            },
+            caller,
+        ));
+        let mut evm = Evm::<BaseEvmTypes>::new(
+            SpecId::BERLIN,
+            BlockEnv { gas_limit: U256::from(30_000_000u64), ..BlockEnv::default() },
+            ethereum_tx_registry(SpecId::BERLIN),
+            database,
+            Precompiles::base(SpecId::BERLIN),
+        );
+
+        let result = evm.transact(&tx).expect("transaction is valid").discard();
+
+        assert!(!result.status);
+        assert_eq!(result.stop, InstrStop::PrecompileError);
+        assert_eq!(result.output, Bytes::from_static(b"wrong input length for blake2"));
+    }
+
+    #[test]
+    fn nested_precompile_halt_keeps_empty_output() {
+        let precompiles = precompiles_with([test_precompile(TEST_PRECOMPILE, |_, _, _| {
+            Err(PrecompileHalt::Blake2WrongLength.into())
+        })]);
+        let mut evm = Evm::<BaseEvmTypes>::new(
+            SpecId::OSAKA,
+            BlockEnv::default(),
+            TxRegistry::new(),
+            InMemoryDB::default(),
+            precompiles,
+        );
+        let mut message = precompile_message(TEST_PRECOMPILE);
+        message.depth = 1;
+
+        let result =
+            Host::execute_message(&mut evm, &TxEnv::default(), Bytecode::default(), &mut message);
+
+        assert_eq!(result.stop, InstrStop::PrecompileError);
+        assert!(result.output.is_empty());
     }
 
     #[test]

--- a/crates/evm2/src/interpreter/instructions/block.rs
+++ b/crates/evm2/src/interpreter/instructions/block.rs
@@ -1,7 +1,7 @@
 use crate::{
     EvmFeatures,
     constants::BLOCK_HASH_HISTORY,
-    interpreter::{Host, Word},
+    interpreter::{Host, InstrStop, Word},
     utils::{address_to_word, b256_to_word, word_to_usize_saturated},
 };
 use evm2_macros::instruction;
@@ -12,7 +12,11 @@ pub(crate) fn blockhash(cx: _, [number]: [Word]) -> Result<out> {
         if diff == 0 || diff > BLOCK_HASH_HISTORY {
             Word::ZERO
         } else {
-            cx.state.host().block_hash(number)?.map(b256_to_word).unwrap_or_default()
+            cx.state
+                .host()
+                .block_hash(number)?
+                .map(b256_to_word)
+                .ok_or(InstrStop::FatalExternalError)?
         }
     } else {
         Word::ZERO
@@ -119,7 +123,7 @@ mod tests {
     }
 
     #[test]
-    fn missing_blockhash_is_zero() {
+    fn missing_blockhash_is_fatal() {
         let mut host = test_host(BlockEnv { number: Word::from(10), ..BlockEnv::default() });
         host.missing_block_hash = true;
         let mut code = Vec::new();
@@ -128,8 +132,7 @@ mod tests {
         code.push(op::STOP);
 
         let interp = run(RunConfig::new(code).host(&mut host));
-        assert_matches!(interp.err, InstrStop::Stop);
-        assert_eq!(interp.stack(), [0]);
+        assert_matches!(interp.err, InstrStop::FatalExternalError);
     }
 
     #[test]

--- a/crates/evm2/src/interpreter/instructions/block.rs
+++ b/crates/evm2/src/interpreter/instructions/block.rs
@@ -1,7 +1,7 @@
 use crate::{
     EvmFeatures,
     constants::BLOCK_HASH_HISTORY,
-    interpreter::{Host, InstrStop, Word},
+    interpreter::{Host, Word},
     utils::{address_to_word, b256_to_word, word_to_usize_saturated},
 };
 use evm2_macros::instruction;
@@ -12,11 +12,7 @@ pub(crate) fn blockhash(cx: _, [number]: [Word]) -> Result<out> {
         if diff == 0 || diff > BLOCK_HASH_HISTORY {
             Word::ZERO
         } else {
-            cx.state
-                .host()
-                .block_hash(number)?
-                .map(b256_to_word)
-                .ok_or(InstrStop::FatalExternalError)?
+            cx.state.host().block_hash(number)?.map(b256_to_word).unwrap_or_default()
         }
     } else {
         Word::ZERO
@@ -117,6 +113,20 @@ mod tests {
         push(&mut code, 10);
         code.push(op::BLOCKHASH);
         code.push(op::STOP);
+        let interp = run(RunConfig::new(code).host(&mut host));
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.stack(), [0]);
+    }
+
+    #[test]
+    fn missing_blockhash_is_zero() {
+        let mut host = test_host(BlockEnv { number: Word::from(10), ..BlockEnv::default() });
+        host.missing_block_hash = true;
+        let mut code = Vec::new();
+        push(&mut code, 9);
+        code.push(op::BLOCKHASH);
+        code.push(op::STOP);
+
         let interp = run(RunConfig::new(code).host(&mut host));
         assert_matches!(interp.err, InstrStop::Stop);
         assert_eq!(interp.stack(), [0]);

--- a/crates/evm2/src/test_utils.rs
+++ b/crates/evm2/src/test_utils.rs
@@ -39,6 +39,7 @@ pub(crate) struct TestHost {
     pub(crate) is_empty: bool,
     pub(crate) is_cold: bool,
     pub(crate) is_touched: bool,
+    pub(crate) missing_block_hash: bool,
     pub(crate) storage: StorageKeyMap<Word>,
     pub(crate) original_storage: StorageKeyMap<Word>,
     pub(crate) transient_storage: StorageKeyMap<Word>,
@@ -62,6 +63,7 @@ impl Default for TestHost {
             is_empty: false,
             is_cold: false,
             is_touched: false,
+            missing_block_hash: false,
             storage: StorageKeyMap::default(),
             original_storage: StorageKeyMap::default(),
             transient_storage: StorageKeyMap::default(),
@@ -121,6 +123,9 @@ impl Host<TestTypes> for TestHost {
     }
 
     fn block_hash(&mut self, number: &Word) -> Result<Option<B256>, InstrStop> {
+        if self.missing_block_hash {
+            return Ok(None);
+        }
         Ok(Some(B256::with_last_byte(number.wrapping_to::<u8>())))
     }
 


### PR DESCRIPTION
Fixes the host/precompile error bundle from the audit: EVM2-2026-095 and EVM2-2026-096.

Fatal custom precompile provider errors now stop the frame with `FatalExternalError` instead of being downgraded to a normal precompile halt. Non-OOG precompile halts preserve the top-level halt reason in the transaction result while keeping nested failed precompile calls' output empty.

Child-frame fatal stop propagation is handled separately in #254. The `BLOCKHASH` host-result regression that was previously in this branch is now isolated in #259.
