### PR TITLE
feat(evm): support generic RPC adapters

### DIFF
--- a/crates/cli/src/fuzzer/normalize.rs
+++ b/crates/cli/src/fuzzer/normalize.rs
@@ -105,7 +105,7 @@ fn normalize_error(error: String) -> String {
     if error.starts_with("IntrinsicGasTooLow") || error.starts_with("CallGasCostMoreThanGasLimit") {
         return "IntrinsicGasTooLow".to_string();
     }
-    if error.starts_with("LackOfFundForMaxFee") || error == "InsufficientFunds" {
+    if error.starts_with("LackOfFundForMaxFee") || error.starts_with("InsufficientFunds") {
         return "InsufficientFunds".to_string();
     }
     if error.starts_with("NonceTooHigh")

--- a/crates/evm2/src/error.rs
+++ b/crates/evm2/src/error.rs
@@ -24,6 +24,11 @@ impl AnyError {
     pub fn new(err: impl Error + Send + Sync + 'static) -> Self {
         Self(Arc::new(err))
     }
+
+    /// Returns the contained error when it has type `T`.
+    pub fn downcast_ref<T: Error + 'static>(&self) -> Option<&T> {
+        self.0.downcast_ref()
+    }
 }
 
 struct StringError(String);
@@ -124,6 +129,12 @@ pub(crate) fn error_unavailable(code: ErrorCode) -> AnyError {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn downcasts_inner_error() {
+        let error = AnyError::new(StringError("test".into()));
+        assert_eq!(error.downcast_ref::<StringError>().unwrap().0, "test");
+    }
 
     #[test]
     fn reserved_codes_stay_in_reserved_range() {

--- a/crates/evm2/src/ethereum/mod.rs
+++ b/crates/evm2/src/ethereum/mod.rs
@@ -398,7 +398,10 @@ pub fn validate_sender<'a, T: EvmTypes>(
         return Err(HandlerError::InvalidNonce { expected: sender.nonce(), got: nonce });
     }
     if has_balance_check && sender.balance() < max_upfront {
-        return Err(HandlerError::InsufficientFunds);
+        return Err(HandlerError::InsufficientFunds {
+            cost: max_upfront,
+            balance: sender.balance(),
+        });
     }
     if !has_balance_check && has_balance_top_up && sender.balance() < max_upfront {
         sender.add_balance(max_upfront - sender.balance());
@@ -1038,6 +1041,25 @@ mod tests {
 
         assert!(validate_sender(&mut evm, caller, 0, U256::from(100)).is_ok());
         assert!(evm.state.account_info_untracked(&caller).unwrap().is_none());
+    }
+
+    #[test]
+    fn insufficient_funds_reports_cost_and_balance() {
+        let caller = Address::with_last_byte(0xaa);
+        let mut database = InMemoryDB::default();
+        database.insert_account_info(&caller, AccountInfo::default().with_balance(U256::from(40)));
+        let mut evm = Evm::<BaseEvmTypes>::new(
+            SpecId::OSAKA,
+            BlockEnv::default(),
+            TxRegistry::new(),
+            database,
+            Precompiles::base(SpecId::OSAKA),
+        );
+
+        assert_eq!(
+            validate_sender(&mut evm, caller, 0, U256::from(100)),
+            Err(HandlerError::InsufficientFunds { cost: U256::from(100), balance: U256::from(40) })
+        );
     }
 
     #[test]

--- a/crates/evm2/src/evm/async.rs
+++ b/crates/evm2/src/evm/async.rs
@@ -1079,6 +1079,18 @@ mod tests {
             false
         }
 
+        fn move_precompiles(
+            &mut self,
+            moves: &[(Address, Address)],
+        ) -> Result<(), crate::precompiles::MovePrecompileError> {
+            match moves.iter().find(|(source, destination)| source != destination) {
+                Some((source, _)) => {
+                    Err(crate::precompiles::MovePrecompileError::NotAPrecompile(*source))
+                }
+                None => Ok(()),
+            }
+        }
+
         fn execute(
             &mut self,
             _evm: &mut Evm<'_, BaseEvmTypes>,

--- a/crates/evm2/src/evm/db/cache.rs
+++ b/crates/evm2/src/evm/db/cache.rs
@@ -1,6 +1,6 @@
 //! In-memory cache database.
 
-use super::{DbResult, DynDatabase, EmptyDB};
+use super::{DbResult, DynDatabase, EmptyDB, OverrideBlockHashes};
 use crate::{
     AnyError, ErrorCode,
     bytecode::Bytecode,
@@ -261,6 +261,13 @@ impl<ExtDB> StateChangeSink for CacheDB<ExtDB> {
             }
         }
         Ok(())
+    }
+}
+
+impl<ExtDB> OverrideBlockHashes for CacheDB<ExtDB> {
+    #[inline]
+    fn insert_block_hash(&mut self, number: &Word, hash: &B256) {
+        Self::insert_block_hash(self, number, hash);
     }
 }
 

--- a/crates/evm2/src/evm/db/mod.rs
+++ b/crates/evm2/src/evm/db/mod.rs
@@ -32,6 +32,13 @@ pub trait Database: NonStaticAny {
     fn get_block_hash(&mut self, number: &Word) -> Result<Option<B256>, Self::Error>;
 }
 
+/// Database overlay capable of overriding historical block hashes.
+#[auto_impl(&mut, Box)]
+pub trait OverrideBlockHashes {
+    /// Sets the block hash returned for `number`.
+    fn insert_block_hash(&mut self, number: &Word, hash: &B256);
+}
+
 /// Object-safe database adapter for typed database implementations.
 #[derive(Clone, Debug)]
 pub struct Db<T: Database> {
@@ -119,6 +126,13 @@ impl<T: Database> DynDatabase for Db<T> {
             return err;
         }
         error_unavailable(code)
+    }
+}
+
+impl<T: Database + OverrideBlockHashes> OverrideBlockHashes for Db<T> {
+    #[inline]
+    fn insert_block_hash(&mut self, number: &Word, hash: &B256) {
+        self.db.insert_block_hash(number, hash);
     }
 }
 

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -135,7 +135,7 @@ use alloy_eips::eip2718::Typed2718;
 use alloy_primitives::{Address, B256, Bytes, Log, LogData};
 #[cfg(feature = "async")]
 use core::future::Future;
-use core::ptr::NonNull;
+use core::{marker::PhantomData, ptr::NonNull};
 use derive_where::derive_where;
 
 #[cfg(feature = "async")]
@@ -165,7 +165,7 @@ mod db;
 use db::boxed_dyn_database;
 pub use db::{
     AccountStorageCache, Cache, CacheDB, Database, Db, DbResult, DbStats, DbStatsCounts,
-    DynDatabase, EmptyDB, InMemoryDB,
+    DynDatabase, EmptyDB, InMemoryDB, OverrideBlockHashes,
 };
 
 mod tx;
@@ -974,6 +974,48 @@ struct ExecutionGuard {
     was_running: bool,
 }
 
+struct ScopedInspector<'evm, 'host, T: EvmTypesHost> {
+    evm: NonNull<Evm<'host, T>>,
+    previous: Option<Box<dyn Inspector<T> + 'host>>,
+    evm_send: bool,
+    _borrow: PhantomData<&'evm mut Evm<'host, T>>,
+}
+
+impl<'evm, 'host, T: EvmTypes> ScopedInspector<'evm, 'host, T> {
+    fn new<I: Inspector<T>>(evm: &'evm mut Evm<'host, T>, inspector: &'evm mut I) -> Self {
+        evm.assert_inspector_mutable();
+        let previous = evm.inspector.take();
+        let evm_send = evm.evm_send;
+        let inspector = boxed_inspector(inspector);
+        // SAFETY: `ScopedInspector` exclusively borrows the EVM and removes this inspector in its
+        // `Drop` implementation before the shorter inspector borrow can end.
+        let inspector = unsafe {
+            core::mem::transmute::<Box<dyn Inspector<T> + 'evm>, Box<dyn Inspector<T> + 'host>>(
+                inspector,
+            )
+        };
+        evm.inspector = Some(inspector);
+        evm.evm_send = false;
+        Self { evm: NonNull::from(evm), previous, evm_send, _borrow: PhantomData }
+    }
+
+    const fn evm_mut(&mut self) -> &mut Evm<'host, T> {
+        // SAFETY: the guard owns the exclusive borrow represented by `_borrow`.
+        unsafe { self.evm.as_mut() }
+    }
+}
+
+impl<T: EvmTypesHost> Drop for ScopedInspector<'_, '_, T> {
+    fn drop(&mut self) {
+        // SAFETY: the guard owns the exclusive EVM borrow and the scoped inspector is still alive
+        // for the duration of this drop.
+        let evm = unsafe { self.evm.as_mut() };
+        drop(evm.inspector.take());
+        evm.inspector = self.previous.take();
+        evm.evm_send = self.evm_send;
+    }
+}
+
 impl Drop for ExecutionGuard {
     #[inline]
     fn drop(&mut self) {
@@ -1031,6 +1073,16 @@ impl<'a, T: EvmTypes<Tx: Typed2718>> Evm<'a, T> {
                 Err(err)
             }
         }
+    }
+
+    /// Executes a transaction with a scoped borrowed inspector and detaches its state changes.
+    pub fn transact_with_inspector<I: Inspector<T>>(
+        &mut self,
+        tx: &Recovered<T::Tx>,
+        inspector: &mut I,
+    ) -> HandlerResult<TxResultWithState<T>> {
+        let mut scoped = ScopedInspector::new(self, inspector);
+        scoped.evm_mut().transact(tx).map(ExecutedTx::detach)
     }
 
     /// Executes a transaction for its outcome and discards its state changes.
