### PR TITLE
feat(evm): add serde support for BlockStateAccumulator

### DIFF
--- a/crates/evm2/Cargo.toml
+++ b/crates/evm2/Cargo.toml
@@ -87,6 +87,7 @@ aws-lc-rs = { workspace = true, optional = true }
 alloy-primitives = { workspace = true, features = ["serde", "std"] }
 serde = { workspace = true, features = ["derive", "std"] }
 serde_json = { workspace = true, features = ["std"] }
+postcard = { workspace = true, features = ["alloc"] }
 rand = { workspace = true, features = ["std"] }
 ark-std = { workspace = true }
 rstest.workspace = true

--- a/crates/evm2/src/bytecode/serde_impl.rs
+++ b/crates/evm2/src/bytecode/serde_impl.rs
@@ -1,6 +1,10 @@
 use super::Bytecode;
 use alloy_primitives::{Address, Bytes};
-use serde::{Deserialize, Serialize};
+use core::fmt;
+use serde::{
+    Deserialize, Deserializer, Serialize, Serializer,
+    de::{Error, Visitor},
+};
 
 // TODO: eventually remove `BytecodeSerdeOld`.
 
@@ -18,31 +22,53 @@ enum BytecodeSerdeOld {
 }
 
 impl Serialize for Bytecode {
-    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        self.original_bytes().serialize(serializer)
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        if serializer.is_human_readable() {
+            self.original_bytes().serialize(serializer)
+        } else {
+            serializer.serialize_bytes(self.original_byte_slice())
+        }
     }
 }
 
 impl<'de> Deserialize<'de> for Bytecode {
-    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        match BytecodeSerde::deserialize(deserializer)? {
-            BytecodeSerde::New(bytes) => {
-                Self::new_raw_checked(bytes).map_err(serde::de::Error::custom)
-            }
-            BytecodeSerde::Old(bytecode_serde_old) => match bytecode_serde_old {
-                BytecodeSerdeOld::LegacyAnalyzed { bytecode, original_len } => {
-                    if original_len > bytecode.len() {
-                        return Err(serde::de::Error::custom(
-                            "original_len is greater than bytecode length",
-                        ));
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        if deserializer.is_human_readable() {
+            match BytecodeSerde::deserialize(deserializer)? {
+                BytecodeSerde::New(bytes) => {
+                    Self::new_raw_checked(bytes).map_err(serde::de::Error::custom)
+                }
+                BytecodeSerde::Old(bytecode_serde_old) => match bytecode_serde_old {
+                    BytecodeSerdeOld::LegacyAnalyzed { bytecode, original_len } => {
+                        if original_len > bytecode.len() {
+                            return Err(serde::de::Error::custom(
+                                "original_len is greater than bytecode length",
+                            ));
+                        }
+                        Ok(Self::new_legacy(bytecode.slice(..original_len)))
                     }
-                    Ok(Self::new_legacy(bytecode.slice(..original_len)))
-                }
-                BytecodeSerdeOld::Eip7702 { delegated_address } => {
-                    Ok(Self::new_eip7702(delegated_address))
-                }
-            },
+                    BytecodeSerdeOld::Eip7702 { delegated_address } => {
+                        Ok(Self::new_eip7702(delegated_address))
+                    }
+                },
+            }
+        } else {
+            deserializer.deserialize_bytes(BytecodeVisitor)
         }
+    }
+}
+
+struct BytecodeVisitor;
+
+impl Visitor<'_> for BytecodeVisitor {
+    type Value = Bytecode;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("EVM bytecode")
+    }
+
+    fn visit_bytes<E: Error>(self, value: &[u8]) -> Result<Self::Value, E> {
+        Bytecode::new_raw_checked(Bytes::copy_from_slice(value)).map_err(Error::custom)
     }
 }
 
