### PR TITLE
ci: keep Cyclops publish after ack failure

### DIFF
--- a/.github/workflows/cyclops-audit.yml
+++ b/.github/workflows/cyclops-audit.yml
@@ -239,13 +239,17 @@ jobs:
             }
 
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            const { data: comment } = await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body: `cc @${process.env.ACTOR}\n\nCyclops audit event queued. [View workflow run](${runUrl})\n\n${process.env.SUMMARY}`,
-            });
-            core.setOutput('comment-id', String(comment.id));
+            try {
+              const { data: comment } = await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: `cc @${process.env.ACTOR}\n\nCyclops audit event queued. [View workflow run](${runUrl})\n\n${process.env.SUMMARY}`,
+              });
+              core.setOutput('comment-id', String(comment.id));
+            } catch (error) {
+              core.warning(`Could not create acknowledgement comment: ${error.message}`);
+            }
 
       - name: Publish event
         id: publish


### PR DESCRIPTION
## Summary
- make the Cyclops acknowledgement comment best-effort
- allow the audit event publish step to run even when GitHub denies comment writes

## Testing
- `uv run --with pyyaml python -c "import yaml; yaml.safe_load(open('.github/workflows/cyclops-audit.yml')); print('yaml ok')"`

Prompted by: @DaniPopes