### PR TITLE
feat: add inspector forwarding impls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ alloy-sol-types = { version = "1.5.7", default-features = false }
 alloy-trie = { version = "0.9", default-features = false }
 
 anstyle = { version = "1.0", default-features = false }
+auto_impl = "1.3"
 bitvec = { version = "1", default-features = false }
 boa_engine = { version = "0.21", default-features = false }
 boa_gc = { version = "0.21", default-features = false }

--- a/crates/evm2/Cargo.toml
+++ b/crates/evm2/Cargo.toml
@@ -22,6 +22,7 @@ alloy-consensus.workspace = true
 alloy-eip7928.workspace = true
 alloy-eips = { workspace = true, features = ["k256"] }
 alloy-primitives.workspace = true
+auto_impl.workspace = true
 bitvec = { workspace = true, features = ["alloc"] }
 derive-where.workspace = true
 thiserror.workspace = true

--- a/crates/evm2/src/evm/db/mod.rs
+++ b/crates/evm2/src/evm/db/mod.rs
@@ -4,6 +4,7 @@ use super::{NonStaticAny, state::AccountInfo};
 use crate::{AnyError, ErrorCode, bytecode::Bytecode, error::error_unavailable, interpreter::Word};
 use alloc::{boxed::Box, string::ToString};
 use alloy_primitives::{Address, B256, keccak256};
+use auto_impl::auto_impl;
 use core::error::Error;
 
 mod cache;
@@ -13,6 +14,7 @@ pub use cache::{AccountStorageCache, Cache, CacheDB, InMemoryDB};
 pub type DbResult<T> = Result<T, ErrorCode>;
 
 /// Backing database implementation with a concrete error type.