@@ -75,6 +101,19 @@ mod tests {
 
         assert_eq!(deserialized.kind(), BytecodeKind::Eip7702);
         assert_eq!(deserialized.eip7702_address(), Some(delegated_address));
+    }
+
+    #[test]
+    fn serde_binary_roundtrip() {
+        for bytes in [&hex!()[..], &hex!("0x1234")[..]] {
+            let bytecode = Bytecode::new_raw_checked(bytes.to_vec().into()).unwrap();
+            let encoded = postcard::to_allocvec(&bytecode).unwrap();
+            let deserialized: Bytecode = postcard::from_bytes(&encoded).unwrap();
+
+            assert_eq!(deserialized.kind(), BytecodeKind::Legacy);
+            assert_eq!(deserialized.eip7702_address(), None);
+            assert_eq!(deserialized.original_byte_slice(), bytes);
+        }
     }
 
     #[test]

--- a/crates/evm2/src/evm/state/account.rs
+++ b/crates/evm2/src/evm/state/account.rs
@@ -12,6 +12,7 @@ use derive_where::derive_where;
 /// [`Self::code_hash`]; [`Self::code`] is a cache keyed by the code hash and may or may not be
 /// populated.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AccountInfo {
     /// Account balance.
     pub balance: Word,
@@ -22,6 +23,7 @@ pub struct AccountInfo {
     /// Bytecode associated with this account.
     pub code: Option<Bytecode>,
     #[doc(hidden)] // Not public API. Please use an existing constructor.
+    #[cfg_attr(feature = "serde", serde(skip))]
     pub _non_exhaustive: (),
 }
 

--- a/crates/evm2/src/evm/state/block.rs
+++ b/crates/evm2/src/evm/state/block.rs
@@ -18,10 +18,12 @@ use core::convert::Infallible;
 
 /// Mutable block-level state accumulator.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BlockStateAccumulator {
     accounts: AddressMap<Tracked<Option<AccountInfo>>>,
     storage_wipes: AddressSet,
     storage: StorageKeyMap<Tracked<Word>>,
+    #[cfg_attr(feature = "serde", serde(with = "bytecode_map_serde"))]
     code: B256Map<Bytecode>,
 }
 
@@ -174,6 +176,32 @@ impl StateChangeSource for BlockStateAccumulator {
     #[inline]
     fn visit<S: StateChangeSink>(&self, sink: &mut S) -> Result<(), S::Error> {
         visit_block_changes(&self.accounts, &self.storage_wipes, &self.storage, &self.code, sink)
+    }
+}
+
+#[cfg(feature = "serde")]
+mod bytecode_map_serde {
+    use super::*;
+    use alloy_primitives::Bytes;
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    pub(super) fn serialize<S>(code: &B256Map<Bytecode>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        code.iter()
+            .map(|(&hash, bytecode)| (hash, bytecode.original_bytes()))
+            .collect::<B256Map<Bytes>>()
+            .serialize(serializer)
+    }
+
+    pub(super) fn deserialize<'de, D>(deserializer: D) -> Result<B256Map<Bytecode>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        B256Map::<Bytes>::deserialize(deserializer).map(|code| {
+            code.into_iter().map(|(hash, bytes)| (hash, Bytecode::new_raw(bytes))).collect()
+        })
     }
 }
 

