### PR TITLE
perf(jit): initialize only native LLVM target

### DIFF
--- a/crates/jit/llvm/src/lib.rs
+++ b/crates/jit/llvm/src/lib.rs
@@ -2077,7 +2077,7 @@ fn init_() -> Result<()> {
         info: true,
         machine_code: true,
     };
-    Target::initialize_all(&config);
+    Target::initialize_native(&config).map_err(|e| eyre::eyre!(e))?;
 
     Ok(())
 }


### PR DESCRIPTION
Initialize only the native LLVM target instead of registering every compiled-in backend. This avoids unnecessary global LLVM target initialization while retaining the assembler, disassembler, target info, and machine-code components used by the JIT and AOT paths. Native initialization errors are propagated through the existing backend result.