### PR TITLE
feat: support generic RPC integrations

### DIFF
--- a/crates/cli/benches/evm/fixture.rs
+++ b/crates/cli/benches/evm/fixture.rs
@@ -6,7 +6,7 @@ use evm2::{
     SpecId, Version,
     bytecode::Bytecode,
     env::BlockEnv,
-    ethereum::RecoveredTxEnvelope,
+    ethereum::{RecoveredTxEnvelope, TxEnvelope},
     evm::{AccountInfo, InMemoryDB},
 };
 use evm2_eest::{StateTestPost, StateTestSuite, StateTestUnit};
@@ -144,10 +144,10 @@ impl Case<'_> {
                 .cloned()
                 .expect("fixture transaction data index must exist"),
         };
-        RecoveredTxEnvelope::Legacy(Recovered::new_unchecked(
-            tx,
+        Recovered::new_unchecked(
+            TxEnvelope::Legacy(tx),
             raw.sender.expect("benchmark transaction sender is required"),
-        ))
+        )
     }
 
     #[cfg(feature = "jit")]

--- a/crates/cli/src/fuzzer/case.rs
+++ b/crates/cli/src/fuzzer/case.rs
@@ -12,7 +12,12 @@ use alloy_eips::{
     eip7702::{Authorization, SignedAuthorization},
 };
 use alloy_primitives::{Address, B256, Bytes, TxKind, U256};
