### PR TITLE
fix(inspectors): handle nested call steps

### DIFF
--- a/crates/inspectors/src/opcode.rs
+++ b/crates/inspectors/src/opcode.rs
@@ -1,4 +1,4 @@
-use alloc::string::ToString;
+use alloc::{string::ToString, vec::Vec};
 use alloy_primitives::map::HashMap;
 use alloy_rpc_types_trace::opcode::OpcodeGas;
 use evm2::{
@@ -9,6 +9,13 @@ use evm2::{
     },
 };
 
+#[derive(Clone, Copy, Debug)]
+struct PendingOpcodeGas {
+    opcode: OpCode,
+    gas_remaining: u64,
+    child_gas_used: u64,
+}
+
 /// An Inspector that counts opcodes and measures gas usage per opcode.
 #[derive(Clone, Debug, Default)]
 pub struct OpcodeGasInspector {
@@ -16,8 +23,8 @@ pub struct OpcodeGasInspector {
     opcode_counts: HashMap<OpCode, u64>,
     /// Map of total gas used per opcode.
     opcode_gas: HashMap<OpCode, u64>,
-    /// Keep track of the last opcode executed and the remaining gas
-    last_opcode_gas_remaining: Option<(OpCode, u64)>,
+    /// Tracks opcodes waiting for `step_end`.
+    pending_steps: Vec<PendingOpcodeGas>,
 }
 
 impl OpcodeGasInspector {
@@ -57,12 +64,16 @@ impl OpcodeGasInspector {
         })
     }
 
-    /// Helper function to subtract gas limit from opcode gas tracking.
+    /// Helper function to exclude child gas from opcode gas tracking.
     /// This prevents call/create opcodes from including the gas consumed within the call/create.
