### PR TITLE
fix(evm): preserve EIP-7702 call target as code address

### DIFF
--- a/crates/evm2/src/ethereum/mod.rs
+++ b/crates/evm2/src/ethereum/mod.rs
@@ -495,8 +495,7 @@ pub(crate) fn initial_message<'a, T: EvmTypes>(
                 caller,
                 input: input.clone(),
                 value,
-                code_address: initial_code.code_address,
-                disable_precompiles: initial_code.disable_precompiles,
+                code_address: to,
                 caller_is_static: false,
                 salt: B256::ZERO,
                 ext: T::MessageExt::default(),
@@ -516,7 +515,6 @@ pub(crate) fn initial_message<'a, T: EvmTypes>(
                 input: input.clone(),
                 value,
                 code_address: address,
-                disable_precompiles: false,
                 caller_is_static: false,
                 salt: B256::ZERO,
                 ext: T::MessageExt::default(),
@@ -531,8 +529,6 @@ pub(crate) fn initial_message<'a, T: EvmTypes>(
 
 struct InitialCallCode {
     code: Bytecode,
-    code_address: Address,
-    disable_precompiles: bool,
 }
 
 fn initial_call_code<'a, T: EvmTypes>(
@@ -552,13 +548,9 @@ fn initial_call_code<'a, T: EvmTypes>(
             host.state.account(&delegated_address, false).map_err(error_handler!(host))?;
         account.warm();
         let delegated_code = account.load_code().map_err(error_handler!(host))?;
-        return Ok(InitialCallCode {
-            code: delegated_code,
-            code_address: delegated_address,
-            disable_precompiles: true,
-        });
+        return Ok(InitialCallCode { code: delegated_code });
     }
-    Ok(InitialCallCode { code, code_address: to, disable_precompiles: false })
+    Ok(InitialCallCode { code })
 }
 
 pub(super) fn rollback_failed_execution<'a, T: EvmTypes>(
@@ -1045,7 +1037,57 @@ mod tests {
     }
 
     #[test]
-    fn initial_delegated_call_uses_delegated_code_address() {
+    fn initial_delegated_call_keeps_target_code_address() {
+        let caller = Address::with_last_byte(0xaa);
+        let target = Address::with_last_byte(0x42);
+        let delegated = Address::with_last_byte(0x33);
+        let delegated_code = Bytecode::new_legacy(Bytes::from_static(&[
+            op::PUSH1,
+            0x2a,
+            op::PUSH0,
+            op::MSTORE,
+            op::PUSH1,
+            0x20,
+            op::PUSH0,
+            op::RETURN,
+        ]));
+        let mut database = InMemoryDB::default();
+        database.insert_account_info(
+            &target,
+            AccountInfo::default().with_code(Bytecode::new_eip7702(delegated)),
+        );
+        database.insert_account_info(&delegated, AccountInfo::default().with_code(delegated_code));
+        let mut evm = Evm::<BaseEvmTypes>::new(
+            SpecId::PRAGUE,
+            BlockEnv::default(),
+            TxRegistry::new(),
+            database,
+            Precompiles::base(SpecId::PRAGUE),
+        );
+
+        let (bytecode, mut message) = initial_message(
+            &mut evm,
+            caller,
+            0,
+            TxKind::Call(target),
+            &Bytes::new(),
+            U256::ZERO,
+            100_000,
+            0,
+        )
+        .unwrap();
+        assert_eq!(message.destination, target);
+        assert_eq!(message.code_address, target);
+
+        let result = Host::execute_message(&mut evm, &TxEnv::default(), bytecode, &mut message);
+
+        assert_eq!(result.stop, InstrStop::Return);
+        assert_eq!(result.output.len(), 32);
+        assert_eq!(result.output[31], 0x2a);
+    }
+
+    #[test]
+    fn initial_delegated_precompile_keeps_precompile_precedence() {
         let caller = Address::with_last_byte(0xaa);
         let target = Address::with_last_byte(0x02);
         let delegated = Address::with_last_byte(0x33);
@@ -1084,15 +1126,17 @@ mod tests {
             0,
         )
         .unwrap();
-        assert_eq!(message.destination, target);
-        assert_eq!(message.code_address, delegated);
-        assert!(message.disable_precompiles);
-
         let result = Host::execute_message(&mut evm, &TxEnv::default(), bytecode, &mut message);
 
         assert_eq!(result.stop, InstrStop::Return);
-        assert_eq!(result.output.len(), 32);
-        assert_eq!(result.output[31], 0x2a);
+        assert_eq!(
+            result.output,
+            Bytes::from_static(&[
+                0xe3, 0xb0, 0xc4, 0x42, 0x98, 0xfc, 0x1c, 0x14, 0x9a, 0xfb, 0xf4, 0xc8, 0x99, 0x6f,
+                0xb9, 0x24, 0x27, 0xae, 0x41, 0xe4, 0x64, 0x9b, 0x93, 0x4c, 0xa4, 0x95, 0x99, 0x1b,
+                0x78, 0x52, 0xb8, 0x55,
+            ])
+        );
     }
 
     #[test]

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -342,7 +342,7 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
 
     #[inline]
     fn contains_precompile(&self, message: &Message<T>) -> bool {
-        !message.disable_precompiles && self.precompiles.contains(&message.code_address)
+        self.precompiles.contains(&message.code_address)
     }
 
     #[inline]
@@ -1093,7 +1093,6 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
             return Self::error_message_result(stop, message.gas_limit, message.reservoir);
         }
         message.code_address = message.destination;
