### PR TITLE
feat: add send async entrypoints

### DIFF
--- a/crates/evm2/src/evm/async.rs
+++ b/crates/evm2/src/evm/async.rs
@@ -144,6 +144,23 @@ where
     OnFiber::new(func)
 }
 
+/// Runs `func` on a native fiber backed by a reusable EVM stack slot, returning a local future.
+///
+/// # Safety
+///
+/// `stack` must point to valid stack storage for the lifetime of the returned future. That storage
+/// must not be accessed by anything else until the returned future is dropped.
+pub(crate) unsafe fn on_local_fiber_result_with_stack<'a, R, E>(
+    stack: NonNull<FiberStack>,
+    func: impl FnOnce() -> Result<R, E> + 'a,
+) -> impl Future<Output = AsyncResult<R, E>> + 'a
+where
+    R: 'a,
+    E: 'a,
+{
+    LocalOnFiber::new(OnFiber::with_stack(stack, func))
+}
+
 /// Runs `func` on a native fiber backed by a reusable EVM stack slot.
 ///
 /// # Safety
@@ -171,6 +188,23 @@ where
     on_fiber_result(move || Ok::<_, core::convert::Infallible>(func()))
 }
 
+/// Runs `func` on a native fiber backed by a reusable EVM stack slot, returning a local future.
+///
+/// # Safety
+///
+/// See [`on_local_fiber_result_with_stack`].
+pub(crate) unsafe fn on_local_fiber_with_stack<'a, R>(
+    stack: NonNull<FiberStack>,
+    func: impl FnOnce() -> R + 'a,
+) -> impl Future<Output = AsyncResult<R>> + 'a
+where
+    R: 'a,
+{
+    unsafe {
+        on_local_fiber_result_with_stack(stack, move || Ok::<_, core::convert::Infallible>(func()))
+    }
+}
+
 /// Runs `func` on a native fiber backed by a reusable EVM stack slot.
 ///
 /// # Safety
@@ -184,6 +218,25 @@ where
     R: 'a,
 {
     unsafe { on_fiber_result_with_stack(stack, move || Ok::<_, core::convert::Infallible>(func())) }
+}
+
+struct LocalOnFiber<F> {
+    inner: F,
+    _not_send: PhantomData<*mut ()>,
+}
+
+impl<F> LocalOnFiber<F> {
+    const fn new(inner: F) -> Self {
+        Self { inner, _not_send: PhantomData }
+    }
+}
+
+impl<F: Future + Unpin> Future for LocalOnFiber<F> {
+    type Output = F::Output;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        Pin::new(&mut self.get_mut().inner).poll(cx)
+    }
 }
 
 enum OnFiber<'a, R, E> {
@@ -669,7 +722,6 @@ mod tests {
             InMemoryDB::default(),
             Precompiles::base(SpecId::OSAKA),
         );
-        evm.evm_is_send::<InMemoryDB, Precompiles<BaseEvmTypes>>();
         let tx = test_tx(41);
 
         let result = poll_ready(evm.transact_async(&tx)).unwrap();
@@ -678,7 +730,7 @@ mod tests {
     }
 
     #[test]
