### PR TITLE
docs(jit): avoid rustdoc ICE on inkwell re-export

### DIFF
--- a/crates/jit/llvm/src/lib.rs
+++ b/crates/jit/llvm/src/lib.rs
@@ -47,6 +47,7 @@ use std::{
     },
 };
 
+#[doc(no_inline)] // Work around rustdoc ICE: https://github.com/rust-lang/rust/issues/158686
 pub use inkwell::{self, context::Context};
 
 mod cpp;


### PR DESCRIPTION
Adds a no-inline rustdoc workaround to the public `inkwell` re-export so rustdoc does not descend into `inkwell::llvm_sys` on the 2026-07-01 nightly. The comment links the upstream Rust ICE tracked in rust-lang/rust#158686, matching the workaround style used for Solar.