-    fn subtract_gas_limit(&mut self, opcode_value: u8, gas_limit: u64) {
-        if let Some(opcode) = OpCode::new(opcode_value) {
-            let opcode_gas = self.opcode_gas.entry(opcode).or_default();
-            *opcode_gas = opcode_gas.saturating_sub(gas_limit);
+    fn exclude_child_gas(&mut self, opcode_value: u8, child_gas_used: u64) {
+        let Some(opcode) = OpCode::new(opcode_value) else {
+            return;
+        };
+        if let Some(pending) = self.pending_steps.last_mut()
+            && pending.opcode == opcode
+        {
+            pending.child_gas_used = pending.child_gas_used.saturating_add(child_gas_used);
         }
     }
 }
@@ -75,29 +86,38 @@ impl<T: EvmTypesHost> Inspector<T> for OpcodeGasInspector {
             *self.opcode_counts.entry(opcode).or_default() += 1;
 
             // keep track of the last opcode executed
-            self.last_opcode_gas_remaining = Some((opcode, interp.gas().remaining()));
+            self.pending_steps.push(PendingOpcodeGas {
+                opcode,
+                gas_remaining: interp.gas().remaining(),
+                child_gas_used: 0,
+            });
         }
     }
 
     fn step_end(&mut self, interp: &mut Interpreter<'_, '_, T>) {
         // update gas usage for the last opcode
-        if let Some((opcode, gas_remaining)) = self.last_opcode_gas_remaining.take() {
-            let gas_cost = gas_remaining.saturating_sub(interp.gas().remaining());
+        if let Some(pending) = self.pending_steps.pop() {
+            let gas_cost = pending
+                .gas_remaining
+                .saturating_sub(interp.gas().remaining())
+                .saturating_sub(pending.child_gas_used);
+            let opcode = pending.opcode;
             *self.opcode_gas.entry(opcode).or_default() += gas_cost;
         }
     }
 
-    fn call(
+    fn call_end(
         &mut self,
         _interp: &mut Interpreter<'_, '_, T>,
-        message: &mut Message<T>,
-    ) -> Option<MessageResult<T>> {
+        message: &Message<T>,
+        result: &mut MessageResult<T>,
+    ) {
         if message.depth == 0 {
             // skip the root call
-            return None;
+            return;
         }
 
-        // for accurate call opcode gas tracking, we need to deduct the gas limit from the opcode
+        // for accurate call opcode gas tracking, we need to deduct the child gas from the opcode
         // gas, because otherwise the call opcodes would include the total gas consumed within the
         // call itself, but we want to track how much gas the call opcode itself consumes.
         let opcode = match message.kind {
@@ -105,35 +125,32 @@ impl<T: EvmTypesHost> Inspector<T> for OpcodeGasInspector {
             MessageKind::CallCode => op::CALLCODE,
             MessageKind::DelegateCall => op::DELEGATECALL,
             MessageKind::StaticCall => op::STATICCALL,
-            MessageKind::Create | MessageKind::Create2 => return None,
-            _ => return None,
+            MessageKind::Create | MessageKind::Create2 => return,
+            _ => return,
         };
-        self.subtract_gas_limit(opcode, message.gas_limit);
-
-        None
+        self.exclude_child_gas(opcode, result.gas.spent());
     }
 
-    fn create(
+    fn create_end(
         &mut self,
         _interp: &mut Interpreter<'_, '_, T>,
-        message: &mut Message<T>,
-    ) -> Option<MessageResult<T>> {
+        message: &Message<T>,
+        result: &mut MessageResult<T>,
+    ) {
         if message.depth == 0 {
             // skip the root create
-            return None;
+            return;
         }
 
-        // for accurate create opcode gas tracking, we need to deduct the gas limit from the opcode
+        // for accurate create opcode gas tracking, we need to deduct the child gas from the opcode
         // gas, because otherwise the create opcodes would include the total gas consumed within the
         // create itself, but we want to track how much gas the create opcode itself consumes.
         let opcode = match message.kind {
             MessageKind::Create => op::CREATE,
             MessageKind::Create2 => op::CREATE2,
-            _ => return None,
+            _ => return,
         };
-        self.subtract_gas_limit(opcode, message.gas_limit);
-
-        None
+        self.exclude_child_gas(opcode, result.gas.spent());
     }
 }
 

--- a/crates/inspectors/src/tracing/js/mod.rs
+++ b/crates/inspectors/src/tracing/js/mod.rs
@@ -68,6 +68,8 @@ struct PendingStep {
     refund: u64,
     /// Contract info
     contract: Contract,
+    /// Memory before opcode execution.
+    memory: MemorySnapshot,
     /// Total gas spent before this opcode (to compute delta in step_end)
     gas_spent_before: u64,
 }
@@ -118,12 +120,14 @@ pub struct JsInspector {
     call_stack: Vec<CallStackItem>,
     /// Marker to track whether the precompiles have been registered.
     precompiles_registered: bool,
-    /// Pre-execution state captured in `step()` to be processed in `step_end()`.
-    pending_step: Option<PendingStep>,
+    /// Pre-execution states captured in `step()` to be processed in `step_end()`.
+    pending_steps: Vec<PendingStep>,
     /// Cached memory snapshot, only updated when the previous opcode modifies memory.
     cached_memory: MemorySnapshot,
     /// The opcode from the previous step, used to decide whether to re-snapshot memory.
     prev_op: Option<OpCode>,
+    /// The call depth from the previous step, used to refresh memory across frames.
+    prev_depth: Option<u16>,
 }
 
 impl JsInspector {
@@ -237,9 +241,10 @@ impl JsInspector {
             reusable_db,
             call_stack: Default::default(),
             precompiles_registered: false,
-            pending_step: None,
+            pending_steps: Vec::new(),
             cached_memory: MemorySnapshot::default(),
             prev_op: None,
+            prev_depth: None,
         })
     }
 
@@ -459,19 +464,22 @@ impl<T: EvmTypes> Inspector<T> for JsInspector {
             return;
         }
 
-        // Update the cached memory snapshot only if the previous opcode modified memory.
+        let message = interp.message();
+
+        // Update the cached memory snapshot only if the previous opcode modified memory or
+        // execution moved to a different frame.
         // This avoids an expensive Vec<u8> clone on every single step.
-        let should_update_memory = self.prev_op.is_none_or(|prev| prev.modifies_memory());
+        let should_update_memory = self.prev_op.is_none_or(|prev| prev.modifies_memory())
+            || self.prev_depth != Some(message.depth);
         if should_update_memory {
             self.cached_memory = MemorySnapshot::new(interp.memory());
         }
 
         let op = interp.opcode();
         self.prev_op = OpCode::new(op);
-
+        self.prev_depth = Some(message.depth);
         let active_call = self.active_call();
-        let message = interp.message();
-        self.pending_step = Some(PendingStep {
+        self.pending_steps.push(PendingStep {
             stack: interp.stack().as_slice().to_vec(),
             pc: interp.pc() as u64,
             op,
@@ -484,6 +492,7 @@ impl<T: EvmTypes> Inspector<T> for JsInspector {
                 value: active_call.contract.value,
                 input: active_call.contract.input.clone(),
             },
+            memory: self.cached_memory.clone(),
             gas_spent_before: interp.gas().spent(),
         });
     }
@@ -493,7 +502,7 @@ impl<T: EvmTypes> Inspector<T> for JsInspector {
             return;
         }
 
-        let Some(pending) = self.pending_step.take() else {
+        let Some(pending) = self.pending_steps.pop() else {
             return;
         };
 
@@ -503,7 +512,7 @@ impl<T: EvmTypes> Inspector<T> for JsInspector {
 
         let (db, db_guard) = EvmDbRef::new_state(interp.host().state_mut());
         let (stack, stack_guard) = StackRef::new_owned(pending.stack);
-        let (memory, memory_guard) = MemoryRef::new_owned(self.cached_memory.clone());
+        let (memory, memory_guard) = MemoryRef::new_owned(pending.memory);
 
         let stop = if is_revert {
             let step = StepLog {

--- a/crates/inspectors/tests/it/geth_js.rs
+++ b/crates/inspectors/tests/it/geth_js.rs
@@ -195,6 +195,68 @@ fn test_geth_jstracer_proxy_contract() {
 }
 
 #[test]
+fn test_geth_jstracer_records_call_step_after_nested_execution() {
+    let child = address!("0000000000000000000000000000000000001234");
+    let parent = address!("0000000000000000000000000000000000000022");
+
+    let child_code =
+        Bytecode::new_legacy([0x60, 1, 0x60, 0x40, 0x52, 0x60, 1, 0x60, 1, 0x01, 0x00].into());
+    let parent_code = Bytecode::new_legacy(
+        [
+            0x60, 1, 0x60, 0, 0x52, 0x60, 0, 0x60, 0, 0x60, 0, 0x60, 0, 0x60, 0, 0x61, 0x12, 0x34,
+            0x61, 0xff, 0xff, 0xf1, 0x00,
+        ]
+        .into(),
+    );
+
+    let context =
+        Context::mainnet().with_db(CacheDB::<EmptyDB>::default()).modify_db_chained(|db| {
+            db.insert_account_info(
+                &child,
+                AccountInfo { code: Some(child_code), ..Default::default() },
+            );
+            db.insert_account_info(
+                &parent,
+                AccountInfo { code: Some(parent_code), ..Default::default() },
+            );
+        });
+
+    let code = r#"
+{
+    ops: [],
+    step: function(log) {
+        this.ops.push({ op: log.op.toString(), depth: log.getDepth(), mem: log.memory.length() });
+    },
+    fault: function() {},
+    result: function() { return this.ops; }
+}"#;
+    let insp = JsInspector::new(code.to_string(), serde_json::Value::Null).unwrap();
+    let mut evm = context.build_mainnet().with_inspector(insp);
+    let res = evm
+        .inspect_tx(TxEnv {
+            caller: Address::ZERO,
+            gas_limit: 1_000_000,
+            kind: TransactTo::Call(parent),
+            ..Default::default()
+        })
+        .unwrap();
+    assert!(res.result.is_success(), "{res:#?}");
+
+    let (context, insp) = evm.ctx_inspector();
+    let result = js_result(insp, &res, context);
+    let ops = result.as_array().unwrap();
+    let call = ops.iter().position(|step| step["op"] == "CALL").expect("missing CALL step");
+    let add = ops.iter().position(|step| step["op"] == "ADD").expect("missing child ADD step");
+    assert!(add < call, "CALL step_end should be observed after child execution: {ops:?}");
+
+    let parent_stop = ops
+        .iter()
+        .find(|step| step["op"] == "STOP" && step["depth"].as_u64() == Some(0))
+        .expect("missing parent STOP step");
+    assert_eq!(parent_stop["mem"].as_u64(), Some(32));
+}
+
+#[test]
 fn test_geth_debug_inspector_jstracer() {
     let account = address!("1000000000000000000000000000000000000001");
     let caller = address!("1000000000000000000000000000000000000002");

--- a/crates/inspectors/tests/it/main.rs
+++ b/crates/inspectors/tests/it/main.rs
@@ -11,6 +11,8 @@ mod geth;
 #[cfg(feature = "js-tracer")]
 mod geth_js;
 #[cfg(feature = "std")]
+mod opcode;
+#[cfg(feature = "std")]
 mod parity;
 #[cfg(feature = "js-tracer")]
 mod test_native_bigint;

--- a/crates/inspectors/tests/it/opcode.rs
+++ b/crates/inspectors/tests/it/opcode.rs
@@ -1,0 +1,65 @@
+use crate::utils::{AccountInfo, Bytecode, CacheDB, Context, EmptyDB, TransactTo, TxEnv};
+use alloy_primitives::{Address, address};
+use evm2::interpreter::opcode::{OpCode, op};
+use evm2_inspectors::opcode::OpcodeGasInspector;
+
+#[test]
+fn opcode_gas_records_parent_call_after_child_execution() {
+    let child = address!("0000000000000000000000000000000000001234");
+    let parent = address!("0000000000000000000000000000000000000022");
+
+    let child_code = Bytecode::new_legacy([op::PUSH1, 1, op::PUSH1, 1, op::ADD, op::STOP].into());
+    let parent_code = Bytecode::new_legacy(
+        [
+            op::PUSH1,
+            0,
+            op::PUSH1,
+            0,
+            op::PUSH1,
+            0,
+            op::PUSH1,
+            0,
+            op::PUSH1,
+            0,
+            op::PUSH2,
+            0x12,
+            0x34,
+            op::PUSH2,
+            0xff,
+            0xff,
+            op::CALL,
+            op::STOP,
+        ]
+        .into(),
+    );
+
+    let context =
+        Context::mainnet().with_db(CacheDB::<EmptyDB>::default()).modify_db_chained(|db| {
+            db.insert_account_info(
+                &child,
+                AccountInfo { code: Some(child_code), ..Default::default() },
+            );
+            db.insert_account_info(
+                &parent,
+                AccountInfo { code: Some(parent_code), ..Default::default() },
+            );
+        });
+
+    let mut inspector = OpcodeGasInspector::new();
+    let mut evm = context.build_mainnet().with_inspector(&mut inspector);
+    let res = evm
+        .inspect_tx(TxEnv {
+            caller: Address::ZERO,
+            gas_limit: 1_000_000,
+            kind: TransactTo::Call(parent),
+            ..Default::default()
+        })
+        .unwrap();
+    assert!(res.result.is_success(), "{res:#?}");
+
+    let call = OpCode::new(op::CALL).unwrap();
+    let add = OpCode::new(op::ADD).unwrap();
+    assert_eq!(evm.inspector().opcode_counts().get(&call), Some(&1));
+    assert_eq!(evm.inspector().opcode_counts().get(&add), Some(&1));
+    assert!(evm.inspector().opcode_gas().get(&call).copied().unwrap_or_default() > 0);
+}


### PR DESCRIPTION
This keeps evm2's current CALL/CREATE inspector ordering and fixes inspectors that assumed a single pending step could not be interrupted by a child frame. Opcode gas tracking now keeps a pending-step stack and subtracts settled child gas when the child ends. The JS tracer also keeps a pending-step stack and stores the pre-step memory snapshot per pending step so parent CALL steps survive nested execution with the right frame-local memory.

The new regression coverage exercises a nested CALL where the child executes before the parent opcode's step_end, including the JS tracer's parent CALL step and parent memory snapshot after returning from the child.
