### PR TITLE
fix: avoid bail macros in expression position

### DIFF
--- a/crates/cli/src/run.rs
+++ b/crates/cli/src/run.rs
@@ -857,7 +857,7 @@ fn read_code_string(contents: &[u8], ext: Option<&str>) -> eyre::Result<Vec<u8>>
             }
         })
     } else {
-        eyre::bail!("could not determine bytecode type")
+        eyre::bail!("could not determine bytecode type");
     }
 }
 

--- a/crates/jit/codegen/src/bytecode/asm.rs
+++ b/crates/jit/codegen/src/bytecode/asm.rs
@@ -307,8 +307,12 @@ fn parse_define<'a>(after: &'a str, macros: &mut HashMap<&'a str, MacroDef<'a>>)
 
     let name = match tok.next() {
         Some(Token { src, kind: TokenKind::Ident }) => src,
-        Some(other) => eyre::bail!("expected macro name after #define, got {other:?}"),
-        None => eyre::bail!("expected macro name after #define"),
+        Some(other) => {
+            eyre::bail!("expected macro name after #define, got {other:?}");
+        }
+        None => {
+            eyre::bail!("expected macro name after #define");
+        }
     };
 
     // Function-like macro: NAME(a, b).
@@ -330,7 +334,7 @@ fn parse_define<'a>(after: &'a str, macros: &mut HashMap<&'a str, MacroDef<'a>>)
                         i += 1;
                     }
                     other => {
-                        eyre::bail!("expected parameter name in #define {name}, got {other:?}")
+                        eyre::bail!("expected parameter name in #define {name}, got {other:?}");
                     }
                 }
                 match all_tokens.get(i) {
@@ -339,9 +343,11 @@ fn parse_define<'a>(after: &'a str, macros: &mut HashMap<&'a str, MacroDef<'a>>)
                         break;
                     }
                     Some(Token { kind: TokenKind::Comma, .. }) => i += 1,
-                    other => eyre::bail!(
-                        "expected ',' or ')' in #define {name} parameter list, got {other:?}"
-                    ),
+                    other => {
+                        eyre::bail!(
+                            "expected ',' or ')' in #define {name} parameter list, got {other:?}"
+                        );
+                    }
                 }
             }
         } else {
@@ -571,8 +577,12 @@ fn parse_items<'a>(tokens: &[Token<'a>]) -> Result<Vec<Item<'a>>> {
                     }
                 }
             }
-            TokenKind::Unknown => eyre::bail!("unexpected token: {:?}", tokens[i].src),
-            _ => eyre::bail!("unexpected token: {:?}", tokens[i]),
+            TokenKind::Unknown => {
+                eyre::bail!("unexpected token: {:?}", tokens[i].src);
+            }
+            _ => {
+                eyre::bail!("unexpected token: {:?}", tokens[i]);
+            }
         }
     }
     Ok(items)
@@ -592,7 +602,9 @@ fn expect_number_u8(
                 n.try_into().map_err(|_| eyre::eyre!("invalid {ctx} immediate: too large"))?;
             u8::try_from(v).map_err(|_| eyre::eyre!("invalid {ctx} immediate: too large"))
         }
-        _ => eyre::bail!("expected numeric immediate for {ctx}, got {tok:?}"),
+        _ => {
+            eyre::bail!("expected numeric immediate for {ctx}, got {tok:?}");
+        }
     }
 }
 
@@ -607,7 +619,9 @@ fn expect_imm<'a>(
     match &tok.kind {
         TokenKind::Number(n) => Ok(Imm::Number(*n)),
         TokenKind::LabelRef => Ok(Imm::Label(tok.src)),
-        _ => eyre::bail!("expected immediate for {ctx}, got {tok:?}"),
+        _ => {
+            eyre::bail!("expected immediate for {ctx}, got {tok:?}");
+        }
     }
 }
 

--- a/crates/jit/runtime/src/runtime/backend.rs
+++ b/crates/jit/runtime/src/runtime/backend.rs
@@ -118,7 +118,7 @@ impl JitObjectLinker {
         &mut self,
         _success: &JitObjectSuccess,
     ) -> eyre::Result<(EvmCompilerFn, Arc<JitCodeBacking>)> {
-        eyre::bail!("LLVM backend not available")
+        eyre::bail!("LLVM backend not available");
     }
 }
 

--- a/crates/jit/runtime/src/runtime/mod.rs
+++ b/crates/jit/runtime/src/runtime/mod.rs
@@ -64,7 +64,7 @@ pub fn maybe_run_jit_helper() -> eyre::Result<ControlFlow<()>> {
     #[cfg(not(all(feature = "llvm", unix)))]
     {
         if std::env::var_os("EVM2_JIT_HELPER").is_some() {
-            eyre::bail!("out-of-process JIT helper is only available on Unix with LLVM")
+            eyre::bail!("out-of-process JIT helper is only available on Unix with LLVM");
         }
         Ok(ControlFlow::Continue(()))
     }
@@ -321,10 +321,10 @@ impl JitBackend {
         match rx.recv_timeout(self.inner.tuning.sync_compile_timeout) {
             Ok(()) => Ok(()),
             Err(chan::RecvTimeoutError::Timeout) => {
-                eyre::bail!("timed out waiting for compilation to complete")
+                eyre::bail!("timed out waiting for compilation to complete");
             }
             Err(chan::RecvTimeoutError::Disconnected) => {
-                eyre::bail!("backend shut down before compilation completed")
+                eyre::bail!("backend shut down before compilation completed");
             }
         }
     }

--- a/crates/jit/runtime/src/runtime/out_of_process.rs
+++ b/crates/jit/runtime/src/runtime/out_of_process.rs
@@ -726,7 +726,7 @@ fn read_helper_init<R: Read + ?Sized>(stdin: &mut BufReader<R>) -> eyre::Result<
     match read_message(stdin)? {
         HelperRequest::Init(init) => runtime_config_from_init(init),
         HelperRequest::Compile(_) | HelperRequest::Pause { .. } | HelperRequest::Resume => {
-            eyre::bail!("JIT helper received request before init")
+            eyre::bail!("JIT helper received request before init");
         }
     }
 }
@@ -742,7 +742,9 @@ fn read_helper_request<R: Read + ?Sized>(stdin: &mut BufReader<R>) -> eyre::Resu
         HelperRequest::Compile(req) => req,
         HelperRequest::Pause { id } => return Ok(HelperWork::Pause { id }),
         HelperRequest::Resume => return Ok(HelperWork::Resume),
-        HelperRequest::Init(_) => eyre::bail!("JIT helper received duplicate init"),
+        HelperRequest::Init(_) => {
+            eyre::bail!("JIT helper received duplicate init");
+        }
     };
     let spec_id = SpecId::try_from_u32(u32::from(req.spec_id))
         .ok_or_else(|| eyre::eyre!("invalid spec id"))?;
@@ -830,7 +832,9 @@ fn opt_level_from_u8(level: u8) -> eyre::Result<OptimizationLevel> {
         1 => OptimizationLevel::Less,
         2 => OptimizationLevel::Default,
         3 => OptimizationLevel::Aggressive,
-        _ => eyre::bail!("invalid optimization level"),
+        _ => {
+            eyre::bail!("invalid optimization level");
+        }
     })
 }
 


### PR DESCRIPTION
Nightly now rejects trailing-semicolon macro expansions from `eyre::bail!` in expression position. This terminates affected invocations as statements and wraps match-arm uses in blocks, including runtime and CLI paths that CI had not reached after codegen failed, restoring nightly builds without changing behavior.