### PR TITLE
revert: rustdoc no_inline workaround

### DIFF
--- a/crates/jit/llvm/src/lib.rs
+++ b/crates/jit/llvm/src/lib.rs
@@ -47,7 +47,6 @@ use std::{
     },
 };
 
-#[doc(no_inline)] // Work around rustdoc ICE: https://github.com/rust-lang/rust/issues/158686
 pub use inkwell::{self, context::Context};
 
 mod cpp;

--- a/crates/jit/runtime/src/runtime/mod.rs
+++ b/crates/jit/runtime/src/runtime/mod.rs
@@ -441,9 +441,7 @@ impl JitBackend {
             .inner
             .shared
             .pause_depth
-            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |depth| {
-                Some(depth.saturating_sub(1))
-            })
+            .try_update(Ordering::Relaxed, Ordering::Relaxed, |depth| Some(depth.saturating_sub(1)))
             .is_ok_and(|depth| depth == 1)
         {
             self.try_send_control(Command::Resume);


### PR DESCRIPTION
Reverts the temporary rustdoc ICE workaround now that the upstream rustdoc panic has been fixed.

Prompted by: @DaniPopes