--- a/crates/evm2/src/evm/state/block.rs
+++ b/crates/evm2/src/evm/state/block.rs
@@ -234,6 +234,8 @@ mod tests {
     #[cfg(feature = "serde")]
     use crate::bytecode::Bytecode;
     #[cfg(feature = "serde")]
+    use alloc::vec;
+    #[cfg(feature = "serde")]
     use alloy_primitives::B256;
 
     fn changes(address: Address, change: AccountChange) -> StateChanges {

--- a/crates/evm2/src/evm/state/block.rs
+++ b/crates/evm2/src/evm/state/block.rs
@@ -23,7 +23,6 @@ pub struct BlockStateAccumulator {
     accounts: AddressMap<Tracked<Option<AccountInfo>>>,
     storage_wipes: AddressSet,
     storage: StorageKeyMap<Tracked<Word>>,
-    #[cfg_attr(feature = "serde", serde(with = "bytecode_map_serde"))]
     code: B256Map<Bytecode>,
 }
 
@@ -179,32 +178,6 @@ impl StateChangeSource for BlockStateAccumulator {
     }
 }
 
-#[cfg(feature = "serde")]
-mod bytecode_map_serde {
-    use super::*;
-    use alloy_primitives::Bytes;
-    use serde::{Deserialize, Deserializer, Serialize, Serializer};
-
-    pub(super) fn serialize<S>(code: &B256Map<Bytecode>, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        code.iter()
-            .map(|(&hash, bytecode)| (hash, bytecode.original_bytes()))
-            .collect::<B256Map<Bytes>>()
-            .serialize(serializer)
-    }
-
-    pub(super) fn deserialize<'de, D>(deserializer: D) -> Result<B256Map<Bytecode>, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        B256Map::<Bytes>::deserialize(deserializer).map(|code| {
-            code.into_iter().map(|(hash, bytes)| (hash, Bytecode::new_raw(bytes))).collect()
-        })
-    }
-}
-
 fn visit_block_changes<S: StateChangeSink>(
     accounts: &AddressMap<Tracked<Option<AccountInfo>>>,
     storage_wipes: &AddressSet,
@@ -256,6 +229,13 @@ mod tests {
     use crate::interpreter::Word;
     use alloy_primitives::{Address, map::U256Map};
 
+    #[cfg(feature = "serde")]
+    use super::super::StateChangeSink;
+    #[cfg(feature = "serde")]
+    use crate::bytecode::Bytecode;
+    #[cfg(feature = "serde")]
+    use alloy_primitives::B256;
+
     fn changes(address: Address, change: AccountChange) -> StateChanges {
         let mut changes = StateChanges::default();
         changes.accounts.insert(address, change);
@@ -264,6 +244,20 @@ mod tests {
 
     fn slot(key: Word, original: Word, current: Word) -> U256Map<Tracked<Word>> {
         U256Map::from_iter([(key, Tracked::from_parts(original, current))])
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn serde_binary_roundtrip() {
+        let mut accumulator = BlockStateAccumulator::new();
+        let code_hash = B256::with_last_byte(1);
+        let bytecode = Bytecode::new_raw_checked(vec![0x60, 0x00].into()).unwrap();
+        accumulator.bytecode(code_hash, &bytecode).unwrap();
+
+        let encoded = postcard::to_allocvec(&accumulator).unwrap();
+        let deserialized: BlockStateAccumulator = postcard::from_bytes(&encoded).unwrap();
+
+        assert_eq!(deserialized, accumulator);
     }
 
     #[test]

--- a/crates/evm2/src/evm/state/tracked.rs
+++ b/crates/evm2/src/evm/state/tracked.rs
@@ -9,6 +9,7 @@
 /// value after all observed mutations in that boundary. When a transaction is accepted, `current`
 /// becomes the next transaction's `original` without writing anything to the backing database.
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Tracked<T> {
     /// Value at the start of the aggregation boundary.
     pub original: T,

--- a/crates/evm2/src/storage_key.rs
+++ b/crates/evm2/src/storage_key.rs
@@ -16,6 +16,7 @@ pub type StorageKeySet = HashSet<StorageKey, FbBuildHasher<52>>;
 
 /// Storage key for account-address and storage-slot pairs.
 #[derive(Clone, Copy, Debug, Default, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(C)]
 pub struct StorageKey {
     address: Address,


### PR DESCRIPTION
Adds optional serde derives for BlockStateAccumulator and the state value types it stores. The code map uses a small raw-byte serde adapter so the derived accumulator remains compatible with bincode while preserving Bytecode's existing representation.

This lets downstream execution-state types serialize the native accumulator directly instead of maintaining a duplicate visitor-based adapter.