### PR TITLE
feat(state): expose transaction integration APIs

### DIFF
--- a/crates/evm2/src/evm/state/journal.rs
+++ b/crates/evm2/src/evm/state/journal.rs
@@ -14,6 +14,26 @@ pub struct StateCheckpoint {
     pub(crate) logs_len: usize,
 }
 
+impl StateCheckpoint {
+    /// Creates a checkpoint from journal and log cursors.
+    #[inline]
+    pub const fn new(journal_len: usize, logs_len: usize) -> Self {
+        Self { journal_len, logs_len }
+    }
+
+    /// Returns the revert-journal cursor captured by this checkpoint.
+    #[inline]
+    pub const fn journal_len(&self) -> usize {
+        self.journal_len
+    }
+
+    /// Returns the emitted-log cursor captured by this checkpoint.
+    #[inline]
+    pub const fn logs_len(&self) -> usize {
+        self.logs_len
+    }
+}
+
 /// Compact journal entry for reverting state changes.
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[non_exhaustive]

--- a/crates/evm2/src/evm/state/mod.rs
+++ b/crates/evm2/src/evm/state/mod.rs
@@ -117,7 +117,7 @@ impl<'a> State<'a> {
     /// Returns a checkpoint for later rollback.
     #[inline]
     pub const fn checkpoint(&self) -> StateCheckpoint {
-        StateCheckpoint { journal_len: self.inner.journal.len(), logs_len: self.inner.logs.len() }
+        StateCheckpoint::new(self.inner.journal.len(), self.inner.logs.len())
     }
 
     /// Returns the initial database.
@@ -584,6 +584,28 @@ impl<'a> State<'a> {
         }
     }
 
+    /// Removes and returns every transient storage slot owned by `address`.
+    ///
+    /// This is intended for transaction-finalization policies that encode per-account pending
+    /// work in EIP-1153 storage and must consume it before transaction scratch is cleared.
+    pub fn take_transient_storage(&mut self, address: &Address) -> Vec<(Word, Word)> {
+        let keys = self
+            .transient_storage
+            .keys()
+            .copied()
+            .filter(|key| key.address() == *address)
+            .collect::<Vec<_>>();
+        keys.into_iter()
+            .map(|key| {
+                let value = self
+                    .transient_storage
+                    .remove(&key)
+                    .expect("collected transient storage key must exist");
+                (key.key(), value)
+            })
+            .collect()
+    }
+
     /// Reverts state changes after the checkpoint.
     #[inline(never)]
     pub fn rollback(&mut self, checkpoint: StateCheckpoint, features: EvmFeatures) {
@@ -806,7 +828,7 @@ impl<'a> State<'a> {
     /// This advances the in-memory accepted overlay by the transaction's write-set and clears the
     /// transaction account/storage layers. It does not take logs or write to the wrapped backing
     /// database.
-    pub(crate) fn commit_transaction(&mut self) {
+    pub fn commit_transaction(&mut self) {
         // The transaction overlay is folded into the accepted-overlay database directly, without
         // detaching it.
         self.inner.database.commit(&self.accounts, &self.storage);

--- a/crates/evm2/src/evm/state/storage.rs
+++ b/crates/evm2/src/evm/state/storage.rs
@@ -318,6 +318,7 @@ mod tests {
             state::{AccountInfo, State},
         },
     };
+    use alloc::vec;
     use alloy_primitives::Address;
 
     #[test]
@@ -355,6 +356,23 @@ mod tests {
         assert_eq!(state.tload(&address, &Word::from(1)), Word::from(20));
         state.rollback(checkpoint, Version::base(SpecId::FRONTIER).features);
         assert_eq!(state.tload(&address, &Word::from(1)), Word::from(10));
+    }
+
+    #[test]
+    fn take_transient_storage_only_drains_requested_account() {
+        let address = Address::from([0x22; 20]);
+        let other = Address::from([0x23; 20]);
+        let mut state = State::new(CacheDB::default());
+
+        state.tstore(&address, &Word::from(1), &Word::from(10));
+        state.tstore(&address, &Word::from(2), &Word::from(20));
+        state.tstore(&other, &Word::from(1), &Word::from(30));
+
+        let mut slots = state.take_transient_storage(&address);
+        slots.sort_unstable_by_key(|(key, _)| *key);
+        assert_eq!(slots, vec![(Word::from(1), Word::from(10)), (Word::from(2), Word::from(20))]);
+        assert_eq!(state.tload(&address, &Word::from(1)), Word::ZERO);
+        assert_eq!(state.tload(&other, &Word::from(1)), Word::from(30));
     }
 
     #[test]


### PR DESCRIPTION
Exposes checkpoint cursors, transaction-state commit, and per-account transient-storage draining. Custom transaction lifecycles can consume pending state before transaction scratch is cleared.