@@ -2929,6 +2981,50 @@ mod tests {
         let tx = test_tx(41);
 
         assert_eq!(evm.transact(&tx).map(|executed| executed.discard().tx_gas_used()), Ok(42));
+    }
+
+    #[test]
+    fn transact_with_borrowed_inspector() {
+        fn handle_inspected_tx(
+            req: TxRequest<'_, '_, BaseEvmTypes, TxLegacy>,
+        ) -> HandlerResult<TxResult> {
+            Host::log(
+                req.host,
+                Log { address: Address::ZERO, data: LogData::new_unchecked(vec![], Bytes::new()) },
+            );
+            handle_test_tx(req)
+        }
+
+        struct BorrowedInspector<'a>(&'a mut usize);
+
+        impl Inspector<BaseEvmTypes> for BorrowedInspector<'_> {
+            fn log(&mut self, _log: &Log, _host: &mut Evm<'_, BaseEvmTypes>) {
+                *self.0 += 1;
+            }
+        }
+
+        let registry = TxRegistry::new().with_handler(
+            TEST_TX_TYPE,
+            TxEnvelope::as_legacy,
+            handle_inspected_tx,
+        );
+        let mut evm = Evm::<BaseEvmTypes>::new(
+            SpecId::OSAKA,
+            BlockEnv::default(),
+            registry,
+            InMemoryDB::default(),
+            Precompiles::base(SpecId::OSAKA),
+        );
+        let mut calls = 0;
+        let mut inspector = BorrowedInspector(&mut calls);
+
+        let result = evm
+            .transact_with_inspector(&test_tx(41), &mut inspector)
+            .expect("transaction succeeds");
+
+        assert_eq!(result.result.tx_gas_used(), 42);
+        assert_eq!(calls, 1);
+        assert!(evm.inspector().is_none());
     }
 
     #[test]

