### PR TITLE
feat(evm): make refund quotient configurable

### DIFF
--- a/crates/evm2/src/ethereum/mod.rs
+++ b/crates/evm2/src/ethereum/mod.rs
@@ -610,15 +610,16 @@ pub(super) fn settle_gas<'a, T: EvmTypes>(
         return Err(HandlerError::Fatal(code));
     }
 
-    let is_eip3529 = host.feature(EvmFeatures::EIP3529);
-    let (gas_remaining, gas_used) = final_tx_gas(&result, tx_gas_limit, is_eip3529, floor_gas);
+    let max_refund_quotient = u64::from(host.version().gas_params.get(GasId::MaxRefundQuotient));
+    let (gas_remaining, gas_used) =
+        final_tx_gas(&result, tx_gas_limit, max_refund_quotient, floor_gas);
     // Self-contained gas breakdown for the result. `total_gas_spent` is defined so that
     // `TxResult::tx_gas_used` reproduces the local `gas_used` (used here for the beneficiary
     // reward). State gas is execution state gas plus the upfront `initial_state_gas`, less the
     // EIP-7702 per-authorization `state_refund`.
     let total_gas_spent =
         tx_gas_limit.saturating_sub(result.gas.remaining()).saturating_sub(result.gas.reservoir());
-    let refunded = result.final_refund(tx_gas_limit, is_eip3529);
+    let refunded = result.final_refund(tx_gas_limit, max_refund_quotient);
     // EIP-7623: when the calldata floor exceeds spent-minus-refund, `TxResult::tx_gas_used`
     // resolves to the floor. `total_gas_spent` stays pre-refund and pre-floor: block-level
     // regular gas (EIP-7778/EIP-8037) accumulates `tx_gas_used_before_refund` per
@@ -680,11 +681,11 @@ pub(super) fn settle_gas<'a, T: EvmTypes>(
 const fn final_tx_gas<T: EvmTypesHost>(
     result: &MessageResult<T>,
     tx_gas_limit: u64,
-    is_eip3529: bool,
+    max_refund_quotient: u64,
     floor_gas: u64,
 ) -> (u64, u64) {
-    let gas_remaining = result.gas_remaining_after_final_refund(tx_gas_limit, is_eip3529);
-    let gas_used = result.gas_used_after_final_refund(tx_gas_limit, is_eip3529);
+    let gas_remaining = result.gas_remaining_after_final_refund(tx_gas_limit, max_refund_quotient);
+    let gas_used = result.gas_used_after_final_refund(tx_gas_limit, max_refund_quotient);
     // EIP-7623 charges at least the calldata floor after applying refunds.
     if gas_used < floor_gas {
         return (tx_gas_limit.saturating_sub(floor_gas), floor_gas);
@@ -1030,7 +1031,7 @@ mod tests {
             ..MessageResult::<BaseEvmTypes>::default()
         };
 
-        assert_eq!(final_tx_gas(&result, 100_000, true, 60_000), (40_000, 60_000));
+        assert_eq!(final_tx_gas(&result, 100_000, 5, 60_000), (40_000, 60_000));
     }
 
     #[test]
@@ -1041,7 +1042,7 @@ mod tests {
             ..MessageResult::<BaseEvmTypes>::default()
         };
 
-        assert_eq!(final_tx_gas(&result, 100_000, true, 60_000), (30_000, 70_000));
+        assert_eq!(final_tx_gas(&result, 100_000, 5, 60_000), (30_000, 70_000));
     }
 
     #[test]

