### PR TITLE
test: cover missing blockhash fatal

### DIFF
--- a/crates/evm2/src/interpreter/instructions/block.rs
+++ b/crates/evm2/src/interpreter/instructions/block.rs
@@ -123,6 +123,19 @@ mod tests {
     }
 
     #[test]
+    fn missing_blockhash_is_fatal() {
+        let mut host = test_host(BlockEnv { number: Word::from(10), ..BlockEnv::default() });
+        host.missing_block_hash = true;
+        let mut code = Vec::new();
+        push(&mut code, 9);
+        code.push(op::BLOCKHASH);
+        code.push(op::STOP);
+
+        let interp = run(RunConfig::new(code).host(&mut host));
+        assert_matches!(interp.err, InstrStop::FatalExternalError);
+    }
+
+    #[test]
     fn coinbase_opcode() {
         let beneficiary = Address::from([0x44; 20]);
         let mut host = test_host(BlockEnv { beneficiary, ..BlockEnv::default() });

--- a/crates/evm2/src/test_utils.rs
+++ b/crates/evm2/src/test_utils.rs
@@ -39,6 +39,7 @@ pub(crate) struct TestHost {
     pub(crate) is_empty: bool,
     pub(crate) is_cold: bool,
     pub(crate) is_touched: bool,
+    pub(crate) missing_block_hash: bool,
     pub(crate) storage: StorageKeyMap<Word>,
     pub(crate) original_storage: StorageKeyMap<Word>,
     pub(crate) transient_storage: StorageKeyMap<Word>,
@@ -62,6 +63,7 @@ impl Default for TestHost {
             is_empty: false,
             is_cold: false,
             is_touched: false,
+            missing_block_hash: false,
             storage: StorageKeyMap::default(),
             original_storage: StorageKeyMap::default(),
             transient_storage: StorageKeyMap::default(),
@@ -121,6 +123,9 @@ impl Host<TestTypes> for TestHost {
     }
 
     fn block_hash(&mut self, number: &Word) -> Result<Option<B256>, InstrStop> {
+        if self.missing_block_hash {
+            return Ok(None);
+        }
         Ok(Some(B256::with_last_byte(number.wrapping_to::<u8>())))
     }
 


### PR DESCRIPTION
Adds an isolated regression for the revm `BLOCKHASH` host interaction. Once the current-block and history-window checks pass, a host response of `None` is a fatal external error rather than zero, matching revm at `00fa9a6a27c43d992f45a0c0380198f5e39a41bd`.

This was split out from #258 so the host/precompile error PR no longer carries unrelated `BLOCKHASH` coverage.