--- a/crates/evm2/src/evm/precompile.rs
+++ b/crates/evm2/src/evm/precompile.rs
@@ -4,7 +4,7 @@ use super::{Evm, NonStaticAny};
 use crate::{
     EvmTypesHost, PrecompileError,
     interpreter::{GasTracker, Message},
-    precompiles::PrecompileId,
+    precompiles::{MovePrecompileError, PrecompileId},
 };
 use alloc::{boxed::Box, vec::Vec};
 use alloy_primitives::{Address, Bytes};
@@ -53,6 +53,10 @@ pub trait PrecompileProvider<T: EvmTypesHost>: NonStaticAny {
     /// Returns whether `address` has a registered precompile.
     fn contains(&self, address: &Address) -> bool;
 
+    /// Moves precompiles from source addresses to destination addresses.
+    fn move_precompiles(&mut self, moves: &[(Address, Address)])
+    -> Result<(), MovePrecompileError>;
+
     /// Executes the precompile at `address`, if one is registered.
     fn execute(
         &mut self,
@@ -99,6 +103,17 @@ impl<T: EvmTypesHost> PrecompileProvider<T> for NoPrecompiles {
     #[inline]
     fn contains(&self, _address: &Address) -> bool {
         false
+    }
+
+    #[inline]
+    fn move_precompiles(
+        &mut self,
+        moves: &[(Address, Address)],
+    ) -> Result<(), MovePrecompileError> {
+        match moves.iter().find(|(source, destination)| source != destination) {
+            Some((source, _)) => Err(MovePrecompileError::NotAPrecompile(*source)),
+            None => Ok(()),
+        }
     }
 
     #[inline]

--- a/crates/evm2/src/evm/registry.rs
+++ b/crates/evm2/src/evm/registry.rs
@@ -63,8 +63,13 @@ pub enum HandlerError {
         got: u64,
     },
     /// Sender cannot pay value plus maximum gas cost.
-    #[error("insufficient funds")]
-    InsufficientFunds,
+    #[error("insufficient funds: required {cost}, balance {balance}")]
+    InsufficientFunds {
+        /// Maximum upfront transaction cost.
+        cost: U256,
+        /// Sender balance.
+        balance: U256,
+    },
     /// Sender account has deployed code.
     #[error("caller has code")]
     RejectCallerWithCode,

--- a/crates/evm2/src/evm/state/pending.rs
+++ b/crates/evm2/src/evm/state/pending.rs
@@ -1,10 +1,13 @@
 //! Owned pending transaction state detached from the EVM.
 
 use super::{
-    Account, AccountChangeRef, AccountInfoRef, StateChangeSink, StateChangeSource, StorageChange,
-    StorageOverlay,
+    Account, AccountChangeRef, AccountInfo, AccountInfoRef, StateChangeSink, StateChangeSource,
+    StorageChange, StorageOverlay,
 };
-use alloy_primitives::map::{AddressMap, AddressSet};
+use alloy_primitives::{
+    Address,
+    map::{AddressMap, AddressSet},
+};
 
 /// A transaction's finalized-but-uncommitted state, moved out of the EVM.
 ///
@@ -38,6 +41,12 @@ pub struct PendingState {
 }
 
 impl PendingState {
+    /// Returns current account information when the account is present in the pending state.
+    #[inline]
+    pub fn account_info(&self, address: &Address) -> Option<&AccountInfo> {
+        self.accounts.get(address).and_then(|account| account.present.as_ref())
+    }
+
     /// Returns whether the transaction loaded no accounts and no storage.
     #[inline]
     pub fn is_empty(&self) -> bool {

--- a/crates/evm2/src/evm/state/stream.rs
+++ b/crates/evm2/src/evm/state/stream.rs
@@ -20,8 +20,9 @@ pub struct AccountInfoRef<'a> {
 }
 
 impl<'a> AccountInfoRef<'a> {
+    /// Borrows account information for a state change.
     #[inline]
-    pub(crate) const fn from_info(info: &'a AccountInfo) -> Self {
+    pub const fn from_info(info: &'a AccountInfo) -> Self {
         Self {
             balance: info.balance,
             nonce: info.nonce,

--- a/crates/evm2/src/precompiles/mod.rs
+++ b/crates/evm2/src/precompiles/mod.rs
@@ -150,6 +150,14 @@ impl<T: EvmTypesHost> PrecompileProvider<T> for Precompiles<T> {
     }
 
     #[inline]
+    fn move_precompiles(
+        &mut self,
+        moves: &[(Address, Address)],
+    ) -> Result<(), MovePrecompileError> {
+        self.as_map_mut().move_precompiles(moves.iter().copied())
+    }
+
+    #[inline]
     fn execute(
         &mut self,
         evm: &mut Evm<'_, T>,

--- a/crates/inspectors/src/tracing/debug.rs
+++ b/crates/inspectors/src/tracing/debug.rs
@@ -12,7 +12,7 @@ use alloy_rpc_types_trace::geth::{
     erc7562::Erc7562Config, mux::MuxConfig,
 };
 use evm2::{
-    ErrorCode, EvmTypes, EvmTypesHost, Inspector, NoopInspector, TxResultWithState,
+    EvmTypes, EvmTypesHost, Inspector, NoopInspector, TxResultWithState,
     env::BlockEnv,
     evm::DynDatabase,
     interpreter::{Interpreter, Message, MessageResult},
@@ -226,13 +226,13 @@ impl DebugInspector {
                 inspector
                     .geth_builder()
                     .geth_prestate_traces(res, config, db)
-                    .map_err(DebugInspectorError::Database)?
+                    .map_err(|code| database_error(db, code))?
                     .into()
             }
             Self::Noop(_) => NoopFrame::default().into(),
             Self::Mux(inspector, _) => inspector
                 .try_into_mux_frame(res, db, tx_info)
-                .map_err(DebugInspectorError::Database)?
+                .map_err(|code| database_error(db, code))?
                 .into(),
             Self::FlatCallTracer(inspector) => {
                 inspector.set_transaction_gas_limit(tx.gas_limit());
@@ -249,7 +249,7 @@ impl DebugInspector {
                 inspector
                     .geth_builder()
                     .geth_erc7562_traces(config.clone(), res.result.tx_gas_used(), db)
-                    .map_err(DebugInspectorError::Database)?
+                    .map_err(|code| database_error(db, code))?
                     .into()
             }
             Self::Default(inspector, config) => {
@@ -370,6 +370,47 @@ pub enum DebugInspectorError {
     #[error(transparent)]
     JsInspector(#[from] crate::tracing::js::JsInspectorError),
     /// Database operation failed
-    #[error("database error {0:?}")]
-    Database(ErrorCode),
+    #[error(transparent)]
+    Database(evm2::AnyError),
+}
+
+fn database_error(db: &mut dyn DynDatabase, code: evm2::ErrorCode) -> DebugInspectorError {
+    DebugInspectorError::Database(db.error(code))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use evm2::{AnyError, ErrorCode, bytecode::Bytecode, evm::DbResult, interpreter::Word};
+
+    struct ErrorDatabase;
+
+    impl DynDatabase for ErrorDatabase {
+        fn get_account(&mut self, _address: &Address) -> DbResult<Option<evm2::AccountInfo>> {
+            unreachable!()
+        }
+
+        fn get_code_by_hash(&mut self, _code_hash: &alloy_primitives::B256) -> DbResult<Bytecode> {
+            unreachable!()
+        }
+
+        fn get_storage(&mut self, _address: &Address, _key: &Word) -> DbResult<Word> {
+            unreachable!()
+        }
+
+        fn get_block_hash(&mut self, _number: &Word) -> DbResult<Option<alloy_primitives::B256>> {
+            unreachable!()
+        }
+
+        fn error(&mut self, _code: ErrorCode) -> AnyError {
+            AnyError::from("sentinel database error")
+        }
+    }
+
+    #[test]
+    fn resolves_database_error_code() {
+        let error = database_error(&mut ErrorDatabase, ErrorCode::new_custom(0).unwrap());
+
+        assert_eq!(error.to_string(), "sentinel database error");
+    }
 }

--- a/crates/inspectors/src/tracing/debug.rs
+++ b/crates/inspectors/src/tracing/debug.rs
@@ -381,6 +381,7 @@ fn database_error(db: &mut dyn DynDatabase, code: evm2::ErrorCode) -> DebugInspe
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::string::ToString;
     use evm2::{AnyError, ErrorCode, bytecode::Bytecode, evm::DbResult, interpreter::Word};
 
     struct ErrorDatabase;


### PR DESCRIPTION
Exposes the existing database, precompile, inspector, and error information needed by generic RPC implementations. This lets Reth preserve its chain-generic RPC boundaries while replacing revm with evm2.