### PR TITLE
perf(jit): reuse cached bytecode hash

### DIFF
--- a/crates/cli/benches/evm/jit.rs
+++ b/crates/cli/benches/evm/jit.rs
@@ -1,4 +1,4 @@
-use crate::fixture::Suites;
+use crate::fixture::{CompiledAccount, Suites};
 use alloy_primitives::{B256, hex, keccak256};
 use criterion::{BatchSize, BenchmarkGroup, black_box, measurement::WallTime};
 use evm2::{
@@ -11,7 +11,11 @@ use evm2::{
 use evm2_cli::evm_bench::BenchCase;
 use evm2_jit_context::EvmCompilerFn;
 use evm2_jit_llvm::EvmLlvmBackend;
-use evm2_jit_runtime::{EvmCompiler, OptimizationLevel};
+use evm2_jit_runtime::{
+    EvmCompiler, OptimizationLevel,
+    evm2_evm::JitInterpreterRunner,
+    runtime::{JitBackend, LookupRequest, RuntimeCacheKey, RuntimeConfig},
+};
 use std::{borrow::Cow, collections::HashMap, sync::Arc};
 
 type BenchEvm = Evm<'static, BaseEvmTypes>;
@@ -27,6 +31,8 @@ const SKIP_COMPILE_JIT: &[&str] = &[
     "usdc_proxy",
 ];
 const SKIP_ALL: &[&str] = &["seaport", "snailtracer"];
+const RUNTIME_LOOKUP_BENCHES: &[&str] =
+    &["counter", "weth", "erc20_transfer", "usdc_proxy", "curve_stableswap"];
 
 #[derive(Debug)]
 pub(crate) struct Compiler {
@@ -48,6 +54,7 @@ pub(crate) struct PreparedBench {
     tx: RecoveredTxEnvelope,
     entry_bytecode: Option<alloy_primitives::Bytes>,
     functions: Arc<HashMap<B256, EvmCompilerFn>>,
+    runtime_backend: Option<JitBackend>,
 }
 
 impl PreparedBench {
@@ -69,7 +76,7 @@ impl PreparedBench {
         }
 
         let mut functions = HashMap::new();
-        for account in accounts {
+        for account in &accounts {
             if functions.contains_key(&account.code_hash) {
                 continue;
             }
@@ -83,6 +90,10 @@ impl PreparedBench {
             compiler.compiler.clear_ir().expect("benchmark JIT compiler IR must clear");
         }
 
+        let runtime_backend = RUNTIME_LOOKUP_BENCHES
+            .contains(&bench.name.as_ref())
+            .then(|| compile_runtime_accounts(&bench.name, spec, &accounts));
+
         Some(Self {
             name: bench.name.clone(),
             spec,
@@ -91,6 +102,7 @@ impl PreparedBench {
             tx: case.tx(spec),
             entry_bytecode: case.entry_bytecode(),
             functions: Arc::new(functions),
+            runtime_backend,
         })
     }
 
@@ -98,7 +110,7 @@ impl PreparedBench {
         let interpreter = self.run_interpreter().unwrap_or_else(|err| {
             panic!("{} interpreter benchmark transaction must execute: {err:?}", self.name)
         });
-        let jit = self.run_jit().unwrap_or_else(|err| {
+        let jit = Runner::with_function_map(self).run().unwrap_or_else(|err| {
             panic!("{} JIT benchmark transaction must execute: {err:?}", self.name)
         });
         assert_eq!(
@@ -106,6 +118,16 @@ impl PreparedBench {
             "{} interpreter and JIT status differ",
             self.name
         );
+        if self.runtime_backend.is_some() {
+            let runtime = Runner::with_runtime_backend(self).run().unwrap_or_else(|err| {
+                panic!("{} runtime JIT benchmark transaction must execute: {err:?}", self.name)
+            });
+            assert_eq!(
+                interpreter.status, runtime.status,
+                "{} interpreter and runtime JIT status differ",
+                self.name
+            );
+        }
     }
 
     pub(crate) fn bench(&self, group: &mut BenchmarkGroup<'_, WallTime>) {
@@ -143,12 +165,24 @@ impl PreparedBench {
             }
         }
 
-        group.bench_function(format!("{}/jit/run", self.name), |b| {
+        self.bench_execution(group, "function_map", Runner::with_function_map);
+        if self.runtime_backend.is_some() {
+            self.bench_execution(group, "runtime_backend", Runner::with_runtime_backend);
+        }
+    }
+
+    fn bench_execution(
+        &self,
+        group: &mut BenchmarkGroup<'_, WallTime>,
+        name: &str,
+        prepare: fn(&Self) -> Runner,
+    ) {
+        group.bench_function(format!("{}/jit/{name}", self.name), |b| {
             b.iter_batched(
-                || Runner::new(self),
+                || prepare(self),
                 |mut runner| {
                     black_box(runner.run().unwrap_or_else(|err| {
-                        panic!("{} JIT benchmark transaction must execute: {err:?}", self.name)
+                        panic!("{} {name} benchmark transaction must execute: {err:?}", self.name)
                     }))
                 },
                 BatchSize::SmallInput,
@@ -160,11 +194,6 @@ impl PreparedBench {
         let mut evm = new_evm(self.spec, self.block, self.db.clone());
         evm.transact(&self.tx).map(evm2::ExecutedTx::commit)
     }
-
-    fn run_jit(&self) -> evm2::registry::HandlerResult<evm2::TxResult> {
-        let mut runner = Runner::new(self);
-        runner.run()
-    }
 }
 
 struct Runner {
@@ -173,15 +202,40 @@ struct Runner {
 }
 
 impl Runner {
-    fn new(prepared: &PreparedBench) -> Self {
+    fn with_function_map(prepared: &PreparedBench) -> Self {
         let mut evm = new_evm(prepared.spec, prepared.block, prepared.db.clone());
         evm.set_interpreter_runner(FixedJitRunner { functions: Arc::clone(&prepared.functions) });
+        Self { evm, tx: prepared.tx.clone() }
+    }
+
+    fn with_runtime_backend(prepared: &PreparedBench) -> Self {
+        let mut evm = new_evm(prepared.spec, prepared.block, prepared.db.clone());
+        let backend = prepared.runtime_backend.as_ref().expect("runtime benchmark is not enabled");
+        evm.set_interpreter_runner(JitInterpreterRunner::new(backend.clone()));
         Self { evm, tx: prepared.tx.clone() }
     }
 
     fn run(&mut self) -> evm2::registry::HandlerResult<evm2::TxResult> {
         self.evm.transact(&self.tx).map(evm2::ExecutedTx::commit)
     }
+}
+
+fn compile_runtime_accounts(name: &str, spec: SpecId, accounts: &[CompiledAccount]) -> JitBackend {
+    let backend = JitBackend::new(RuntimeConfig { enabled: true, ..Default::default() })
+        .expect("benchmark JIT runtime must initialize");
+    for account in accounts {
+        backend
+            .compile_jit_sync(LookupRequest {
+                key: RuntimeCacheKey { code_hash: account.code_hash, spec_id: spec },
+                code: account.bytecode.clone(),
+            })
+            .unwrap_or_else(|err| panic!("{name} runtime JIT compilation failed: {err:?}"));
+        assert!(
+            backend.get_compiled(account.code_hash, spec).is_some(),
+            "{name} runtime JIT program was not resident after compilation"
+        );
+    }
+    backend
 }
 
 #[derive(Clone, Debug)]

--- a/crates/cli/benches/evm/jit.rs
+++ b/crates/cli/benches/evm/jit.rs
@@ -48,7 +48,6 @@ pub(crate) struct PreparedBench {
     tx: RecoveredTxEnvelope,
     entry_bytecode: Option<alloy_primitives::Bytes>,
     functions: Arc<HashMap<B256, EvmCompilerFn>>,
-    runtime_backend: Option<JitBackend>,
 }
 
 impl PreparedBench {

--- a/crates/cli/benches/evm/jit.rs
+++ b/crates/cli/benches/evm/jit.rs
@@ -1,4 +1,4 @@
-use crate::fixture::{CompiledAccount, Suites};
+use crate::fixture::Suites;
 use alloy_primitives::{B256, hex, keccak256};
 use criterion::{BatchSize, BenchmarkGroup, black_box, measurement::WallTime};
 use evm2::{
@@ -11,11 +11,7 @@ use evm2::{
 use evm2_cli::evm_bench::BenchCase;
 use evm2_jit_context::EvmCompilerFn;
 use evm2_jit_llvm::EvmLlvmBackend;
-use evm2_jit_runtime::{
-    EvmCompiler, OptimizationLevel,
-    evm2_evm::JitInterpreterRunner,
-    runtime::{JitBackend, LookupRequest, RuntimeCacheKey, RuntimeConfig},
-};
+use evm2_jit_runtime::{EvmCompiler, OptimizationLevel};
 use std::{borrow::Cow, collections::HashMap, sync::Arc};
 
 type BenchEvm = Evm<'static, BaseEvmTypes>;
@@ -31,8 +27,6 @@ const SKIP_COMPILE_JIT: &[&str] = &[
     "usdc_proxy",
 ];
 const SKIP_ALL: &[&str] = &["seaport", "snailtracer"];
-const RUNTIME_LOOKUP_BENCHES: &[&str] =
-    &["counter", "weth", "erc20_transfer", "usdc_proxy", "curve_stableswap"];
 
 #[derive(Debug)]
 pub(crate) struct Compiler {
@@ -76,7 +70,7 @@ impl PreparedBench {
         }
 
         let mut functions = HashMap::new();
-        for account in &accounts {
+        for account in accounts {
             if functions.contains_key(&account.code_hash) {
                 continue;
             }
@@ -90,10 +84,6 @@ impl PreparedBench {
             compiler.compiler.clear_ir().expect("benchmark JIT compiler IR must clear");
         }
 
-        let runtime_backend = RUNTIME_LOOKUP_BENCHES
-            .contains(&bench.name.as_ref())
-            .then(|| compile_runtime_accounts(&bench.name, spec, &accounts));
-
         Some(Self {
             name: bench.name.clone(),
             spec,
@@ -102,7 +92,6 @@ impl PreparedBench {
             tx: case.tx(spec),
             entry_bytecode: case.entry_bytecode(),
             functions: Arc::new(functions),
-            runtime_backend,
         })
     }
 
@@ -110,7 +99,7 @@ impl PreparedBench {
         let interpreter = self.run_interpreter().unwrap_or_else(|err| {
             panic!("{} interpreter benchmark transaction must execute: {err:?}", self.name)
         });
-        let jit = Runner::with_function_map(self).run().unwrap_or_else(|err| {
+        let jit = self.run_jit().unwrap_or_else(|err| {
             panic!("{} JIT benchmark transaction must execute: {err:?}", self.name)
         });
         assert_eq!(
@@ -118,16 +107,6 @@ impl PreparedBench {
             "{} interpreter and JIT status differ",
             self.name
         );
-        if self.runtime_backend.is_some() {
-            let runtime = Runner::with_runtime_backend(self).run().unwrap_or_else(|err| {
-                panic!("{} runtime JIT benchmark transaction must execute: {err:?}", self.name)
-            });
-            assert_eq!(
-                interpreter.status, runtime.status,
-                "{} interpreter and runtime JIT status differ",
-                self.name
-            );
-        }
     }
 
     pub(crate) fn bench(&self, group: &mut BenchmarkGroup<'_, WallTime>) {
@@ -165,24 +144,12 @@ impl PreparedBench {
             }
         }
 
-        self.bench_execution(group, "function_map", Runner::with_function_map);
-        if self.runtime_backend.is_some() {
-            self.bench_execution(group, "runtime_backend", Runner::with_runtime_backend);
-        }
-    }
-
-    fn bench_execution(
-        &self,
-        group: &mut BenchmarkGroup<'_, WallTime>,
-        name: &str,
-        prepare: fn(&Self) -> Runner,
-    ) {
-        group.bench_function(format!("{}/jit/{name}", self.name), |b| {
+        group.bench_function(format!("{}/jit/run", self.name), |b| {
             b.iter_batched(
-                || prepare(self),
+                || Runner::new(self),
                 |mut runner| {
                     black_box(runner.run().unwrap_or_else(|err| {
-                        panic!("{} {name} benchmark transaction must execute: {err:?}", self.name)
+                        panic!("{} JIT benchmark transaction must execute: {err:?}", self.name)
                     }))
                 },
                 BatchSize::SmallInput,
@@ -194,6 +161,11 @@ impl PreparedBench {
         let mut evm = new_evm(self.spec, self.block, self.db.clone());
         evm.transact(&self.tx).map(evm2::ExecutedTx::commit)
     }
+
+    fn run_jit(&self) -> evm2::registry::HandlerResult<evm2::TxResult> {
+        let mut runner = Runner::new(self);
+        runner.run()
+    }
 }
 
 struct Runner {
@@ -202,40 +174,15 @@ struct Runner {
 }
 
 impl Runner {
-    fn with_function_map(prepared: &PreparedBench) -> Self {
+    fn new(prepared: &PreparedBench) -> Self {
         let mut evm = new_evm(prepared.spec, prepared.block, prepared.db.clone());
         evm.set_interpreter_runner(FixedJitRunner { functions: Arc::clone(&prepared.functions) });
-        Self { evm, tx: prepared.tx.clone() }
-    }
-
-    fn with_runtime_backend(prepared: &PreparedBench) -> Self {
-        let mut evm = new_evm(prepared.spec, prepared.block, prepared.db.clone());
-        let backend = prepared.runtime_backend.as_ref().expect("runtime benchmark is not enabled");
-        evm.set_interpreter_runner(JitInterpreterRunner::new(backend.clone()));
         Self { evm, tx: prepared.tx.clone() }
     }
 
     fn run(&mut self) -> evm2::registry::HandlerResult<evm2::TxResult> {
         self.evm.transact(&self.tx).map(evm2::ExecutedTx::commit)
     }
-}
-
-fn compile_runtime_accounts(name: &str, spec: SpecId, accounts: &[CompiledAccount]) -> JitBackend {
-    let backend = JitBackend::new(RuntimeConfig { enabled: true, ..Default::default() })
-        .expect("benchmark JIT runtime must initialize");
-    for account in accounts {
-        backend
-            .compile_jit_sync(LookupRequest {
-                key: RuntimeCacheKey { code_hash: account.code_hash, spec_id: spec },
-                code: account.bytecode.clone(),
-            })
-            .unwrap_or_else(|err| panic!("{name} runtime JIT compilation failed: {err:?}"));
-        assert!(
-            backend.get_compiled(account.code_hash, spec).is_some(),
-            "{name} runtime JIT program was not resident after compilation"
-        );
-    }
-    backend
 }
 
 #[derive(Clone, Debug)]
@@ -250,8 +197,7 @@ impl InterpreterRunner<BaseEvmTypes> for FixedJitRunner {
         interpreter: &mut Interpreter<'frame, 'host, BaseEvmTypes>,
         host: &mut Evm<'host, BaseEvmTypes>,
     ) -> Option<InstrStop> {
-        let code = interpreter.original_bytecode();
-        let func = *self.functions.get(&keccak256(&code))?;
+        let func = *self.functions.get(&interpreter.original_bytecode_hash())?;
         interpreter.prepare_run(config.base_spec_id(), config.version(), host);
         Some(unsafe { func.call_with_interpreter(interpreter) })
     }

--- a/crates/cli/benches/evm/jit.rs
+++ b/crates/cli/benches/evm/jit.rs
@@ -1,5 +1,5 @@
 use crate::fixture::Suites;
-use alloy_primitives::{B256, hex, keccak256};
+use alloy_primitives::{B256, hex};
 use criterion::{BatchSize, BenchmarkGroup, black_box, measurement::WallTime};
 use evm2::{
     BaseEvmTypes, Evm, ExecutionConfig, InterpreterRunner, Precompiles, SpecId,

--- a/crates/evm2/src/interpreter/runtime.rs
+++ b/crates/evm2/src/interpreter/runtime.rs
@@ -12,7 +12,7 @@ use crate::{
     version::{EvmFeatures, GasParams},
 };
 use alloc::{boxed::Box, vec::Vec};
-use alloy_primitives::{Address, Bytes};
+use alloy_primitives::{Address, B256, Bytes};
 use core::{fmt, ops::Range, ptr::NonNull};
 use derive_where::derive_where;
 
@@ -171,6 +171,12 @@ impl<'frame, 'host, T: EvmTypesHost> Interpreter<'frame, 'host, T> {
     #[inline]
     pub fn original_bytecode(&self) -> Bytes {
         self.bytecode.original_bytes()
+    }
+
+    /// Calculates or returns the cached hash of the original active bytecode.
+    #[inline]
+    pub fn original_bytecode_hash(&self) -> B256 {
+        self.bytecode.hash_slow()
     }
 
     /// Returns the current operand stack.

--- a/crates/jit/runtime/src/evm2_evm.rs
+++ b/crates/jit/runtime/src/evm2_evm.rs
@@ -1,7 +1,6 @@
 //! evm2 JIT interpreter dispatch helpers.
 
 use crate::runtime::{JitBackend, LookupDecision, LookupRequest, RuntimeCacheKey};
-use alloy_primitives::keccak256;
 use evm2::{
     BaseEvmTypes, Evm, ExecutionConfig, InterpreterRunner,
     interpreter::{InstrStop, Interpreter},
@@ -50,9 +49,10 @@ pub fn run_interpreter<'frame, 'host>(
     interpreter: &mut Interpreter<'frame, 'host, BaseEvmTypes>,
     host: &mut Evm<'host, BaseEvmTypes>,
 ) -> Option<InstrStop> {
+    let code_hash = interpreter.original_bytecode_hash();
     let code = interpreter.original_bytecode();
     let decision = backend.lookup(LookupRequest {
-        key: RuntimeCacheKey { code_hash: keccak256(&code), spec_id: config.base_spec_id() },
+        key: RuntimeCacheKey { code_hash, spec_id: config.base_spec_id() },
         code,
     });
 


### PR DESCRIPTION
## Overview

Reuses the hash cached by `Bytecode` when constructing JIT runtime lookup keys instead of re-hashing on every interpreter frame.

## Benchmarks

| Workload | Before | After | Criterion change |
|---|---:|---:|---:|
| `counter` | 1.6080 µs | 1.2931 µs | **-20.09%** |
| `weth` | 4.3691 µs | 1.5345 µs | **-65.10%** |
| `erc20_transfer` | 834.40 µs | 831.30 µs | -0.26% |
| `usdc_proxy` | 3.5027 µs | 1.4758 µs | **-58.20%** |
| `curve_stableswap` | 21.183 µs | 16.112 µs | **-23.90%** |
