### PR TITLE
fix: preserve stack length on failed instruction setup

### DIFF
--- a/crates/evm2/src/interpreter/stack.rs
+++ b/crates/evm2/src/interpreter/stack.rs
@@ -289,9 +289,13 @@ impl<'a> StackMut<'a> {
     #[inline(always)]
     pub(crate) fn instr_stack_setup(&mut self, input: usize, output: usize) -> Result<*mut Word> {
         let len = self.len();
-        // SAFETY: Assumes that the stack is never used after execution fails.
-        *self.len = len.wrapping_sub(input).wrapping_add(output);
+        // Validate before committing the new length. On failure the length must stay intact:
+        // the dispatch loop still fires `step_end` (and exposes `Interpreter::stack()`) with this
+        // length live before it observes the error, so a wrapped length would be read by
+        // inspectors. `check_bounds_` guarantees `len >= input` and `len - input + output <=
+        // CAPACITY`, so the update below neither underflows nor overflows.
         Self::check_bounds_(len, input, output)?;
+        *self.len = len - input + output;
         debug_assert!(*self.len <= Self::CAPACITY);
         Ok(unsafe { self.as_word_mut_ptr().add(len).sub(input) })
     }
@@ -525,6 +529,26 @@ mod tests {
         run_with_len(StackMut::CAPACITY, |stack| {
             assert!(stack.check_bounds(1, 1).is_ok());
             assert_matches!(stack.check_bounds(0, 1), Err(InstrStop::StackOverflow));
+        });
+    }
+
+    #[test]
+    fn instr_stack_setup_preserves_len_on_failure() {
+        // A failed setup must leave the length untouched: the dispatch loop reads it (and exposes
+        // it through `Interpreter::stack()` to inspectors) before it observes the error.
+        run_with_len(1, |stack| {
+            assert_matches!(stack.instr_stack_setup(2, 1), Err(InstrStop::StackUnderflow));
+            assert_eq!(stack.len(), 1);
+        });
+
+        run_with_len(StackMut::CAPACITY, |stack| {
+            assert_matches!(stack.instr_stack_setup(0, 1), Err(InstrStop::StackOverflow));
+            assert_eq!(stack.len(), StackMut::CAPACITY);
+        });
+
+        run_with_len(3, |stack| {
+            assert!(stack.instr_stack_setup(2, 1).is_ok());
+            assert_eq!(stack.len(), 2);
         });
     }
 


### PR DESCRIPTION
`instr_stack_setup` committed the post-instruction stack length before validating bounds:

```rust
*self.len = len.wrapping_sub(input).wrapping_add(output);
Self::check_bounds_(len, input, output)?;
```

On a stack underflow or overflow the wrapped length (`usize::MAX`, or `1025` on overflow) is left in the interpreter. The dispatch loop still fires `step_end` — and exposes `Interpreter::stack()` — with that length live before it observes the error, so any inspector that reads the stack there trips `StackRef::len`'s `assert_unchecked(len <= 1024)`. That is a debug-assertion panic and, in release, undefined behavior (an out-of-bounds `from_raw_parts`).

This is reachable through the shipping `TracingInspector`: its `all()` config and the parity vm-trace config both read the stack in `step_end`. Tracing any transaction that executes a stack-underflowing or -overflowing opcode (trivially attacker-constructable, e.g. init code `0x50`) crashes a debug build and is UB in release. A node exposing `debug_traceTransaction` / `debug_traceCall` / `trace_call` can therefore be driven into it by a crafted call.

The fix validates before committing the new length, so a failed bounds check leaves the stack length intact. After the check, `len >= input` and `len - input + output <= CAPACITY` hold, so the update neither underflows nor overflows. Consensus execution is unaffected — the non-inspected path never reads the stack after a failure — which is why the change is invisible to the state-test corpus and shows up only in the inspector contract.