-        message.disable_precompiles = false;
         let input = core::mem::take(&mut message.input);
 
         // Creates pay their NEW_ACCOUNT-equivalent state gas upfront via the tx-level
@@ -1990,7 +1989,6 @@ mod tests {
             input: Bytes::new(),
             value: U256::ZERO,
             code_address: address,
-            disable_precompiles: false,
             caller_is_static: false,
             salt: B256::ZERO,
             ext: (),
@@ -2457,7 +2455,6 @@ mod tests {
             assert_eq!(message.input, Bytes::from_static(b"message input"));
             assert_eq!(message.value, U256::from(99));
             assert_eq!(message.code_address, TEST_PRECOMPILE);
-            assert!(!message.disable_precompiles);
             Ok(PrecompileOutput::new(Bytes::copy_from_slice(&evm.block.number.to_be_bytes::<32>())))
         })]);
         let mut evm = Evm::<BaseEvmTypes>::new(
@@ -2477,7 +2474,6 @@ mod tests {
             input: Bytes::from_static(b"message input"),
             value: U256::from(99),
             code_address: address,
-            disable_precompiles: false,
             caller_is_static: false,
             salt: B256::ZERO,
             ext: (),

--- a/crates/evm2/src/interpreter/instructions/system.rs
+++ b/crates/evm2/src/interpreter/instructions/system.rs
@@ -77,7 +77,7 @@ fn load_acc_and_calc_gas<T: EvmTypesHost>(
     transfers_value: bool,
     create_empty_account: bool,
     stack_gas_limit: u64,
-) -> Result<(u64, u64, Bytecode, Address, bool)> {
+) -> Result<(u64, u64, Bytecode)> {
     if transfers_value {
         gas.spend(state.gas_params().get(GasId::TransferValueCost).into())?;
     }
@@ -92,7 +92,6 @@ fn load_acc_and_calc_gas<T: EvmTypesHost>(
         cost += additional_cold_cost;
     }
     let mut code = account.code;
-    let mut code_address = to;
     if state.feature(EvmFeatures::EIP7702)
         && let Some(delegated_address) = code.eip7702_address()
     {
@@ -107,7 +106,6 @@ fn load_acc_and_calc_gas<T: EvmTypesHost>(
             cost += additional_cold_cost;
         }
         code = delegated_account.code;
-        code_address = delegated_address;
     }
     let features = state.version().features;
     let mut new_account_state_gas = 0;
@@ -139,8 +137,7 @@ fn load_acc_and_calc_gas<T: EvmTypesHost>(
         gas_limit = gas_limit.saturating_add(state.gas_params().get(GasId::CallStipend).into());
     }
 
-    let disable_precompiles = code_address != to;
-    Ok((gas_limit, new_account_state_gas, code, code_address, disable_precompiles))
+    Ok((gas_limit, new_account_state_gas, code))
 }
 
 #[inline(never)]
@@ -176,27 +173,22 @@ fn prepare_call<T: EvmTypesHost>(
         return_offset,
         return_len,
     )?;
-    let (gas_limit, new_account_state_gas, loaded_code, resolved_code_address, disable_precompiles) =
-        load_acc_and_calc_gas(
-            gas,
-            state,
-            to,
-            has_transfer,
-            kind == MessageKind::Call,
-            local_gas_limit,
-        )?;
+    let (gas_limit, new_account_state_gas, loaded_code) = load_acc_and_calc_gas(
+        gas,
+        state,
+        to,
+        has_transfer,
+        kind == MessageKind::Call,
+        local_gas_limit,
+    )?;
     let input = memory_range_bytes(state, input_range)?;
 
     let current = state.message();
-    let (destination, caller, call_value, code_address) = match kind {
-        MessageKind::Call => (to, current.destination, value, resolved_code_address),
-        MessageKind::CallCode => {
-            (current.destination, current.destination, value, resolved_code_address)
-        }
-        MessageKind::DelegateCall => {
-            (current.destination, current.caller, current.value, resolved_code_address)
-        }
-        MessageKind::StaticCall => (to, current.destination, Word::ZERO, resolved_code_address),
+    let (destination, caller, call_value) = match kind {
+        MessageKind::Call => (to, current.destination, value),
+        MessageKind::CallCode => (current.destination, current.destination, value),
+        MessageKind::DelegateCall => (current.destination, current.caller, current.value),
+        MessageKind::StaticCall => (to, current.destination, Word::ZERO),
         _ => unreachable!("invalid call message kind"),
     };
     *message = Message {
@@ -208,8 +200,7 @@ fn prepare_call<T: EvmTypesHost>(
         caller,
         input,
         value: call_value,
-        code_address,
-        disable_precompiles,
+        code_address: to,
         caller_is_static: state.is_static(),
         salt: B256::ZERO,
         ext: T::MessageExt::default(),
@@ -339,7 +330,6 @@ fn create_inner<T: EvmTypesHost>(
         input,
         value,
         code_address: current.destination,
-        disable_precompiles: false,
         // CREATE is rejected in a static context (see `require_non_staticcall`).
         caller_is_static: false,
         salt: salt.map(|salt| B256::from(salt.to_be_bytes())).unwrap_or_default(),

--- a/crates/evm2/src/interpreter/message.rs
+++ b/crates/evm2/src/interpreter/message.rs
@@ -53,12 +53,13 @@ pub struct Message<T: EvmTypesHost = BaseEvmTypes> {
     pub input: Bytes,
     /// Value transferred with the message.
     pub value: U256,
-    /// Address whose code is being executed. This can differ from `destination` for `CALLCODE`,
-    /// `DELEGATECALL`, and EIP-7702 delegated-code execution.
+    /// Address whose bytecode account is being called.
+    ///
+    /// This can differ from `destination` for `CALLCODE` and `DELEGATECALL`. For EIP-7702
+    /// delegated-code execution this remains the target account, matching revm's
+    /// `CallInputs::bytecode_address`; the resolved delegated bytecode is passed to the
+    /// interpreter separately.
     pub code_address: Address,
-    /// Whether native precompile dispatch is disabled for this frame because its bytecode was
-    /// loaded through an EIP-7702 delegation designation.
-    pub disable_precompiles: bool,
     /// Whether the immediate caller frame is executing in a static context. Combined with a
     /// `STATICCALL` kind, this determines whether the new frame is static.
     pub caller_is_static: bool,

--- a/crates/inspectors/src/tracing/mod.rs
+++ b/crates/inspectors/src/tracing/mod.rs
@@ -614,9 +614,10 @@ impl<T: EvmTypes> Inspector<T> for TracingInspector {
         };
 
         // if calls to precompiles should be excluded, check whether this is a call to a precompile
-        let maybe_precompile = self.config.exclude_precompile_calls.then(|| {
-            !message.disable_precompiles && self.is_precompile_call(interp.host(), &to, &value)
-        });
+        let maybe_precompile = self
+            .config
+            .exclude_precompile_calls
+            .then(|| self.is_precompile_call(interp.host(), &to, &value));
 
         self.start_trace_on_call(
             usize::from(message.depth),

--- a/crates/jit/builtins/src/lib.rs
+++ b/crates/jit/builtins/src/lib.rs
@@ -691,7 +691,6 @@ pub unsafe extern "C" fn __revmc_builtin_create(
         input: code,
         value: value.to_u256(),
         code_address: current.destination,
-        disable_precompiles: false,
         caller_is_static: false,
         salt,
         ext: (),
@@ -770,19 +769,15 @@ pub unsafe extern "C" fn __revmc_builtin_call(
         usize::MAX
     };
 
-    let (gas_limit, new_account_state_gas, loaded_code, resolved_code_address, disable_precompiles) =
+    let (gas_limit, new_account_state_gas, loaded_code) =
         load_acc_and_calc_gas(ecx, to, transfers_value, call_kind == CallKind::Call, local_gas_limit)?;
 
     let current = ecx.message();
-    let (destination, caller, call_value, code_address) = match call_kind {
-        CallKind::Call => (to, current.destination, value, resolved_code_address),
-        CallKind::CallCode => {
-            (current.destination, current.destination, value, resolved_code_address)
-        }
-        CallKind::DelegateCall => {
-            (current.destination, current.caller, current.value, resolved_code_address)
-        }
-        CallKind::StaticCall => (to, current.destination, U256::ZERO, resolved_code_address),
+    let (destination, caller, call_value) = match call_kind {
+        CallKind::Call => (to, current.destination, value),
+        CallKind::CallCode => (current.destination, current.destination, value),
+        CallKind::DelegateCall => (current.destination, current.caller, current.value),
+        CallKind::StaticCall => (to, current.destination, U256::ZERO),
     };
     let mut message = Message {
         kind: call_kind.into(),
@@ -793,8 +788,7 @@ pub unsafe extern "C" fn __revmc_builtin_call(
         caller,
         input,
         value: call_value,
-        code_address,
-        disable_precompiles,
+        code_address: to,
         caller_is_static: ecx.is_static(),
         salt: B256::ZERO,
         ext: (),
@@ -834,7 +828,7 @@ fn load_acc_and_calc_gas(
     transfers_value: bool,
     create_empty_account: bool,
     stack_gas_limit: u64,
-) -> Result<(u64, u64, Bytecode, Address, bool), BuiltinError> {
+) -> Result<(u64, u64, Bytecode), BuiltinError> {
     let version = *ecx.version();
     if transfers_value {
         ecx.gas.spend(version.gas_params.get(GasId::TransferValueCost).into())?;
@@ -854,7 +848,6 @@ fn load_acc_and_calc_gas(
     }
     let mut new_account_state_gas = 0;
     let mut code = account.code;
-    let mut code_address = to;
     if ecx.enables(EvmFeatures::EIP7702)
         && let Some(delegated_address) = code.eip7702_address()
     {
@@ -871,7 +864,6 @@ fn load_acc_and_calc_gas(
             cost += additional_cold_cost;
         }
         code = delegated_account.code;
-        code_address = delegated_address;
     }
     let features = ecx.version().features;
     if create_empty_account
@@ -900,8 +892,7 @@ fn load_acc_and_calc_gas(
         gas_limit = gas_limit.saturating_add(version.gas_params.get(GasId::CallStipend).into());
     }
 
-    let disable_precompiles = code_address != to;
-    Ok((gas_limit, new_account_state_gas, code, code_address, disable_precompiles))
+    Ok((gas_limit, new_account_state_gas, code))
 }
 
 #[unsafe(no_mangle)]

--- a/crates/jit/runtime/src/evm2_evm.rs
+++ b/crates/jit/runtime/src/evm2_evm.rs
@@ -74,12 +74,13 @@ mod tests {
     use alloy_primitives::Address;
     use alloy_primitives::Bytes;
     use evm2::{
-        BaseEvmConfigSelector, BaseEvmTypes, Evm, EvmConfigSelector, Precompiles, SpecId,
+        BaseEvmConfigSelector, BaseEvmTypes, Evm, EvmConfigSelector, Inspector, Precompiles,
+        SpecId,
         bytecode::Bytecode,
         env::{BlockEnv, TxEnv},
         ethereum::ethereum_tx_registry,
         evm::EmptyDB,
-        interpreter::{Message, op},
+        interpreter::{Interpreter, Message, MessageResult, op},
     };
     #[cfg(feature = "llvm")]
     use evm2::{
@@ -278,6 +279,87 @@ mod tests {
         );
         assert_eq!(interpreter.output().len(), 32);
         assert_eq!(interpreter.output()[31], 0x42);
+    }
+
+    #[test]
+    #[cfg(feature = "llvm")]
+    fn compiled_nested_delegated_call_keeps_target_code_address() {
+        #[derive(Default)]
+        struct CodeAddressInspector {
+            nested_call: Option<(Address, Address)>,
+        }
+
+        impl Inspector<BaseEvmTypes> for CodeAddressInspector {
+            fn call(
+                &mut self,
+                _interp: &mut Interpreter<'_, '_, BaseEvmTypes>,
+                message: &mut Message<BaseEvmTypes>,
+            ) -> Option<MessageResult<BaseEvmTypes>> {
+                if message.depth > 0 {
+                    self.nested_call = Some((message.destination, message.code_address));
+                }
+                None
+            }
+        }
+
+        let config = <BaseEvmConfigSelector as EvmConfigSelector<BaseEvmTypes>>::execution_config(
+            SpecId::PRAGUE,
+        );
+        let outer = Address::from([0x11; 20]);
+        let target = Address::from([0x22; 20]);
+        let delegated = Address::from([0x33; 20]);
+        let mut database = InMemoryDB::default();
+        database.insert_account_info(&outer, AccountInfo::default());
+        database.insert_account_info(
+            &target,
+            AccountInfo::default().with_code(Bytecode::new_eip7702(delegated)),
+        );
+        database.insert_account_info(
+            &delegated,
+            AccountInfo::default()
+                .with_code(Bytecode::new_legacy(Bytes::copy_from_slice(BYTECODE_RET42))),
+        );
+        let backend = blocking_backend();
+        let mut host = Evm::<BaseEvmTypes>::new(
+            SpecId::PRAGUE,
+            BlockEnv::default(),
+            ethereum_tx_registry(SpecId::PRAGUE),
+            database,
+            Precompiles::base(SpecId::PRAGUE),
+        );
+        host.set_interpreter_runner(JitInterpreterRunner::new(backend.clone()));
+        host.set_inspector(CodeAddressInspector::default());
+        let tx_env = TxEnv::default();
+        let message = Message {
+            gas_limit: 1_000_000,
+            destination: outer,
+            code_address: outer,
+            ..Message::default()
+        };
+        let mut code = vec![op::PUSH1, 0x20, op::PUSH0, op::PUSH0, op::PUSH0, op::PUSH0];
+        push20(&mut code, target);
+        code.extend([
+            op::PUSH2,
+            0x27,
+            0x10,
+            op::CALL,
+            op::POP,
+            op::PUSH1,
+            0x20,
+            op::PUSH0,
+            op::RETURN,
+        ]);
+        let mut interpreter =
+            Interpreter::<BaseEvmTypes>::new(Bytecode::new_legacy(code.into()), &tx_env, &message);
+
+        assert_eq!(
+            run_interpreter(&backend, &config, &mut interpreter, &mut host),
+            Some(InstrStop::Return),
+        );
+        assert_eq!(interpreter.output().len(), 32);
+        assert_eq!(interpreter.output()[31], 0x42);
+        let inspector = host.clear_inspector_as::<CodeAddressInspector>().unwrap();
+        assert_eq!(inspector.nested_call, Some((target, target)));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Keep ordinary CALL and STATICCALL `code_address` equal to the supplied target.
- Carry resolved EIP-7702 delegated bytecode separately.
- Preserve precompile dispatch precedence at delegated precompile targets.
- Align interpreter, inspector, and JIT message handling.

## Impact

Inspector consumers previously saw the delegation address instead of the call target. A precompile address carrying delegation could also execute delegated bytecode instead of the precompile.

## Testing

- Ordinary delegated-call code-address regression
- Delegated-precompile precedence regression
- Compiled nested delegated-call inspector regression
- Warnings-denied touched-package Clippy
- Prague differential artifact replays cleanly