-use evm2::{SpecId, env::BlockEnv, ethereum::RecoveredTxEnvelope, interpreter::op};
+use evm2::{
+    SpecId,
+    env::BlockEnv,
+    ethereum::{RecoveredTxEnvelope, TxEnvelope},
+    interpreter::op,
+};
 use revm::{
     context::{BlockEnv as RevmBlockEnv, TxEnv as RevmTxEnv},
     primitives::TxKind as RevmTxKind,
@@ -570,8 +575,8 @@ impl CaseTx {
 
     pub(crate) fn evm2(&self) -> RecoveredTxEnvelope {
         match self.kind {
-            TxKindCase::Legacy => RecoveredTxEnvelope::Legacy(Recovered::new_unchecked(
-                TxLegacy {
+            TxKindCase::Legacy => Recovered::new_unchecked(
+                TxEnvelope::Legacy(TxLegacy {
                     nonce: self.nonce,
                     gas_price: self.gas_price,
                     gas_limit: self.gas_limit,
@@ -579,11 +584,11 @@ impl CaseTx {
                     value: self.value,
                     input: self.input.clone(),
                     chain_id: None,
-                },
+                }),
                 self.caller,
-            )),
-            TxKindCase::Eip2930 => RecoveredTxEnvelope::Eip2930(Recovered::new_unchecked(
-                TxEip2930 {
+            ),
+            TxKindCase::Eip2930 => Recovered::new_unchecked(
+                TxEnvelope::Eip2930(TxEip2930 {
                     chain_id: 1,
                     nonce: self.nonce,
                     gas_price: self.gas_price,
@@ -592,11 +597,11 @@ impl CaseTx {
                     value: self.value,
                     access_list: self.access_list.clone(),
                     input: self.input.clone(),
-                },
+                }),
                 self.caller,
-            )),
-            TxKindCase::Eip1559 => RecoveredTxEnvelope::Eip1559(Recovered::new_unchecked(
-                TxEip1559 {
+            ),
+            TxKindCase::Eip1559 => Recovered::new_unchecked(
+                TxEnvelope::Eip1559(TxEip1559 {
                     chain_id: 1,
                     nonce: self.nonce,
                     gas_limit: self.gas_limit,
@@ -606,11 +611,11 @@ impl CaseTx {
                     value: self.value,
                     access_list: self.access_list.clone(),
                     input: self.input.clone(),
-                },
+                }),
                 self.caller,
-            )),
-            TxKindCase::Eip4844 => RecoveredTxEnvelope::Eip4844(Recovered::new_unchecked(
-                TxEip4844Variant::TxEip4844(TxEip4844 {
+            ),
+            TxKindCase::Eip4844 => Recovered::new_unchecked(
+                TxEnvelope::Eip4844(TxEip4844Variant::TxEip4844(TxEip4844 {
                     chain_id: 1,
                     nonce: self.nonce,
                     gas_limit: self.gas_limit,
@@ -622,24 +627,27 @@ impl CaseTx {
                     blob_versioned_hashes: self.blob_hashes.clone(),
                     max_fee_per_blob_gas: 1,
                     input: self.input.clone(),
-                }),
+                })),
                 self.caller,
-            )),
-            TxKindCase::Eip7702 => RecoveredTxEnvelope::from(Recovered::new_unchecked(
-                TxEip7702 {
-                    chain_id: 1,
-                    nonce: self.nonce,
-                    gas_limit: self.gas_limit,
-                    max_fee_per_gas: self.gas_price,
-                    max_priority_fee_per_gas: 0,
-                    to: self.target,
-                    value: self.value,
-                    access_list: self.access_list.clone(),
-                    authorization_list: self.eip7702_authorization_list(),
-                    input: self.input.clone(),
-                },
+            ),
+            TxKindCase::Eip7702 => Recovered::new_unchecked(
+                TxEnvelope::Eip7702(
+                    TxEip7702 {
+                        chain_id: 1,
+                        nonce: self.nonce,
+                        gas_limit: self.gas_limit,
+                        max_fee_per_gas: self.gas_price,
+                        max_priority_fee_per_gas: 0,
+                        to: self.target,
+                        value: self.value,
+                        access_list: self.access_list.clone(),
+                        authorization_list: self.eip7702_authorization_list(),
+                        input: self.input.clone(),
+                    }
+                    .into(),
+                ),
                 self.caller,
-            )),
+            ),
         }
     }
 

--- a/crates/cli/src/run.rs
+++ b/crates/cli/src/run.rs
@@ -5,7 +5,7 @@ use evm2::{
     BaseEvmTypes, Evm, ExecutionConfig, InterpreterRunner, Precompiles, SpecId, Version,
     bytecode::Bytecode,
     env::BlockEnv,
-    ethereum::{RecoveredTxEnvelope, ethereum_tx_registry},
+    ethereum::{RecoveredTxEnvelope, TxEnvelope, ethereum_tx_registry},
     evm::{AccountInfo, InMemoryDB},
     interpreter::{InstrStop, Interpreter},
 };
@@ -715,7 +715,7 @@ fn parse_bytecode_bench(bench: &Bench, bytecode: &[u8]) -> eyre::Result<Prepared
         vec![ParsedAccount { bytecode, code_hash }],
         BlockEnv::default(),
         db,
-        RecoveredTxEnvelope::Legacy(Recovered::new_unchecked(tx, BENCH_CALLER)),
+        Recovered::new_unchecked(TxEnvelope::Legacy(tx), BENCH_CALLER),
     ))
 }
 
@@ -798,7 +798,7 @@ fn build_fixture_tx(
         value,
         input: data,
     };
-    Ok(RecoveredTxEnvelope::Legacy(Recovered::new_unchecked(tx, caller)))
+    Ok(Recovered::new_unchecked(TxEnvelope::Legacy(tx), caller))
 }
 
 impl Bench {

--- a/crates/eest/src/blockchaintest/execute.rs
+++ b/crates/eest/src/blockchaintest/execute.rs
@@ -19,6 +19,7 @@ use crate::{
     state::{insert_account_with_storage, parse_bytecode},
     tx::{TxFields, build_recovered_tx, rpc_access_list, signed_authorizations},
 };
+use alloy_consensus::Transaction as _;
 use alloy_eip7928::BlockAccessList;
 use alloy_eips::eip7840::BlobParams;
 use alloy_primitives::{Address, B256, Bytes, KECCAK256_EMPTY, U256};

--- a/crates/eest/src/execute.rs
+++ b/crates/eest/src/execute.rs
@@ -631,11 +631,11 @@ mod tests {
 
         let tx = build_tx(&raw, &TxPartIndices { data: 0, gas: 0, value: 0 }, None).unwrap();
 
-        let RecoveredTxEnvelope::Legacy(tx) = tx else {
+        let evm2::ethereum::TxEnvelope::Legacy(inner) = tx.inner() else {
             panic!("expected legacy transaction");
         };
         assert_eq!(tx.signer(), caller);
-        assert_eq!(tx.inner().gas_price, 7);
+        assert_eq!(inner.gas_price, 7);
     }
 
     #[test]
@@ -659,11 +659,11 @@ mod tests {
 
         let tx = build_tx(&raw, &TxPartIndices { data: 0, gas: 0, value: 0 }, None).unwrap();
 
-        let RecoveredTxEnvelope::Eip2930(tx) = tx else {
+        let evm2::ethereum::TxEnvelope::Eip2930(inner) = tx.inner() else {
             panic!("expected EIP-2930 transaction");
         };
         assert_eq!(tx.signer(), caller);
-        assert_eq!(tx.inner().access_list[0].address, access_address);
+        assert_eq!(inner.access_list[0].address, access_address);
     }
 
     #[test]
@@ -694,10 +694,10 @@ mod tests {
 
         let tx = build_tx(&raw, &TxPartIndices { data: 1, gas: 0, value: 0 }, None).unwrap();
 
-        let RecoveredTxEnvelope::Eip2930(tx) = tx else {
+        let evm2::ethereum::TxEnvelope::Eip2930(inner) = tx.inner() else {
             panic!("expected EIP-2930 transaction");
         };
-        assert_eq!(tx.inner().access_list[0].address, second_address);
+        assert_eq!(inner.access_list[0].address, second_address);
     }
 
     #[cfg(feature = "jit")]

--- a/crates/eest/src/tx.rs
+++ b/crates/eest/src/tx.rs
@@ -5,7 +5,7 @@ use alloy_rpc_types_eth::{
     AccessList as RpcAccessList, AccessListItem as RpcAccessListItem, TransactionInput,
     TransactionRequest,
 };
-use evm2::ethereum::RecoveredTxEnvelope;
+use evm2::ethereum::{RecoveredTxEnvelope, TxEnvelope};
 use k256::ecdsa::SigningKey;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
@@ -199,21 +199,11 @@ pub(crate) fn recover_address(private_key: &[u8]) -> Option<Address> {
 
 fn recovered_envelope(tx: TypedTransaction, caller: Address) -> RecoveredTxEnvelope {
     match tx {
-        TypedTransaction::Legacy(tx) => {
-            RecoveredTxEnvelope::Legacy(Recovered::new_unchecked(tx, caller))
-        }
-        TypedTransaction::Eip2930(tx) => {
-            RecoveredTxEnvelope::Eip2930(Recovered::new_unchecked(tx, caller))
-        }
-        TypedTransaction::Eip1559(tx) => {
-            RecoveredTxEnvelope::Eip1559(Recovered::new_unchecked(tx, caller))
-        }
-        TypedTransaction::Eip4844(tx) => {
-            RecoveredTxEnvelope::Eip4844(Recovered::new_unchecked(tx, caller))
-        }
-        TypedTransaction::Eip7702(tx) => {
-            RecoveredTxEnvelope::from(Recovered::new_unchecked(tx, caller))
-        }
+        TypedTransaction::Legacy(tx) => Recovered::new_unchecked(TxEnvelope::Legacy(tx), caller),
+        TypedTransaction::Eip2930(tx) => Recovered::new_unchecked(TxEnvelope::Eip2930(tx), caller),
+        TypedTransaction::Eip1559(tx) => Recovered::new_unchecked(TxEnvelope::Eip1559(tx), caller),
+        TypedTransaction::Eip4844(tx) => Recovered::new_unchecked(TxEnvelope::Eip4844(tx), caller),
+        TypedTransaction::Eip7702(tx) => Recovered::new_unchecked(tx.into(), caller),
     }
 }
 

--- a/crates/evm2/examples/bal_build.rs
+++ b/crates/evm2/examples/bal_build.rs
@@ -14,7 +14,7 @@ use evm2::{
     BaseEvmTypes, Evm, Precompiles, SpecId,
     bytecode::Bytecode,
     env::BlockEnv,
-    ethereum::{RecoveredTxEnvelope, ethereum_tx_registry},
+    ethereum::{RecoveredTxEnvelope, TxEnvelope, ethereum_tx_registry},
     evm::{AccountInfo, BlockAccessIndex, InMemoryDB, SystemTx},
     interpreter::op,
 };
@@ -50,16 +50,16 @@ fn main() {
     // Transaction 1 is recorded at index 2: a call that stores 42 at slot 5.
     evm.state_mut().bump_bal_index();
     assert_eq!(evm.state_mut().bal_index(), idx(2));
-    let tx1 = RecoveredTxEnvelope::Legacy(Recovered::new_unchecked(
-        TxLegacy {
+    let tx1 = Recovered::new_unchecked(
+        TxEnvelope::Legacy(TxLegacy {
             to: TxKind::Call(STORAGE_CONTRACT),
             input: word(42),
             gas_limit: 300_000,
             nonce: 1,
             ..Default::default()
-        },
+        }),
         CALLER,
-    ));
+    );
     let result = evm.transact(&tx1).expect("transaction 1 should execute").commit();
     assert!(result.status);
 
@@ -146,16 +146,16 @@ fn block_evm() -> Evm<'static, BaseEvmTypes> {
 }
 
 fn transfer(from: Address, to: Address, value: u64, nonce: u64) -> RecoveredTxEnvelope {
-    RecoveredTxEnvelope::Legacy(Recovered::new_unchecked(
-        TxLegacy {
+    Recovered::new_unchecked(
+        TxEnvelope::Legacy(TxLegacy {
             to: TxKind::Call(to),
             value: U256::from(value),
             gas_limit: 300_000,
             nonce,
             ..Default::default()
-        },
+        }),
         from,
-    ))
+    )
 }
 
 /// Stores the first calldata word at storage slot `slot`.

--- a/crates/evm2/examples/bal_parallel.rs
+++ b/crates/evm2/examples/bal_parallel.rs
@@ -17,7 +17,7 @@ use alloy_primitives::{Address, TxKind, U256};
 use evm2::{
     BaseEvmTypes, Evm, Precompiles, SpecId, TxResultWithState,
     env::BlockEnv,
-    ethereum::{RecoveredTxEnvelope, ethereum_tx_registry},
+    ethereum::{RecoveredTxEnvelope, TxEnvelope, ethereum_tx_registry},
     evm::{AccountInfo, Bal, BlockAccessIndex, InMemoryDB},
 };
 use std::sync::Arc;
@@ -128,16 +128,16 @@ fn pre_block_evm() -> Evm<'static, BaseEvmTypes> {
 }
 
 fn transfer(from: Address, to: Address, value: u64, nonce: u64) -> RecoveredTxEnvelope {
-    RecoveredTxEnvelope::Legacy(Recovered::new_unchecked(
-        TxLegacy {
+    Recovered::new_unchecked(
+        TxEnvelope::Legacy(TxLegacy {
             to: TxKind::Call(to),
             value: U256::from(value),
             gas_limit: 300_000,
             nonce,
             ..Default::default()
-        },
+        }),
         from,
-    ))
+    )
 }
 
 const fn idx(index: u64) -> BlockAccessIndex {

--- a/crates/evm2/examples/custom_evm/main.rs
+++ b/crates/evm2/examples/custom_evm/main.rs
@@ -3,6 +3,7 @@
 #![allow(missing_docs, clippy::missing_const_for_fn)]
 
 use crate::config::CustomConfigSelector;
+use alloy_consensus::transaction::Recovered;
 use alloy_eips::eip2718::Typed2718;
 use alloy_primitives::{Address, B256, Bytes, U256};
 use config::{CustomBlockEnvExt, CustomSpecId, CustomTypes, custom_version};
@@ -71,11 +72,20 @@ fn state_change_consumer() -> HandlerResult<()> {
     database.insert_account_info(&target, AccountInfo::default().with_nonce(1));
     let mut evm = custom_evm_with_database(database);
     let mut consumer = ExampleStateConsumer::default();
-    let tx = CustomEnvelope::ExecuteCode(ExecuteCodeTx {
-        target,
-        gas_limit: 100_000,
-        code: Bytes::from_static(&[opcode::CUSTOM_OPCODE, op::PUSH1, 0x01, op::SSTORE, op::STOP]),
-    });
+    let tx = Recovered::new_unchecked(
+        CustomEnvelope::ExecuteCode(ExecuteCodeTx {
+            target,
+            gas_limit: 100_000,
+            code: Bytes::from_static(&[
+                opcode::CUSTOM_OPCODE,
+                op::PUSH1,
+                0x01,
+                op::SSTORE,
+                op::STOP,
+            ]),
+        }),
+        Address::ZERO,
+    );
 
     let Ok(result) = evm.transact(&tx)?.commit_with(&mut consumer);
     let storage_change = consumer.storage_changes.first().expect("storage change observed");
@@ -224,12 +234,15 @@ fn custom_execution_config() -> ExecutionConfig<CustomTypes> {
         .with_version(configured_custom_version())
 }
 
-fn custom_opcode_tx(code: Bytes) -> CustomEnvelope {
-    CustomEnvelope::ExecuteCode(ExecuteCodeTx {
-        target: Address::from([0xcc; 20]),
-        gas_limit: 100_000,
-        code,
-    })
+fn custom_opcode_tx(code: Bytes) -> Recovered<CustomEnvelope> {
+    Recovered::new_unchecked(
+        CustomEnvelope::ExecuteCode(ExecuteCodeTx {
+            target: Address::from([0xcc; 20]),
+            gas_limit: 100_000,
+            code,
+        }),
+        Address::ZERO,
+    )
 }
 
 pub fn configured_custom_version() -> Version {

--- a/crates/evm2/src/ethereum/eip1559.rs
+++ b/crates/evm2/src/ethereum/eip1559.rs
@@ -13,11 +13,11 @@ use crate::{
     interpreter::Host,
     registry::{HandlerResult, TxRequest},
 };
-use alloy_consensus::{TxEip1559, transaction::Recovered};
+use alloy_consensus::TxEip1559;
 use alloy_primitives::U256;
 
 pub(super) fn handle<T: EvmTypes>(
-    req: TxRequest<'_, '_, T, Recovered<TxEip1559>>,
+    req: TxRequest<'_, '_, T, TxEip1559>,
 ) -> HandlerResult<TxResult<T>> {
     let caller = req.tx.signer();
     let tx = req.tx.inner();

--- a/crates/evm2/src/ethereum/eip2930.rs
+++ b/crates/evm2/src/ethereum/eip2930.rs
@@ -13,11 +13,11 @@ use crate::{
     interpreter::Host,
     registry::{HandlerResult, TxRequest},
 };
-use alloy_consensus::{TxEip2930, transaction::Recovered};
+use alloy_consensus::TxEip2930;
 use alloy_primitives::U256;
 
 pub(super) fn handle<T: EvmTypes>(
-    req: TxRequest<'_, '_, T, Recovered<TxEip2930>>,
+    req: TxRequest<'_, '_, T, TxEip2930>,
 ) -> HandlerResult<TxResult<T>> {
     let caller = req.tx.signer();
     let tx = req.tx.inner();

--- a/crates/evm2/src/ethereum/eip4844.rs
+++ b/crates/evm2/src/ethereum/eip4844.rs
@@ -14,12 +14,12 @@ use crate::{
     registry::{HandlerError, HandlerResult, TxRequest},
     utils::b256_to_word,
 };
-use alloy_consensus::transaction::{Recovered, TxEip4844Variant};
+use alloy_consensus::transaction::TxEip4844Variant;
 use alloy_eips::eip4844::{DATA_GAS_PER_BLOB, VERSIONED_HASH_VERSION_KZG};
 use alloy_primitives::U256;
 
 pub(super) fn handle<T: EvmTypes>(
-    req: TxRequest<'_, '_, T, Recovered<TxEip4844Variant>>,
+    req: TxRequest<'_, '_, T, TxEip4844Variant>,
 ) -> HandlerResult<TxResult<T>> {
     let caller = req.tx.signer();
     let tx = req.tx.inner().tx();

--- a/crates/evm2/src/ethereum/eip7702.rs
+++ b/crates/evm2/src/ethereum/eip7702.rs
@@ -14,11 +14,10 @@ use crate::{
     registry::{HandlerError, HandlerResult, TxRequest},
     version::GasId,
 };
-use alloy_consensus::transaction::Recovered;
 use alloy_primitives::U256;
 
 pub(super) fn handle<T: EvmTypes>(
-    req: TxRequest<'_, '_, T, Recovered<super::LazyTxEip7702>>,
+    req: TxRequest<'_, '_, T, super::LazyTxEip7702>,
 ) -> HandlerResult<TxResult<T>> {
     let caller = req.tx.signer();
     let tx = req.tx.inner();

--- a/crates/evm2/src/ethereum/lazy_eip7702.rs
+++ b/crates/evm2/src/ethereum/lazy_eip7702.rs
@@ -1,11 +1,11 @@
 use alloc::vec::Vec;
-use alloy_consensus::{TxEip7702, TxType};
+use alloy_consensus::{Transaction, TxEip7702, TxType};
 use alloy_eips::{
     Typed2718,
     eip2930::AccessList,
     eip7702::{Authorization, RecoveredAuthorization, SignedAuthorization},
 };
-use alloy_primitives::{Address, Bytes, ChainId, U256};
+use alloy_primitives::{Address, B256, Bytes, ChainId, TxKind, U256};
 
 /// EIP-7702 authorization that may already have its authority recovered.
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
@@ -104,6 +104,7 @@ pub struct LazyTxEip7702 {
     pub access_list: AccessList,
     /// EIP-7702 authorizations, either signed or with cached recovery results.
     pub authorization_list: Vec<LazyAuthorization>,
+    signed_authorization_list: Vec<SignedAuthorization>,
     /// Transaction input calldata.
     pub input: Bytes,
 }
@@ -111,7 +112,8 @@ pub struct LazyTxEip7702 {
 impl LazyTxEip7702 {
     /// Converts a consensus transaction while keeping signed authorizations unresolved.
     pub fn from_signed_authorizations(tx: TxEip7702) -> Self {
-        tx.map_authorizations(Into::into)
+        let authorization_list = tx.authorization_list.iter().cloned().map(Into::into).collect();
+        Self::from_authorizations(tx, authorization_list)
     }
 
     /// Converts a consensus transaction and eagerly recovers all authorization authorities.
@@ -119,7 +121,13 @@ impl LazyTxEip7702 {
     /// Invalid authorization signatures are cached as invalid recovered authorizations so execution
     /// skips them in the same way as a failed on-demand recovery.
     pub fn from_recovered_authorizations(tx: TxEip7702) -> Self {
-        tx.map_authorizations(|authorization| authorization.into_recovered().into())
+        let authorization_list = tx
+            .authorization_list
+            .iter()
+            .cloned()
+            .map(|authorization| authorization.into_recovered().into())
+            .collect();
+        Self::from_authorizations(tx, authorization_list)
     }
 
     /// Converts a consensus transaction using an externally supplied authorization list.
@@ -135,7 +143,7 @@ impl LazyTxEip7702 {
             to,
             value,
             access_list,
-            authorization_list: _,
+            authorization_list: signed_authorization_list,
             input,
         } = tx;
         Self {
@@ -148,6 +156,7 @@ impl LazyTxEip7702 {
             value,
             access_list,
             authorization_list,
+            signed_authorization_list,
             input,
         }
     }
@@ -169,45 +178,7 @@ impl LazyTxEip7702 {
             + self.access_list.size()
             + self.input.len()
             + self.authorization_list.capacity() * size_of::<LazyAuthorization>()
-    }
-}
-
-trait MapAuthorizationList {
-    fn map_authorizations(
-        self,
-        f: impl FnMut(SignedAuthorization) -> LazyAuthorization,
-    ) -> LazyTxEip7702;
-}
-
-impl MapAuthorizationList for TxEip7702 {
-    fn map_authorizations(
-        self,
-        f: impl FnMut(SignedAuthorization) -> LazyAuthorization,
-    ) -> LazyTxEip7702 {
-        let Self {
-            chain_id,
-            nonce,
-            gas_limit,
-            max_fee_per_gas,
-            max_priority_fee_per_gas,
-            to,
-            value,
-            access_list,
-            authorization_list,
-            input,
-        } = self;
-        LazyTxEip7702 {
-            chain_id,
-            nonce,
-            gas_limit,
-            max_fee_per_gas,
-            max_priority_fee_per_gas,
-            to,
-            value,
-            access_list,
-            authorization_list: authorization_list.into_iter().map(f).collect(),
-            input,
-        }
+            + self.signed_authorization_list.capacity() * size_of::<SignedAuthorization>()
     }
 }
 
@@ -220,5 +191,79 @@ impl From<TxEip7702> for LazyTxEip7702 {
 impl Typed2718 for LazyTxEip7702 {
     fn ty(&self) -> u8 {
         TxType::Eip7702 as u8
+    }
+}
+
+impl Transaction for LazyTxEip7702 {
+    fn chain_id(&self) -> Option<ChainId> {
+        Some(self.chain_id)
+    }
+
+    fn nonce(&self) -> u64 {
+        self.nonce
+    }
+
+    fn gas_limit(&self) -> u64 {
+        self.gas_limit
+    }
+
+    fn gas_price(&self) -> Option<u128> {
+        None
+    }
+
+    fn max_fee_per_gas(&self) -> u128 {
+        self.max_fee_per_gas
+    }
+
+    fn max_priority_fee_per_gas(&self) -> Option<u128> {
+        Some(self.max_priority_fee_per_gas)
+    }
+
+    fn max_fee_per_blob_gas(&self) -> Option<u128> {
+        None
+    }
+
+    fn priority_fee_or_price(&self) -> u128 {
+        self.max_priority_fee_per_gas
+    }
+
+    fn effective_gas_price(&self, base_fee: Option<u64>) -> u128 {
+        alloy_eips::eip1559::calc_effective_gas_price(
+            self.max_fee_per_gas,
+            self.max_priority_fee_per_gas,
+            base_fee,
+        )
+    }
+
+    fn is_dynamic_fee(&self) -> bool {
+        true
+    }
+
+    fn kind(&self) -> TxKind {
+        TxKind::Call(self.to)
+    }
+
+    fn is_create(&self) -> bool {
+        false
+    }
+
+    fn value(&self) -> U256 {
+        self.value
+    }
+
+    fn input(&self) -> &Bytes {
+        &self.input
+    }
+
+    fn access_list(&self) -> Option<&AccessList> {
+        Some(&self.access_list)
+    }
+
+    fn blob_versioned_hashes(&self) -> Option<&[B256]> {
+        None
+    }
+
+    fn authorization_list(&self) -> Option<&[SignedAuthorization]> {
+        Some(&self.signed_authorization_list)
     }
 }

--- a/crates/evm2/src/ethereum/legacy.rs
+++ b/crates/evm2/src/ethereum/legacy.rs
@@ -12,11 +12,11 @@ use crate::{
     interpreter::Host,
     registry::{HandlerResult, TxRequest},
 };
-use alloy_consensus::{TxLegacy, transaction::Recovered};
+use alloy_consensus::TxLegacy;
 use alloy_primitives::U256;
 
 pub(super) fn handle<T: EvmTypes>(
-    req: TxRequest<'_, '_, T, Recovered<TxLegacy>>,
+    req: TxRequest<'_, '_, T, TxLegacy>,
 ) -> HandlerResult<TxResult<T>> {
     let caller = req.tx.signer();
     let tx = req.tx.inner();

--- a/crates/evm2/src/ethereum/mod.rs
+++ b/crates/evm2/src/ethereum/mod.rs
@@ -27,50 +27,42 @@ use alloy_consensus::{
 };
 use alloy_eips::{eip2718::Typed2718, eip2930::AccessList};
 use alloy_primitives::{Address, B256, Bytes, KECCAK256_EMPTY, TxKind, U256};
-use core::fmt::Debug;
 
-/// Ethereum transaction envelope containing recovered transactions.
+/// Ethereum transaction envelope.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub enum RecoveredTxEnvelope {
+pub enum TxEnvelope {
     /// Legacy transaction.
-    Legacy(Recovered<TxLegacy>),
+    Legacy(TxLegacy),
     /// EIP-2930 access-list transaction.
-    Eip2930(Recovered<TxEip2930>),
+    Eip2930(TxEip2930),
     /// EIP-1559 dynamic-fee transaction.
-    Eip1559(Recovered<TxEip1559>),
+    Eip1559(TxEip1559),
     /// EIP-4844 blob transaction.
-    Eip4844(Recovered<TxEip4844Variant>),
+    Eip4844(TxEip4844Variant),
     /// EIP-7702 set-code transaction.
-    Eip7702(Recovered<LazyTxEip7702>),
+    Eip7702(LazyTxEip7702),
 }
 
-impl From<Recovered<EthereumTxEnvelope<TxEip4844>>> for RecoveredTxEnvelope {
-    fn from(tx: Recovered<EthereumTxEnvelope<TxEip4844>>) -> Self {
-        let (tx, signer) = tx.into_parts();
+/// Recovered Ethereum transaction envelope.
+pub type RecoveredTxEnvelope = Recovered<TxEnvelope>;
+
+impl From<EthereumTxEnvelope<TxEip4844>> for TxEnvelope {
+    fn from(tx: EthereumTxEnvelope<TxEip4844>) -> Self {
         match tx {
-            EthereumTxEnvelope::Legacy(tx) => {
-                Self::Legacy(Recovered::new_unchecked(tx.strip_signature(), signer))
+            EthereumTxEnvelope::Legacy(tx) => Self::Legacy(tx.strip_signature()),
+            EthereumTxEnvelope::Eip2930(tx) => Self::Eip2930(tx.strip_signature()),
+            EthereumTxEnvelope::Eip1559(tx) => Self::Eip1559(tx.strip_signature()),
+            EthereumTxEnvelope::Eip4844(tx) => Self::Eip4844(tx.strip_signature().into()),
+            EthereumTxEnvelope::Eip7702(tx) => {
+                Self::Eip7702(LazyTxEip7702::from_recovered_authorizations(tx.strip_signature()))
             }
-            EthereumTxEnvelope::Eip2930(tx) => {
-                Self::Eip2930(Recovered::new_unchecked(tx.strip_signature(), signer))
-            }
-            EthereumTxEnvelope::Eip1559(tx) => {
-                Self::Eip1559(Recovered::new_unchecked(tx.strip_signature(), signer))
-            }
-            EthereumTxEnvelope::Eip4844(tx) => {
-                Self::Eip4844(Recovered::new_unchecked(tx.strip_signature().into(), signer))
-            }
-            EthereumTxEnvelope::Eip7702(tx) => Self::Eip7702(Recovered::new_unchecked(
-                LazyTxEip7702::from_recovered_authorizations(tx.strip_signature()),
-                signer,
-            )),
         }
     }
 }
 
-impl RecoveredTxEnvelope {
+impl TxEnvelope {
     /// Returns the contained legacy transaction, if this is legacy.
-    pub const fn as_legacy(&self) -> Option<&Recovered<TxLegacy>> {
+    pub const fn as_legacy(&self) -> Option<&TxLegacy> {
         match self {
             Self::Legacy(tx) => Some(tx),
             Self::Eip2930(_) | Self::Eip1559(_) | Self::Eip4844(_) | Self::Eip7702(_) => None,
@@ -78,7 +70,7 @@ impl RecoveredTxEnvelope {
     }
 
     /// Returns the contained EIP-2930 transaction, if this is EIP-2930.
-    pub const fn as_eip2930(&self) -> Option<&Recovered<TxEip2930>> {
+    pub const fn as_eip2930(&self) -> Option<&TxEip2930> {
         match self {
             Self::Eip2930(tx) => Some(tx),
             Self::Legacy(_) | Self::Eip1559(_) | Self::Eip4844(_) | Self::Eip7702(_) => None,
@@ -86,7 +78,7 @@ impl RecoveredTxEnvelope {
     }
 
     /// Returns the contained EIP-1559 transaction, if this is EIP-1559.
-    pub const fn as_eip1559(&self) -> Option<&Recovered<TxEip1559>> {
+    pub const fn as_eip1559(&self) -> Option<&TxEip1559> {
         match self {
             Self::Eip1559(tx) => Some(tx),
             Self::Legacy(_) | Self::Eip2930(_) | Self::Eip4844(_) | Self::Eip7702(_) => None,
@@ -94,7 +86,7 @@ impl RecoveredTxEnvelope {
     }
 
     /// Returns the contained EIP-4844 transaction, if this is EIP-4844.
-    pub const fn as_eip4844(&self) -> Option<&Recovered<TxEip4844Variant>> {
+    pub const fn as_eip4844(&self) -> Option<&TxEip4844Variant> {
         match self {
             Self::Eip4844(tx) => Some(tx),
             Self::Legacy(_) | Self::Eip2930(_) | Self::Eip1559(_) | Self::Eip7702(_) => None,
@@ -102,173 +94,132 @@ impl RecoveredTxEnvelope {
     }
 
     /// Returns the contained EIP-7702 transaction, if this is EIP-7702.
-    pub const fn as_eip7702(&self) -> Option<&Recovered<LazyTxEip7702>> {
+    pub const fn as_eip7702(&self) -> Option<&LazyTxEip7702> {
         match self {
             Self::Eip7702(tx) => Some(tx),
             Self::Legacy(_) | Self::Eip2930(_) | Self::Eip1559(_) | Self::Eip4844(_) => None,
         }
     }
+}
 
-    /// Returns the transaction signer.
-    pub const fn signer(&self) -> Address {
-        match self {
-            Self::Legacy(tx) => tx.signer(),
-            Self::Eip2930(tx) => tx.signer(),
-            Self::Eip1559(tx) => tx.signer(),
-            Self::Eip4844(tx) => tx.signer(),
-            Self::Eip7702(tx) => tx.signer(),
-        }
-    }
-
-    /// Returns the transaction gas limit.
-    pub fn gas_limit(&self) -> u64 {
-        match self {
-            Self::Legacy(tx) => tx.gas_limit(),
-            Self::Eip2930(tx) => tx.gas_limit(),
-            Self::Eip1559(tx) => tx.gas_limit(),
-            Self::Eip4844(tx) => tx.gas_limit(),
-            Self::Eip7702(tx) => tx.gas_limit,
-        }
-    }
-
-    /// Returns the transaction target kind.
-    pub fn kind(&self) -> TxKind {
-        match self {
-            Self::Legacy(tx) => tx.kind(),
-            Self::Eip2930(tx) => tx.kind(),
-            Self::Eip1559(tx) => tx.kind(),
-            Self::Eip4844(tx) => tx.kind(),
-            Self::Eip7702(tx) => tx.to.into(),
-        }
-    }
-
-    /// Returns the transaction input.
-    pub fn input(&self) -> &Bytes {
-        match self {
-            Self::Legacy(tx) => tx.input(),
-            Self::Eip2930(tx) => tx.input(),
-            Self::Eip1559(tx) => tx.input(),
-            Self::Eip4844(tx) => tx.input(),
-            Self::Eip7702(tx) => &tx.input,
-        }
-    }
-
-    /// Returns the transaction effective gas price for the block base fee.
-    pub fn effective_gas_price(&self, base_fee: Option<u64>) -> u128 {
-        match self {
-            Self::Legacy(tx) => tx.effective_gas_price(base_fee),
-            Self::Eip2930(tx) => tx.effective_gas_price(base_fee),
-            Self::Eip1559(tx) => tx.effective_gas_price(base_fee),
-            Self::Eip4844(tx) => tx.effective_gas_price(base_fee),
-            Self::Eip7702(tx) => alloy_eips::eip1559::calc_effective_gas_price(
-                tx.max_fee_per_gas,
-                tx.max_priority_fee_per_gas,
-                base_fee,
-            ),
-        }
-    }
-
-    /// Returns the transaction value.
-    pub fn value(&self) -> U256 {
-        match self {
-            Self::Legacy(tx) => tx.value(),
-            Self::Eip2930(tx) => tx.value(),
-            Self::Eip1559(tx) => tx.value(),
-            Self::Eip4844(tx) => tx.value(),
-            Self::Eip7702(tx) => tx.value,
-        }
+impl From<TxEip7702> for TxEnvelope {
+    fn from(tx: TxEip7702) -> Self {
+        Self::Eip7702(tx.into())
     }
 }
 
-/// Transaction fields used by RPC execution and tracing.
-pub trait TransactionExt: Debug + Clone + Send + Sync + 'static {
-    /// Returns the transaction caller.
-    fn caller(&self) -> Address;
-
-    /// Returns the transaction gas limit.
-    fn gas_limit(&self) -> u64;
-
-    /// Returns the transaction value.
-    fn value(&self) -> U256;
-
-    /// Returns the transaction input.
-    fn input(&self) -> &Bytes;
-
-    /// Returns the transaction target kind.
-    fn kind(&self) -> TxKind;
-
-    /// Returns the transaction effective gas price for the block base fee.
-    fn effective_gas_price(&self, base_fee: Option<u64>) -> u128;
-}
-
-impl TransactionExt for RecoveredTxEnvelope {
-    fn caller(&self) -> Address {
-        self.signer()
-    }
-
-    fn gas_limit(&self) -> u64 {
-        Self::gas_limit(self)
-    }
-
-    fn value(&self) -> U256 {
-        Self::value(self)
-    }
-
-    fn input(&self) -> &Bytes {
-        Self::input(self)
-    }
-
-    fn kind(&self) -> TxKind {
-        Self::kind(self)
-    }
-
-    fn effective_gas_price(&self, base_fee: Option<u64>) -> u128 {
-        Self::effective_gas_price(self, base_fee)
-    }
-}
-
-impl From<Recovered<TxEip7702>> for RecoveredTxEnvelope {
-    fn from(tx: Recovered<TxEip7702>) -> Self {
-        Self::Eip7702(tx.convert())
-    }
-}
-
-impl From<Recovered<LazyTxEip7702>> for RecoveredTxEnvelope {
-    fn from(tx: Recovered<LazyTxEip7702>) -> Self {
+impl From<LazyTxEip7702> for TxEnvelope {
+    fn from(tx: LazyTxEip7702) -> Self {
         Self::Eip7702(tx)
     }
 }
 
-impl Typed2718 for RecoveredTxEnvelope {
-    fn ty(&self) -> u8 {
-        match self {
-            Self::Legacy(tx) => tx.ty(),
-            Self::Eip2930(tx) => tx.ty(),
-            Self::Eip1559(tx) => tx.ty(),
-            Self::Eip4844(tx) => tx.ty(),
-            Self::Eip7702(tx) => tx.ty(),
+macro_rules! delegate {
+    ($self:expr, $method:ident $(, $arg:expr)*) => {
+        match $self {
+            Self::Legacy(tx) => tx.$method($($arg),*),
+            Self::Eip2930(tx) => tx.$method($($arg),*),
+            Self::Eip1559(tx) => tx.$method($($arg),*),
+            Self::Eip4844(tx) => tx.$method($($arg),*),
+            Self::Eip7702(tx) => tx.$method($($arg),*),
         }
+    };
+}
+
+impl Typed2718 for TxEnvelope {
+    fn ty(&self) -> u8 {
+        delegate!(self, ty)
+    }
+}
+
+impl Transaction for TxEnvelope {
+    fn chain_id(&self) -> Option<u64> {
+        delegate!(self, chain_id)
+    }
+
+    fn nonce(&self) -> u64 {
+        delegate!(self, nonce)
+    }
+
+    fn gas_limit(&self) -> u64 {
+        delegate!(self, gas_limit)
+    }
+
+    fn gas_price(&self) -> Option<u128> {
+        delegate!(self, gas_price)
+    }
+
+    fn max_fee_per_gas(&self) -> u128 {
+        delegate!(self, max_fee_per_gas)
+    }
+
+    fn max_priority_fee_per_gas(&self) -> Option<u128> {
+        delegate!(self, max_priority_fee_per_gas)
+    }
+
+    fn max_fee_per_blob_gas(&self) -> Option<u128> {
+        delegate!(self, max_fee_per_blob_gas)
+    }
+
+    fn priority_fee_or_price(&self) -> u128 {
+        delegate!(self, priority_fee_or_price)
+    }
+
+    fn effective_gas_price(&self, base_fee: Option<u64>) -> u128 {
+        delegate!(self, effective_gas_price, base_fee)
+    }
+
+    fn is_dynamic_fee(&self) -> bool {
+        delegate!(self, is_dynamic_fee)
+    }
+
+    fn kind(&self) -> TxKind {
+        delegate!(self, kind)
+    }
+
+    fn is_create(&self) -> bool {
+        delegate!(self, is_create)
+    }
+
+    fn value(&self) -> U256 {
+        delegate!(self, value)
+    }
+
+    fn input(&self) -> &Bytes {
+        delegate!(self, input)
+    }
+
+    fn access_list(&self) -> Option<&AccessList> {
+        delegate!(self, access_list)
+    }
+
+    fn blob_versioned_hashes(&self) -> Option<&[B256]> {
+        delegate!(self, blob_versioned_hashes)
+    }
+
+    fn authorization_list(&self) -> Option<&[alloy_eips::eip7702::SignedAuthorization]> {
+        delegate!(self, authorization_list)
     }
 }
 
 /// Returns the Ethereum transaction registry for `spec_id`.
-pub fn ethereum_tx_registry<T: EvmTypes<Tx = RecoveredTxEnvelope>>(
+pub fn ethereum_tx_registry<T: EvmTypes<Tx = TxEnvelope>>(
     spec_id: SpecId,
 ) -> TxRegistry<T, TxResult<T>> {
     let mut registry =
-        TxRegistry::new().with_handler(0, RecoveredTxEnvelope::as_legacy, legacy::handle::<T>);
+        TxRegistry::new().with_handler(0, TxEnvelope::as_legacy, legacy::handle::<T>);
 
     if spec_id.enables(SpecId::BERLIN) {
-        registry.register(1, RecoveredTxEnvelope::as_eip2930, eip2930::handle::<T>);
+        registry.register(1, TxEnvelope::as_eip2930, eip2930::handle::<T>);
     }
     if spec_id.enables(SpecId::LONDON) {
-        registry.register(2, RecoveredTxEnvelope::as_eip1559, eip1559::handle::<T>);
+        registry.register(2, TxEnvelope::as_eip1559, eip1559::handle::<T>);
     }
     if spec_id.enables(SpecId::CANCUN) {
-        registry.register(3, RecoveredTxEnvelope::as_eip4844, eip4844::handle::<T>);
+        registry.register(3, TxEnvelope::as_eip4844, eip4844::handle::<T>);
     }
     if spec_id.enables(SpecId::PRAGUE) {
-        registry.register(4, RecoveredTxEnvelope::as_eip7702, eip7702::handle::<T>);
+        registry.register(4, TxEnvelope::as_eip7702, eip7702::handle::<T>);
     }
 
     registry
@@ -959,8 +910,8 @@ mod tests {
             &caller,
             AccountInfo::default().with_balance(U256::from(1_000_000_000u64)),
         );
-        let tx = RecoveredTxEnvelope::Eip2930(Recovered::new_unchecked(
-            TxEip2930 {
+        let tx = Recovered::new_unchecked(
+            TxEnvelope::Eip2930(TxEip2930 {
                 chain_id: 1,
                 nonce: 0,
                 gas_price: 1,
@@ -969,9 +920,9 @@ mod tests {
                 value: U256::ZERO,
                 input: Bytes::new(),
                 access_list: AccessList::default(),
-            },
+            }),
             caller,
-        ));
+        );
         let mut evm = Evm::<BaseEvmTypes>::new(
             SpecId::BERLIN,
             BlockEnv::default(),

--- a/crates/evm2/src/ethereum/mod.rs
+++ b/crates/evm2/src/ethereum/mod.rs
@@ -22,11 +22,12 @@ use crate::{
     version::GasId,
 };
 use alloy_consensus::{
-    TxEip1559, TxEip2930, TxEip7702, TxLegacy,
+    EthereumTxEnvelope, TxEip1559, TxEip2930, TxEip4844, TxEip7702, TxLegacy,
     transaction::{Recovered, Transaction, TxEip4844Variant},
 };
 use alloy_eips::{eip2718::Typed2718, eip2930::AccessList};
 use alloy_primitives::{Address, B256, Bytes, KECCAK256_EMPTY, TxKind, U256};
+use core::fmt::Debug;
 
 /// Ethereum transaction envelope containing recovered transactions.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -41,6 +42,30 @@ pub enum RecoveredTxEnvelope {
     Eip4844(Recovered<TxEip4844Variant>),
     /// EIP-7702 set-code transaction.
     Eip7702(Recovered<LazyTxEip7702>),
+}
+
+impl From<Recovered<EthereumTxEnvelope<TxEip4844>>> for RecoveredTxEnvelope {
+    fn from(tx: Recovered<EthereumTxEnvelope<TxEip4844>>) -> Self {
+        let (tx, signer) = tx.into_parts();
+        match tx {
+            EthereumTxEnvelope::Legacy(tx) => {
+                Self::Legacy(Recovered::new_unchecked(tx.strip_signature(), signer))
+            }
+            EthereumTxEnvelope::Eip2930(tx) => {
+                Self::Eip2930(Recovered::new_unchecked(tx.strip_signature(), signer))
+            }
+            EthereumTxEnvelope::Eip1559(tx) => {
+                Self::Eip1559(Recovered::new_unchecked(tx.strip_signature(), signer))
+            }
+            EthereumTxEnvelope::Eip4844(tx) => {
+                Self::Eip4844(Recovered::new_unchecked(tx.strip_signature().into(), signer))
+            }
+            EthereumTxEnvelope::Eip7702(tx) => Self::Eip7702(Recovered::new_unchecked(
+                LazyTxEip7702::from_recovered_authorizations(tx.strip_signature()),
+                signer,
+            )),
+        }
+    }
 }
 
 impl RecoveredTxEnvelope {
@@ -152,6 +177,53 @@ impl RecoveredTxEnvelope {
             Self::Eip4844(tx) => tx.value(),
             Self::Eip7702(tx) => tx.value,
         }
+    }
+}
+
+/// Transaction fields used by RPC execution and tracing.
+pub trait TransactionExt: Debug + Clone + Send + Sync + 'static {
+    /// Returns the transaction caller.
+    fn caller(&self) -> Address;
+
+    /// Returns the transaction gas limit.
+    fn gas_limit(&self) -> u64;
+
+    /// Returns the transaction value.
+    fn value(&self) -> U256;
+
+    /// Returns the transaction input.
+    fn input(&self) -> &Bytes;
+
+    /// Returns the transaction target kind.
+    fn kind(&self) -> TxKind;
+
+    /// Returns the transaction effective gas price for the block base fee.
+    fn effective_gas_price(&self, base_fee: Option<u64>) -> u128;
+}
+
+impl TransactionExt for RecoveredTxEnvelope {
+    fn caller(&self) -> Address {
+        self.signer()
+    }
+
+    fn gas_limit(&self) -> u64 {
+        Self::gas_limit(self)
+    }
+
+    fn value(&self) -> U256 {
+        Self::value(self)
+    }
+
+    fn input(&self) -> &Bytes {
+        Self::input(self)
+    }
+
+    fn kind(&self) -> TxKind {
+        Self::kind(self)
+    }
+
+    fn effective_gas_price(&self, base_fee: Option<u64>) -> u128 {
+        Self::effective_gas_price(self, base_fee)
     }
 }
 

--- a/crates/evm2/src/evm/async.rs
+++ b/crates/evm2/src/evm/async.rs
@@ -678,7 +678,7 @@ mod tests {
     fn dispatches_transaction_async_by_typed_2718_type() {
         let registry = TxRegistry::new().with_handler(
             TEST_TX_TYPE,
-            crate::ethereum::RecoveredTxEnvelope::as_legacy,
+            crate::ethereum::TxEnvelope::as_legacy,
             handle_test_tx,
         );
         let mut evm = Evm::<BaseEvmTypes>::new(
@@ -699,7 +699,7 @@ mod tests {
     fn transaction_async_send_future_is_send_with_send_erased_fields() {
         let registry = TxRegistry::new().with_handler(
             TEST_TX_TYPE,
-            crate::ethereum::RecoveredTxEnvelope::as_legacy,
+            crate::ethereum::TxEnvelope::as_legacy,
             handle_test_tx,
         );
         let mut evm = Evm::<BaseEvmTypes>::new(
@@ -721,7 +721,7 @@ mod tests {
     fn transaction_async_send_future_is_send_after_type_check() {
         let registry = TxRegistry::new().with_handler(
             TEST_TX_TYPE,
-            crate::ethereum::RecoveredTxEnvelope::as_legacy,
+            crate::ethereum::TxEnvelope::as_legacy,
             handle_test_tx,
         );
         let mut evm = Evm::<BaseEvmTypes>::new(
@@ -761,7 +761,7 @@ mod tests {
         let marker = Rc::new(());
         let registry = TxRegistry::new().with_handler(
             TEST_TX_TYPE,
-            crate::ethereum::RecoveredTxEnvelope::as_legacy,
+            crate::ethereum::TxEnvelope::as_legacy,
             handle_test_tx,
         );
         let mut evm = Evm::<BaseEvmTypes>::new(
@@ -783,7 +783,7 @@ mod tests {
         let marker = Rc::new(());
         let registry = TxRegistry::new().with_handler(
             TEST_TX_TYPE,
-            crate::ethereum::RecoveredTxEnvelope::as_legacy,
+            crate::ethereum::TxEnvelope::as_legacy,
             handle_test_tx,
         );
         let database = Db::new(NonSendDb { marker: Rc::clone(&marker) });
@@ -912,10 +912,13 @@ mod tests {
             Db::new(FailOnceAccountDb { fail_next_account: true }),
             Precompiles::base(SpecId::OSAKA),
         );
-        let tx = crate::ethereum::RecoveredTxEnvelope::Legacy(Recovered::new_unchecked(
-            TxLegacy { gas_limit: 100_000, ..TxLegacy::default() },
+        let tx = Recovered::new_unchecked(
+            crate::ethereum::TxEnvelope::Legacy(TxLegacy {
+                gas_limit: 100_000,
+                ..TxLegacy::default()
+            }),
             Address::ZERO,
-        ));
+        );
 
         assert_matches!(evm.transact(&tx), Err(HandlerError::Fatal(_)));
         assert!(evm.error_code().is_some());
@@ -941,10 +944,14 @@ mod tests {
             Precompiles::base(SpecId::OSAKA),
         );
         evm.evm_is_send::<AsyncDb<CancellingDb>, Precompiles<BaseEvmTypes>>();
-        let tx = crate::ethereum::RecoveredTxEnvelope::Legacy(Recovered::new_unchecked(
-            TxLegacy { to: TxKind::Call(contract), gas_limit: 100_000, ..TxLegacy::default() },
+        let tx = Recovered::new_unchecked(
+            crate::ethereum::TxEnvelope::Legacy(TxLegacy {
+                to: TxKind::Call(contract),
+                gas_limit: 100_000,
+                ..TxLegacy::default()
+            }),
             caller,
-        ));
+        );
         {
             let mut future = core::pin::pin!(evm.transact_async(&tx));
             let waker = Waker::noop();
@@ -976,15 +983,13 @@ mod tests {
     const TEST_TX_TYPE: u8 = 0x00;
 
     fn test_tx(value: u64) -> crate::ethereum::RecoveredTxEnvelope {
-        crate::ethereum::RecoveredTxEnvelope::Legacy(Recovered::new_unchecked(
-            TxLegacy { nonce: value, ..TxLegacy::default() },
+        Recovered::new_unchecked(
+            crate::ethereum::TxEnvelope::Legacy(TxLegacy { nonce: value, ..TxLegacy::default() }),
             Address::ZERO,
-        ))
+        )
     }
 
-    fn handle_test_tx(
-        req: TxRequest<'_, '_, BaseEvmTypes, Recovered<TxLegacy>>,
-    ) -> HandlerResult<TxResult> {
+    fn handle_test_tx(req: TxRequest<'_, '_, BaseEvmTypes, TxLegacy>) -> HandlerResult<TxResult> {
         let _ = req.host.spec_id();
         Ok(TxResult { status: true, total_gas_spent: req.tx.nonce + 1, ..TxResult::default() })
     }

--- a/crates/evm2/src/evm/config.rs
+++ b/crates/evm2/src/evm/config.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     Evm, OpcodeConfig, SpecId,
-    ethereum::RecoveredTxEnvelope,
+    ethereum::TxEnvelope,
     interpreter::{
         Host,
         dispatch::{ConfigInstrTables, InstrTable, SelectorInstrTables},
@@ -215,7 +215,7 @@ pub struct BaseEvmTypes(());
 impl EvmTypesHost for BaseEvmTypes {
     type ConfigSelector = BaseEvmConfigSelector;
     type SpecId = SpecId;
-    type Tx = RecoveredTxEnvelope;
+    type Tx = TxEnvelope;
     type MessageExt = ();
     type MessageResultExt = ();
     type TxEnvExt = ();

--- a/crates/evm2/src/evm/db/cache.rs
+++ b/crates/evm2/src/evm/db/cache.rs
@@ -310,6 +310,37 @@ impl<ExtDB: DynDatabase> DynDatabase for CacheDB<ExtDB> {
     }
 }
 
+mod typed {
+    use super::*;
+    use crate::evm::Database;
+
+    impl<ExtDB: DynDatabase> Database for CacheDB<ExtDB> {
+        type Error = AnyError;
+
+        #[inline]
+        fn get_account(&mut self, address: &Address) -> Result<Option<AccountInfo>, Self::Error> {
+            DynDatabase::get_account(self, address).map_err(|code| DynDatabase::error(self, code))
+        }
+
+        #[inline]
+        fn get_code_by_hash(&mut self, code_hash: &B256) -> Result<Bytecode, Self::Error> {
+            DynDatabase::get_code_by_hash(self, code_hash)
+                .map_err(|code| DynDatabase::error(self, code))
+        }
+
+        #[inline]
+        fn get_storage(&mut self, address: &Address, key: &Word) -> Result<Word, Self::Error> {
+            DynDatabase::get_storage(self, address, key)
+                .map_err(|code| DynDatabase::error(self, code))
+        }
+
+        #[inline]
+        fn get_block_hash(&mut self, number: &Word) -> Result<Option<B256>, Self::Error> {
+            DynDatabase::get_block_hash(self, number).map_err(|code| DynDatabase::error(self, code))
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/evm2/src/evm/inspector.rs
+++ b/crates/evm2/src/evm/inspector.rs
@@ -148,7 +148,7 @@ mod tests {
         bytecode::Bytecode,
         constants::CALL_DEPTH_LIMIT,
         env::{BlockEnv, TxEnv},
-        ethereum::{RecoveredTxEnvelope, ethereum_tx_registry},
+        ethereum::{TxEnvelope, ethereum_tx_registry},
         evm::{AccountInfo, InMemoryDB, SYSTEM_ADDRESS},
         interpreter::{GasTracker, Host, InstrStop, Interpreter, Message, MessageResult, Word, op},
         registry::TxRegistry,
@@ -981,10 +981,14 @@ mod tests {
             Precompiles::base(SpecId::OSAKA),
         );
         evm.set_inspector(SharedE2eInspector::default());
-        let tx = RecoveredTxEnvelope::Legacy(Recovered::new_unchecked(
-            TxLegacy { to: TxKind::Call(contract), gas_limit: 100_000, ..Default::default() },
+        let tx = Recovered::new_unchecked(
+            TxEnvelope::Legacy(TxLegacy {
+                to: TxKind::Call(contract),
+                gas_limit: 100_000,
+                ..Default::default()
+            }),
             caller,
-        ));
+        );
 
         let result = evm.transact(&tx).expect("transaction should execute").discard();
         let inspector = evm.inspector().unwrap().downcast_ref::<SharedE2eInspector>().unwrap();
@@ -1017,15 +1021,15 @@ mod tests {
             Precompiles::base(SpecId::AMSTERDAM),
         );
         evm.set_inspector(SharedE2eInspector::default());
-        let tx = RecoveredTxEnvelope::Legacy(Recovered::new_unchecked(
-            TxLegacy {
+        let tx = Recovered::new_unchecked(
+            TxEnvelope::Legacy(TxLegacy {
                 to: TxKind::Call(target),
                 value: U256::from(7),
                 gas_limit: 300_000,
                 ..Default::default()
-            },
+            }),
             caller,
-        ));
+        );
 
         let result = evm.transact(&tx).expect("transaction should execute").detach();
         let inspector = evm.inspector().unwrap().downcast_ref::<SharedE2eInspector>().unwrap();
@@ -1053,15 +1057,15 @@ mod tests {
             Precompiles::base(SpecId::OSAKA),
         );
         evm.set_inspector(SharedE2eInspector::default());
-        let tx = RecoveredTxEnvelope::Legacy(Recovered::new_unchecked(
-            TxLegacy {
+        let tx = Recovered::new_unchecked(
+            TxEnvelope::Legacy(TxLegacy {
                 to: TxKind::Create,
                 input: Bytes::from_static(&[op::STOP]),
                 gas_limit: 100_000,
                 ..Default::default()
-            },
+            }),
             caller,
-        ));
+        );
 
         let result = evm.transact(&tx).expect("transaction should execute").discard();
         let inspector = evm.inspector().unwrap().downcast_ref::<SharedE2eInspector>().unwrap();

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -132,6 +132,7 @@ use crate::{
     version::{EvmFeatures, GasId},
 };
 use alloc::{boxed::Box, sync::Arc, vec};
+use alloy_consensus::transaction::Recovered;
 use alloy_eips::eip2718::Typed2718;
 use alloy_primitives::{Address, B256, Bytes, Log, LogData};
 #[cfg(feature = "async")]
@@ -957,7 +958,7 @@ impl<'a, T: EvmTypes<Tx: Typed2718>> Evm<'a, T> {
     /// [`ExecutedTx::detach`] before
     /// another transaction can be executed. Dropping the handle is equivalent to
     /// [`ExecutedTx::discard`].
-    pub fn transact(&mut self, tx: &T::Tx) -> HandlerResult<ExecutedTx<'_, 'a, T>> {
+    pub fn transact(&mut self, tx: &Recovered<T::Tx>) -> HandlerResult<ExecutedTx<'_, 'a, T>> {
         self.clear_top_level_error_state();
         let handler = self.registry.try_get_by_type(tx.ty())?;
         let result = handler.call(tx, self);
@@ -979,7 +980,7 @@ impl<'a, T: EvmTypes<Tx: Typed2718>> Evm<'a, T> {
     /// This is the cheapest convenience entrypoint for `eth_call`-style simulations: execution
     /// output and logs are returned, but transaction writes are not accepted and no owned
     /// [`StateChanges`] is materialized.
-    pub fn call_tx(&mut self, tx: &T::Tx) -> HandlerResult<TxResult<T>> {
+    pub fn call_tx(&mut self, tx: &Recovered<T::Tx>) -> HandlerResult<TxResult<T>> {
         self.transact(tx).map(ExecutedTx::discard)
     }
 
@@ -997,7 +998,7 @@ impl<'a, T: EvmTypes<Tx: Typed2718>> Evm<'a, T> {
     #[cfg(feature = "async")]
     pub fn transact_async<'fut>(
         &'fut mut self,
-        tx: &'fut T::Tx,
+        tx: &'fut Recovered<T::Tx>,
     ) -> impl Future<Output = r#async::AsyncResult<ExecutedTx<'fut, 'a, T>, registry::HandlerError>> + 'fut
     where
         T::Tx: Sync,
@@ -1016,7 +1017,7 @@ impl<'a, T: EvmTypes<Tx: Typed2718>> Evm<'a, T> {
     #[cfg(feature = "async")]
     pub fn transact_async_send<'fut>(
         &'fut mut self,
-        tx: &'fut T::Tx,
+        tx: &'fut Recovered<T::Tx>,
     ) -> impl Future<Output = r#async::AsyncResult<ExecutedTx<'fut, 'a, T>, registry::HandlerError>>
     + Send
     + 'fut
@@ -1046,7 +1047,7 @@ impl<'a, T: EvmTypes<Tx: Typed2718>> Evm<'a, T> {
         txs: I,
     ) -> impl Iterator<Item = HandlerResult<TxResult<T>>> + 'txs
     where
-        I: IntoIterator<Item = &'txs T::Tx>,
+        I: IntoIterator<Item = &'txs Recovered<T::Tx>>,
         I::IntoIter: 'txs,
         T::Tx: 'txs,
         Self: 'txs,
@@ -1971,7 +1972,7 @@ mod tests {
         BaseEvmConfigSelector, BaseEvmTypes, NoopInspector, Precompiles, SpecId, Version,
         bytecode::Bytecode,
         env::TxEnv,
-        ethereum::{RecoveredTxEnvelope, ethereum_tx_registry},
+        ethereum::{RecoveredTxEnvelope, TxEnvelope, ethereum_tx_registry},
         interpreter::{GasTracker, Interpreter, MessageKind, op},
         precompiles::{Precompile, PrecompileError, PrecompileId, PrecompileMap},
         registry::{HandlerError, TxRequest},
@@ -1992,15 +1993,13 @@ mod tests {
     const INNER_TEST_PRECOMPILE: Address = Address::with_last_byte(0x43);
 
     fn test_tx(value: u64) -> RecoveredTxEnvelope {
-        RecoveredTxEnvelope::Legacy(Recovered::new_unchecked(
-            TxLegacy { nonce: value, ..TxLegacy::default() },
+        Recovered::new_unchecked(
+            TxEnvelope::Legacy(TxLegacy { nonce: value, ..TxLegacy::default() }),
             Address::ZERO,
-        ))
+        )
     }
 
-    fn handle_test_tx(
-        req: TxRequest<'_, '_, BaseEvmTypes, Recovered<TxLegacy>>,
-    ) -> HandlerResult<TxResult> {
+    fn handle_test_tx(req: TxRequest<'_, '_, BaseEvmTypes, TxLegacy>) -> HandlerResult<TxResult> {
         let _ = req.host.spec_id();
         Ok(TxResult { status: true, total_gas_spent: req.tx.nonce + 1, ..TxResult::default() })
     }
@@ -2053,7 +2052,7 @@ mod tests {
     const LIFECYCLE_STORAGE_KEY: Word = Word::from_limbs([1, 0, 0, 0]);
 
     fn handle_lifecycle_tx(
-        req: TxRequest<'_, '_, BaseEvmTypes, Recovered<TxLegacy>>,
+        req: TxRequest<'_, '_, BaseEvmTypes, TxLegacy>,
     ) -> HandlerResult<TxResult> {
         let value = Word::from(req.tx.nonce);
         req.host
@@ -2112,7 +2111,7 @@ mod tests {
     fn lifecycle_evm() -> Evm<'static, BaseEvmTypes> {
         let registry = TxRegistry::new().with_handler(
             TEST_TX_TYPE,
-            RecoveredTxEnvelope::as_legacy,
+            TxEnvelope::as_legacy,
             handle_lifecycle_tx,
         );
         let mut database = InMemoryDB::default();
@@ -2267,14 +2266,14 @@ mod tests {
         impl Error for TestPrecompileError {}
 
         let caller = Address::from([0xaa; 20]);
-        let tx = RecoveredTxEnvelope::Legacy(Recovered::new_unchecked(
-            TxLegacy {
+        let tx = Recovered::new_unchecked(
+            TxEnvelope::Legacy(TxLegacy {
                 gas_limit: 50_000,
                 to: TxKind::Call(FATAL_PRECOMPILE_ADDRESS),
                 ..TxLegacy::default()
-            },
+            }),
             caller,
-        ));
+        );
         let mut precompiles = Precompiles::base(SpecId::OSAKA);
         precompiles.as_map_mut().insert(Precompile::new(
             FATAL_PRECOMPILE_ADDRESS,
@@ -2782,11 +2781,8 @@ mod tests {
 
     #[test]
     fn dispatches_transaction_by_typed_2718_type() {
-        let registry = TxRegistry::new().with_handler(
-            TEST_TX_TYPE,
-            RecoveredTxEnvelope::as_legacy,
-            handle_test_tx,
-        );
+        let registry =
+            TxRegistry::new().with_handler(TEST_TX_TYPE, TxEnvelope::as_legacy, handle_test_tx);
         let mut evm = Evm::<BaseEvmTypes>::new(
             SpecId::OSAKA,
             BlockEnv::default(),
@@ -2801,11 +2797,8 @@ mod tests {
 
     #[test]
     fn dispatches_transaction_without_evm_config() {
-        let registry = TxRegistry::new().with_handler(
-            TEST_TX_TYPE,
-            RecoveredTxEnvelope::as_legacy,
-            handle_test_tx,
-        );
+        let registry =
+            TxRegistry::new().with_handler(TEST_TX_TYPE, TxEnvelope::as_legacy, handle_test_tx);
         let mut evm = Evm::<BaseEvmTypes>::new_with_execution_config(
             ExecutionConfig::for_base_spec::<BaseEvmConfigSelector>(SpecId::OSAKA),
             SpecId::OSAKA,
@@ -2835,7 +2828,7 @@ mod tests {
     #[test]
     fn dispatches_transaction_with_dynamic_version() {
         fn handle_test_tx_version(
-            req: TxRequest<'_, '_, BaseEvmTypes, Recovered<TxLegacy>>,
+            req: TxRequest<'_, '_, BaseEvmTypes, TxLegacy>,
         ) -> HandlerResult<TxResult> {
             Ok(TxResult {
                 status: true,
@@ -2846,7 +2839,7 @@ mod tests {
 
         let registry = TxRegistry::new().with_handler(
             TEST_TX_TYPE,
-            RecoveredTxEnvelope::as_legacy,
+            TxEnvelope::as_legacy,
             handle_test_tx_version,
         );
         let mut version = crate::Version::new(SpecId::OSAKA);
@@ -2866,11 +2859,8 @@ mod tests {
 
     #[test]
     fn dispatches_transaction_iter() {
-        let registry = TxRegistry::new().with_handler(
-            TEST_TX_TYPE,
-            RecoveredTxEnvelope::as_legacy,
-            handle_test_tx,
-        );
+        let registry =
+            TxRegistry::new().with_handler(TEST_TX_TYPE, TxEnvelope::as_legacy, handle_test_tx);
         let mut evm = Evm::<BaseEvmTypes>::new(
             SpecId::OSAKA,
             BlockEnv::default(),

--- a/crates/evm2/src/evm/precompile.rs
+++ b/crates/evm2/src/evm/precompile.rs
@@ -4,6 +4,7 @@ use super::{Evm, NonStaticAny};
 use crate::{
     EvmTypesHost, PrecompileError,
     interpreter::{GasTracker, Message},
+    precompiles::PrecompileId,
 };
 use alloc::{boxed::Box, vec::Vec};
 use alloy_primitives::{Address, Bytes};
@@ -41,6 +42,11 @@ impl PrecompileOutput {
 pub trait PrecompileProvider<T: EvmTypesHost>: NonStaticAny {
     /// Returns precompile addresses.
     fn addresses(&self) -> Vec<Address> {
+        Vec::new()
+    }
+
+    /// Returns precompile addresses and identifiers.
+    fn precompile_ids(&self) -> Vec<(Address, PrecompileId)> {
         Vec::new()
     }
 

--- a/crates/evm2/src/evm/registry.rs
+++ b/crates/evm2/src/evm/registry.rs
@@ -9,6 +9,7 @@
 
 use crate::{ErrorCode, EvmTypesHost};
 use alloc::{string::String, sync::Arc};
+use alloy_consensus::transaction::Recovered;
 use alloy_primitives::{Address, U256, map::HashMap};
 use core::{fmt, marker::PhantomData};
 use thiserror::Error;
@@ -147,7 +148,7 @@ pub enum HandlerError {
 #[derive(Debug)]
 pub struct TxRequest<'a, 'host, T: EvmTypesHost, Tx> {
     /// Concrete transaction extracted from the envelope.
-    pub tx: &'a Tx,
+    pub tx: Recovered<&'a Tx>,
     /// Mutable host used by this handler.
     pub host: &'a mut T::Host<'host>,
     #[doc(hidden)] // Not public API. Please use an existing constructor.
@@ -186,13 +187,21 @@ impl<T: EvmTypesHost, Output> fmt::Debug for AnyTxHandler<T, Output> {
 
 impl<T: EvmTypesHost, Output> AnyTxHandler<T, Output> {
     /// Executes the erased handler against an envelope and host.
-    pub fn call<'host>(&self, env: &T::Tx, host: &mut T::Host<'host>) -> HandlerResult<Output> {
+    pub fn call<'host>(
+        &self,
+        env: &Recovered<T::Tx>,
+        host: &mut T::Host<'host>,
+    ) -> HandlerResult<Output> {
         self.inner.call(env, host)
     }
 }
 
 trait ErasedTxHandler<T: EvmTypesHost, Output>: Send + Sync {
-    fn call<'host>(&self, env: &T::Tx, host: &mut T::Host<'host>) -> HandlerResult<Output>;
+    fn call<'host>(
+        &self,
+        env: &Recovered<T::Tx>,
+        host: &mut T::Host<'host>,
+    ) -> HandlerResult<Output>;
 }
 
 struct HandlerAdapter<Tx, H, F> {
@@ -214,10 +223,18 @@ where
     H: TxHandler<T, Tx, Output> + Send + Sync,
     F: for<'a> Fn(&'a T::Tx) -> Option<&'a Tx> + Send + Sync,
 {
-    fn call<'host>(&self, env: &T::Tx, host: &mut T::Host<'host>) -> HandlerResult<Output> {
-        let tx = (self.extract)(env)
+    fn call<'host>(
+        &self,
+        env: &Recovered<T::Tx>,
+        host: &mut T::Host<'host>,
+    ) -> HandlerResult<Output> {
+        let tx = (self.extract)(env.inner())
             .ok_or(HandlerError::WrongTransactionType { expected: self.type_id })?;
-        self.handler.call(TxRequest { tx, host, _non_exhaustive: () })
+        self.handler.call(TxRequest {
+            tx: Recovered::new_unchecked(tx, env.signer()),
+            host,
+            _non_exhaustive: (),
+        })
     }
 }
 
@@ -299,17 +316,17 @@ mod tests {
     use alloc::vec::Vec;
     use alloy_primitives::{Address, B256, Log};
 
-    #[derive(Debug)]
+    #[derive(Clone, Debug)]
     struct TransferTx {
         amount: u64,
     }
 
-    #[derive(Debug)]
+    #[derive(Clone, Debug)]
     struct CreateTx {
         initcode: Vec<u8>,
     }
 
-    #[derive(Debug)]
+    #[derive(Clone, Debug)]
     enum Envelope {
         Transfer(TransferTx),
         Create(CreateTx),
@@ -452,7 +469,10 @@ mod tests {
         type_id: u8,
         env: &Envelope,
     ) -> HandlerResult<Receipt> {
-        registry.try_get_by_type(type_id)?.call(env, &mut TestHost { block: BlockEnv::default() })
+        registry.try_get_by_type(type_id)?.call(
+            &Recovered::new_unchecked(env.clone(), Address::ZERO),
+            &mut TestHost { block: BlockEnv::default() },
+        )
     }
 
     #[test]

--- a/crates/evm2/src/precompiles/mod.rs
+++ b/crates/evm2/src/precompiles/mod.rs
@@ -134,6 +134,17 @@ impl<T: EvmTypesHost> PrecompileProvider<T> for Precompiles<T> {
     }
 
     #[inline]
+    fn precompile_ids(&self) -> Vec<(Address, PrecompileId)> {
+        self.map
+            .as_ref()
+            .addresses()
+            .filter_map(|address| {
+                Some((address, self.map.as_ref().get_data(&address)?.id().clone()))
+            })
+            .collect()
+    }
+
+    #[inline]
     fn contains(&self, address: &Address) -> bool {
         self.map.as_ref().contains(address)
     }

--- a/crates/inspectors/Cargo.toml
+++ b/crates/inspectors/Cargo.toml
@@ -51,5 +51,11 @@ std = [
     "evm2/std",
     "thiserror/std",
 ]
-serde = ["dep:serde", "alloy-primitives/serde", "alloy-rpc-types-eth/serde", "evm2/serde"]
+serde = [
+    "dep:serde",
+    "alloy-primitives/serde",
+    "alloy-consensus/serde",
+    "alloy-rpc-types-eth/serde",
+    "evm2/serde",
+]
 js-tracer = ["std", "dep:boa_engine", "dep:boa_gc"]

--- a/crates/inspectors/Cargo.toml
+++ b/crates/inspectors/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 
 [dependencies]
 # eth
+alloy-consensus.workspace = true
 alloy-rpc-types-eth.workspace = true
 alloy-rpc-types-trace.workspace = true
 alloy-sol-types.workspace = true
@@ -35,13 +36,13 @@ boa_gc = { workspace = true, optional = true }
 
 [dev-dependencies]
 alloy-hardforks.workspace = true
-alloy-consensus = { workspace = true, features = ["std"] }
 snapbox = { workspace = true, features = ["term-svg"] }
 
 [features]
 default = ["std"]
 std = [
     "alloy-primitives/std",
+    "alloy-consensus/std",
     "alloy-rpc-types-eth/std",
     "alloy-sol-types/std",
     "anstyle/std",

--- a/crates/inspectors/src/access_list.rs
+++ b/crates/inspectors/src/access_list.rs
@@ -58,7 +58,7 @@ impl AccessListInspector {
         let authorities = tx
             .as_eip7702()
             .into_iter()
-            .flat_map(|tx| &tx.inner().authorization_list)
+            .flat_map(|tx| &tx.authorization_list)
             .filter_map(|authorization| authorization.authority());
         self.with_excluded(authorities)
     }

--- a/crates/inspectors/src/tracing/debug.rs
+++ b/crates/inspectors/src/tracing/debug.rs
@@ -3,6 +3,7 @@ use crate::tracing::{
 };
 #[cfg(feature = "js-tracer")]
 use alloc::boxed::Box;
+use alloy_consensus::{Transaction, transaction::Recovered};
 use alloy_primitives::{Address, Log, U256};
 use alloy_rpc_types_eth::TransactionInfo;
 use alloy_rpc_types_trace::geth::{
@@ -13,7 +14,6 @@ use alloy_rpc_types_trace::geth::{
 use evm2::{
     ErrorCode, EvmTypes, EvmTypesHost, Inspector, NoopInspector, TxResultWithState,
     env::BlockEnv,
-    ethereum::TransactionExt,
     evm::DynDatabase,
     interpreter::{Interpreter, Message, MessageResult},
 };
@@ -196,10 +196,10 @@ impl DebugInspector {
     }
 
     /// Should be invoked after each transaction to obtain the resulting [`GethTrace`].
-    pub fn get_result<T: EvmTypesHost<Tx: TransactionExt>>(
+    pub fn get_result<T: EvmTypesHost<Tx: Transaction>>(
         &mut self,
         tx_context: Option<TransactionContext>,
-        tx: &T::Tx,
+        tx: &Recovered<T::Tx>,
         block_env: &BlockEnv<T>,
         res: &TxResultWithState<T>,
         db: &mut dyn DynDatabase,
@@ -218,7 +218,7 @@ impl DebugInspector {
             Self::FourByte(inspector) => FourByteFrame::from(&*inspector).into(),
             Self::CallTracer(inspector, config) => {
                 inspector.set_transaction_gas_limit(tx.gas_limit());
-                inspector.set_transaction_caller(tx.caller());
+                inspector.set_transaction_caller(tx.signer());
                 inspector.geth_builder().geth_call_traces(*config, res.result.tx_gas_used()).into()
             }
             Self::PreStateTracer(inspector, config) => {
@@ -236,7 +236,7 @@ impl DebugInspector {
                 .into(),
             Self::FlatCallTracer(inspector) => {
                 inspector.set_transaction_gas_limit(tx.gas_limit());
-                inspector.set_transaction_caller(tx.caller());
+                inspector.set_transaction_caller(tx.signer());
                 inspector
                     .clone()
                     .into_parity_builder()
@@ -245,7 +245,7 @@ impl DebugInspector {
             }
             Self::Erc7562Tracer(inspector, config) => {
                 inspector.set_transaction_gas_limit(tx.gas_limit());
-                inspector.set_transaction_caller(tx.caller());
+                inspector.set_transaction_caller(tx.signer());
                 inspector
                     .geth_builder()
                     .geth_erc7562_traces(config.clone(), res.result.tx_gas_used(), db)
@@ -254,7 +254,7 @@ impl DebugInspector {
             }
             Self::Default(inspector, config) => {
                 inspector.set_transaction_gas_limit(tx.gas_limit());
-                inspector.set_transaction_caller(tx.caller());
+                inspector.set_transaction_caller(tx.signer());
                 inspector
                     .geth_builder()
                     .geth_traces(res.result.tx_gas_used(), res.result.output.clone(), *config)

--- a/crates/inspectors/src/tracing/debug.rs
+++ b/crates/inspectors/src/tracing/debug.rs
@@ -13,7 +13,7 @@ use alloy_rpc_types_trace::geth::{
 use evm2::{
     ErrorCode, EvmTypes, EvmTypesHost, Inspector, NoopInspector, TxResultWithState,
     env::BlockEnv,
-    ethereum::RecoveredTxEnvelope,
+    ethereum::TransactionExt,
     evm::DynDatabase,
     interpreter::{Interpreter, Message, MessageResult},
 };
@@ -196,11 +196,11 @@ impl DebugInspector {
     }
 
     /// Should be invoked after each transaction to obtain the resulting [`GethTrace`].
-    pub fn get_result<T: EvmTypesHost>(
+    pub fn get_result<T: EvmTypesHost<Tx: TransactionExt>>(
         &mut self,
         tx_context: Option<TransactionContext>,
-        tx: &RecoveredTxEnvelope,
-        block_env: &BlockEnv,
+        tx: &T::Tx,
+        block_env: &BlockEnv<T>,
         res: &TxResultWithState<T>,
         db: &mut dyn DynDatabase,
     ) -> Result<GethTrace, DebugInspectorError> {
@@ -218,7 +218,7 @@ impl DebugInspector {
             Self::FourByte(inspector) => FourByteFrame::from(&*inspector).into(),
             Self::CallTracer(inspector, config) => {
                 inspector.set_transaction_gas_limit(tx.gas_limit());
-                inspector.set_transaction_caller(tx.signer());
+                inspector.set_transaction_caller(tx.caller());
                 inspector.geth_builder().geth_call_traces(*config, res.result.tx_gas_used()).into()
             }
             Self::PreStateTracer(inspector, config) => {
@@ -236,7 +236,7 @@ impl DebugInspector {
                 .into(),
             Self::FlatCallTracer(inspector) => {
                 inspector.set_transaction_gas_limit(tx.gas_limit());
-                inspector.set_transaction_caller(tx.signer());
+                inspector.set_transaction_caller(tx.caller());
                 inspector
                     .clone()
                     .into_parity_builder()
@@ -245,7 +245,7 @@ impl DebugInspector {
             }
             Self::Erc7562Tracer(inspector, config) => {
                 inspector.set_transaction_gas_limit(tx.gas_limit());
-                inspector.set_transaction_caller(tx.signer());
+                inspector.set_transaction_caller(tx.caller());
                 inspector
                     .geth_builder()
                     .geth_erc7562_traces(config.clone(), res.result.tx_gas_used(), db)
@@ -254,7 +254,7 @@ impl DebugInspector {
             }
             Self::Default(inspector, config) => {
                 inspector.set_transaction_gas_limit(tx.gas_limit());
-                inspector.set_transaction_caller(tx.signer());
+                inspector.set_transaction_caller(tx.caller());
                 inspector
                     .geth_builder()
                     .geth_traces(res.result.tx_gas_used(), res.result.output.clone(), *config)

--- a/crates/inspectors/src/tracing/js/mod.rs
+++ b/crates/inspectors/src/tracing/js/mod.rs
@@ -25,7 +25,7 @@ use boa_engine::{Context, JsError, JsObject, JsResult, JsValue, Source, js_strin
 use evm2::{
     Evm, EvmTypes, EvmTypesHost, Inspector, TxResultWithState,
     env::BlockEnv,
-    ethereum::RecoveredTxEnvelope,
+    ethereum::TransactionExt,
     evm::DynDatabase,
     interpreter::{
         GasTracker, InstrStop, Interpreter, Message, MessageKind, MessageResult, Word,
@@ -278,11 +278,11 @@ impl JsInspector {
     /// Calls the result function and returns the result as [serde_json::Value].
     ///
     /// Note: This is supposed to be called after the inspection has finished.
-    pub fn json_result<T: EvmTypesHost>(
+    pub fn json_result<T: EvmTypesHost<Tx: TransactionExt>>(
         &mut self,
         res: &TxResultWithState<T>,
-        tx: &RecoveredTxEnvelope,
-        block: &BlockEnv,
+        tx: &T::Tx,
+        block: &BlockEnv<T>,
         db: &mut dyn DynDatabase,
     ) -> Result<serde_json::Value, JsInspectorError> {
         let result = self.result(res, tx, block, db)?;
@@ -290,11 +290,11 @@ impl JsInspector {
     }
 
     /// Calls the result function and returns the result.
-    pub fn result<T: EvmTypesHost>(
+    pub fn result<T: EvmTypesHost<Tx: TransactionExt>>(
         &mut self,
         res: &TxResultWithState<T>,
-        tx: &RecoveredTxEnvelope,
-        block: &BlockEnv,
+        tx: &T::Tx,
+        block: &BlockEnv<T>,
         db: &mut dyn DynDatabase,
     ) -> Result<JsValue, JsInspectorError> {
         let TxResultWithState { result, state_changes: state, .. } = res;
@@ -327,7 +327,7 @@ impl JsInspector {
                 TxKind::Create => "CREATE",
             }
             .to_string(),
-            from: tx.signer(),
+            from: tx.caller(),
             to,
             input: tx.input().clone(),
             gas: tx.gas_limit(),

--- a/crates/inspectors/src/tracing/js/mod.rs
+++ b/crates/inspectors/src/tracing/js/mod.rs
@@ -19,13 +19,13 @@ use alloc::{
     string::{String, ToString},
     vec::Vec,
 };
+use alloy_consensus::{Transaction, transaction::Recovered};
 use alloy_primitives::{Address, Bytes, TxKind, U256, map::HashSet};
 pub use boa_engine::vm::RuntimeLimits;
 use boa_engine::{Context, JsError, JsObject, JsResult, JsValue, Source, js_string};
 use evm2::{
     Evm, EvmTypes, EvmTypesHost, Inspector, TxResultWithState,
     env::BlockEnv,
-    ethereum::TransactionExt,
     evm::DynDatabase,
     interpreter::{
         GasTracker, InstrStop, Interpreter, Message, MessageKind, MessageResult, Word,
@@ -278,10 +278,10 @@ impl JsInspector {
     /// Calls the result function and returns the result as [serde_json::Value].
     ///
     /// Note: This is supposed to be called after the inspection has finished.
-    pub fn json_result<T: EvmTypesHost<Tx: TransactionExt>>(
+    pub fn json_result<T: EvmTypesHost<Tx: Transaction>>(
         &mut self,
         res: &TxResultWithState<T>,
-        tx: &T::Tx,
+        tx: &Recovered<T::Tx>,
         block: &BlockEnv<T>,
         db: &mut dyn DynDatabase,
     ) -> Result<serde_json::Value, JsInspectorError> {
@@ -290,10 +290,10 @@ impl JsInspector {
     }
 
     /// Calls the result function and returns the result.
-    pub fn result<T: EvmTypesHost<Tx: TransactionExt>>(
+    pub fn result<T: EvmTypesHost<Tx: Transaction>>(
         &mut self,
         res: &TxResultWithState<T>,
-        tx: &T::Tx,
+        tx: &Recovered<T::Tx>,
         block: &BlockEnv<T>,
         db: &mut dyn DynDatabase,
     ) -> Result<JsValue, JsInspectorError> {
@@ -327,7 +327,7 @@ impl JsInspector {
                 TxKind::Create => "CREATE",
             }
             .to_string(),
-            from: tx.caller(),
+            from: tx.signer(),
             to,
             input: tx.input().clone(),
             gas: tx.gas_limit(),
@@ -750,7 +750,7 @@ mod tests {
     use evm2::{
         BaseEvmTypes, Evm, Precompiles, SpecId,
         bytecode::Bytecode,
-        ethereum::{RecoveredTxEnvelope, ethereum_tx_registry},
+        ethereum::{TxEnvelope, ethereum_tx_registry},
         evm::{AccountInfo, CacheDB, EmptyDB},
         interpreter::Host,
     };
@@ -815,15 +815,15 @@ mod tests {
         );
         evm.set_inspector(insp);
 
-        let tx = RecoveredTxEnvelope::Legacy(Recovered::new_unchecked(
-            TxLegacy {
+        let tx = Recovered::new_unchecked(
+            TxEnvelope::Legacy(TxLegacy {
                 gas_price: 1024,
                 gas_limit: 1_000_000,
                 to: TxKind::Call(addr),
                 ..Default::default()
-            },
+            }),
             Address::ZERO,
-        ));
+        );
         let res = evm.transact(&tx).expect("pass without error").detach();
 
         assert_eq!(res.result.status, success);

--- a/crates/inspectors/tests/it/compat.rs
+++ b/crates/inspectors/tests/it/compat.rs
@@ -5,7 +5,7 @@ use alloy_primitives::{Address, B256, Bytes, TxKind, U256};
 use evm2::{
     BaseEvmTypes, Evm, EvmTypesHost, Inspector, NoopInspector, Precompiles, TxResult,
     TxResultWithState, env as evm_env,
-    ethereum::{RecoveredTxEnvelope, ethereum_tx_registry},
+    ethereum::{RecoveredTxEnvelope, TxEnvelope, ethereum_tx_registry},
     evm::StateChanges,
     interpreter::{Interpreter, Message, MessageResult},
     registry::HandlerError,
@@ -318,26 +318,28 @@ impl TxEnv {
     pub fn envelope(&self) -> RecoveredTxEnvelope {
         if !self.blob_hashes.is_empty() {
             let TxKind::Call(to) = self.kind else { panic!("blob transactions must be calls") };
-            return RecoveredTxEnvelope::Eip4844(Recovered::new_unchecked(
-                TxEip4844 {
-                    chain_id: self.chain_id.unwrap_or(1),
-                    nonce: self.nonce,
-                    gas_limit: self.gas_limit,
-                    max_fee_per_gas: self.gas_price,
-                    max_priority_fee_per_gas: self.gas_priority_fee.unwrap_or_default(),
-                    to,
-                    value: self.value,
-                    access_list: Default::default(),
-                    blob_versioned_hashes: self.blob_hashes.clone(),
-                    max_fee_per_blob_gas: self.max_fee_per_blob_gas,
-                    input: self.data.clone(),
-                }
-                .into(),
+            return Recovered::new_unchecked(
+                TxEnvelope::Eip4844(
+                    TxEip4844 {
+                        chain_id: self.chain_id.unwrap_or(1),
+                        nonce: self.nonce,
+                        gas_limit: self.gas_limit,
+                        max_fee_per_gas: self.gas_price,
+                        max_priority_fee_per_gas: self.gas_priority_fee.unwrap_or_default(),
+                        to,
+                        value: self.value,
+                        access_list: Default::default(),
+                        blob_versioned_hashes: self.blob_hashes.clone(),
+                        max_fee_per_blob_gas: self.max_fee_per_blob_gas,
+                        input: self.data.clone(),
+                    }
+                    .into(),
+                ),
                 self.caller,
-            ));
+            );
         }
-        RecoveredTxEnvelope::Legacy(Recovered::new_unchecked(
-            TxLegacy {
+        Recovered::new_unchecked(
+            TxEnvelope::Legacy(TxLegacy {
                 chain_id: self.chain_id,
                 nonce: self.nonce,
                 gas_price: self.gas_price,
@@ -345,9 +347,9 @@ impl TxEnv {
                 to: self.kind,
                 value: self.value,
                 input: self.data.clone(),
-            },
+            }),
             self.caller,
-        ))
+        )
     }
 }
 


### PR DESCRIPTION
Moves recovered signer ownership to the EVM boundary by accepting `Recovered<T::Tx>` throughout execution and inspectors. Ethereum's runtime transaction type now implements Alloy's `Transaction` trait directly, and registry handlers receive recovered typed transactions, eliminating the custom transaction extension trait while preserving custom transaction support.