--- a/crates/evm2/src/interpreter/host.rs
+++ b/crates/evm2/src/interpreter/host.rs
@@ -56,11 +56,11 @@ impl<T: EvmTypesHost> MessageResult<T> {
 
     /// Calculates the final refund amount for a top-level transaction.
     #[inline]
-    pub const fn final_refund(&self, gas_limit: u64, is_eip3529: bool) -> u64 {
+    pub const fn final_refund(&self, gas_limit: u64, max_refund_quotient: u64) -> u64 {
         if self.gas.refunded() <= 0 {
             return 0;
         }
-        let max_refund_quotient = if is_eip3529 { 5 } else { 2 };
+        let max_refund_quotient = if max_refund_quotient == 0 { 1 } else { max_refund_quotient };
         // EIP-8037: the unused state-gas reservoir is reimbursed to the caller, so it
         // is not part of the gas actually spent. The EIP-3529 refund cap is a fraction
         // of the gas the transaction truly consumed, so the reservoir must be excluded
@@ -74,8 +74,12 @@ impl<T: EvmTypesHost> MessageResult<T> {
 
     /// Returns top-level gas remaining after applying the final refund cap.
     #[inline]
-    pub const fn gas_remaining_after_final_refund(&self, gas_limit: u64, is_eip3529: bool) -> u64 {
-        let refunded = self.final_refund(gas_limit, is_eip3529);
+    pub const fn gas_remaining_after_final_refund(
+        &self,
+        gas_limit: u64,
+        max_refund_quotient: u64,
+    ) -> u64 {
+        let refunded = self.final_refund(gas_limit, max_refund_quotient);
         // EIP-8037: the unused reservoir (already settled to its frame-start value
         // on failure by `rollback_state_gas`) is also reimbursed to the caller.
         let remaining =
@@ -85,8 +89,13 @@ impl<T: EvmTypesHost> MessageResult<T> {
 
     /// Returns top-level gas used after applying the final refund cap.
     #[inline]
-    pub const fn gas_used_after_final_refund(&self, gas_limit: u64, is_eip3529: bool) -> u64 {
-        gas_limit.saturating_sub(self.gas_remaining_after_final_refund(gas_limit, is_eip3529))
+    pub const fn gas_used_after_final_refund(
+        &self,
+        gas_limit: u64,
+        max_refund_quotient: u64,
+    ) -> u64 {
+        gas_limit
+            .saturating_sub(self.gas_remaining_after_final_refund(gas_limit, max_refund_quotient))
     }
 }
 
@@ -157,4 +166,23 @@ pub trait Host<T: EvmTypesHost> {
         target: &Address,
         skip_cold_load: bool,
     ) -> Result<SelfDestructResult, InstrStop>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::interpreter::GasTracker;
+
+    #[test]
+    fn final_refund_uses_configured_quotient() {
+        let mut result =
+            MessageResult::<BaseEvmTypes> { gas: GasTracker::new(100), ..Default::default() };
+        result.gas.set_remaining(20);
+        result.gas.set_refunded(60);
+
+        assert_eq!(result.final_refund(100, 2), 40);
+        assert_eq!(result.final_refund(100, 5), 16);
+        assert_eq!(result.final_refund(100, 1), 60);
+        assert_eq!(result.final_refund(100, 0), 60);
+    }
 }

--- a/crates/evm2/src/version/gas_params.rs
+++ b/crates/evm2/src/version/gas_params.rs
@@ -116,6 +116,8 @@ gas_ids! {
     SelfdestructRefund;
     /// Gas stipend for a value-transferring call.
     CallStipend;
+    /// Maximum transaction gas refund quotient.
+    MaxRefundQuotient;
     /// Additional gas charged for cold storage.
     ColdStorageAdditionalCost;
     /// Gas charged for cold storage.
@@ -478,6 +480,7 @@ mod tests {
         assert_eq!(params.get(GasId::SstoreStatic), 5000);
         assert_eq!(params.get(GasId::SstoreSetWithoutLoadCost), 15000);
         assert_eq!(params.get(GasId::TxCreateCost), 0);
+        assert_eq!(params.get(GasId::MaxRefundQuotient), 2);
     }
 
     #[test]
@@ -502,10 +505,12 @@ mod tests {
         assert_eq!(berlin.get(GasId::SstoreStatic), 100);
         assert_eq!(berlin.get(GasId::ColdAccountAdditionalCost), 2500);
         assert_eq!(berlin.get(GasId::ColdStorageCost), 2100);
+        assert_eq!(berlin.get(GasId::MaxRefundQuotient), 2);
 
         let london = gas_params(SpecId::LONDON);
         assert_eq!(london.get(GasId::SstoreClearingSlotRefund), 4800);
         assert_eq!(london.get(GasId::SelfdestructRefund), 0);
+        assert_eq!(london.get(GasId::MaxRefundQuotient), 5);
 
         let shanghai = gas_params(SpecId::SHANGHAI);
         assert_eq!(shanghai.get(GasId::TxInitcodeCost), 2);

--- a/crates/evm2/src/version/mod.rs
+++ b/crates/evm2/src/version/mod.rs
@@ -516,6 +516,7 @@ evm_versions! {
             SstoreClearingSlotRefund: REFUND_SSTORE_CLEARS,
             SelfdestructRefund: SELFDESTRUCT_REFUND,
             CallStipend: CALL_STIPEND,
+            MaxRefundQuotient: 2,
             CodeDepositCost: CODEDEPOSIT,
             TxTokenNonZeroByteMultiplier: NON_ZERO_BYTE_MULTIPLIER,
             TxTokenCost: STANDARD_TOKEN_COST,
@@ -660,6 +661,7 @@ evm_versions! {
         dynamic_gas: [
             SstoreClearingSlotRefund: WARM_SSTORE_RESET + EIP2930_ACCESS_LIST_STORAGE_KEY,
             SelfdestructRefund: 0,
+            MaxRefundQuotient: 5,
         ],
     }
 


### PR DESCRIPTION
Adds MaxRefundQuotient to the version gas parameters and uses it when settling transaction refunds. Existing fork behavior stays unchanged: 2 before London and 5 from London onward.

Tested with cargo test -p evm2 and cargo cl -p evm2.