### PR TITLE
fix: handle transfer overflows

### DIFF
--- a/crates/evm2/src/ethereum/eip1559.rs
+++ b/crates/evm2/src/ethereum/eip1559.rs
@@ -1,10 +1,11 @@
 use super::{
-    access_list_counts, charge_upfront, create_initial_state_gas, effective_gas_price, floor_gas,
-    initial_gas_and_reservoir, initial_message, intrinsic_gas, refund_create_state_gas,
-    rollback_failed_execution, settle_gas, validate_block_gas_limit, validate_chain_id,
-    validate_create_initcode, validate_floor_gas, validate_gas_price, validate_intrinsic_gas,
-    validate_nonce_not_overflow, validate_priority_fee, validate_regular_gas_limit_cap,
-    validate_sender, validate_tx_gas_limit_cap, warm_access_list, warm_base_accounts,
+    access_list_counts, charge_upfront, checked_payment_add, create_initial_state_gas,
+    effective_gas_price, floor_gas, initial_gas_and_reservoir, initial_message, intrinsic_gas,
+    refund_create_state_gas, rollback_failed_execution, settle_gas, validate_block_gas_limit,
+    validate_chain_id, validate_create_initcode, validate_floor_gas, validate_gas_price,
+    validate_intrinsic_gas, validate_nonce_not_overflow, validate_priority_fee,
+    validate_regular_gas_limit_cap, validate_sender, validate_tx_gas_limit_cap, warm_access_list,
+    warm_base_accounts,
 };
 use crate::{
     EvmTypes, TxResult,
@@ -51,7 +52,8 @@ pub(super) fn handle<T: EvmTypes>(
     validate_regular_gas_limit_cap(req.host.version(), tx.gas_limit, intrinsic, floor_gas)?;
 
     let max_gas_cost = U256::from(tx.gas_limit) * max_fee_per_gas;
-    validate_sender(req.host, caller, tx.nonce, max_gas_cost.saturating_add(tx.value))?;
+    let max_upfront = checked_payment_add(max_gas_cost, tx.value)?;
+    validate_sender(req.host, caller, tx.nonce, max_upfront)?;
 
     warm_base_accounts(req.host, caller, tx.to);
     warm_access_list(req.host, &tx.access_list);

--- a/crates/evm2/src/ethereum/eip2930.rs
+++ b/crates/evm2/src/ethereum/eip2930.rs
@@ -1,5 +1,5 @@
 use super::{
-    access_list_counts, charge_upfront, create_initial_state_gas, floor_gas,
+    access_list_counts, charge_upfront, checked_payment_add, create_initial_state_gas, floor_gas,
     initial_gas_and_reservoir, initial_message, intrinsic_gas, refund_create_state_gas,
     rollback_failed_execution, settle_gas, validate_block_gas_limit, validate_chain_id,
     validate_create_initcode, validate_floor_gas, validate_gas_price, validate_intrinsic_gas,
@@ -47,7 +47,8 @@ pub(super) fn handle<T: EvmTypes>(
     validate_regular_gas_limit_cap(req.host.version(), tx.gas_limit, intrinsic, floor_gas)?;
 
     let max_gas_cost = U256::from(tx.gas_limit) * gas_price;
-    validate_sender(req.host, caller, tx.nonce, max_gas_cost.saturating_add(tx.value))?;
+    let max_upfront = checked_payment_add(max_gas_cost, tx.value)?;
+    validate_sender(req.host, caller, tx.nonce, max_upfront)?;
 
     warm_base_accounts(req.host, caller, tx.to);
     warm_access_list(req.host, &tx.access_list);

--- a/crates/evm2/src/ethereum/eip4844.rs
+++ b/crates/evm2/src/ethereum/eip4844.rs
@@ -1,10 +1,10 @@
 use super::{
-    access_list_counts, charge_upfront, create_initial_state_gas, effective_gas_price, floor_gas,
-    initial_gas_and_reservoir, initial_message, intrinsic_gas, rollback_failed_execution,
-    settle_gas, validate_block_gas_limit, validate_chain_id, validate_create_initcode,
-    validate_floor_gas, validate_gas_price, validate_intrinsic_gas, validate_nonce_not_overflow,
-    validate_priority_fee, validate_regular_gas_limit_cap, validate_sender,
-    validate_tx_gas_limit_cap, warm_access_list, warm_base_accounts,
+    access_list_counts, charge_upfront, checked_payment_add, create_initial_state_gas,
+    effective_gas_price, floor_gas, initial_gas_and_reservoir, initial_message, intrinsic_gas,
+    rollback_failed_execution, settle_gas, validate_block_gas_limit, validate_chain_id,
+    validate_create_initcode, validate_floor_gas, validate_gas_price, validate_intrinsic_gas,
+    validate_nonce_not_overflow, validate_priority_fee, validate_regular_gas_limit_cap,
+    validate_sender, validate_tx_gas_limit_cap, warm_access_list, warm_base_accounts,
 };
 use crate::{
     EvmTypes, TxResult,
@@ -58,12 +58,9 @@ pub(super) fn handle<T: EvmTypes>(
     let blob_gas_cost = U256::from(DATA_GAS_PER_BLOB) * U256::from(tx.blob_versioned_hashes.len());
     let max_blob_gas_cost = blob_gas_cost * max_fee_per_blob_gas;
     let max_gas_cost = U256::from(tx.gas_limit) * max_fee_per_gas;
-    validate_sender(
-        req.host,
-        caller,
-        tx.nonce,
-        max_gas_cost.saturating_add(max_blob_gas_cost).saturating_add(tx.value),
-    )?;
+    let max_upfront =
+        checked_payment_add(checked_payment_add(max_gas_cost, max_blob_gas_cost)?, tx.value)?;
+    validate_sender(req.host, caller, tx.nonce, max_upfront)?;
 
     warm_base_accounts(req.host, caller, tx.to.into());
     warm_access_list(req.host, &tx.access_list);

--- a/crates/evm2/src/ethereum/eip7702.rs
+++ b/crates/evm2/src/ethereum/eip7702.rs
@@ -1,10 +1,10 @@
 use super::{
-    access_list_counts, charge_upfront, effective_gas_price, floor_gas, initial_gas_and_reservoir,
-    initial_message, intrinsic_gas, rollback_failed_execution, settle_gas,
-    validate_block_gas_limit, validate_chain_id, validate_create_initcode, validate_floor_gas,
-    validate_gas_price, validate_intrinsic_gas, validate_nonce_not_overflow, validate_priority_fee,
-    validate_regular_gas_limit_cap, validate_sender, validate_tx_gas_limit_cap, warm_access_list,
-    warm_base_accounts,
+    access_list_counts, charge_upfront, checked_payment_add, effective_gas_price, floor_gas,
+    initial_gas_and_reservoir, initial_message, intrinsic_gas, rollback_failed_execution,
+    settle_gas, validate_block_gas_limit, validate_chain_id, validate_create_initcode,
+    validate_floor_gas, validate_gas_price, validate_intrinsic_gas, validate_nonce_not_overflow,
+    validate_priority_fee, validate_regular_gas_limit_cap, validate_sender,
+    validate_tx_gas_limit_cap, warm_access_list, warm_base_accounts,
 };
 use crate::{
     Evm, EvmFeatures, EvmTypes, TxResult,
@@ -57,7 +57,8 @@ pub(super) fn handle<T: EvmTypes>(
     validate_regular_gas_limit_cap(req.host.version(), tx.gas_limit, intrinsic, floor_gas)?;
 
     let max_gas_cost = U256::from(tx.gas_limit) * max_fee_per_gas;
-    validate_sender(req.host, caller, tx.nonce, max_gas_cost.saturating_add(tx.value))?;
+    let max_upfront = checked_payment_add(max_gas_cost, tx.value)?;
+    validate_sender(req.host, caller, tx.nonce, max_upfront)?;
 
     warm_base_accounts(req.host, caller, tx.to.into());
     warm_access_list(req.host, &tx.access_list);

--- a/crates/evm2/src/ethereum/legacy.rs
+++ b/crates/evm2/src/ethereum/legacy.rs
@@ -1,9 +1,10 @@
 use super::{
-    charge_upfront, create_initial_state_gas, floor_gas, initial_gas_and_reservoir,
-    initial_message, intrinsic_gas, refund_create_state_gas, rollback_failed_execution, settle_gas,
-    validate_block_gas_limit, validate_chain_id, validate_create_initcode, validate_floor_gas,
-    validate_gas_price, validate_intrinsic_gas, validate_nonce_not_overflow,
-    validate_regular_gas_limit_cap, validate_sender, validate_tx_gas_limit_cap, warm_base_accounts,
+    charge_upfront, checked_payment_add, create_initial_state_gas, floor_gas,
+    initial_gas_and_reservoir, initial_message, intrinsic_gas, refund_create_state_gas,
+    rollback_failed_execution, settle_gas, validate_block_gas_limit, validate_chain_id,
+    validate_create_initcode, validate_floor_gas, validate_gas_price, validate_intrinsic_gas,
+    validate_nonce_not_overflow, validate_regular_gas_limit_cap, validate_sender,
+    validate_tx_gas_limit_cap, warm_base_accounts,
 };
 use crate::{
     EvmTypes, TxResult,
@@ -36,7 +37,8 @@ pub(super) fn handle<T: EvmTypes>(
     validate_regular_gas_limit_cap(req.host.version(), tx.gas_limit, intrinsic, floor_gas)?;
 
     let max_gas_cost = U256::from(tx.gas_limit) * gas_price;
-    validate_sender(req.host, caller, tx.nonce, max_gas_cost.saturating_add(tx.value))?;
+    let max_upfront = checked_payment_add(max_gas_cost, tx.value)?;
+    validate_sender(req.host, caller, tx.nonce, max_upfront)?;
 
     warm_base_accounts(req.host, caller, tx.to);
 

--- a/crates/evm2/src/ethereum/mod.rs
+++ b/crates/evm2/src/ethereum/mod.rs
@@ -237,6 +237,10 @@ pub(super) fn effective_gas_price(
     max_fee_per_gas.min(basefee.saturating_add(max_priority_fee_per_gas))
 }
 
+pub(super) fn checked_payment_add(lhs: U256, rhs: U256) -> HandlerResult<U256> {
+    lhs.checked_add(rhs).ok_or(HandlerError::OverflowPayment)
+}
+
 pub(super) fn validate_block_gas_limit(
     version: &Version,
     tx_gas_limit: u64,
@@ -650,10 +654,11 @@ pub(super) fn settle_gas<'a, T: EvmTypes>(
         .saturating_sub(alive_create_refund);
     if host.feature(EvmFeatures::FEE_CHARGE) {
         let caller_refund = U256::from(gas_remaining) * gas_price;
-        host.state
+        let _ = host
+            .state
             .account(&caller, false)
             .map_err(error_handler!(host))?
-            .add_balance(caller_refund);
+            .increment_balance(caller_refund);
         let beneficiary_gas_price = if host.feature(EvmFeatures::BASE_FEE_CHECK) {
             gas_price.saturating_sub(host.block.basefee)
         } else {
@@ -661,10 +666,11 @@ pub(super) fn settle_gas<'a, T: EvmTypes>(
         };
         let beneficiary = host.block.beneficiary;
         let beneficiary_reward = U256::from(gas_used) * beneficiary_gas_price;
-        host.state
+        let _ = host
+            .state
             .account(&beneficiary, false)
             .map_err(error_handler!(host))?
-            .add_balance(beneficiary_reward);
+            .increment_balance(beneficiary_reward);
     }
     Ok(TxResult {
         status: result.stop.is_success(),
@@ -813,7 +819,7 @@ mod tests {
         registry::TxRegistry,
     };
     use alloc::vec;
-    use alloy_consensus::{TxEip2930, transaction::Recovered};
+    use alloy_consensus::{TxEip2930, TxLegacy, transaction::Recovered};
     use alloy_eips::eip2930::AccessList;
 
     #[test]
@@ -914,6 +920,79 @@ mod tests {
         assert_eq!(
             evm.transact(&tx).map(|executed| executed.discard()),
             Err(HandlerError::IntrinsicGasTooLow { required: 21_000, got: 20_999 })
+        );
+    }
+
+    #[test]
+    fn legacy_rejects_upfront_payment_overflow() {
+        let caller = Address::with_last_byte(0xaa);
+        let mut database = InMemoryDB::default();
+        database.insert_account_info(&caller, AccountInfo::default().with_balance(U256::MAX));
+        let tx = RecoveredTxEnvelope::Legacy(Recovered::new_unchecked(
+            TxLegacy {
+                nonce: 0,
+                gas_price: 1,
+                gas_limit: 21_000,
+                to: TxKind::Call(Address::with_last_byte(0xbb)),
+                value: U256::MAX,
+                input: Bytes::new(),
+                chain_id: None,
+            },
+            caller,
+        ));
+        let mut evm = Evm::<BaseEvmTypes>::new(
+            SpecId::LONDON,
+            BlockEnv::default(),
+            ethereum_tx_registry(SpecId::LONDON),
+            database,
+            Precompiles::base(SpecId::LONDON),
+        );
+
+        assert_eq!(
+            evm.transact(&tx).map(|executed| executed.discard()),
+            Err(HandlerError::OverflowPayment)
+        );
+    }
+
+    #[test]
+    fn settlement_ignores_overflowing_beneficiary_reward() {
+        let caller = Address::with_last_byte(0xaa);
+        let target = Address::with_last_byte(0xbb);
+        let beneficiary = Address::with_last_byte(0xcc);
+        let mut database = InMemoryDB::default();
+        database.insert_account_info(
+            &caller,
+            AccountInfo::default().with_balance(U256::from(1_000_000u64)),
+        );
+        database.insert_account_info(&beneficiary, AccountInfo::default().with_balance(U256::MAX));
+        let tx = RecoveredTxEnvelope::Legacy(Recovered::new_unchecked(
+            TxLegacy {
+                nonce: 0,
+                gas_price: 1,
+                gas_limit: 21_000,
+                to: TxKind::Call(target),
+                value: U256::ZERO,
+                input: Bytes::new(),
+                chain_id: None,
+            },
+            caller,
+        ));
+        let block =
+            BlockEnv { beneficiary, gas_limit: U256::from(30_000_000u64), ..BlockEnv::default() };
+        let mut evm = Evm::<BaseEvmTypes>::new(
+            SpecId::LONDON,
+            block,
+            ethereum_tx_registry(SpecId::LONDON),
+            database,
+            Precompiles::base(SpecId::LONDON),
+        );
+
+        let result = evm.transact(&tx).unwrap().commit();
+
+        assert!(result.status);
+        assert_eq!(
+            evm.state.account_info_untracked(&beneficiary).unwrap().unwrap().balance,
+            U256::MAX
         );
     }
 

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -1292,20 +1292,21 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
             message.kind,
             MessageKind::Call | MessageKind::CallCode | MessageKind::StaticCall
         );
-        let transfer_succeeded = !transfers_balance
-            || match self.state.transfer(&message.caller, &message.destination, &message.value) {
+        let transfer_result = if transfers_balance {
+            match self.state.transfer(&message.caller, &message.destination, &message.value) {
                 Ok(result) => result,
                 Err(code) => {
                     let stop = self.store_error(code);
+                    self.state.rollback(checkpoint, self.features);
                     return Self::error_message_result(stop, message.gas_limit, message.reservoir);
                 }
-            };
-        if transfers_balance && !transfer_succeeded {
-            return Self::error_message_result(
-                InstrStop::OutOfFunds,
-                message.gas_limit,
-                message.reservoir,
-            );
+            }
+        } else {
+            Ok(())
+        };
+        if let Err(stop) = transfer_result {
+            self.state.rollback(checkpoint, self.features);
+            return Self::error_message_result(stop, message.gas_limit, message.reservoir);
         }
         if transfers_balance {
             self.log_eip7708_transfer(&message.caller, &message.destination, &message.value);
@@ -1688,12 +1689,10 @@ impl<'a, T: EvmTypes> Host<T> for Evm<'a, T> {
         };
 
         if contract != target {
-            let transferred = self
-                .state
-                .transfer(contract, target, &balance)
-                .map_err(|code| self.store_error(code))?;
-            if transferred {
-                self.log_eip7708_transfer(contract, target, &balance);
+            match self.state.transfer(contract, target, &balance) {
+                Ok(Ok(())) => self.log_eip7708_transfer(contract, target, &balance),
+                Ok(Err(stop)) => return Err(stop),
+                Err(code) => return Err(self.store_error(code)),
             }
         } else if should_destroy && !balance.is_zero() && !self.feature(EvmFeatures::EIP8246) {
             // Pre-EIP-8246: SELFDESTRUCT to self burns the contract's balance. EIP-8246 removes
@@ -3093,7 +3092,7 @@ mod tests {
         let mut state = State::new(InMemoryDB::default());
         state.account(&from, false).unwrap().add_balance(U256::from(10));
 
-        assert!(state.transfer(&from, &to, &U256::from(7)).unwrap());
+        assert_eq!(state.transfer(&from, &to, &U256::from(7)).unwrap(), Ok(()));
         assert_eq!(
             state
                 .account_info_untracked(&from)
@@ -3110,6 +3109,96 @@ mod tests {
                 .balance,
             U256::from(7)
         );
+    }
+
+    #[test]
+    fn transfer_recipient_overflow_returns_overflow_payment() {
+        let from = Address::from([0x01; 20]);
+        let to = Address::from([0x02; 20]);
+        let mut state = State::new(InMemoryDB::default());
+        state.account(&from, false).unwrap().add_balance(U256::from(1));
+        state.account(&to, false).unwrap().add_balance(U256::MAX);
+
+        assert_eq!(
+            state.transfer(&from, &to, &U256::from(1)).unwrap(),
+            Err(InstrStop::OverflowPayment)
+        );
+        assert_eq!(state.account_info_untracked(&from).unwrap().unwrap().balance, U256::from(1));
+        assert_eq!(state.account_info_untracked(&to).unwrap().unwrap().balance, U256::MAX);
+    }
+
+    #[test]
+    fn call_value_transfer_recipient_overflow_halts() {
+        let caller = Address::from([0x01; 20]);
+        let target = Address::from([0x02; 20]);
+        let mut database = InMemoryDB::default();
+        database.insert_account_info(&caller, AccountInfo::default().with_balance(U256::from(1)));
+        database.insert_account_info(&target, AccountInfo::default().with_balance(U256::MAX));
+        let mut evm = Evm::<BaseEvmTypes>::new(
+            SpecId::OSAKA,
+            BlockEnv::default(),
+            TxRegistry::new(),
+            database,
+            Precompiles::base(SpecId::OSAKA),
+        );
+        let mut message = Message {
+            kind: MessageKind::Call,
+            caller,
+            destination: target,
+            code_address: target,
+            value: U256::from(1),
+            gas_limit: 300_000,
+            ..Message::default()
+        };
+
+        let result =
+            Host::execute_message(&mut evm, &TxEnv::default(), Bytecode::default(), &mut message);
+
+        assert_eq!(result.stop, InstrStop::OverflowPayment);
+        assert_eq!(
+            evm.state.account_info_untracked(&caller).unwrap().unwrap().balance,
+            U256::from(1)
+        );
+        assert_eq!(evm.state.account_info_untracked(&target).unwrap().unwrap().balance, U256::MAX);
+    }
+
+    #[test]
+    fn create_prefunded_target_endowment_overflow_halts() {
+        let caller = Address::from([0x01; 20]);
+        let created = Address::from([0x02; 20]);
+        let mut database = InMemoryDB::default();
+        database.insert_account_info(&caller, AccountInfo::default().with_balance(U256::from(1)));
+        database.insert_account_info(&created, AccountInfo::default().with_balance(U256::MAX));
+        let mut evm = Evm::<BaseEvmTypes>::new(
+            SpecId::OSAKA,
+            BlockEnv::default(),
+            TxRegistry::new(),
+            database,
+            Precompiles::base(SpecId::OSAKA),
+        );
+        let mut message = Message {
+            kind: MessageKind::Create,
+            caller,
+            destination: created,
+            value: U256::from(1),
+            gas_limit: 300_000,
+            ..Message::default()
+        };
+
+        let result = Host::execute_message(
+            &mut evm,
+            &TxEnv::default(),
+            Bytecode::new_legacy(Bytes::from_static(&[op::STOP])),
+            &mut message,
+        );
+
+        assert_eq!(result.stop, InstrStop::OverflowPayment);
+        assert_eq!(result.created_address, None);
+        assert_eq!(
+            evm.state.account_info_untracked(&caller).unwrap().unwrap().balance,
+            U256::from(1)
+        );
+        assert_eq!(evm.state.account_info_untracked(&created).unwrap().unwrap().balance, U256::MAX);
     }
 
     #[test]

--- a/crates/evm2/src/evm/registry.rs
+++ b/crates/evm2/src/evm/registry.rs
@@ -64,6 +64,9 @@ pub enum HandlerError {
     /// Sender cannot pay value plus maximum gas cost.
     #[error("insufficient funds")]
     InsufficientFunds,
+    /// Transaction payment amount overflows.
+    #[error("payment amount overflows")]
+    OverflowPayment,
     /// Sender account has deployed code.
     #[error("caller has code")]
     RejectCallerWithCode,

--- a/crates/evm2/src/evm/state/account.rs
+++ b/crates/evm2/src/evm/state/account.rs
@@ -401,6 +401,21 @@ impl<'a, 'db> AccountHandle<'a, 'db> {
         self.set_balance(balance);
     }
 
+    /// Adds an unsigned balance increment, touching the account even on overflow.
+    #[inline]
+    pub fn increment_balance(&mut self, delta: Word) -> bool {
+        if delta.is_zero() {
+            self.touch();
+            return true;
+        }
+        let Some(balance) = self.balance().checked_add(delta) else {
+            self.touch();
+            return false;
+        };
+        self.set_balance(balance);
+        true
+    }
+
     /// Sets the account nonce, touching the account and recording a revert snapshot.
     #[inline]
     pub fn set_nonce(&mut self, nonce: u64) {
@@ -511,7 +526,10 @@ impl<'a, 'db> AccountHandle<'a, 'db> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::evm::{CacheDB, state::State};
+    use crate::{
+        evm::{CacheDB, state::State},
+        interpreter::InstrStop,
+    };
     use alloy_primitives::Address;
 
     #[test]
@@ -521,8 +539,11 @@ mod tests {
         database.insert_account_info(&address, AccountInfo::default().with_balance(Word::from(3)));
         let mut state = State::new(database);
 
-        assert!(!state.transfer(&address, &address, &Word::from(4)).unwrap());
-        assert!(state.transfer(&address, &address, &Word::from(3)).unwrap());
+        assert_eq!(
+            state.transfer(&address, &address, &Word::from(4)).unwrap(),
+            Err(InstrStop::OutOfFunds)
+        );
+        assert_eq!(state.transfer(&address, &address, &Word::from(3)).unwrap(), Ok(()));
     }
 
     #[test]

--- a/crates/evm2/src/evm/state/mod.rs
+++ b/crates/evm2/src/evm/state/mod.rs
@@ -393,37 +393,46 @@ impl<'a> State<'a> {
     }
 
     /// Transfers value between accounts.
-    pub fn transfer(&mut self, from: &Address, to: &Address, value: &Word) -> DbResult<bool> {
+    pub fn transfer(
+        &mut self,
+        from: &Address,
+        to: &Address,
+        value: &Word,
+    ) -> DbResult<Result<(), InstrStop>> {
         if value.is_zero() {
             self.account(to, false)?.touch();
-            return Ok(true);
+            return Ok(Ok(()));
         }
 
         if from == to {
             let mut account = self.account(from, false)?;
             if account.balance() < *value {
-                return Ok(false);
+                return Ok(Err(InstrStop::OutOfFunds));
             }
             account.touch();
-            return Ok(true);
+            return Ok(Ok(()));
         }
 
+        let from_balance = self.account(from, false)?.balance();
+        let Some(new_from_balance) = from_balance.checked_sub(*value) else {
+            return Ok(Err(InstrStop::OutOfFunds));
+        };
+        let to_balance = self.account(to, false)?.balance();
+        let Some(new_to_balance) = to_balance.checked_add(*value) else {
+            return Ok(Err(InstrStop::OverflowPayment));
+        };
         {
             let mut from_account = self.account(from, false)?;
-            let Some(new_from_balance) = from_account.balance().checked_sub(*value) else {
-                return Ok(false);
-            };
             // `set_balance` touches the account, matching the touch the prior `transfer` performed.
             from_account.set_balance(new_from_balance);
             from_account.touch();
         }
         {
             let mut to_account = self.account(to, false)?;
-            let new_to_balance = to_account.balance().saturating_add(*value);
             to_account.set_balance(new_to_balance);
             to_account.touch();
         }
-        Ok(true)
+        Ok(Ok(()))
     }
 
     /// Creates a contract account and transfers endowment from the caller.
@@ -445,22 +454,28 @@ impl<'a> State<'a> {
             return Ok(Err(InstrStop::CreateCollision));
         }
 
-        // Deduct the endowment from the caller. A zero endowment moves nothing and leaves the
+        // Check balances before mutating either side. A zero endowment moves nothing and leaves the
         // caller untouched, matching the prior `transfer` behaviour.
-        if !value.is_zero() {
-            let mut caller_account = self.account(caller, false)?;
-            let Some(new_caller_balance) = caller_account.balance().checked_sub(*value) else {
+        let new_caller_balance = if !value.is_zero() {
+            let caller_account = self.account(caller, false)?;
+            let Some(balance) = caller_account.balance().checked_sub(*value) else {
                 return Ok(Err(InstrStop::OutOfFunds));
             };
-            caller_account.set_balance(new_caller_balance);
+            Some(balance)
+        } else {
+            None
+        };
+        let Some(balance) = self.account(address, false)?.balance().checked_add(*value) else {
+            return Ok(Err(InstrStop::OverflowPayment));
+        };
+
+        if let Some(new_caller_balance) = new_caller_balance {
+            self.account(caller, false)?.set_balance(new_caller_balance);
         }
 
         self.storage(address).wipe();
 
         let mut target = self.account(address, false)?;
-        // Preserve any balance the address already held (e.g. funds sent before creation) and add
-        // the endowment.
-        let balance = target.balance().wrapping_add(*value);
         *target.get_or_insert() = AccountInfo {
             nonce: u64::from(features.contains(EvmFeatures::EIP161)),
             balance,

--- a/crates/evm2/src/tests.rs
+++ b/crates/evm2/src/tests.rs
@@ -4,7 +4,7 @@ use crate::{
     evm::{AccountInfo, InMemoryDB},
     interpreter::{Host, InstrStop, Message, Word, op},
     registry::TxRegistry,
-    test_utils::{legacy_bytecode, push},
+    test_utils::{legacy_bytecode, push, push_address},
 };
 use alloc::vec::Vec;
 use alloy_primitives::Address;
@@ -20,6 +20,10 @@ fn run_tx(evm: &mut TestEvm, destination: Address, code: impl Into<Vec<u8>>) {
     };
     let result = Host::execute_message(evm, &TxEnv::default(), legacy_bytecode(code), &mut message);
     assert!(result.stop.is_success());
+}
+
+fn return_top_word(code: &mut Vec<u8>) {
+    code.extend([op::PUSH0, op::MSTORE, op::PUSH1, 32, op::PUSH0, op::RETURN]);
 }
 
 #[test]
@@ -88,6 +92,51 @@ fn evm_runs_transactions_against_initial_state() {
         evm.state.storage_slot(&contract, Word::from(2), false).unwrap().current(),
         Word::from(42)
     );
+}
+
+#[test]
+fn call_value_transfer_recipient_balance_overflow_fails() {
+    let contract = Address::from([0x11; 20]);
+    let target = Address::from([0x22; 20]);
+
+    let mut database = InMemoryDB::default();
+    database.insert_account_info(&contract, AccountInfo::default().with_balance(Word::from(1)));
+    database.insert_account_info(&target, AccountInfo::default().with_balance(Word::MAX));
+    let mut evm = TestEvm::new(
+        SpecId::OSAKA,
+        BlockEnv::default(),
+        TxRegistry::new(),
+        database,
+        Precompiles::base(SpecId::OSAKA),
+    );
+
+    let mut code = Vec::new();
+    push(&mut code, 0);
+    push(&mut code, 0);
+    push(&mut code, 0);
+    push(&mut code, 0);
+    push(&mut code, 1);
+    push_address(&mut code, &target);
+    push(&mut code, 300_000);
+    code.push(op::CALL);
+    return_top_word(&mut code);
+
+    let mut message = Message {
+        destination: contract,
+        code_address: contract,
+        gas_limit: 400_000,
+        ..Default::default()
+    };
+    let result =
+        Host::execute_message(&mut evm, &TxEnv::default(), legacy_bytecode(code), &mut message);
+
+    assert_eq!(result.stop, InstrStop::Return);
+    assert_eq!(Word::from_be_slice(&result.output), Word::ZERO);
+    assert_eq!(
+        evm.state.account_info_untracked(&contract).unwrap().unwrap().balance,
+        Word::from(1)
+    );
+    assert_eq!(evm.state.account_info_untracked(&target).unwrap().unwrap().balance, Word::MAX);
 }
 
 #[test]


### PR DESCRIPTION
This aggregates the transfer overflow fixes from #235, #253, and #260, matching revm's checked transfer/create path. Transaction max payment validation now rejects U256 overflow instead of saturating, runtime value transfers and CREATE endowments report OverflowPayment when the recipient credit would overflow, and gas settlement credits use a checked increment that preserves the current balance on overflow.

It also keeps failed transfer state scoped to the message checkpoint so access-list and EIP-2780 side effects do not leak from a failed child frame.