-    fn transaction_async_future_is_send_with_send_erased_fields() {
+    fn transaction_async_send_future_is_send_with_send_erased_fields() {
         let registry = TxRegistry::new().with_handler(
             TEST_TX_TYPE,
             crate::ethereum::RecoveredTxEnvelope::as_legacy,
@@ -694,13 +746,13 @@ mod tests {
         evm.evm_is_send::<InMemoryDB, Precompiles<BaseEvmTypes>>();
         let tx = test_tx(41);
 
-        let result = poll_ready(assert_send(evm.transact_async(&tx))).unwrap();
+        let result = poll_ready(assert_send(evm.transact_async_send(&tx))).unwrap();
 
         assert_eq!(result.result().gas_used(), 42);
     }
 
     #[test]
-    fn transaction_async_future_is_send_after_type_check() {
+    fn transaction_async_send_future_is_send_after_type_check() {
         let registry = TxRegistry::new().with_handler(
             TEST_TX_TYPE,
             crate::ethereum::RecoveredTxEnvelope::as_legacy,
@@ -717,14 +769,14 @@ mod tests {
         evm.evm_is_send_with_inspector::<InMemoryDB, Precompiles<BaseEvmTypes>, SendInspector>();
         let tx = test_tx(41);
 
-        let result = poll_ready(assert_send(evm.transact_async(&tx))).unwrap();
+        let result = poll_ready(assert_send(evm.transact_async_send(&tx))).unwrap();
 
         assert_eq!(result.result().gas_used(), 42);
     }
 
     #[test]
     #[should_panic = "async EVM execution requires EVM erased fields to be verified as Send with Evm::evm_is_send"]
-    fn transaction_async_panics_with_non_send_erased_fields() {
+    fn transaction_async_send_panics_with_non_send_erased_fields() {
         let mut evm = Evm::<BaseEvmTypes>::new(
             SpecId::OSAKA,
             BlockEnv::default(),
@@ -734,12 +786,12 @@ mod tests {
         );
         let tx = test_tx(41);
 
-        drop(evm.transact_async(&tx));
+        drop(evm.transact_async_send(&tx));
     }
 
     #[test]
     #[should_panic = "async EVM execution requires EVM erased fields to be verified as Send with Evm::evm_is_send"]
-    fn transaction_async_panics_after_non_send_setter() {
+    fn transaction_async_send_panics_after_non_send_setter() {
         let marker = Rc::new(());
         let registry = TxRegistry::new().with_handler(
             TEST_TX_TYPE,
@@ -757,7 +809,32 @@ mod tests {
         evm.set_inspector(NonSendInspector { marker });
         let tx = test_tx(41);
 
-        drop(evm.transact_async(&tx));
+        drop(evm.transact_async_send(&tx));
+    }
+
+    #[test]
+    fn transaction_async_accepts_non_send_erased_fields() {
+        let marker = Rc::new(());
+        let registry = TxRegistry::new().with_handler(
+            TEST_TX_TYPE,
+            crate::ethereum::RecoveredTxEnvelope::as_legacy,
+            handle_test_tx,
+        );
+        let database = Db::new(NonSendDb { marker: Rc::clone(&marker) });
+        let precompiles = NonSendPrecompiles { marker: Rc::clone(&marker) };
+        let mut evm = Evm::<BaseEvmTypes>::new(
+            SpecId::OSAKA,
+            BlockEnv::default(),
+            registry,
+            database,
+            precompiles,
+        );
+        evm.set_inspector(NonSendInspector { marker });
+        let tx = test_tx(41);
+
+        let result = poll_ready(evm.transact_async(&tx)).unwrap();
+
+        assert_eq!(result.result().gas_used(), 42);
     }
 
     #[test]
@@ -791,7 +868,6 @@ mod tests {
             InMemoryDB::default(),
             Precompiles::base(SpecId::OSAKA),
         );
-        evm.evm_is_send::<InMemoryDB, Precompiles<BaseEvmTypes>>();
         let tx = test_tx(41);
 
         let result = poll_ready(evm.transact_async(&tx));
@@ -825,11 +901,32 @@ mod tests {
             InMemoryDB::default(),
             Precompiles::base(SpecId::OSAKA),
         );
-        evm.evm_is_send::<InMemoryDB, Precompiles<BaseEvmTypes>>();
 
         let result = poll_ready(evm.system_call_async(SystemTx::new(contract, Bytes::new())))
             .unwrap()
             .discard();
+
+        assert!(result.status);
+        assert_eq!(result.gas_used, 0);
+    }
+
+    #[test]
+    fn system_call_async_send_future_is_send() {
+        let contract = Address::from([0x42; 20]);
+        let mut evm = Evm::<BaseEvmTypes>::new(
+            SpecId::OSAKA,
+            BlockEnv::default(),
+            TxRegistry::new(),
+            InMemoryDB::default(),
+            Precompiles::base(SpecId::OSAKA),
+        );
+        evm.evm_is_send::<InMemoryDB, Precompiles<BaseEvmTypes>>();
+
+        let result = poll_ready(assert_send(
+            evm.system_call_async_send(SystemTx::new(contract, Bytes::new())),
+        ))
+        .unwrap()
+        .discard();
 
         assert!(result.status);
         assert_eq!(result.gas_used, 0);
@@ -845,7 +942,6 @@ mod tests {
             Db::new(FailOnceAccountDb { fail_next_account: true }),
             Precompiles::base(SpecId::OSAKA),
         );
-        evm.evm_is_send::<Db<FailOnceAccountDb>, Precompiles<BaseEvmTypes>>();
         let tx = crate::ethereum::RecoveredTxEnvelope::Legacy(Recovered::new_unchecked(
             TxLegacy { gas_limit: 100_000, ..TxLegacy::default() },
             Address::ZERO,
@@ -923,7 +1019,7 @@ mod tests {
         Ok(TxResult { status: true, gas_used: req.tx.nonce + 1, ..TxResult::default() })
     }
 
-    fn poll_ready<F: Future + Send>(future: F) -> F::Output {
+    fn poll_ready<F: Future>(future: F) -> F::Output {
         let mut future = core::pin::pin!(future);
         let waker = Waker::noop();
         let mut cx = Context::from_waker(waker);

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -807,11 +807,30 @@ impl<T: EvmTypes<Tx: Typed2718, Host = Self>> Evm<T> {
     /// advantage of yielding database I/O. With a synchronous database this is mostly equivalent to
     /// running the synchronous transaction on a fiber.
     ///
-    /// This returns a `Send` future. Before calling it, the current erased database, precompile
-    /// provider, and optional inspector must be verified with [`Self::evm_is_send`] or
-    /// [`Self::evm_is_send_with_inspector`].
+    /// This returns a local future and does not require the erased database, precompile provider,
+    /// or optional inspector to be `Send`. Use [`Self::transact_async_send`] when the returned
+    /// future must be `Send`.
     #[cfg(feature = "async")]
     pub fn transact_async<'a>(
+        &'a mut self,
+        tx: &'a T::Tx,
+    ) -> impl Future<Output = r#async::AsyncResult<ExecutedTx<'a, T>, registry::HandlerError>> + 'a
+    where
+        T::Tx: Sync,
+    {
+        let stack = self.async_stack();
+        // SAFETY: The returned future owns the exclusive `&mut self` borrow, so nothing else can
+        // access the EVM stack slot until that future is dropped.
+        unsafe { r#async::on_local_fiber_result_with_stack(stack, move || self.transact(tx)) }
+    }
+
+    /// Dispatches the transaction to the handler registered for its EIP-2718 type byte on an async
+    /// fiber and returns a `Send` future.
+    ///
+    /// Before calling it, the current erased database, precompile provider, and optional inspector
+    /// must be verified with [`Self::evm_is_send`] or [`Self::evm_is_send_with_inspector`].
+    #[cfg(feature = "async")]
+    pub fn transact_async_send<'a>(
         &'a mut self,
         tx: &'a T::Tx,
     ) -> impl Future<Output = r#async::AsyncResult<ExecutedTx<'a, T>, registry::HandlerError>> + Send + 'a

--- a/crates/evm2/src/evm/system.rs
+++ b/crates/evm2/src/evm/system.rs
@@ -157,12 +157,28 @@ impl<T: EvmTypes<Host = Self>> Evm<T> {
     /// advantage of yielding database I/O. With a synchronous database this is mostly equivalent to
     /// running the synchronous system call on a fiber.
     ///
-    /// This returns a `Send` future. Before calling it, the current erased database, precompile
-    /// provider, and optional inspector must be verified with [`Evm::evm_is_send`] or
-    /// [`Evm::evm_is_send_with_inspector`].
+    /// This returns a local future and does not require the erased database, precompile provider,
+    /// or optional inspector to be `Send`. Use [`Evm::system_call_async_send`] when the returned
+    /// future must be `Send`.
     #[cfg(feature = "async")]
     #[inline]
     pub fn system_call_async(
+        &mut self,
+        tx: SystemTx,
+    ) -> impl Future<Output = r#async::AsyncResult<ExecutedTx<'_, T>, Infallible>> + '_ {
+        let stack = self.async_stack();
+        // SAFETY: The returned future owns the exclusive `&mut self` borrow, so nothing else can
+        // access the EVM stack slot until that future is dropped.
+        unsafe { r#async::on_local_fiber_with_stack(stack, move || self.system_call(tx)) }
+    }
+
+    /// Executes a system call on an async fiber and returns a `Send` future.
+    ///
+    /// Before calling it, the current erased database, precompile provider, and optional inspector
+    /// must be verified with [`Evm::evm_is_send`] or [`Evm::evm_is_send_with_inspector`].
+    #[cfg(feature = "async")]
+    #[inline]
+    pub fn system_call_async_send(
         &mut self,
         tx: SystemTx,
     ) -> impl Future<Output = r#async::AsyncResult<ExecutedTx<'_, T>, Infallible>> + Send + '_ {


### PR DESCRIPTION
This splits the async EVM entrypoints into local and send variants. transact_async and system_call_async now return local futures without requiring evm_is_send(), allowing non-Send erased database, precompile, and inspector fields. New transact_async_send and system_call_async_send preserve the previous Send future contract and runtime verification path for callers that need to move the future across threads.