+#[auto_impl(&mut, Box)]
 pub trait Database: NonStaticAny {
     /// Database error type.
     type Error: Error + Send + Sync + 'static;
@@ -28,30 +30,6 @@ pub trait Database: NonStaticAny {
 
     /// Loads a historical block hash.
     fn get_block_hash(&mut self, number: &Word) -> Result<Option<B256>, Self::Error>;
-}
-
-impl<T: Database + ?Sized> Database for &mut T {
-    type Error = T::Error;
-
-    #[inline]
-    fn get_account(&mut self, address: &Address) -> Result<Option<AccountInfo>, Self::Error> {
-        (**self).get_account(address)
-    }
-
-    #[inline]
-    fn get_code_by_hash(&mut self, code_hash: &B256) -> Result<Bytecode, Self::Error> {
-        (**self).get_code_by_hash(code_hash)
-    }
-
-    #[inline]
-    fn get_storage(&mut self, address: &Address, key: &Word) -> Result<Word, Self::Error> {
-        (**self).get_storage(address, key)
-    }
-
-    #[inline]
-    fn get_block_hash(&mut self, number: &Word) -> Result<Option<B256>, Self::Error> {
-        (**self).get_block_hash(number)
-    }
 }
 
 /// Object-safe database adapter for typed database implementations.
@@ -145,6 +123,7 @@ impl<T: Database> DynDatabase for Db<T> {
 }
 
 /// Backing database view used to initialize mutable [`super::State`].
+#[auto_impl(&mut, Box)]
 pub trait DynDatabase: NonStaticAny {
     /// Loads account information.
     fn get_account(&mut self, address: &Address) -> DbResult<Option<AccountInfo>>;
@@ -317,60 +296,6 @@ impl<'a> core::ops::DerefMut for dyn DynDatabase + 'a {
 #[inline]
 pub(crate) fn boxed_dyn_database<'a>(database: impl DynDatabase + 'a) -> Box<dyn DynDatabase + 'a> {
     Box::new(database)
-}
-
-impl<T: DynDatabase + ?Sized> DynDatabase for Box<T> {
-    #[inline]
-    fn get_account(&mut self, address: &Address) -> DbResult<Option<AccountInfo>> {
-        self.as_mut().get_account(address)
-    }
-
-    #[inline]
-    fn get_code_by_hash(&mut self, code_hash: &B256) -> DbResult<Bytecode> {
-        self.as_mut().get_code_by_hash(code_hash)
-    }
-
-    #[inline]
-    fn get_storage(&mut self, address: &Address, key: &Word) -> DbResult<Word> {
-        self.as_mut().get_storage(address, key)
-    }
-
-    #[inline]
-    fn get_block_hash(&mut self, number: &Word) -> DbResult<Option<B256>> {
-        self.as_mut().get_block_hash(number)
-    }
-
-    #[inline]
-    fn error(&mut self, code: ErrorCode) -> AnyError {
-        self.as_mut().error(code)
-    }
-}
-
-impl<T: DynDatabase + ?Sized> DynDatabase for &mut T {
-    #[inline]
-    fn get_account(&mut self, address: &Address) -> DbResult<Option<AccountInfo>> {
-        (**self).get_account(address)
-    }
-
-    #[inline]
-    fn get_code_by_hash(&mut self, code_hash: &B256) -> DbResult<Bytecode> {
-        (**self).get_code_by_hash(code_hash)
-    }
-
-    #[inline]
-    fn get_storage(&mut self, address: &Address, key: &Word) -> DbResult<Word> {
-        (**self).get_storage(address, key)
-    }
-
-    #[inline]
-    fn get_block_hash(&mut self, number: &Word) -> DbResult<Option<B256>> {
-        (**self).get_block_hash(number)
-    }
-
-    #[inline]
-    fn error(&mut self, code: ErrorCode) -> AnyError {
-        (**self).error(code)
-    }
 }
 
 /// Empty backing database.

--- a/crates/evm2/src/evm/inspector.rs
+++ b/crates/evm2/src/evm/inspector.rs
@@ -7,8 +7,10 @@ use crate::{
 };
 use alloc::boxed::Box;
 use alloy_primitives::{Address, Log, U256};
+use auto_impl::auto_impl;
 
 /// EVM execution inspector.
+#[auto_impl(&mut, Box)]
 pub trait Inspector<T: EvmTypesHost>: NonStaticAny {
     /// Called after a frame interpreter has been initialized.
     #[inline]

--- a/crates/evm2/src/evm/precompile.rs
+++ b/crates/evm2/src/evm/precompile.rs
@@ -7,6 +7,7 @@ use crate::{
 };
 use alloc::{boxed::Box, vec::Vec};
 use alloy_primitives::{Address, Bytes};
+use auto_impl::auto_impl;
 
 /// Result returned by a precompile.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
@@ -36,6 +37,7 @@ impl PrecompileOutput {
 }
 
 /// Precompile execution hook.
+#[auto_impl(&mut, Box)]
 pub trait PrecompileProvider<T: EvmTypesHost>: NonStaticAny {
     /// Returns precompile addresses.
     fn addresses(&self) -> Vec<Address> {
@@ -74,28 +76,6 @@ impl<'a, T: EvmTypesHost> core::ops::DerefMut for dyn PrecompileProvider<T> + 'a
     #[inline]
     fn deref_mut(&mut self) -> &mut Self::Target {
         self
-    }
-}
-
-impl<T: EvmTypesHost, P: PrecompileProvider<T> + ?Sized> PrecompileProvider<T> for Box<P> {
-    #[inline]
-    fn addresses(&self) -> Vec<Address> {
-        self.as_ref().addresses()
-    }
-
-    #[inline]
-    fn contains(&self, address: &Address) -> bool {
-        self.as_ref().contains(address)
-    }
-
-    #[inline]
-    fn execute(
-        &mut self,
-        evm: &mut Evm<'_, T>,
-        message: &Message<T>,
-        gas: &mut GasTracker,
-    ) -> Option<Result<PrecompileOutput, PrecompileError>> {
-        self.as_mut().execute(evm, message, gas)
     }
 }
 

--- a/crates/evm2/src/evm/state/stream.rs
+++ b/crates/evm2/src/evm/state/stream.rs
@@ -3,6 +3,7 @@
 use super::AccountInfo;
 use crate::{bytecode::Bytecode, interpreter::Word};
 use alloy_primitives::{Address, B256};
+use auto_impl::auto_impl;
 use core::convert::Infallible;
 
 /// Borrowed account information exposed to change sinks.
@@ -92,6 +93,7 @@ pub struct StorageChange {
 }
 
 /// Consumer of borrowed transaction or block state changes.
+#[auto_impl(&mut, Box)]
 pub trait StateChangeSink {
     /// Error returned by this sink.
     type Error;
@@ -121,33 +123,6 @@ pub trait StateChangeSink {
     #[inline]
     fn storage(&mut self, _change: StorageChange) -> Result<(), Self::Error> {
         Ok(())
-    }
-}
-
-impl<S> StateChangeSink for &mut S
-where
-    S: StateChangeSink + ?Sized,
-{
-    type Error = S::Error;
-
-    #[inline]
-    fn bytecode(&mut self, code_hash: B256, code: &Bytecode) -> Result<(), Self::Error> {
-        (**self).bytecode(code_hash, code)
-    }
-
-    #[inline]
-    fn account(&mut self, change: AccountChangeRef<'_>) -> Result<(), Self::Error> {
-        (**self).account(change)
-    }
-
-    #[inline]
-    fn storage_wipe(&mut self, address: Address) -> Result<(), Self::Error> {
-        (**self).storage_wipe(address)
-    }
-
-    #[inline]
-    fn storage(&mut self, change: StorageChange) -> Result<(), Self::Error> {
-        (**self).storage(change)
     }
 }
 


### PR DESCRIPTION
Adds `Inspector` forwarding implementations for `&mut` and `Box` using `auto_impl`. It also migrates the existing hand-written forwarding implementations for `Database`, `DynDatabase`, `PrecompileProvider`, and `StateChangeSink` to the same macro, reducing duplication while preserving their existing wrapper coverage.