### PR TITLE
feat(evm): add instance extension state

### DIFF
--- a/crates/evm2/examples/custom_evm/config.rs
+++ b/crates/evm2/examples/custom_evm/config.rs
@@ -56,6 +56,7 @@ impl EvmTypesHost for CustomTypes {
     type ConfigSelector = CustomConfigSelector;
     type SpecId = CustomSpecId;
     type Tx = crate::tx::CustomEnvelope;
+    type EvmExt = ();
     type MessageExt = CustomMessageExt;
     type MessageResultExt = CustomMessageResultExt;
     type TxEnvExt = CustomTxEnvExt;

--- a/crates/evm2/src/evm/config.rs
+++ b/crates/evm2/src/evm/config.rs
@@ -31,6 +31,9 @@ pub trait EvmTypesHost: Sized + 'static {
     /// Transaction type handled by this EVM.
     type Tx;
 
+    /// EVM instance-specific extension state.
+    type EvmExt;
+
     /// Extra data stored in frame messages.
     type MessageExt: Clone + Debug + Default;
 
@@ -216,6 +219,7 @@ impl EvmTypesHost for BaseEvmTypes {
     type ConfigSelector = BaseEvmConfigSelector;
     type SpecId = SpecId;
     type Tx = RecoveredTxEnvelope;
+    type EvmExt = ();
     type MessageExt = ();
     type MessageResultExt = ();
     type TxEnvExt = ();

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -241,6 +241,8 @@ pub struct Evm<'a, T: EvmTypesHost> {
     #[derive_where(skip)]
     pub(crate) state: State<'a>,
     #[derive_where(skip)]
+    ext: T::EvmExt,
+    #[derive_where(skip)]
     precompiles: Box<dyn PrecompileProvider<T> + 'a>,
     #[derive_where(skip)]
     interpreter_pool: InterpreterPool<T>,
@@ -274,14 +276,31 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
         registry: TxRegistry<T, TxResult<T>>,
         database: impl DynDatabase + 'a,
         precompiles: impl PrecompileProvider<T> + 'a,
+    ) -> Self
+    where
+        T::EvmExt: Default,
+    {
+        Self::new_with_ext(spec_id, block, registry, database, precompiles, T::EvmExt::default())
+    }
+
+    /// Creates an EVM with explicit instance-specific extension state.
+    #[inline]
+    pub fn new_with_ext(
+        spec_id: T::SpecId,
+        block: BlockEnv<T>,
+        registry: TxRegistry<T, TxResult<T>>,
+        database: impl DynDatabase + 'a,
+        precompiles: impl PrecompileProvider<T> + 'a,
+        ext: T::EvmExt,
     ) -> Self {
-        Self::new_with_execution_config(
+        Self::new_with_execution_config_and_ext(
             <T::ConfigSelector as EvmConfigSelector<T>>::execution_config(spec_id),
             spec_id,
             block,
             registry,
             database,
             precompiles,
+            ext,
         )
     }
 
@@ -294,6 +313,31 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
         registry: TxRegistry<T, TxResult<T>>,
         database: impl DynDatabase + 'a,
         precompiles: impl PrecompileProvider<T> + 'a,
+    ) -> Self
+    where
+        T::EvmExt: Default,
+    {
+        Self::new_with_execution_config_and_ext(
+            execution_config,
+            spec_id,
+            block,
+            registry,
+            database,
+            precompiles,
+            T::EvmExt::default(),
+        )
+    }
+
+    /// Creates an EVM with an execution config and explicit instance-specific extension state.
+    #[inline]
+    pub fn new_with_execution_config_and_ext(
+        execution_config: ExecutionConfig<T>,
+        spec_id: T::SpecId,
+        block: BlockEnv<T>,
+        registry: TxRegistry<T, TxResult<T>>,
+        database: impl DynDatabase + 'a,
+        precompiles: impl PrecompileProvider<T> + 'a,
+        ext: T::EvmExt,
     ) -> Self {
         Self::new_mono(
             execution_config,
@@ -302,6 +346,7 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
             registry,
             boxed_dyn_database(database),
             boxed_precompile_provider(precompiles),
+            ext,
         )
     }
 
@@ -313,6 +358,7 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
         registry: TxRegistry<T, TxResult<T>>,
         database: Box<dyn DynDatabase + 'a>,
         precompiles: Box<dyn PrecompileProvider<T> + 'a>,
+        ext: T::EvmExt,
     ) -> Self {
         assert_eq!(
             spec_id.into(),
@@ -326,6 +372,7 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
             block,
             registry,
             state: State::new_mono(database),
+            ext,
             precompiles,
             interpreter_pool: InterpreterPool::new(),
             inspector: None,
@@ -400,6 +447,18 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
     #[inline]
     pub const fn registry(&self) -> &TxRegistry<T, TxResult<T>> {
         &self.registry
+    }
+
+    /// Returns the EVM instance-specific extension state.
+    #[inline]
+    pub const fn ext(&self) -> &T::EvmExt {
+        &self.ext
+    }
+
+    /// Returns the EVM instance-specific extension state mutably.
+    #[inline]
+    pub const fn ext_mut(&mut self) -> &mut T::EvmExt {
+        &mut self.ext
     }
 
     /// Returns the active block environment.
@@ -940,6 +999,7 @@ where
     T: EvmTypesHost,
     T::SpecId: Send,
     T::Tx: Send,
+    T::EvmExt: Send,
     T::MessageExt: Send,
     T::MessageResultExt: Send,
     T::TxEnvExt: Send,
@@ -1990,6 +2050,37 @@ mod tests {
     const TEST_TX_TYPE: u8 = 0x00;
     const TEST_PRECOMPILE: Address = Address::with_last_byte(0x42);
     const INNER_TEST_PRECOMPILE: Address = Address::with_last_byte(0x43);
+
+    struct ExtensionTestTypes;
+
+    impl EvmTypesHost for ExtensionTestTypes {
+        type ConfigSelector = BaseEvmConfigSelector;
+        type SpecId = SpecId;
+        type Tx = ();
+        type EvmExt = u64;
+        type MessageExt = ();
+        type MessageResultExt = ();
+        type TxEnvExt = ();
+        type TxResultExt = ();
+        type BlockEnvExt = ();
+        type Host<'a> = Evm<'a, Self>;
+    }
+
+    #[test]
+    fn stores_typed_evm_extension_state() {
+        let mut evm = Evm::<ExtensionTestTypes>::new_with_ext(
+            SpecId::OSAKA,
+            BlockEnv::default(),
+            TxRegistry::new(),
+            InMemoryDB::default(),
+            precompile::NoPrecompiles::default(),
+            41,
+        );
+
+        assert_eq!(*evm.ext(), 41);
+        *evm.ext_mut() += 1;
+        assert_eq!(*evm.ext(), 42);
+    }
 
     fn test_tx(value: u64) -> RecoveredTxEnvelope {
         RecoveredTxEnvelope::Legacy(Recovered::new_unchecked(

--- a/crates/evm2/src/evm/registry.rs
+++ b/crates/evm2/src/evm/registry.rs
@@ -321,6 +321,7 @@ mod tests {
         type ConfigSelector = BaseEvmConfigSelector;
         type SpecId = SpecId;
         type Tx = Envelope;
+        type EvmExt = ();
         type MessageExt = ();
         type MessageResultExt = ();
         type TxEnvExt = ();

--- a/crates/evm2/src/test_utils.rs
+++ b/crates/evm2/src/test_utils.rs
@@ -21,6 +21,7 @@ impl EvmTypesHost for TestTypes {
     type ConfigSelector = crate::BaseEvmConfigSelector;
     type SpecId = crate::SpecId;
     type Tx = ();
+    type EvmExt = ();
     type MessageExt = ();
     type MessageResultExt = ();
     type TxEnvExt = ();


### PR DESCRIPTION
Adds typed instance extension state to EvmTypesHost and Evm, while keeping existing constructors available when the extension implements Default. Custom EVMs can initialize it explicitly and access it through ext()/ext_mut().

Tested with cargo test -p evm2 and cargo cl -p evm2.