### PR TITLE
fix(evm): apply calldata floor to regular block gas

### DIFF
--- a/crates/evm2/src/ethereum/mod.rs
+++ b/crates/evm2/src/ethereum/mod.rs
@@ -681,9 +681,8 @@ pub fn finalize_gas<'a, T: EvmTypes>(
         tx_gas_limit.saturating_sub(result.gas.remaining()).saturating_sub(result.gas.reservoir());
     let refunded = result.final_refund(tx_gas_limit, max_refund_quotient);
     // EIP-7623: when the calldata floor exceeds spent-minus-refund, `TxResult::tx_gas_used`
-    // resolves to the floor. `total_gas_spent` stays pre-refund and pre-floor: block-level
-    // regular gas (EIP-7778/EIP-8037) accumulates `tx_gas_used_before_refund` per
-    // execution-specs, without the floor clamp.
+    // resolves to the floor. `total_gas_spent` stays pre-refund and pre-floor;
+    // `TxResult::regular_gas_spent` applies the floor when block-level regular gas is accumulated.
     // Execution state gas contributes only on success: a revert/halt rolls back its state changes.
     // A failed top-level CREATE additionally unwinds its intrinsic `create_state_gas` (refunded to
     // the reservoir by `refund_create_state_gas`), so it nets out of the block state gas.

--- a/crates/evm2/src/evm/tx.rs
+++ b/crates/evm2/src/evm/tx.rs
@@ -58,14 +58,15 @@ impl<E> TxResultExt<E> {
         if spent_sub_refunded > self.floor_gas { spent_sub_refunded } else { self.floor_gas }
     }
 
-    /// Returns this transaction's regular (non-state) gas: `total_gas_spent - state_gas_spent`,
-    /// pre-refund (refund and floor only affect [`Self::tx_gas_used`]).
+    /// Returns this transaction's regular (non-state) block gas:
+    /// `max(total_gas_spent - state_gas_spent, floor_gas)`.
     ///
-    /// Together with [`Self::state_gas_spent()`] this is the per-transaction split that callers add
-    /// to the block's separate regular- and state-gas counters (EIP-8037 + EIP-7778).
+    /// Callers add this and [`Self::state_gas_spent()`] to the block's separate regular- and
+    /// state-gas counters (EIP-8037 + EIP-7778).
     #[inline]
     pub const fn regular_gas_spent(&self) -> u64 {
-        self.total_gas_spent.saturating_sub(self.state_gas_spent)
+        let regular_gas_spent = self.total_gas_spent.saturating_sub(self.state_gas_spent);
+        if regular_gas_spent > self.floor_gas { regular_gas_spent } else { self.floor_gas }
     }
 
     /// Returns this transaction's state gas (EIP-8037) — the stored `state_gas_spent` field,
@@ -303,6 +304,12 @@ mod tests {
         assert_eq!(r.regular_gas_spent(), 70_000);
         assert_eq!(r.state_gas_spent(), 30_000);
         assert_eq!(r.regular_gas_spent() + r.state_gas_spent(), r.total_gas_spent);
+    }
+
+    #[test]
+    fn floor_gas_applies_to_regular_block_gas() {
+        let r = result(100_000, 80_000, 0, 30_000);
+        assert_eq!(r.regular_gas_spent(), 30_000);
     }
 
     #[test]


### PR DESCRIPTION
Applies the calldata floor when deriving regular block gas from a transaction result. This matches EIP-8037/EIP-7778 accounting and revm block gas calculation.