### PR TITLE
ci: use samply for codspeed profiling

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -10,6 +10,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  CODSPEED_WALLTIME_PROFILER: samply
   RUSTC_WRAPPER: "sccache"
   RUSTFLAGS: -Csymbol-mangling-version=v0
 


### PR DESCRIPTION
Configures the CodSpeed wall-time profiler override to use Samply. CodSpeed Action v4.18.5 installs runner v4.18.4, which bundles Samply internally, so the workflow does not need a separate installation step.