### PR TITLE
fix: surface transfer overflows

### DIFF
--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -1141,15 +1141,18 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
             message.kind,
             MessageKind::Call | MessageKind::CallCode | MessageKind::StaticCall
         );
-        let transfer_succeeded = !transfers_balance
-            || match self.state.transfer(&message.caller, &message.destination, &message.value) {
+        let transfer_result = if transfers_balance {
+            match self.state.transfer(&message.caller, &message.destination, &message.value) {
                 Ok(result) => result,
                 Err(code) => {
                     return Self::error_message_result(self.db_error_stop(code), message.gas_limit);
                 }
-            };
-        if transfers_balance && !transfer_succeeded {
-            return Self::error_message_result(InstrStop::OutOfFunds, message.gas_limit);
+            }
+        } else {
+            Ok(())
+        };
+        if let Err(stop) = transfer_result {
+            return Self::error_message_result(stop, message.gas_limit);
         }
         if transfers_balance {
             self.log_eip7708_transfer(&message.caller, &message.destination, &message.value);
@@ -1453,12 +1456,10 @@ impl<T: EvmTypes<Host = Self>> Host<T> for Evm<T> {
         };
 
         if contract != target {
-            let transferred = self
-                .state
-                .transfer(contract, target, &balance)
-                .map_err(|code| self.db_error_stop(code))?;
-            if transferred {
-                self.log_eip7708_transfer(contract, target, &balance);
+            match self.state.transfer(contract, target, &balance) {
+                Ok(Ok(())) => self.log_eip7708_transfer(contract, target, &balance),
+                Ok(Err(stop)) => return Err(stop),
+                Err(code) => return Err(self.db_error_stop(code)),
             }
         } else if should_destroy && !balance.is_zero() && !self.feature(EvmFeatures::EIP8246) {
             // Pre-EIP-8246: SELFDESTRUCT to self burns the contract's balance. EIP-8246 removes
@@ -2593,7 +2594,7 @@ mod tests {
         let mut state = State::new(InMemoryDB::default());
         state.account(&from, false).unwrap().add_balance(U256::from(10));
 
-        assert!(state.transfer(&from, &to, &U256::from(7)).unwrap());
+        assert_eq!(state.transfer(&from, &to, &U256::from(7)).unwrap(), Ok(()));
         assert_eq!(
             state
                 .account_info_untracked(&from)

--- a/crates/evm2/src/evm/state/account.rs
+++ b/crates/evm2/src/evm/state/account.rs
@@ -488,7 +488,10 @@ impl<'a> AccountHandle<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::evm::{CacheDB, state::State};
+    use crate::{
+        evm::{CacheDB, state::State},
+        interpreter::InstrStop,
+    };
     use alloy_primitives::Address;
 
     #[test]
@@ -498,8 +501,11 @@ mod tests {
         database.insert_account_info(&address, AccountInfo::default().with_balance(Word::from(3)));
         let mut state = State::new(database);
 
-        assert!(!state.transfer(&address, &address, &Word::from(4)).unwrap());
-        assert!(state.transfer(&address, &address, &Word::from(3)).unwrap());
+        assert_eq!(
+            state.transfer(&address, &address, &Word::from(4)).unwrap(),
+            Err(InstrStop::OutOfFunds)
+        );
+        assert_eq!(state.transfer(&address, &address, &Word::from(3)).unwrap(), Ok(()));
     }
 
     #[test]

--- a/crates/evm2/src/evm/state/mod.rs
+++ b/crates/evm2/src/evm/state/mod.rs
@@ -393,37 +393,46 @@ impl State {
     }
 
     /// Transfers value between accounts.
-    pub fn transfer(&mut self, from: &Address, to: &Address, value: &Word) -> DbResult<bool> {
+    pub fn transfer(
+        &mut self,
+        from: &Address,
+        to: &Address,
+        value: &Word,
+    ) -> DbResult<Result<(), InstrStop>> {
         if value.is_zero() {
             self.account(to, false)?.touch();
-            return Ok(true);
+            return Ok(Ok(()));
         }
 
         if from == to {
             let mut account = self.account(from, false)?;
             if account.balance() < *value {
-                return Ok(false);
+                return Ok(Err(InstrStop::OutOfFunds));
             }
             account.touch();
-            return Ok(true);
+            return Ok(Ok(()));
         }
 
+        let from_balance = self.account(from, false)?.balance();
+        let Some(new_from_balance) = from_balance.checked_sub(*value) else {
+            return Ok(Err(InstrStop::OutOfFunds));
+        };
+        let to_balance = self.account(to, false)?.balance();
+        let Some(new_to_balance) = to_balance.checked_add(*value) else {
+            return Ok(Err(InstrStop::OverflowPayment));
+        };
         {
             let mut from_account = self.account(from, false)?;
-            let Some(new_from_balance) = from_account.balance().checked_sub(*value) else {
-                return Ok(false);
-            };
             // `set_balance` touches the account, matching the touch the prior `transfer` performed.
             from_account.set_balance(new_from_balance);
             from_account.touch();
         }
         {
             let mut to_account = self.account(to, false)?;
-            let new_to_balance = to_account.balance().saturating_add(*value);
             to_account.set_balance(new_to_balance);
             to_account.touch();
         }
-        Ok(true)
+        Ok(Ok(()))
     }
 
     /// Creates a contract account and transfers endowment from the caller.

--- a/crates/evm2/src/tests.rs
+++ b/crates/evm2/src/tests.rs
@@ -4,7 +4,7 @@ use crate::{
     evm::{AccountInfo, InMemoryDB},
     interpreter::{Host, InstrStop, Message, Word, op},
     registry::TxRegistry,
-    test_utils::{legacy_bytecode, push},
+    test_utils::{legacy_bytecode, push, push_address},
 };
 use alloc::vec::Vec;
 use alloy_primitives::Address;
@@ -20,6 +20,10 @@ fn run_tx(evm: &mut TestEvm, destination: Address, code: impl Into<Vec<u8>>) {
     };
     let result = Host::execute_message(evm, &TxEnv::default(), legacy_bytecode(code), &mut message);
     assert!(result.stop.is_success());
+}
+
+fn return_top_word(code: &mut Vec<u8>) {
+    code.extend([op::PUSH0, op::MSTORE, op::PUSH1, 32, op::PUSH0, op::RETURN]);
 }
 
 #[test]
@@ -88,6 +92,51 @@ fn evm_runs_transactions_against_initial_state() {
         evm.state.storage_slot(&contract, Word::from(2), false).unwrap().current(),
         Word::from(42)
     );
+}
+
+#[test]
+fn call_value_transfer_recipient_balance_overflow_fails() {
+    let contract = Address::from([0x11; 20]);
+    let target = Address::from([0x22; 20]);
+
+    let mut database = InMemoryDB::default();
+    database.insert_account_info(&contract, AccountInfo::default().with_balance(Word::from(1)));
+    database.insert_account_info(&target, AccountInfo::default().with_balance(Word::MAX));
+    let mut evm = TestEvm::new(
+        SpecId::OSAKA,
+        BlockEnv::default(),
+        TxRegistry::new(),
+        database,
+        Precompiles::base(SpecId::OSAKA),
+    );
+
+    let mut code = Vec::new();
+    push(&mut code, 0);
+    push(&mut code, 0);
+    push(&mut code, 0);
+    push(&mut code, 0);
+    push(&mut code, 1);
+    push_address(&mut code, &target);
+    push(&mut code, 50_000);
+    code.push(op::CALL);
+    return_top_word(&mut code);
+
+    let mut message = Message {
+        destination: contract,
+        code_address: contract,
+        gas_limit: 100_000,
+        ..Default::default()
+    };
+    let result =
+        Host::execute_message(&mut evm, &TxEnv::default(), legacy_bytecode(code), &mut message);
+
+    assert_eq!(result.stop, InstrStop::Return);
+    assert_eq!(Word::from_be_slice(&result.output), Word::ZERO);
+    assert_eq!(
+        evm.state.account_info_untracked(&contract).unwrap().unwrap().balance,
+        Word::from(1)
+    );
+    assert_eq!(evm.state.account_info_untracked(&target).unwrap().unwrap().balance, Word::MAX);
 }
 
 #[test]


### PR DESCRIPTION
Splits the transfer-result part out of #253. `State::transfer` now distinguishes successful transfers, insufficient sender balance, and recipient balance overflow, so CALL and SELFDESTRUCT can propagate the same `InstrStop` instead of flattening everything into a boolean.

The branch keeps the focused CALL value-transfer overflow reproducer here, while upfront payment, gas settlement, and CREATE endowment checked arithmetic remain in #253.
