### PR TITLE
ci: fix cyclops author permission

### DIFF
--- a/.github/workflows/cyclops-audit.yml
+++ b/.github/workflows/cyclops-audit.yml
@@ -60,13 +60,22 @@ jobs:
               return;
             }
 
+            const trustedPermissions = new Set(['admin', 'maintain', 'write']);
             const { data: pr } = await github.rest.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
               pull_number: context.issue.number,
             });
             if (!allowed.has(pr.author_association)) {
-              core.setFailed(`PR author @${pr.user.login} is not allowed to trigger Cyclops audits (${pr.author_association})`);
+              const { data: authorPermission } = await github.rest.repos.getCollaboratorPermissionLevel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                username: pr.user.login,
+              });
+              if (!trustedPermissions.has(authorPermission.permission)) {
+                core.setFailed(`PR author @${pr.user.login} is not allowed to trigger Cyclops audits (${pr.author_association}, ${authorPermission.permission})`);
+                return;
+              }
             }
 
       - name: Parse arguments


### PR DESCRIPTION
GitHub's author_association can classify private org members as CONTRIBUTOR when the workflow token fetches PR metadata. This keeps the existing trusted PR-author gate, but falls back to repository permission and allows write, maintain, or admin users before rejecting. Fixes the Cyclops audit trigger on #206.