### PR TITLE
ci: fix cyclops acknowledgement permissions

### DIFF
--- a/.github/workflows/cyclops-audit.yml
+++ b/.github/workflows/cyclops-audit.yml
@@ -239,13 +239,18 @@ jobs:
             }
 
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            const { data: comment } = await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body: `cc @${process.env.ACTOR}\n\nCyclops audit event queued. [View workflow run](${runUrl})\n\n${process.env.SUMMARY}`,
-            });
-            core.setOutput('comment-id', String(comment.id));
+            try {
+              const { data: comment } = await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: `cc @${process.env.ACTOR}\n\nCyclops audit event queued. [View workflow run](${runUrl})\n\n${process.env.SUMMARY}`,
+              });
+              core.setOutput('comment-id', String(comment.id));
+            } catch (error) {
+              core.warning(`Could not create acknowledgement comment: ${error.message}`);
+              core.setOutput('comment-id', '');
+            }
 
       - name: Publish event
         id: publish
@@ -267,7 +272,7 @@ jobs:
             -d @"${RUNNER_TEMP}/pr-audit-event.json"
 
       - name: Update status
-        if: ${{ always() && steps.ack.outcome == 'success' && steps.ack.outputs['comment-id'] != '' }}
+        if: ${{ always() && steps.args.outcome == 'success' }}
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           COMMENT_ID: ${{ steps.ack.outputs['comment-id'] }}
@@ -283,10 +288,16 @@ jobs:
               ? `cc @${process.env.ACTOR}\n\nCyclops audit event published. [View workflow run](${runUrl})\n\n${process.env.SUMMARY}`
               : `cc @${process.env.ACTOR}\n\nCyclops audit event failed to publish. [View workflow run](${runUrl})\n\n${process.env.SUMMARY}`;
 
-            await github.rest.issues.updateComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              comment_id: Number(process.env.COMMENT_ID),
-              body,
-            });
+            if (process.env.COMMENT_ID) {
+              try {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: Number(process.env.COMMENT_ID),
+                  body,
+                });
+              } catch (error) {
+                core.warning(`Could not update acknowledgement comment: ${error.message}`);
+              }
+            }
             if (!success) core.setFailed('Failed to publish pr_audit event');

--- a/.github/workflows/cyclops-audit.yml
+++ b/.github/workflows/cyclops-audit.yml
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       issues: write
-      pull-requests: read
+      pull-requests: write
     steps:
       - name: Check commenter permission
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0


### PR DESCRIPTION
The Cyclops comment trigger can reach the acknowledgement step with a token that has issue writes but only pull request reads, which GitHub rejects for PR-thread comment and reaction writes. Grant the job pull request write permission and keep acknowledgement/status comment updates best-effort so UI feedback cannot block publishing the audit event.