### PR TITLE
ci: check cyclops event secrets

### DIFF
--- a/.github/workflows/cyclops-audit.yml
+++ b/.github/workflows/cyclops-audit.yml
@@ -14,8 +14,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Publish event
+        env:
+          HAS_EVENTS_ARGS: ${{ secrets.EVENTS_ARGS != '' }}
+          HAS_EVENTS_KEY: ${{ secrets.EVENTS_KEY != '' }}
+          HAS_EVENTS_CERT: ${{ secrets.EVENTS_CERT != '' }}
         run: |
           set -euo pipefail
+
+          [[ "$HAS_EVENTS_ARGS" == "true" ]] || { echo "::error::Missing EVENTS_ARGS secret"; exit 1; }
+          [[ "$HAS_EVENTS_KEY" == "true" ]] || { echo "::error::Missing EVENTS_KEY secret"; exit 1; }
+          [[ "$HAS_EVENTS_CERT" == "true" ]] || { echo "::error::Missing EVENTS_CERT secret"; exit 1; }
 
           printf '%s' '${{ secrets.EVENTS_KEY }}' > "${RUNNER_TEMP}/key"
           printf '%s' '${{ secrets.EVENTS_CERT }}' > "${RUNNER_TEMP}/cert"
@@ -218,6 +226,38 @@ jobs:
             core.setOutput('payload-b64', Buffer.from(JSON.stringify(payload), 'utf8').toString('base64'));
             core.setOutput('summary', `**Config:** ${summaryParts.join(', ')}`);
 
+      - name: Check publisher configuration
+        id: publisher-config
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          ACTOR: ${{ steps.args.outputs.actor }}
+          HAS_EVENTS_ARGS: ${{ secrets.EVENTS_ARGS != '' }}
+          HAS_EVENTS_KEY: ${{ secrets.EVENTS_KEY != '' }}
+          HAS_EVENTS_CERT: ${{ secrets.EVENTS_CERT != '' }}
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const required = {
+              EVENTS_ARGS: process.env.HAS_EVENTS_ARGS,
+              EVENTS_KEY: process.env.HAS_EVENTS_KEY,
+              EVENTS_CERT: process.env.HAS_EVENTS_CERT,
+            };
+            const missing = Object.entries(required).filter(([, present]) => present !== 'true').map(([name]) => name);
+            if (!missing.length) return;
+
+            const msg = `Cyclops audit is not configured: missing ${missing.map((name) => `\`${name}\``).join(', ')} secret${missing.length === 1 ? '' : 's'}.`;
+            try {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: `cc @${process.env.ACTOR}\n\n${msg}`,
+              });
+            } catch (error) {
+              core.warning(`Could not create configuration failure comment: ${error.message}`);
+            }
+            core.setFailed(msg);
+
       - name: Acknowledge request
         id: ack
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -257,8 +297,15 @@ jobs:
         continue-on-error: true
         env:
           PAYLOAD_B64: ${{ steps.args.outputs.payload-b64 }}
+          HAS_EVENTS_ARGS: ${{ secrets.EVENTS_ARGS != '' }}
+          HAS_EVENTS_KEY: ${{ secrets.EVENTS_KEY != '' }}
+          HAS_EVENTS_CERT: ${{ secrets.EVENTS_CERT != '' }}
         run: |
           set -euo pipefail
+
+          [[ "$HAS_EVENTS_ARGS" == "true" ]] || { echo "::error::Missing EVENTS_ARGS secret"; exit 1; }
+          [[ "$HAS_EVENTS_KEY" == "true" ]] || { echo "::error::Missing EVENTS_KEY secret"; exit 1; }
+          [[ "$HAS_EVENTS_CERT" == "true" ]] || { echo "::error::Missing EVENTS_CERT secret"; exit 1; }
 
           printf '%s' '${{ secrets.EVENTS_KEY }}' > "${RUNNER_TEMP}/key"
           printf '%s' '${{ secrets.EVENTS_CERT }}' > "${RUNNER_TEMP}/cert"
@@ -272,7 +319,7 @@ jobs:
             -d @"${RUNNER_TEMP}/pr-audit-event.json"
 
       - name: Update status
-        if: ${{ always() && steps.args.outcome == 'success' }}
+        if: ${{ always() && steps.args.outcome == 'success' && steps.publisher-config.outcome == 'success' }}
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           COMMENT_ID: ${{ steps.ack.outputs['comment-id'] }}


### PR DESCRIPTION
Cyclops publishing currently reaches curl with empty publisher secrets, so the event step fails with curl error 2 before it can contact the event endpoint. Add explicit checks for EVENTS_ARGS, EVENTS_KEY, and EVENTS_CERT in both trigger paths, and report the missing configuration before queueing a comment-triggered audit.