### PR TITLE
refactor(env): decouple extension types from EvmTypes

### DIFF
--- a/crates/cli/benches/evm/fixture.rs
+++ b/crates/cli/benches/evm/fixture.rs
@@ -5,7 +5,7 @@ use alloy_primitives::{B256, TxKind, U256};
 use evm2::{
     SpecId, Version,
     bytecode::Bytecode,
-    env::BlockEnv,
+    env::{BlockEnv, BlockEnvExt},
     ethereum::{RecoveredTxEnvelope, TxEnvelope},
     evm::{AccountInfo, InMemoryDB},
 };
@@ -92,7 +92,7 @@ pub(crate) struct Case<'a> {
 impl Case<'_> {
     pub(crate) fn block(&self) -> BlockEnv {
         let env = &self.unit.env;
-        BlockEnv {
+        BlockEnvExt {
             number: env.current_number,
             beneficiary: env.current_coinbase,
             timestamp: env.current_timestamp,
@@ -101,7 +101,7 @@ impl Case<'_> {
             difficulty: env.current_difficulty,
             prevrandao: env.current_random.map_or(U256::ZERO, b256_to_u256),
             slot_num: env.slot_number.unwrap_or_default(),
-            ..BlockEnv::default()
+            ..BlockEnvExt::default()
         }
     }
 

--- a/crates/cli/src/fuzzer/case.rs
+++ b/crates/cli/src/fuzzer/case.rs
@@ -14,7 +14,7 @@ use alloy_eips::{
 use alloy_primitives::{Address, B256, Bytes, TxKind, U256};
 use evm2::{
     SpecId,
-    env::BlockEnv,
+    env::{BlockEnv, BlockEnvExt},
     ethereum::{RecoveredTxEnvelope, TxEnvelope},
     interpreter::op,
 };
@@ -230,13 +230,13 @@ impl CaseBlock {
     }
 
     pub(crate) fn evm2(&self) -> BlockEnv {
-        BlockEnv {
+        BlockEnvExt {
             number: self.number,
             beneficiary: BENEFICIARY,
             timestamp: self.timestamp,
             gas_limit: U256::from(self.gas_limit),
             basefee: U256::from(self.basefee),
-            ..BlockEnv::default()
+            ..BlockEnvExt::default()
         }
     }
 

--- a/crates/cli/src/run.rs
+++ b/crates/cli/src/run.rs
@@ -4,7 +4,7 @@ use clap::ValueEnum;
 use evm2::{
     BaseEvmTypes, Evm, ExecutionConfig, InterpreterRunner, Precompiles, SpecId, Version,
     bytecode::Bytecode,
-    env::BlockEnv,
+    env::{BlockEnv, BlockEnvExt},
     ethereum::{RecoveredTxEnvelope, TxEnvelope, ethereum_tx_registry},
     evm::{AccountInfo, InMemoryDB},
     interpreter::{InstrStop, Interpreter},
@@ -713,7 +713,7 @@ fn parse_bytecode_bench(bench: &Bench, bytecode: &[u8]) -> eyre::Result<Prepared
     Ok((
         bench.name.clone(),
         vec![ParsedAccount { bytecode, code_hash }],
-        BlockEnv::default(),
+        BlockEnvExt::default(),
         db,
         Recovered::new_unchecked(TxEnvelope::Legacy(tx), BENCH_CALLER),
     ))
@@ -750,7 +750,7 @@ fn select_case<'a>(
 }
 
 fn parse_block(env: &evm2_eest::StateTestEnv) -> BlockEnv {
-    BlockEnv {
+    BlockEnvExt {
         number: env.current_number,
         beneficiary: env.current_coinbase,
         timestamp: env.current_timestamp,
@@ -759,7 +759,7 @@ fn parse_block(env: &evm2_eest::StateTestEnv) -> BlockEnv {
         difficulty: env.current_difficulty,
         prevrandao: env.current_random.map_or(U256::ZERO, |value| U256::from_be_bytes(value.0)),
         slot_num: env.slot_number.unwrap_or_default(),
-        ..BlockEnv::default()
+        ..BlockEnvExt::default()
     }
 }
 

--- a/crates/eest/src/blockchaintest/execute.rs
+++ b/crates/eest/src/blockchaintest/execute.rs
@@ -30,7 +30,7 @@ use alloy_rpc_types_eth::AccessList as RpcAccessList;
 use anstyle::{AnsiColor, Color, Style};
 use evm2::{
     BaseEvmTypes, ErrorCode, Evm, Precompiles, SpecId, TxResult,
-    env::BlockEnv,
+    env::{BlockEnv, BlockEnvExt},
     ethereum::{RecoveredTxEnvelope, ethereum_tx_registry},
     evm::{
         AccountChangeRef, AccountInfo as EvmAccountInfo, AccountInfoRef, BEACON_ROOTS_ADDRESS, Bal,
@@ -882,7 +882,7 @@ fn parse_state(
 fn block_env_from_header(header: &BlockHeader, excess_blob_gas: u64, spec: SpecId) -> BlockEnv {
     let excess_blob_gas =
         header.excess_blob_gas.map(|gas| gas.saturating_to::<u64>()).unwrap_or(excess_blob_gas);
-    BlockEnv {
+    BlockEnvExt {
         number: header.number,
         beneficiary: header.coinbase,
         timestamp: header.timestamp,

--- a/crates/eest/src/execute.rs
+++ b/crates/eest/src/execute.rs
@@ -24,7 +24,7 @@ use alloy_trie::{
 use anstyle::{AnsiColor, Color, Style};
 use evm2::{
     BaseEvmTypes, Evm, EvmTypes, Precompiles, SpecId, TxResult,
-    env::BlockEnv,
+    env::{BlockEnv, BlockEnvExt},
     ethereum::{RecoveredTxEnvelope, ethereum_tx_registry},
     evm::{
         AccountInfo as EvmAccountInfo, BEACON_ROOTS_ADDRESS, DbStats, DbStatsCounts,
@@ -540,7 +540,7 @@ fn parse_state(pre: &BTreeMap<Address, AccountInfo>) -> Result<InMemoryDB, TestE
 }
 
 fn parse_block(env: &Env, spec: SpecId) -> BlockEnv {
-    BlockEnv {
+    BlockEnvExt {
         number: env.current_number,
         beneficiary: env.current_coinbase,
         timestamp: env.current_timestamp,

--- a/crates/evm2/examples/bal_build.rs
+++ b/crates/evm2/examples/bal_build.rs
@@ -13,7 +13,7 @@ use alloy_primitives::{Address, Bytes, TxKind, U256};
 use evm2::{
     BaseEvmTypes, Evm, Precompiles, SpecId,
     bytecode::Bytecode,
-    env::BlockEnv,
+    env::BlockEnvExt,
     ethereum::{RecoveredTxEnvelope, TxEnvelope, ethereum_tx_registry},
     evm::{AccountInfo, BlockAccessIndex, InMemoryDB, SystemTx},
     interpreter::op,
@@ -138,7 +138,7 @@ fn block_evm() -> Evm<'static, BaseEvmTypes> {
     let spec = SpecId::AMSTERDAM;
     Evm::new(
         spec,
-        BlockEnv::default(),
+        BlockEnvExt::default(),
         ethereum_tx_registry(spec),
         database,
         Precompiles::base(spec),

--- a/crates/evm2/examples/bal_parallel.rs
+++ b/crates/evm2/examples/bal_parallel.rs
@@ -18,7 +18,7 @@ use alloy_eip7928::BalanceChange;
 use alloy_primitives::{Address, TxKind, U256};
 use evm2::{
     BaseEvmTypes, Evm, Precompiles, SpecId, TxResultWithState,
-    env::BlockEnv,
+    env::BlockEnvExt,
     ethereum::{RecoveredTxEnvelope, TxEnvelope, ethereum_tx_registry},
     evm::{AccountInfo, Bal, BlockAccessIndex, InMemoryDB},
 };
@@ -124,7 +124,7 @@ fn pre_block_evm() -> Evm<'static, BaseEvmTypes> {
     let spec = SpecId::AMSTERDAM;
     Evm::new(
         spec,
-        BlockEnv::default(),
+        BlockEnvExt::default(),
         ethereum_tx_registry(spec),
         database,
         Precompiles::base(spec),

--- a/crates/evm2/examples/custom_evm/main.rs
+++ b/crates/evm2/examples/custom_evm/main.rs
@@ -206,9 +206,9 @@ fn custom_evm_with_database(database: InMemoryDB) -> Evm<'static, CustomTypes> {
     Evm::<CustomTypes>::new_with_execution_config(
         custom_execution_config(),
         CustomSpecId::CustomOsaka,
-        BlockEnv {
+        BlockEnv::<CustomTypes> {
             ext: CustomBlockEnvExt { l1_block_number: CUSTOM_L1_BLOCK_NUMBER },
-            ..BlockEnv::default()
+            ..BlockEnv::<CustomTypes>::default()
         },
         custom_registry(),
         database,
@@ -219,9 +219,9 @@ fn custom_evm_with_database(database: InMemoryDB) -> Evm<'static, CustomTypes> {
 fn mainnet_evm() -> Evm<'static, CustomTypes> {
     Evm::<CustomTypes>::new(
         CustomSpecId::MainnetOsaka,
-        BlockEnv {
+        BlockEnv::<CustomTypes> {
             ext: CustomBlockEnvExt { l1_block_number: MAINNET_L1_BLOCK_NUMBER },
-            ..BlockEnv::default()
+            ..BlockEnv::<CustomTypes>::default()
         },
         custom_registry(),
         InMemoryDB::default(),

--- a/crates/evm2/examples/custom_evm/tx.rs
+++ b/crates/evm2/examples/custom_evm/tx.rs
@@ -7,8 +7,8 @@ use alloy_eips::eip2718::Typed2718;
 use alloy_primitives::{Address, Bytes};
 use evm2::{
     bytecode::Bytecode,
-    env::TxEnv,
-    interpreter::{Host, Message},
+    env::TxEnvExt,
+    interpreter::{Host, MessageExt},
     registry::{HandlerResult, TxRegistry, TxRequest},
 };
 
@@ -52,14 +52,14 @@ pub fn execute_code(
     req: TxRequest<'_, '_, CustomTypes, ExecuteCodeTx>,
 ) -> HandlerResult<evm2::TxResult<CustomTypes>> {
     // The transaction handler owns policy; the interpreter still executes a normal message.
-    let mut message = Message {
+    let mut message = MessageExt {
         gas_limit: req.tx.gas_limit,
         destination: req.tx.target,
         code_address: req.tx.target,
         ext: CustomMessageExt { is_system: false },
-        ..Message::default()
+        ..MessageExt::default()
     };
-    let tx_env = TxEnv { ext: CustomTxEnvExt { label: "execute-code" }, ..TxEnv::default() };
+    let tx_env = TxEnvExt { ext: CustomTxEnvExt { label: "execute-code" }, ..TxEnvExt::default() };
     let mut result =
         req.host.execute_message(&tx_env, Bytecode::new_legacy(req.tx.code.clone()), &mut message);
     result.ext = CustomMessageResultExt { handled_custom_message: true };

--- a/crates/evm2/examples/precompile_subcall.rs
+++ b/crates/evm2/examples/precompile_subcall.rs
@@ -4,9 +4,9 @@ use alloy_primitives::{Address, Bytes, U256};
 use evm2::{
     BaseEvmTypes, Evm, Precompiles, SpecId,
     bytecode::Bytecode,
-    env::{BlockEnv, TxEnv},
+    env::{BlockEnvExt, TxEnvExt},
     evm::{AccountInfo, InMemoryDB, precompile::PrecompileOutput},
-    interpreter::{GasTracker, Host, InstrStop, Message, MessageKind, Word, op},
+    interpreter::{GasTracker, Host, InstrStop, Message, MessageExt, MessageKind, Word, op},
     precompiles::{Precompile, PrecompileError, PrecompileHalt, PrecompileId, PrecompileResult},
     registry::TxRegistry,
 };
@@ -18,15 +18,15 @@ const SUBCALL_TARGET: Address = Address::with_last_byte(0xca);
 fn main() {
     let mut evm = evm_with_custom_precompile();
     let parent_code = Bytecode::new_legacy(parent_code());
-    let mut message = Message {
+    let mut message = MessageExt {
         kind: MessageKind::Call,
         gas_limit: 200_000,
         destination: PARENT,
         code_address: PARENT,
-        ..Message::default()
+        ..MessageExt::default()
     };
 
-    let result = Host::execute_message(&mut evm, &TxEnv::default(), parent_code, &mut message);
+    let result = Host::execute_message(&mut evm, &TxEnvExt::default(), parent_code, &mut message);
     assert_eq!(result.stop, InstrStop::Return);
     assert_eq!(result.output.len(), 32);
 
@@ -54,7 +54,7 @@ fn evm_with_custom_precompile() -> Evm<'static, BaseEvmTypes> {
         staticcall_precompile,
     ));
 
-    Evm::new(SpecId::OSAKA, BlockEnv::default(), TxRegistry::new(), database, precompiles)
+    Evm::new(SpecId::OSAKA, BlockEnvExt::default(), TxRegistry::new(), database, precompiles)
 }
 
 fn staticcall_precompile(
@@ -68,7 +68,7 @@ fn staticcall_precompile(
     let child_gas_limit = gas.remaining().min(50_000);
     gas.spend(child_gas_limit)?;
 
-    let mut child = Message {
+    let mut child = MessageExt {
         kind: MessageKind::StaticCall,
         depth: message.depth.saturating_add(1),
         gas_limit: child_gas_limit,
@@ -80,10 +80,10 @@ fn staticcall_precompile(
         code_address: SUBCALL_TARGET,
         caller_is_static: message.caller_is_static
             || matches!(message.kind, MessageKind::StaticCall),
-        ..Message::default()
+        ..MessageExt::default()
     };
 
-    let result = Host::execute_message(evm, &TxEnv::default(), loaded.code, &mut child);
+    let result = Host::execute_message(evm, &TxEnvExt::default(), loaded.code, &mut child);
     gas.merge_child_gas(result.gas, result.stop);
 
     match result.stop {

--- a/crates/evm2/src/ethereum/eip1559.rs
+++ b/crates/evm2/src/ethereum/eip1559.rs
@@ -8,7 +8,7 @@ use super::{
 };
 use crate::{
     EvmTypes, TxResult,
-    env::TxEnv,
+    env::TxEnvExt,
     evm::error_handler,
     interpreter::Host,
     registry::{HandlerResult, TxRequest},
@@ -67,11 +67,11 @@ pub fn handle<T: EvmTypes>(req: TxRequest<'_, '_, T, TxEip1559>) -> HandlerResul
         initial_state_gas,
         0,
     );
-    let tx_env = TxEnv {
+    let tx_env = TxEnvExt {
         origin: caller,
         gas_price,
         chain_id: U256::from(req.host.version().chain_id),
-        ..TxEnv::default()
+        ..TxEnvExt::default()
     };
     let (bytecode, mut message) = initial_message(
         req.host, caller, tx.nonce, tx.to, &tx.input, tx.value, gas_limit, reservoir,

--- a/crates/evm2/src/ethereum/eip2930.rs
+++ b/crates/evm2/src/ethereum/eip2930.rs
@@ -8,7 +8,7 @@ use super::{
 };
 use crate::{
     EvmTypes, TxResult,
-    env::TxEnv,
+    env::TxEnvExt,
     evm::error_handler,
     interpreter::Host,
     registry::{HandlerResult, TxRequest},
@@ -62,11 +62,11 @@ pub fn handle<T: EvmTypes>(req: TxRequest<'_, '_, T, TxEip2930>) -> HandlerResul
         initial_state_gas,
         0,
     );
-    let tx_env = TxEnv {
+    let tx_env = TxEnvExt {
         origin: caller,
         gas_price,
         chain_id: U256::from(req.host.version().chain_id),
-        ..TxEnv::default()
+        ..TxEnvExt::default()
     };
     let (bytecode, mut message) = initial_message(
         req.host, caller, tx.nonce, tx.to, &tx.input, tx.value, gas_limit, reservoir,

--- a/crates/evm2/src/ethereum/eip4844.rs
+++ b/crates/evm2/src/ethereum/eip4844.rs
@@ -8,7 +8,7 @@ use super::{
 };
 use crate::{
     EvmTypes, TxResult,
-    env::TxEnv,
+    env::TxEnvExt,
     evm::error_handler,
     interpreter::Host,
     registry::{HandlerError, HandlerResult, TxRequest},
@@ -83,7 +83,7 @@ pub fn handle<T: EvmTypes>(
         initial_state_gas,
         0,
     );
-    let tx_env = TxEnv {
+    let tx_env = TxEnvExt {
         origin: caller,
         gas_price,
         chain_id: U256::from(req.host.version().chain_id),

--- a/crates/evm2/src/ethereum/eip7702.rs
+++ b/crates/evm2/src/ethereum/eip7702.rs
@@ -8,7 +8,7 @@ use super::{
 };
 use crate::{
     Evm, EvmFeatures, EvmTypes, TxResult,
-    env::TxEnv,
+    env::TxEnvExt,
     evm::error_handler,
     interpreter::Host,
     registry::{HandlerError, HandlerResult, TxRequest},
@@ -78,11 +78,11 @@ pub fn handle<T: EvmTypes>(
         initial_state_gas,
         state_refund,
     );
-    let tx_env = TxEnv {
+    let tx_env = TxEnvExt {
         origin: caller,
         gas_price,
         chain_id: U256::from(req.host.version().chain_id),
-        ..TxEnv::default()
+        ..TxEnvExt::default()
     };
     let (bytecode, mut message) = initial_message(
         req.host,

--- a/crates/evm2/src/ethereum/legacy.rs
+++ b/crates/evm2/src/ethereum/legacy.rs
@@ -7,7 +7,7 @@ use super::{
 };
 use crate::{
     EvmTypes, TxResult,
-    env::TxEnv,
+    env::TxEnvExt,
     evm::error_handler,
     interpreter::Host,
     registry::{HandlerResult, TxRequest},
@@ -50,11 +50,11 @@ pub fn handle<T: EvmTypes>(req: TxRequest<'_, '_, T, TxLegacy>) -> HandlerResult
         initial_state_gas,
         0,
     );
-    let tx_env = TxEnv {
+    let tx_env = TxEnvExt {
         origin: caller,
         gas_price,
         chain_id: U256::from(req.host.version().chain_id),
-        ..TxEnv::default()
+        ..TxEnvExt::default()
     };
     let (bytecode, mut message) = initial_message(
         req.host, caller, tx.nonce, tx.to, &tx.input, tx.value, gas_limit, reservoir,

--- a/crates/evm2/src/ethereum/mod.rs
+++ b/crates/evm2/src/ethereum/mod.rs
@@ -15,11 +15,11 @@ pub mod legacy;
 pub use lazy_eip7702::{LazyAuthorization, LazyTxEip7702};
 
 use crate::{
-    Evm, EvmFeatures, EvmTypes, EvmTypesHost, SpecId, TxResult, Version,
+    Evm, EvmFeatures, EvmTypes, SpecId, TxResult, TxResultExt, Version,
     bytecode::Bytecode,
     evm::{AccountInfo, StateCheckpoint, error_handler},
     interpreter::{
-        Message, MessageKind, MessageResult, Word,
+        Message, MessageExt, MessageKind, MessageResult, MessageResultExt, Word,
         gas::{EIP2780_TX_BASE_COST, EIP8038_COLD_ACCOUNT_ACCESS},
     },
     registry::{HandlerError, HandlerResult, TxRegistry},
@@ -516,7 +516,7 @@ pub fn initial_message<'a, T: EvmTypes>(
     let r = match to {
         TxKind::Call(to) => {
             let initial_code = initial_call_code(host, to)?;
-            let message = Message {
+            let message = MessageExt {
                 kind: MessageKind::Call,
                 depth: 0,
                 gas_limit,
@@ -536,7 +536,7 @@ pub fn initial_message<'a, T: EvmTypes>(
         }
         TxKind::Create => {
             let address = caller.create(nonce);
-            let message = Message {
+            let message = MessageExt {
                 kind: MessageKind::Create,
                 depth: 0,
                 gas_limit,
@@ -615,10 +615,7 @@ pub fn rollback_failed_execution<'a, T: EvmTypes>(
 /// never actually consumed) or when it succeeded at a pre-existing alive (balance-only) target (no
 /// new leaf was created — execution-specs `created_target_alive`). No-op when `create_state_gas` is
 /// zero (non-create or pre-Amsterdam).
-pub const fn refund_create_state_gas<T: EvmTypesHost>(
-    result: &mut MessageResult<T>,
-    create_state_gas: u64,
-) {
+pub const fn refund_create_state_gas<E>(result: &mut MessageResultExt<E>, create_state_gas: u64) {
     if create_state_gas != 0 && (!result.stop.is_success() || result.created_target_was_alive) {
         let reservoir = result.gas.reservoir().saturating_add(create_state_gas);
         result.gas.set_reservoir(reservoir);
@@ -696,7 +693,7 @@ pub fn settle_gas<'a, T: EvmTypes>(
             .map_err(error_handler!(host))?
             .add_balance(beneficiary_reward);
     }
-    Ok(TxResult {
+    Ok(TxResultExt {
         status: result.stop.is_success(),
         total_gas_spent,
         state_gas_spent,
@@ -706,12 +703,12 @@ pub fn settle_gas<'a, T: EvmTypes>(
         output: result.output,
         created_address: result.created_address,
         ext: T::TxResultExt::default(),
-        ..TxResult::default()
+        ..TxResultExt::default()
     })
 }
 
-const fn final_tx_gas<T: EvmTypesHost>(
-    result: &MessageResult<T>,
+const fn final_tx_gas<E>(
+    result: &MessageResultExt<E>,
     tx_gas_limit: u64,
     max_refund_quotient: u64,
     floor_gas: u64,
@@ -838,7 +835,7 @@ mod tests {
     use super::*;
     use crate::{
         BaseEvmTypes, ExecutionConfig, Precompiles,
-        env::{BlockEnv, TxEnv},
+        env::{BlockEnvExt, TxEnvExt},
         evm::InMemoryDB,
         interpreter::{GasTracker, Host, InstrStop, op},
         registry::TxRegistry,
@@ -936,7 +933,7 @@ mod tests {
         );
         let mut evm = Evm::<BaseEvmTypes>::new(
             SpecId::BERLIN,
-            BlockEnv::default(),
+            BlockEnvExt::default(),
             ethereum_tx_registry(SpecId::BERLIN),
             database,
             Precompiles::base(SpecId::BERLIN),
@@ -1030,7 +1027,7 @@ mod tests {
         let mut evm = Evm::<BaseEvmTypes>::new_with_execution_config(
             ExecutionConfig::for_spec_and_version(SpecId::OSAKA, version),
             SpecId::OSAKA,
-            BlockEnv::default(),
+            BlockEnvExt::default(),
             TxRegistry::new(),
             InMemoryDB::default(),
             Precompiles::base(SpecId::OSAKA),
@@ -1058,7 +1055,7 @@ mod tests {
         let mut evm = Evm::<BaseEvmTypes>::new_with_execution_config(
             ExecutionConfig::for_spec_and_version(SpecId::OSAKA, version),
             SpecId::OSAKA,
-            BlockEnv::default(),
+            BlockEnvExt::default(),
             TxRegistry::new(),
             database,
             Precompiles::base(SpecId::OSAKA),
@@ -1120,7 +1117,7 @@ mod tests {
         database.insert_account_info(&delegated, AccountInfo::default().with_code(delegated_code));
         let mut evm = Evm::<BaseEvmTypes>::new(
             SpecId::PRAGUE,
-            BlockEnv::default(),
+            BlockEnvExt::default(),
             TxRegistry::new(),
             database,
             Precompiles::base(SpecId::PRAGUE),
@@ -1141,7 +1138,7 @@ mod tests {
         assert_eq!(message.code_address, delegated);
         assert!(message.disable_precompiles);
 
-        let result = Host::execute_message(&mut evm, &TxEnv::default(), bytecode, &mut message);
+        let result = Host::execute_message(&mut evm, &TxEnvExt::default(), bytecode, &mut message);
 
         assert_eq!(result.stop, InstrStop::Return);
         assert_eq!(result.output.len(), 32);

--- a/crates/evm2/src/evm/async.rs
+++ b/crates/evm2/src/evm/async.rs
@@ -544,9 +544,9 @@ impl<D: AsyncDatabase + fmt::Debug> fmt::Debug for AsyncDb<D> {
 mod tests {
     use super::{AsyncDatabase, AsyncDb, AsyncError, block_on_current, on_fiber};
     use crate::{
-        BaseEvmTypes, Evm, PrecompileError, Precompiles, SpecId, TxResult,
+        BaseEvmTypes, Evm, PrecompileError, Precompiles, SpecId, TxResult, TxResultExt,
         bytecode::Bytecode,
-        env::BlockEnv,
+        env::BlockEnvExt,
         evm::{Database, Db, DynDatabase, InMemoryDB, PrecompileProvider, SystemTx},
         interpreter::{GasTracker, Message, Word, op},
         precompile::PrecompileOutput,
@@ -683,7 +683,7 @@ mod tests {
         );
         let mut evm = Evm::<BaseEvmTypes>::new(
             SpecId::OSAKA,
-            BlockEnv::default(),
+            BlockEnvExt::default(),
             registry,
             InMemoryDB::default(),
             Precompiles::base(SpecId::OSAKA),
@@ -704,7 +704,7 @@ mod tests {
         );
         let mut evm = Evm::<BaseEvmTypes>::new(
             SpecId::OSAKA,
-            BlockEnv::default(),
+            BlockEnvExt::default(),
             registry,
             InMemoryDB::default(),
             Precompiles::base(SpecId::OSAKA),
@@ -726,7 +726,7 @@ mod tests {
         );
         let mut evm = Evm::<BaseEvmTypes>::new(
             SpecId::OSAKA,
-            BlockEnv::default(),
+            BlockEnvExt::default(),
             registry,
             InMemoryDB::default(),
             Precompiles::base(SpecId::OSAKA),
@@ -745,7 +745,7 @@ mod tests {
     fn transaction_async_send_panics_with_non_send_erased_fields() {
         let mut evm = Evm::<BaseEvmTypes>::new(
             SpecId::OSAKA,
-            BlockEnv::default(),
+            BlockEnvExt::default(),
             TxRegistry::new(),
             InMemoryDB::default(),
             Precompiles::base(SpecId::OSAKA),
@@ -766,7 +766,7 @@ mod tests {
         );
         let mut evm = Evm::<BaseEvmTypes>::new(
             SpecId::OSAKA,
-            BlockEnv::default(),
+            BlockEnvExt::default(),
             registry,
             InMemoryDB::default(),
             Precompiles::base(SpecId::OSAKA),
@@ -790,7 +790,7 @@ mod tests {
         let precompiles = NonSendPrecompiles { marker: Rc::clone(&marker) };
         let mut evm = Evm::<BaseEvmTypes>::new(
             SpecId::OSAKA,
-            BlockEnv::default(),
+            BlockEnvExt::default(),
             registry,
             database,
             precompiles,
@@ -810,7 +810,7 @@ mod tests {
         let precompiles = NonSendPrecompiles { marker: Rc::clone(&marker) };
         let mut evm = Evm::<BaseEvmTypes>::new(
             SpecId::OSAKA,
-            BlockEnv::default(),
+            BlockEnvExt::default(),
             TxRegistry::new(),
             database,
             precompiles,
@@ -829,7 +829,7 @@ mod tests {
     fn transaction_async_flattens_handler_error() {
         let mut evm = Evm::<BaseEvmTypes>::new(
             SpecId::OSAKA,
-            BlockEnv::default(),
+            BlockEnvExt::default(),
             TxRegistry::new(),
             InMemoryDB::default(),
             Precompiles::base(SpecId::OSAKA),
@@ -866,7 +866,7 @@ mod tests {
         let contract = Address::from([0x42; 20]);
         let mut evm = Evm::<BaseEvmTypes>::new(
             SpecId::OSAKA,
-            BlockEnv::default(),
+            BlockEnvExt::default(),
             TxRegistry::new(),
             InMemoryDB::default(),
             Precompiles::base(SpecId::OSAKA),
@@ -885,7 +885,7 @@ mod tests {
         let contract = Address::from([0x42; 20]);
         let mut evm = Evm::<BaseEvmTypes>::new(
             SpecId::OSAKA,
-            BlockEnv::default(),
+            BlockEnvExt::default(),
             TxRegistry::new(),
             InMemoryDB::default(),
             Precompiles::base(SpecId::OSAKA),
@@ -907,7 +907,7 @@ mod tests {
         let contract = Address::from([0x42; 20]);
         let mut evm = Evm::<BaseEvmTypes>::new(
             SpecId::OSAKA,
-            BlockEnv::default(),
+            BlockEnvExt::default(),
             crate::ethereum::ethereum_tx_registry(SpecId::OSAKA),
             Db::new(FailOnceAccountDb { fail_next_account: true }),
             Precompiles::base(SpecId::OSAKA),
@@ -938,7 +938,7 @@ mod tests {
         let code = Bytecode::new_legacy(Bytes::from_static(&[op::PUSH1, 0, op::SLOAD, op::STOP]));
         let mut evm = Evm::<BaseEvmTypes>::new(
             SpecId::OSAKA,
-            BlockEnv::default(),
+            BlockEnvExt::default(),
             crate::ethereum::ethereum_tx_registry(SpecId::OSAKA),
             AsyncDb::new(CancellingDb { contract, code }),
             Precompiles::base(SpecId::OSAKA),
@@ -991,7 +991,11 @@ mod tests {
 
     fn handle_test_tx(req: TxRequest<'_, '_, BaseEvmTypes, TxLegacy>) -> HandlerResult<TxResult> {
         let _ = req.host.spec_id();
-        Ok(TxResult { status: true, total_gas_spent: req.tx.nonce + 1, ..TxResult::default() })
+        Ok(TxResultExt {
+            status: true,
+            total_gas_spent: req.tx.nonce + 1,
+            ..TxResultExt::default()
+        })
     }
 
     fn poll_ready<F: Future>(future: F) -> F::Output {

--- a/crates/evm2/src/evm/env.rs
+++ b/crates/evm2/src/evm/env.rs
@@ -3,11 +3,13 @@
 use crate::{BaseEvmTypes, EvmTypesHost};
 use alloc::{vec, vec::Vec};
 use alloy_primitives::{Address, U256};
-use derive_where::derive_where;
 
-/// Transaction-global environment values visible to opcodes.
-#[derive_where(Clone, Debug, PartialEq, Eq; T::TxEnvExt)]
-pub struct TxEnv<T: EvmTypesHost = BaseEvmTypes> {
+/// Transaction-global environment values visible to opcodes for an EVM type family.
+pub type TxEnv<T = BaseEvmTypes> = TxEnvExt<<T as EvmTypesHost>::TxEnvExt>;
+
+/// Transaction-global environment values visible to opcodes, parameterized by extension data.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TxEnvExt<E = ()> {
     /// Transaction origin.
     pub origin: Address,
     /// Effective gas price.
@@ -17,12 +19,12 @@ pub struct TxEnv<T: EvmTypesHost = BaseEvmTypes> {
     /// Transaction blob versioned hashes.
     pub blob_hashes: Vec<U256>,
     /// EVM type-specific extension data.
-    pub ext: T::TxEnvExt,
+    pub ext: E,
     #[doc(hidden)] // Not public API. Please use an existing constructor.
     pub _non_exhaustive: (),
 }
 
-impl<T: EvmTypesHost> Default for TxEnv<T> {
+impl<E: Default> Default for TxEnvExt<E> {
     #[inline]
     fn default() -> Self {
         Self {
@@ -30,15 +32,18 @@ impl<T: EvmTypesHost> Default for TxEnv<T> {
             gas_price: U256::ZERO,
             chain_id: U256::ONE,
             blob_hashes: vec![],
-            ext: T::TxEnvExt::default(),
+            ext: E::default(),
             _non_exhaustive: (),
         }
     }
 }
 
-/// Block environment values visible to opcodes.
-#[derive_where(Clone, Copy, Debug, PartialEq, Eq; T::BlockEnvExt)]
-pub struct BlockEnv<T: EvmTypesHost = BaseEvmTypes> {
+/// Block environment values visible to opcodes for an EVM type family.
+pub type BlockEnv<T = BaseEvmTypes> = BlockEnvExt<<T as EvmTypesHost>::BlockEnvExt>;
+
+/// Block environment values visible to opcodes, parameterized by extension data.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct BlockEnvExt<E = ()> {
     /// Block number.
     pub number: U256,
     /// Block beneficiary.
@@ -58,12 +63,12 @@ pub struct BlockEnv<T: EvmTypesHost = BaseEvmTypes> {
     /// Beacon slot number.
     pub slot_num: U256,
     /// EVM type-specific extension data.
-    pub ext: T::BlockEnvExt,
+    pub ext: E,
     #[doc(hidden)] // Not public API. Please use an existing constructor.
     pub _non_exhaustive: (),
 }
 
-impl<T: EvmTypesHost> Default for BlockEnv<T> {
+impl<E: Default> Default for BlockEnvExt<E> {
     #[inline]
     fn default() -> Self {
         Self {
@@ -76,7 +81,7 @@ impl<T: EvmTypesHost> Default for BlockEnv<T> {
             prevrandao: U256::ZERO,
             blob_basefee: U256::ONE,
             slot_num: U256::ZERO,
-            ext: T::BlockEnvExt::default(),
+            ext: E::default(),
             _non_exhaustive: (),
         }
     }

--- a/crates/evm2/src/evm/inspector.rs
+++ b/crates/evm2/src/evm/inspector.rs
@@ -147,10 +147,13 @@ mod tests {
         SpecId,
         bytecode::Bytecode,
         constants::CALL_DEPTH_LIMIT,
-        env::{BlockEnv, TxEnv},
+        env::{BlockEnvExt, TxEnvExt},
         ethereum::{TxEnvelope, ethereum_tx_registry},
         evm::{AccountInfo, InMemoryDB, SYSTEM_ADDRESS},
-        interpreter::{GasTracker, Host, InstrStop, Interpreter, Message, MessageResult, Word, op},
+        interpreter::{
+            GasTracker, Host, InstrStop, Interpreter, Message, MessageExt, MessageResult,
+            MessageResultExt, Word, op,
+        },
         registry::TxRegistry,
         test_utils::{TestHost, TestTypes, legacy_bytecode, push, push_all},
         utils::address_to_word,
@@ -272,7 +275,7 @@ mod tests {
             message: &mut Message<BaseEvmTypes>,
         ) -> Option<MessageResult<BaseEvmTypes>> {
             self.create_depth = Some(message.depth);
-            Some(MessageResult {
+            Some(MessageResultExt {
                 stop: InstrStop::Return,
                 gas: GasTracker::new(message.gas_limit),
                 created_address: Some(self.created),
@@ -370,13 +373,13 @@ mod tests {
     ) -> (MessageResult<BaseEvmTypes>, Box<I>, Evm<'static, BaseEvmTypes>) {
         let mut evm = Evm::<BaseEvmTypes>::new(
             SpecId::OSAKA,
-            BlockEnv::default(),
+            BlockEnvExt::default(),
             TxRegistry::new(),
             db,
             Precompiles::base(SpecId::OSAKA),
         );
         evm.set_inspector(inspector);
-        let tx_env = TxEnv::default();
+        let tx_env = TxEnvExt::default();
         let bytecode = legacy_bytecode(code);
         let mut message = message.clone();
         message.gas_limit = gas_limit;
@@ -433,7 +436,7 @@ mod tests {
 
         let (result, inspector, _) = run_evm_with_inspector(
             Vec::from([op::STOP]),
-            &Message::default(),
+            &MessageExt::default(),
             10_000,
             StepInspector::default(),
         );
@@ -469,7 +472,7 @@ mod tests {
 
         let (result, inspector, _) = run_evm_with_inspector(
             Vec::from([op::PUSH1, 1, op::PUSH1, 2, op::ADD, op::STOP]),
-            &Message::default(),
+            &MessageExt::default(),
             10_000,
             StopOnStepInspector { opcode: op::ADD, ..Default::default() },
         );
@@ -508,7 +511,7 @@ mod tests {
 
         let (result, inspector, _) = run_evm_with_inspector(
             Vec::from([op::PUSH1, 1, op::PUSH1, 2, op::ADD, op::STOP]),
-            &Message::default(),
+            &MessageExt::default(),
             10_000,
             StopOnStepEndInspector { opcode: op::PUSH1, ..Default::default() },
         );
@@ -527,7 +530,7 @@ mod tests {
 
         let (result, inspector, _) = run_evm_with_inspector(
             code,
-            &Message { depth: CALL_DEPTH_LIMIT, ..Default::default() },
+            &MessageExt { depth: CALL_DEPTH_LIMIT, ..Default::default() },
             50_000,
             HookInspector::default(),
         );
@@ -541,7 +544,7 @@ mod tests {
     fn call_inspector_override_skips_execution_and_still_calls_end() {
         let target = Address::from([0x22; 20]);
         let inspector = OverrideCallInspector {
-            result: MessageResult {
+            result: MessageResultExt {
                 stop: InstrStop::Return,
                 output: Bytes::from_static(&[0xaa, 0xbb, 0xcc]),
                 ..Default::default()
@@ -555,7 +558,7 @@ mod tests {
         return_top_word(&mut code);
 
         let (result, inspector, _) =
-            run_evm_with_inspector(code, &Message::default(), 50_000, inspector);
+            run_evm_with_inspector(code, &MessageExt::default(), 50_000, inspector);
 
         assert_matches!(result.stop, InstrStop::Return);
         // The override output is observed by the parent frame's RETURNDATASIZE.
@@ -568,7 +571,7 @@ mod tests {
     fn call_inspector_override_wins_at_max_depth() {
         let target = Address::from([0x22; 20]);
         let inspector = OverrideCallInspector {
-            result: MessageResult { stop: InstrStop::Return, ..Default::default() },
+            result: MessageResultExt { stop: InstrStop::Return, ..Default::default() },
             min_depth: CALL_DEPTH_LIMIT + 1,
             call_depth: None,
             call_end_stop: None,
@@ -579,7 +582,7 @@ mod tests {
 
         let (result, inspector, _) = run_evm_with_inspector(
             code,
-            &Message { depth: CALL_DEPTH_LIMIT, ..Default::default() },
+            &MessageExt { depth: CALL_DEPTH_LIMIT, ..Default::default() },
             50_000,
             inspector,
         );
@@ -635,15 +638,15 @@ mod tests {
 
         let mut evm = Evm::<BaseEvmTypes>::new(
             SpecId::OSAKA,
-            BlockEnv::default(),
+            BlockEnvExt::default(),
             TxRegistry::new(),
             db,
             Precompiles::base(SpecId::OSAKA),
         );
         evm.set_inspector(MutateCallInspector { destination: replacement });
-        let tx_env = TxEnv::default();
+        let tx_env = TxEnvExt::default();
         let bytecode = legacy_bytecode(code);
-        let mut message = Message { gas_limit: 100_000, ..Default::default() };
+        let mut message = MessageExt { gas_limit: 100_000, ..Default::default() };
         let result = Host::execute_message(&mut evm, &tx_env, bytecode, &mut message);
 
         assert_matches!(result.stop, InstrStop::Stop);
@@ -671,7 +674,7 @@ mod tests {
                 if message.depth == 0 {
                     return None;
                 }
-                Some(MessageResult {
+                Some(MessageResultExt {
                     stop: InstrStop::Revert,
                     gas: GasTracker::new(message.gas_limit),
                     ..Default::default()
@@ -697,7 +700,7 @@ mod tests {
         return_top_word(&mut code);
 
         let (result, _, _) =
-            run_evm_with_inspector(code, &Message::default(), 50_000, CallEndInspector);
+            run_evm_with_inspector(code, &MessageExt::default(), 50_000, CallEndInspector);
 
         assert_matches!(result.stop, InstrStop::Return);
         // `call_end` upgraded the override from a revert to a 2-byte return.
@@ -711,7 +714,7 @@ mod tests {
 
         let (result, inspector, _) = run_evm_with_inspector(
             code,
-            &Message { depth: CALL_DEPTH_LIMIT, ..Default::default() },
+            &MessageExt { depth: CALL_DEPTH_LIMIT, ..Default::default() },
             50_000,
             HookInspector::default(),
         );
@@ -731,7 +734,7 @@ mod tests {
         return_top_word(&mut code);
 
         let (result, inspector, _) =
-            run_evm_with_inspector(code, &Message::default(), 50_000, inspector);
+            run_evm_with_inspector(code, &MessageExt::default(), 50_000, inspector);
 
         assert_matches!(result.stop, InstrStop::Return);
         assert_eq!(Word::from_be_slice(&result.output), address_to_word(&created));
@@ -748,7 +751,7 @@ mod tests {
 
         let (result, inspector, _) = run_evm_with_inspector(
             code,
-            &Message { destination: contract, ..Default::default() },
+            &MessageExt { destination: contract, ..Default::default() },
             50_000,
             HookInspector::default(),
         );
@@ -768,7 +771,7 @@ mod tests {
 
         let (result, inspector, _) = run_evm_with_inspector(
             code,
-            &Message { depth: CALL_DEPTH_LIMIT, ..Default::default() },
+            &MessageExt { depth: CALL_DEPTH_LIMIT, ..Default::default() },
             50_000,
             inspector,
         );
@@ -791,7 +794,7 @@ mod tests {
                 _interp: &mut Interpreter<'_, '_, BaseEvmTypes>,
                 message: &mut Message<BaseEvmTypes>,
             ) -> Option<MessageResult<BaseEvmTypes>> {
-                Some(MessageResult {
+                Some(MessageResultExt {
                     stop: InstrStop::Revert,
                     gas: GasTracker::new(message.gas_limit),
                     ..Default::default()
@@ -816,7 +819,7 @@ mod tests {
 
         let (result, _, _) = run_evm_with_inspector(
             code,
-            &Message::default(),
+            &MessageExt::default(),
             50_000,
             CreateEndInspector { created },
         );
@@ -832,7 +835,7 @@ mod tests {
 
         let (result, inspector, evm) = run_evm_with_inspector(
             code,
-            &Message { destination: contract, ..Default::default() },
+            &MessageExt { destination: contract, ..Default::default() },
             10_000,
             LogInspector::default(),
         );
@@ -848,7 +851,7 @@ mod tests {
         let code = Vec::from([op::PUSH1, 0, op::PUSH1, 0, op::LOG0, op::STOP]);
 
         let (result, inspector, evm) =
-            run_evm_with_inspector(code, &Message::default(), 6, LogInspector::default());
+            run_evm_with_inspector(code, &MessageExt::default(), 6, LogInspector::default());
 
         assert_eq!(result.stop, InstrStop::OutOfGas);
         assert!(inspector.logs.is_empty());
@@ -876,7 +879,7 @@ mod tests {
 
         let (result, inspector, _) = run_evm_with_inspector(
             Vec::from([op::INVALID]),
-            &Message::default(),
+            &MessageExt::default(),
             10_000,
             FailingStepInspector::default(),
         );
@@ -900,7 +903,7 @@ mod tests {
         let (result, inspector, _) = run_evm_with_inspector_db(
             db,
             code,
-            &Message { destination: contract, ..Default::default() },
+            &MessageExt { destination: contract, ..Default::default() },
             50_000,
             SelfdestructInspector::default(),
         );
@@ -922,7 +925,7 @@ mod tests {
         let (result, inspector, _) = run_evm_with_inspector_db(
             db,
             code,
-            &Message { destination: contract, ..Default::default() },
+            &MessageExt { destination: contract, ..Default::default() },
             7_000,
             SelfdestructInspector::default(),
         );
@@ -944,7 +947,7 @@ mod tests {
         push(&mut code, address_to_word(&target));
         code.push(op::SELFDESTRUCT);
 
-        let tx_env = TxEnv::default();
+        let tx_env = TxEnvExt::default();
         let bytecode = legacy_bytecode(code);
         let message = Message::<TestTypes> { gas_limit: 10_000, ..Default::default() };
         let mut interp = Interpreter::<TestTypes>::new(bytecode, &tx_env, &message);
@@ -975,7 +978,7 @@ mod tests {
         database.insert_account_info(&contract, AccountInfo::default().with_code(code));
         let mut evm = Evm::<BaseEvmTypes>::new(
             SpecId::OSAKA,
-            BlockEnv::default(),
+            BlockEnvExt::default(),
             ethereum_tx_registry(SpecId::OSAKA),
             database,
             Precompiles::base(SpecId::OSAKA),
@@ -1015,7 +1018,7 @@ mod tests {
         );
         let mut evm = Evm::<BaseEvmTypes>::new(
             SpecId::AMSTERDAM,
-            BlockEnv::default(),
+            BlockEnvExt::default(),
             ethereum_tx_registry(SpecId::AMSTERDAM),
             database,
             Precompiles::base(SpecId::AMSTERDAM),
@@ -1051,7 +1054,7 @@ mod tests {
         );
         let mut evm = Evm::<BaseEvmTypes>::new(
             SpecId::OSAKA,
-            BlockEnv::default(),
+            BlockEnvExt::default(),
             ethereum_tx_registry(SpecId::OSAKA),
             database,
             Precompiles::base(SpecId::OSAKA),

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -123,7 +123,7 @@ use crate::{
     error::error_unavailable,
     interpreter::{
         Gas, GasTracker, Host, InstrStop, Interpreter, InterpreterPool, Message, MessageKind,
-        MessageResult, Word, gas::EIP8038_COLD_ACCOUNT_ACCESS,
+        MessageResult, MessageResultExt, Word, gas::EIP8038_COLD_ACCOUNT_ACCESS,
     },
     registry::{HandlerError, HandlerResult, TxRegistry},
     trustme,
@@ -169,7 +169,7 @@ pub use db::{
 };
 
 mod tx;
-pub use tx::{ExecutedTx, TxResult, TxResultWithState};
+pub use tx::{ExecutedTx, TxResult, TxResultExt, TxResultWithState};
 
 mod state;
 pub use state::{
@@ -1359,7 +1359,7 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
         if stop.is_success() {
             if let Err(stop) = self.validate_create_output(&mut gas, &mut output) {
                 self.state.rollback(checkpoint, self.features);
-                return MessageResult {
+                return MessageResultExt {
                     stop,
                     gas: *gas.tracker(),
                     output,
@@ -1383,7 +1383,7 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
             self.state.rollback(checkpoint, self.features);
         }
 
-        MessageResult {
+        MessageResultExt {
             stop,
             gas: *gas.tracker(),
             output,
@@ -1597,7 +1597,7 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
         if !stop.is_success() {
             self.state.rollback(checkpoint, self.features);
         }
-        MessageResult {
+        MessageResultExt {
             stop,
             gas,
             output,
@@ -1621,7 +1621,7 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
             self.state.rollback(checkpoint, self.features);
         }
 
-        MessageResult {
+        MessageResultExt {
             stop,
             gas: *child_gas.tracker(),
             output,
@@ -1638,10 +1638,10 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
         gas_remaining: u64,
         reservoir: u64,
     ) -> MessageResult<T> {
-        MessageResult {
+        MessageResultExt {
             stop,
             gas: GasTracker::new_with_regular_gas_and_reservoir(gas_remaining, reservoir),
-            ..MessageResult::default()
+            ..MessageResultExt::default()
         }
     }
 
@@ -2035,9 +2035,9 @@ mod tests {
     use crate::{
         BaseEvmConfigSelector, BaseEvmTypes, NoopInspector, Precompiles, SpecId, Version,
         bytecode::Bytecode,
-        env::TxEnv,
+        env::{BlockEnvExt, TxEnvExt},
         ethereum::{RecoveredTxEnvelope, TxEnvelope, ethereum_tx_registry},
-        interpreter::{GasTracker, Interpreter, MessageKind, op},
+        interpreter::{GasTracker, Interpreter, Message, MessageExt, MessageKind, op},
         precompiles::{Precompile, PrecompileError, PrecompileId, PrecompileMap},
         registry::{HandlerError, TxRequest},
         test_utils::{legacy_bytecode, push_address},
@@ -2075,7 +2075,7 @@ mod tests {
     fn stores_typed_evm_extension_state() {
         let mut evm = Evm::<ExtensionTestTypes>::new_with_ext(
             SpecId::OSAKA,
-            BlockEnv::default(),
+            BlockEnvExt::default(),
             TxRegistry::new(),
             InMemoryDB::default(),
             precompile::NoPrecompiles::default(),
@@ -2096,7 +2096,11 @@ mod tests {
 
     fn handle_test_tx(req: TxRequest<'_, '_, BaseEvmTypes, TxLegacy>) -> HandlerResult<TxResult> {
         let _ = req.host.spec_id();
-        Ok(TxResult { status: true, total_gas_spent: req.tx.nonce + 1, ..TxResult::default() })
+        Ok(TxResultExt {
+            status: true,
+            total_gas_spent: req.tx.nonce + 1,
+            ..TxResultExt::default()
+        })
     }
 
     #[derive(Debug)]
@@ -2121,14 +2125,14 @@ mod tests {
         let calls = Arc::new(AtomicUsize::new(0));
         let mut evm = Evm::<BaseEvmTypes>::new(
             SpecId::OSAKA,
-            BlockEnv::default(),
+            BlockEnvExt::default(),
             TxRegistry::new(),
             InMemoryDB::default(),
             Precompiles::base(SpecId::OSAKA),
         );
         evm.set_interpreter_runner(TestInterpreterRunner { stop, calls: Arc::clone(&calls) });
-        let tx_env = TxEnv::default();
-        let message = Message { gas_limit: 30_000, ..Default::default() };
+        let tx_env = TxEnvExt::default();
+        let message = MessageExt { gas_limit: 30_000, ..Default::default() };
 
         let frame_gas =
             GasTracker::new_with_regular_gas_and_reservoir(message.gas_limit, message.reservoir);
@@ -2160,7 +2164,7 @@ mod tests {
             address: LIFECYCLE_ACCOUNT,
             data: LogData::new_unchecked(vec![], Bytes::new()),
         });
-        Ok(TxResult { status: true, total_gas_spent: req.tx.nonce, ..TxResult::default() })
+        Ok(TxResultExt { status: true, total_gas_spent: req.tx.nonce, ..TxResultExt::default() })
     }
 
     fn empty_precompiles() -> Precompiles<BaseEvmTypes> {
@@ -2185,7 +2189,7 @@ mod tests {
     }
 
     fn precompile_message(address: Address) -> Message {
-        Message {
+        MessageExt {
             kind: MessageKind::Call,
             depth: 0,
             gas_limit: 30_000,
@@ -2223,7 +2227,7 @@ mod tests {
         })]);
         let mut evm = Evm::<BaseEvmTypes>::new(
             SpecId::OSAKA,
-            BlockEnv::default(),
+            BlockEnvExt::default(),
             TxRegistry::new(),
             InMemoryDB::default(),
             precompiles,
@@ -2233,7 +2237,7 @@ mod tests {
 
         let result = Host::execute_message(
             &mut evm,
-            &TxEnv::default(),
+            &TxEnvExt::default(),
             Bytecode::new_legacy(Bytes::new()),
             &mut message,
         );
@@ -2258,7 +2262,7 @@ mod tests {
         database.insert_account_storage(&LIFECYCLE_ACCOUNT, &LIFECYCLE_STORAGE_KEY, &Word::from(1));
         Evm::<BaseEvmTypes>::new(
             SpecId::OSAKA,
-            BlockEnv::default(),
+            BlockEnvExt::default(),
             registry,
             database,
             Precompiles::base(SpecId::OSAKA),
@@ -2304,20 +2308,20 @@ mod tests {
         ));
         let mut evm = Evm::<BaseEvmTypes>::new(
             SpecId::OSAKA,
-            BlockEnv::default(),
+            BlockEnvExt::default(),
             TxRegistry::new(),
             InMemoryDB::default(),
             precompiles,
         );
-        let mut message = Message {
+        let mut message = MessageExt {
             kind: MessageKind::Call,
             destination: contract,
             code_address: contract,
             gas_limit: 200_000,
-            ..Message::default()
+            ..MessageExt::default()
         };
 
-        let result = Host::execute_message(&mut evm, &TxEnv::default(), bytecode, &mut message);
+        let result = Host::execute_message(&mut evm, &TxEnvExt::default(), bytecode, &mut message);
 
         assert_eq!(result.stop, InstrStop::FatalPrecompileError);
         assert_eq!(evm.error_code(), Some(ErrorCode::FATAL_PRECOMPILE));
@@ -2359,20 +2363,20 @@ mod tests {
         ));
         let mut evm = Evm::<BaseEvmTypes>::new(
             SpecId::OSAKA,
-            BlockEnv::default(),
+            BlockEnvExt::default(),
             TxRegistry::new(),
             InMemoryDB::default(),
             precompiles,
         );
-        let mut message = Message {
+        let mut message = MessageExt {
             kind: MessageKind::Call,
             destination: contract,
             code_address: contract,
             gas_limit: 200_000,
-            ..Message::default()
+            ..MessageExt::default()
         };
 
-        let result = Host::execute_message(&mut evm, &TxEnv::default(), bytecode, &mut message);
+        let result = Host::execute_message(&mut evm, &TxEnvExt::default(), bytecode, &mut message);
 
         assert_eq!(result.stop, InstrStop::Stop);
         assert!(evm.error_code().is_none());
@@ -2418,7 +2422,7 @@ mod tests {
         ));
         let mut evm = Evm::<BaseEvmTypes>::new(
             SpecId::OSAKA,
-            BlockEnv::default(),
+            BlockEnvExt::default(),
             ethereum_tx_registry(SpecId::OSAKA),
             InMemoryDB::default(),
             precompiles,
@@ -2461,7 +2465,7 @@ mod tests {
         )]);
         let mut evm = Evm::<BaseEvmTypes>::new(
             SpecId::OSAKA,
-            BlockEnv::default(),
+            BlockEnvExt::default(),
             TxRegistry::new(),
             InMemoryDB::default(),
             precompiles,
@@ -2489,7 +2493,7 @@ mod tests {
         evm.state.enable_bal_builder();
         evm.state.set_bal_index(BlockAccessIndex::new(57));
 
-        let block = BlockEnv { number: Word::from(58), ..BlockEnv::default() };
+        let block = BlockEnvExt { number: Word::from(58), ..BlockEnvExt::default() };
         evm.set_block(block);
 
         assert!(core::ptr::eq(state, core::ptr::addr_of!(evm.state)));
@@ -2562,7 +2566,7 @@ mod tests {
         })]);
         let mut evm = Evm::<BaseEvmTypes>::new(
             SpecId::OSAKA,
-            BlockEnv::default(),
+            BlockEnvExt::default(),
             TxRegistry::new(),
             InMemoryDB::default(),
             precompiles,
@@ -2623,14 +2627,14 @@ mod tests {
 
         let mut evm = Evm::<BaseEvmTypes>::new(
             SpecId::OSAKA,
-            BlockEnv::default(),
+            BlockEnvExt::default(),
             TxRegistry::new(),
             InMemoryDB::default(),
             Precompiles::base(SpecId::OSAKA),
         );
         evm.set_inspector(AccessingInspector { access });
-        let message = Message::default();
-        let tx_env = TxEnv::default();
+        let message = MessageExt::default();
+        let tx_env = TxEnvExt::default();
         let bytecode = Bytecode::new_legacy(Bytes::from_static(&[op::STOP]));
         let frame_gas =
             GasTracker::new_with_regular_gas_and_reservoir(message.gas_limit, message.reservoir);
@@ -2649,14 +2653,14 @@ mod tests {
 
         let mut evm = Evm::<BaseEvmTypes>::new(
             SpecId::OSAKA,
-            BlockEnv::default(),
+            BlockEnvExt::default(),
             TxRegistry::new(),
             InMemoryDB::default(),
             Precompiles::base(SpecId::OSAKA),
         );
         evm.set_inspector(ReadingInspector {});
-        let message = Message::default();
-        let tx_env = TxEnv::default();
+        let message = MessageExt::default();
+        let tx_env = TxEnvExt::default();
         let bytecode = Bytecode::new_legacy(Bytes::from_static(&[op::STOP]));
 
         let frame_gas =
@@ -2695,10 +2699,10 @@ mod tests {
         impl Inspector<BaseEvmTypes> for BlockReplacingInspector {
             fn initialize_interp(&mut self, interp: &mut Interpreter<'_, '_, BaseEvmTypes>) {
                 let host = interp.host();
-                host.set_block(BlockEnv {
+                host.set_block(BlockEnvExt {
                     number: Word::from(123),
                     timestamp: Word::from(124),
-                    ..BlockEnv::default()
+                    ..BlockEnvExt::default()
                 });
                 assert_eq!(host.block().number, Word::from(123));
                 assert_eq!(host.block().timestamp, Word::from(124));
@@ -2707,14 +2711,14 @@ mod tests {
 
         let mut evm = Evm::<BaseEvmTypes>::new(
             SpecId::OSAKA,
-            BlockEnv::default(),
+            BlockEnvExt::default(),
             TxRegistry::new(),
             InMemoryDB::default(),
             Precompiles::base(SpecId::OSAKA),
         );
         evm.set_inspector(BlockReplacingInspector);
-        let message = Message::default();
-        let tx_env = TxEnv::default();
+        let message = MessageExt::default();
+        let tx_env = TxEnvExt::default();
         let bytecode = Bytecode::new_legacy(Bytes::from_static(&[op::STOP]));
         let frame_gas =
             GasTracker::new_with_regular_gas_and_reservoir(message.gas_limit, message.reservoir);
@@ -2742,14 +2746,14 @@ mod tests {
 
         let mut evm = Evm::<BaseEvmTypes>::new(
             SpecId::OSAKA,
-            BlockEnv::default(),
+            BlockEnvExt::default(),
             TxRegistry::new(),
             InMemoryDB::default(),
             Precompiles::base(SpecId::OSAKA),
         );
         evm.set_inspector(ConfigReplacingInspector);
-        let message = Message::default();
-        let tx_env = TxEnv::default();
+        let message = MessageExt::default();
+        let tx_env = TxEnvExt::default();
         let bytecode = Bytecode::new_legacy(Bytes::from_static(&[op::STOP]));
         let frame_gas =
             GasTracker::new_with_regular_gas_and_reservoir(message.gas_limit, message.reservoir);
@@ -2792,7 +2796,7 @@ mod tests {
 
         let mut evm = Evm::<BaseEvmTypes>::new(
             SpecId::OSAKA,
-            BlockEnv::default(),
+            BlockEnvExt::default(),
             TxRegistry::new(),
             InMemoryDB::default(),
             Precompiles::base(SpecId::OSAKA),
@@ -2805,19 +2809,19 @@ mod tests {
                 Log { address: Address::ZERO, data: LogData::new_unchecked(vec![], Bytes::new()) },
             ),
             TopLevelInspectorHook::Call => {
-                let mut message = Message { kind: MessageKind::Call, ..Default::default() };
+                let mut message = MessageExt { kind: MessageKind::Call, ..Default::default() };
                 let _ = Host::execute_message(
                     &mut evm,
-                    &TxEnv::default(),
+                    &TxEnvExt::default(),
                     Bytecode::default(),
                     &mut message,
                 );
             }
             TopLevelInspectorHook::Create => {
-                let mut message = Message { kind: MessageKind::Create, ..Default::default() };
+                let mut message = MessageExt { kind: MessageKind::Create, ..Default::default() };
                 let _ = Host::execute_message(
                     &mut evm,
-                    &TxEnv::default(),
+                    &TxEnvExt::default(),
                     Bytecode::default(),
                     &mut message,
                 );
@@ -2846,7 +2850,7 @@ mod tests {
     #[test]
     fn passes_evm_to_precompile_provider() {
         let address = TEST_PRECOMPILE;
-        let block = BlockEnv { number: U256::from(17), ..BlockEnv::default() };
+        let block = BlockEnvExt { number: U256::from(17), ..BlockEnvExt::default() };
         let precompiles = precompiles_with([test_precompile(address, |evm, message, _| {
             assert_eq!(message.kind, MessageKind::Call);
             assert_eq!(message.depth, 67);
@@ -2865,7 +2869,7 @@ mod tests {
             InMemoryDB::default(),
             precompiles,
         );
-        let message = Message {
+        let message = MessageExt {
             kind: MessageKind::Call,
             depth: 67,
             gas_limit: 30_000,
@@ -2901,7 +2905,7 @@ mod tests {
         ]);
         let mut evm = Evm::<BaseEvmTypes>::new(
             SpecId::OSAKA,
-            BlockEnv::default(),
+            BlockEnvExt::default(),
             TxRegistry::new(),
             InMemoryDB::default(),
             precompiles,
@@ -2921,7 +2925,7 @@ mod tests {
             TxRegistry::new().with_handler(TEST_TX_TYPE, TxEnvelope::as_legacy, handle_test_tx);
         let mut evm = Evm::<BaseEvmTypes>::new(
             SpecId::OSAKA,
-            BlockEnv::default(),
+            BlockEnvExt::default(),
             registry,
             InMemoryDB::default(),
             Precompiles::base(SpecId::OSAKA),
@@ -2938,7 +2942,7 @@ mod tests {
         let mut evm = Evm::<BaseEvmTypes>::new_with_execution_config(
             ExecutionConfig::for_base_spec::<BaseEvmConfigSelector>(SpecId::OSAKA),
             SpecId::OSAKA,
-            BlockEnv::default(),
+            BlockEnvExt::default(),
             registry,
             InMemoryDB::default(),
             Precompiles::base(SpecId::OSAKA),
@@ -2966,10 +2970,10 @@ mod tests {
         fn handle_test_tx_version(
             req: TxRequest<'_, '_, BaseEvmTypes, TxLegacy>,
         ) -> HandlerResult<TxResult> {
-            Ok(TxResult {
+            Ok(TxResultExt {
                 status: true,
                 total_gas_spent: req.host.version().tx_gas_limit_cap,
-                ..TxResult::default()
+                ..TxResultExt::default()
             })
         }
 
@@ -2983,7 +2987,7 @@ mod tests {
         let mut evm = Evm::<BaseEvmTypes>::new_with_execution_config(
             ExecutionConfig::for_spec_and_version(SpecId::OSAKA, version),
             SpecId::OSAKA,
-            BlockEnv::default(),
+            BlockEnvExt::default(),
             registry,
             InMemoryDB::default(),
             Precompiles::base(SpecId::OSAKA),
@@ -2999,7 +3003,7 @@ mod tests {
             TxRegistry::new().with_handler(TEST_TX_TYPE, TxEnvelope::as_legacy, handle_test_tx);
         let mut evm = Evm::<BaseEvmTypes>::new(
             SpecId::OSAKA,
-            BlockEnv::default(),
+            BlockEnvExt::default(),
             registry,
             InMemoryDB::default(),
             Precompiles::base(SpecId::OSAKA),
@@ -3217,22 +3221,22 @@ mod tests {
     fn host_executes_message() {
         let mut evm = Evm::<BaseEvmTypes>::new(
             SpecId::OSAKA,
-            BlockEnv::default(),
+            BlockEnvExt::default(),
             TxRegistry::new(),
             InMemoryDB::default(),
             Precompiles::base(SpecId::OSAKA),
         );
         let contract = Address::from([0x11; 20]);
         let bytecode = Bytecode::new_legacy(Bytes::from_static(&[op::ADDRESS, op::STOP]));
-        let mut message = Message {
+        let mut message = MessageExt {
             kind: MessageKind::Call,
             destination: contract,
             code_address: contract,
             gas_limit: 50_000,
-            ..Message::default()
+            ..MessageExt::default()
         };
 
-        let result = Host::execute_message(&mut evm, &TxEnv::default(), bytecode, &mut message);
+        let result = Host::execute_message(&mut evm, &TxEnvExt::default(), bytecode, &mut message);
         assert!(result.stop.is_success());
     }
 
@@ -3281,22 +3285,22 @@ mod tests {
 
         let mut evm = Evm::<BaseEvmTypes>::new(
             SpecId::OSAKA,
-            BlockEnv::default(),
+            BlockEnvExt::default(),
             TxRegistry::new(),
             Db::new(FailingStorageDb),
             Precompiles::base(SpecId::OSAKA),
         );
         let contract = Address::from([0x11; 20]);
         let bytecode = Bytecode::new_legacy(Bytes::from_static(&[op::PUSH0, op::SLOAD]));
-        let mut message = Message {
+        let mut message = MessageExt {
             kind: MessageKind::Call,
             destination: contract,
             code_address: contract,
             gas_limit: 50_000,
-            ..Message::default()
+            ..MessageExt::default()
         };
 
-        let result = Host::execute_message(&mut evm, &TxEnv::default(), bytecode, &mut message);
+        let result = Host::execute_message(&mut evm, &TxEnvExt::default(), bytecode, &mut message);
 
         assert_eq!(result.stop, InstrStop::FatalExternalError);
         let error_code = evm.error_code().unwrap();
@@ -3308,7 +3312,7 @@ mod tests {
     fn cold_storage_oog_rolls_back_warmth() {
         let mut evm = Evm::<BaseEvmTypes>::new(
             SpecId::OSAKA,
-            BlockEnv::default(),
+            BlockEnvExt::default(),
             TxRegistry::new(),
             InMemoryDB::default(),
             Precompiles::base(SpecId::OSAKA),
@@ -3317,15 +3321,15 @@ mod tests {
         let key = Word::ZERO;
         let bytecode =
             Bytecode::new_legacy(Bytes::from_static(&[op::PUSH1, 0, op::SLOAD, op::STOP]));
-        let mut message = Message {
+        let mut message = MessageExt {
             kind: MessageKind::Call,
             destination: contract,
             code_address: contract,
             gas_limit: 500,
-            ..Message::default()
+            ..MessageExt::default()
         };
 
-        let result = Host::execute_message(&mut evm, &TxEnv::default(), bytecode, &mut message);
+        let result = Host::execute_message(&mut evm, &TxEnvExt::default(), bytecode, &mut message);
 
         assert_eq!(result.stop, InstrStop::OutOfGas);
         assert!(!evm.state.storage(&contract).is_warm(&key));
@@ -3394,22 +3398,22 @@ mod tests {
         let database = SelfdestructTargetLoadDb { target, target_reads: Arc::clone(&target_reads) };
         let mut evm = Evm::<BaseEvmTypes>::new(
             SpecId::BERLIN,
-            BlockEnv::default(),
+            BlockEnvExt::default(),
             TxRegistry::new(),
             Db::new(database),
             Precompiles::base(SpecId::BERLIN),
         );
-        let mut message = Message {
+        let mut message = MessageExt {
             kind: MessageKind::Call,
             destination: contract,
             code_address: contract,
             gas_limit: 6_000,
-            ..Message::default()
+            ..MessageExt::default()
         };
 
         let result = Host::execute_message(
             &mut evm,
-            &TxEnv::default(),
+            &TxEnvExt::default(),
             selfdestruct_to_code(&target),
             &mut message,
         );
@@ -3426,22 +3430,22 @@ mod tests {
         database.insert_account_info(&caller, AccountInfo::default().with_balance(Word::from(1)));
         let mut evm = Evm::<BaseEvmTypes>::new(
             SpecId::FRONTIER,
-            BlockEnv::default(),
+            BlockEnvExt::default(),
             TxRegistry::new(),
             database,
             Precompiles::base(SpecId::FRONTIER),
         );
-        let mut message = Message {
+        let mut message = MessageExt {
             kind: MessageKind::Create,
             destination: created,
             caller,
             gas_limit: 50,
-            ..Message::default()
+            ..MessageExt::default()
         };
         let code =
             Bytecode::new_legacy(Bytes::from_static(&[op::PUSH1, 1, op::PUSH1, 0, op::RETURN]));
 
-        let result = Host::execute_message(&mut evm, &TxEnv::default(), code, &mut message);
+        let result = Host::execute_message(&mut evm, &TxEnvExt::default(), code, &mut message);
         assert!(result.stop.is_success());
 
         evm.state.finalize_transaction_(Version::base(SpecId::FRONTIER));
@@ -3459,22 +3463,22 @@ mod tests {
         database.insert_account_info(&caller, AccountInfo::default().with_balance(Word::from(1)));
         let mut evm = Evm::<BaseEvmTypes>::new(
             SpecId::HOMESTEAD,
-            BlockEnv::default(),
+            BlockEnvExt::default(),
             TxRegistry::new(),
             database,
             Precompiles::base(SpecId::HOMESTEAD),
         );
-        let mut message = Message {
+        let mut message = MessageExt {
             kind: MessageKind::Create,
             destination: created,
             caller,
             gas_limit: 50,
-            ..Message::default()
+            ..MessageExt::default()
         };
         let code =
             Bytecode::new_legacy(Bytes::from_static(&[op::PUSH1, 1, op::PUSH1, 0, op::RETURN]));
 
-        let result = Host::execute_message(&mut evm, &TxEnv::default(), code, &mut message);
+        let result = Host::execute_message(&mut evm, &TxEnvExt::default(), code, &mut message);
         assert_eq!(result.stop, InstrStop::OutOfGas);
 
         evm.state.finalize_transaction_(Version::base(SpecId::HOMESTEAD));
@@ -3490,21 +3494,25 @@ mod tests {
         database.insert_account_storage(&target, &Word::ZERO, &Word::from(1));
         let mut evm = Evm::<BaseEvmTypes>::new(
             SpecId::SPURIOUS_DRAGON,
-            BlockEnv::default(),
+            BlockEnvExt::default(),
             TxRegistry::new(),
             database,
             Precompiles::base(SpecId::SPURIOUS_DRAGON),
         );
-        let mut message = Message {
+        let mut message = MessageExt {
             kind: MessageKind::StaticCall,
             destination: target,
             code_address: target,
             gas_limit: 50_000,
-            ..Message::default()
+            ..MessageExt::default()
         };
 
-        let result =
-            Host::execute_message(&mut evm, &TxEnv::default(), Bytecode::default(), &mut message);
+        let result = Host::execute_message(
+            &mut evm,
+            &TxEnvExt::default(),
+            Bytecode::default(),
+            &mut message,
+        );
         assert!(result.stop.is_success());
 
         evm.state.finalize_transaction_(Version::base(SpecId::SPURIOUS_DRAGON));
@@ -3526,21 +3534,25 @@ mod tests {
         database.insert_account_storage(&code_address, &Word::ZERO, &Word::from(1));
         let mut evm = Evm::<BaseEvmTypes>::new(
             SpecId::SPURIOUS_DRAGON,
-            BlockEnv::default(),
+            BlockEnvExt::default(),
             TxRegistry::new(),
             database,
             Precompiles::base(SpecId::SPURIOUS_DRAGON),
         );
-        let mut message = Message {
+        let mut message = MessageExt {
             kind: MessageKind::DelegateCall,
             destination,
             code_address,
             gas_limit: 50_000,
-            ..Message::default()
+            ..MessageExt::default()
         };
 
-        let result =
-            Host::execute_message(&mut evm, &TxEnv::default(), Bytecode::default(), &mut message);
+        let result = Host::execute_message(
+            &mut evm,
+            &TxEnvExt::default(),
+            Bytecode::default(),
+            &mut message,
+        );
         assert!(result.stop.is_success());
 
         evm.state.finalize_transaction_(Version::base(SpecId::SPURIOUS_DRAGON));
@@ -3590,12 +3602,12 @@ mod tests {
         database.insert_account_info(&caller, AccountInfo::default().with_balance(U256::from(10)));
         let mut evm = Evm::<BaseEvmTypes>::new(
             SpecId::AMSTERDAM,
-            BlockEnv::default(),
+            BlockEnvExt::default(),
             TxRegistry::new(),
             database,
             Precompiles::base(SpecId::AMSTERDAM),
         );
-        let mut message = Message {
+        let mut message = MessageExt {
             kind: MessageKind::Call,
             destination: target,
             caller,
@@ -3603,11 +3615,15 @@ mod tests {
             // Covers the EIP-2780 depth-0 `new_account_state_gas` charge for the
             // value transfer to the empty target account.
             gas_limit: 300_000,
-            ..Message::default()
+            ..MessageExt::default()
         };
 
-        let result =
-            Host::execute_message(&mut evm, &TxEnv::default(), Bytecode::default(), &mut message);
+        let result = Host::execute_message(
+            &mut evm,
+            &TxEnvExt::default(),
+            Bytecode::default(),
+            &mut message,
+        );
         assert!(result.stop.is_success());
 
         let version = *evm.version();

--- a/crates/evm2/src/evm/registry.rs
+++ b/crates/evm2/src/evm/registry.rs
@@ -327,7 +327,7 @@ mod tests {
     use crate::{
         BaseEvmConfigSelector, EvmFeatures, EvmTypesHost, SpecId,
         bytecode::Bytecode,
-        env::{BlockEnv, TxEnv},
+        env::{BlockEnv, BlockEnvExt, TxEnv},
         evm::{AccountLoad, SLoad, SStore, SelfDestructResult},
         interpreter::{Host, InstrStop, Message, MessageResult, Word},
     };
@@ -501,7 +501,7 @@ mod tests {
     ) -> HandlerResult<Receipt> {
         registry.try_get_by_type(type_id)?.call(
             &Recovered::new_unchecked(env.clone(), Address::ZERO),
-            &mut TestHost { block: BlockEnv::default() },
+            &mut TestHost { block: BlockEnvExt::default() },
         )
     }
 

--- a/crates/evm2/src/evm/system.rs
+++ b/crates/evm2/src/evm/system.rs
@@ -6,12 +6,12 @@
 //! before calling [`Evm::system_call`]. Calling an address without code succeeds as an empty call
 //! and produces no state changes.
 
-use super::{Evm, ExecutedTx, TxResult};
+use super::{Evm, ExecutedTx, TxResult, TxResultExt};
 #[cfg(feature = "async")]
 use super::{SendEvmRef, r#async};
 use crate::{
     EvmTypes,
-    env::TxEnv,
+    env::TxEnvExt,
     ethereum::initial_message,
     interpreter::Host,
     registry::{HandlerError, HandlerResult},
@@ -128,7 +128,7 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
     pub fn execute_system_call(&mut self, tx: SystemTx) -> HandlerResult<TxResult<T>> {
         let SystemTx { caller, system_contract_address, data, .. } = tx;
         self.state.prewarm(&system_contract_address);
-        let tx_env = TxEnv {
+        let tx_env = TxEnvExt {
             origin: caller,
             gas_price: U256::ZERO,
             chain_id: U256::from(self.version().chain_id),
@@ -165,7 +165,7 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
         } else {
             0
         };
-        Ok(TxResult {
+        Ok(TxResultExt {
             status: result.stop.is_success(),
             total_gas_spent: gas_spent,
             state_gas_spent: result.gas.state_gas_spent().max(0) as u64,
@@ -173,7 +173,7 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
             floor_gas: 0,
             stop: result.stop,
             output: result.output,
-            ..TxResult::default()
+            ..TxResultExt::default()
         })
     }
 
@@ -231,7 +231,7 @@ mod tests {
     use crate::{
         BaseEvmTypes, ErrorCode, Precompiles, SpecId,
         bytecode::Bytecode,
-        env::BlockEnv,
+        env::BlockEnvExt,
         evm::{AccountInfo, InMemoryDB},
         interpreter::{GasTracker, InstrStop, Message, op},
         precompiles::{Precompile, PrecompileError, PrecompileId, PrecompileResult},
@@ -257,7 +257,7 @@ mod tests {
         ]));
         let mut database = InMemoryDB::default();
         database.insert_account_info(&contract, AccountInfo::default().with_code(code));
-        let block = BlockEnv { beneficiary, basefee: U256::from(7), ..BlockEnv::default() };
+        let block = BlockEnvExt { beneficiary, basefee: U256::from(7), ..BlockEnvExt::default() };
         let mut evm = TestEvm::new(
             SpecId::OSAKA,
             block,
@@ -300,7 +300,7 @@ mod tests {
         database.insert_account_info(&contract, AccountInfo::default().with_code(code));
         let mut evm = TestEvm::new(
             SpecId::OSAKA,
-            BlockEnv::default(),
+            BlockEnvExt::default(),
             TxRegistry::new(),
             database,
             Precompiles::base(SpecId::OSAKA),
@@ -327,7 +327,7 @@ mod tests {
         database.insert_account_info(&contract, AccountInfo::default().with_code(code));
         let mut evm = TestEvm::new(
             SpecId::OSAKA,
-            BlockEnv::default(),
+            BlockEnvExt::default(),
             TxRegistry::new(),
             database,
             Precompiles::base(SpecId::OSAKA),
@@ -348,7 +348,7 @@ mod tests {
         let contract = Address::from([0x42; 20]);
         let mut evm = TestEvm::new(
             SpecId::OSAKA,
-            BlockEnv::default(),
+            BlockEnvExt::default(),
             TxRegistry::new(),
             InMemoryDB::default(),
             Precompiles::base(SpecId::OSAKA),
@@ -380,7 +380,7 @@ mod tests {
         database.insert_account_info(&contract, AccountInfo::default().with_code(code));
         let mut evm = TestEvm::new(
             SpecId::OSAKA,
-            BlockEnv::default(),
+            BlockEnvExt::default(),
             TxRegistry::new(),
             database,
             Precompiles::base(SpecId::OSAKA),
@@ -425,7 +425,7 @@ mod tests {
 
         let mut evm = TestEvm::new(
             SpecId::OSAKA,
-            BlockEnv::default(),
+            BlockEnvExt::default(),
             TxRegistry::new(),
             InMemoryDB::default(),
             precompiles,

--- a/crates/evm2/src/evm/tx.rs
+++ b/crates/evm2/src/evm/tx.rs
@@ -7,15 +7,18 @@ use alloy_primitives::{Address, Bytes, Log};
 use core::fmt;
 use derive_where::derive_where;
 
-/// Transaction execution result without an owned state diff.
+/// Transaction execution result without an owned state diff for an EVM type family.
+pub type TxResult<T = crate::BaseEvmTypes> = TxResultExt<<T as EvmTypesHost>::TxResultExt>;
+
+/// Transaction execution result without an owned state diff, parameterized by extension data.
 ///
 /// This is the result-only half of transaction execution: status, gas used, output, stop reason,
 /// logs, host error code, and extension data. Logs live here because they are execution
 /// output, not database state. Use [`ExecutedTx::detach`] only when an owned [`PendingState`]
 /// value is required.
 #[must_use = "transaction results contain execution status, gas, logs, and errors"]
-#[derive_where(Clone, Debug, Default, PartialEq, Eq; T::TxResultExt)]
-pub struct TxResult<T: EvmTypesHost = crate::BaseEvmTypes> {
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct TxResultExt<E = ()> {
     /// Whether execution succeeded.
     pub status: bool,
     /// Total gas spent (regular + state) before refund. The receipt gas-used value is
@@ -41,12 +44,12 @@ pub struct TxResult<T: EvmTypesHost = crate::BaseEvmTypes> {
     /// Host error code raised during execution, if any.
     pub error_code: Option<ErrorCode>,
     /// EVM type-specific extension data.
-    pub ext: T::TxResultExt,
+    pub ext: E,
     #[doc(hidden)] // Not public API. Please use an existing constructor.
     pub _non_exhaustive: (),
 }
 
-impl<T: EvmTypesHost> TxResult<T> {
+impl<E> TxResultExt<E> {
     /// Returns the receipt gas-used value: `max(total_gas_spent - refunded, floor_gas)`.
     #[inline]
     pub const fn tx_gas_used(&self) -> u64 {
@@ -274,21 +277,20 @@ pub struct TxResultWithState<T: EvmTypesHost = crate::BaseEvmTypes> {
 
 #[cfg(test)]
 mod tests {
-    use super::TxResult;
-    use crate::BaseEvmTypes;
+    use super::TxResultExt;
 
     fn result(
         total_gas_spent: u64,
         state_gas_spent: u64,
         refunded: u64,
         floor_gas: u64,
-    ) -> TxResult {
-        TxResult::<BaseEvmTypes> {
+    ) -> TxResultExt {
+        TxResultExt {
             total_gas_spent,
             state_gas_spent,
             refunded,
             floor_gas,
-            ..TxResult::default()
+            ..TxResultExt::default()
         }
     }
 

--- a/crates/evm2/src/interpreter/host.rs
+++ b/crates/evm2/src/interpreter/host.rs
@@ -6,16 +6,18 @@ use crate::{
     evm::{AccountLoad, SLoad, SStore, SelfDestructResult},
 };
 use alloy_primitives::{Address, B256, Bytes, Log};
-use derive_where::derive_where;
 
-/// Result of executing a call/create message.
+/// Result of executing a call/create message for an EVM type family.
+pub type MessageResult<T = BaseEvmTypes> = MessageResultExt<<T as EvmTypesHost>::MessageResultExt>;
+
+/// Result of executing a call/create message, parameterized by extension data.
 ///
 /// [`Self::gas`] is normalized for the frame's [`stop`](Self::stop) reason by the executor
 /// before it is returned, so applying a child result to its caller is just
 /// [`GasTracker::merge_child_gas`]. Use [`Self::gas_remaining_after_final_refund`] or
 /// [`Self::gas_used_after_final_refund`] for top-level transaction accounting.
-#[derive_where(Clone, Debug, Default, PartialEq, Eq; T::MessageResultExt)]
-pub struct MessageResult<T: EvmTypesHost = BaseEvmTypes> {
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct MessageResultExt<E = ()> {
     /// Interpreter stop reason.
     pub stop: InstrStop,
     /// Gas accounting for the child frame.
@@ -30,12 +32,12 @@ pub struct MessageResult<T: EvmTypesHost = BaseEvmTypes> {
     /// for call messages and fresh-target creates.
     pub created_target_was_alive: bool,
     /// EVM type-specific extension data.
-    pub ext: T::MessageResultExt,
+    pub ext: E,
     #[doc(hidden)] // Not public API. Please use an existing constructor.
     pub _non_exhaustive: (),
 }
 
-impl<T: EvmTypesHost> MessageResult<T> {
+impl<E> MessageResultExt<E> {
     /// Returns whether the message committed state changes.
     #[inline]
     pub const fn is_success(&self) -> bool {

--- a/crates/evm2/src/interpreter/instructions/block.rs
+++ b/crates/evm2/src/interpreter/instructions/block.rs
@@ -88,8 +88,8 @@ pub(crate) fn slotnum(cx: _) -> Result<out> {
 mod tests {
     use crate::{
         SpecId,
-        env::{BlockEnv, TxEnv},
-        interpreter::{InstrStop, Message, Word, op},
+        env::{BlockEnv, BlockEnvExt, TxEnvExt},
+        interpreter::{InstrStop, MessageExt, Word, op},
         test_utils::{RunConfig, TestHost, TestTypes, push, run},
         utils::{address_to_word, b256_to_word},
     };
@@ -103,7 +103,7 @@ mod tests {
 
     #[test]
     fn blockhash_opcode() {
-        let mut host = test_host(BlockEnv { number: Word::from(10), ..BlockEnv::default() });
+        let mut host = test_host(BlockEnvExt { number: Word::from(10), ..BlockEnvExt::default() });
         let mut code = Vec::new();
         push(&mut code, 9);
         code.push(op::BLOCKHASH);
@@ -124,7 +124,7 @@ mod tests {
 
     #[test]
     fn missing_blockhash_is_fatal() {
-        let mut host = test_host(BlockEnv { number: Word::from(10), ..BlockEnv::default() });
+        let mut host = test_host(BlockEnvExt { number: Word::from(10), ..BlockEnvExt::default() });
         host.missing_block_hash = true;
         let mut code = Vec::new();
         push(&mut code, 9);
@@ -138,7 +138,7 @@ mod tests {
     #[test]
     fn coinbase_opcode() {
         let beneficiary = Address::from([0x44; 20]);
-        let mut host = test_host(BlockEnv { beneficiary, ..BlockEnv::default() });
+        let mut host = test_host(BlockEnvExt { beneficiary, ..BlockEnvExt::default() });
         let interp = run(RunConfig::new([op::COINBASE, op::STOP]).host(&mut host));
         assert_matches!(interp.err, InstrStop::Stop);
         assert_eq!(interp.stack(), [address_to_word(&beneficiary)]);
@@ -146,7 +146,8 @@ mod tests {
 
     #[test]
     fn timestamp_opcode() {
-        let mut host = test_host(BlockEnv { timestamp: Word::from(12), ..BlockEnv::default() });
+        let mut host =
+            test_host(BlockEnvExt { timestamp: Word::from(12), ..BlockEnvExt::default() });
         let interp = run(RunConfig::new([op::TIMESTAMP, op::STOP]).host(&mut host));
         assert_matches!(interp.err, InstrStop::Stop);
         assert_eq!(interp.stack(), [Word::from(12)]);
@@ -154,7 +155,7 @@ mod tests {
 
     #[test]
     fn number_opcode() {
-        let mut host = test_host(BlockEnv { number: Word::from(13), ..BlockEnv::default() });
+        let mut host = test_host(BlockEnvExt { number: Word::from(13), ..BlockEnvExt::default() });
         let interp = run(RunConfig::new([op::NUMBER, op::STOP]).host(&mut host));
         assert_matches!(interp.err, InstrStop::Stop);
         assert_eq!(interp.stack(), [Word::from(13)]);
@@ -163,10 +164,10 @@ mod tests {
     #[test]
     fn difficulty_opcode() {
         let randao = B256::with_last_byte(0x55);
-        let mut host = test_host(BlockEnv {
+        let mut host = test_host(BlockEnvExt {
             difficulty: Word::from(14),
             prevrandao: b256_to_word(randao),
-            ..BlockEnv::default()
+            ..BlockEnvExt::default()
         });
         let interp =
             run(RunConfig::new([op::DIFFICULTY, op::STOP]).host(&mut host).spec(SpecId::FRONTIER));
@@ -181,7 +182,8 @@ mod tests {
 
     #[test]
     fn gaslimit_opcode() {
-        let mut host = test_host(BlockEnv { gas_limit: Word::from(15), ..BlockEnv::default() });
+        let mut host =
+            test_host(BlockEnvExt { gas_limit: Word::from(15), ..BlockEnvExt::default() });
         let interp = run(RunConfig::new([op::GASLIMIT, op::STOP]).host(&mut host));
         assert_matches!(interp.err, InstrStop::Stop);
         assert_eq!(interp.stack(), [Word::from(15)]);
@@ -190,7 +192,7 @@ mod tests {
     #[test]
     fn chainid_opcode() {
         let mut host = TestHost::default();
-        let tx_env = TxEnv { chain_id: Word::from(1), ..TxEnv::default() };
+        let tx_env = TxEnvExt { chain_id: Word::from(1), ..TxEnvExt::default() };
         let interp = run(RunConfig::new([op::CHAINID, op::STOP])
             .host(&mut host)
             .tx_env(tx_env)
@@ -203,7 +205,7 @@ mod tests {
     fn selfbalance_opcode() {
         let address = Address::from([0x66; 20]);
         let mut host = TestHost::default();
-        let message = Message { destination: address, gas_limit: 10_000, ..Default::default() };
+        let message = MessageExt { destination: address, gas_limit: 10_000, ..Default::default() };
         let interp =
             run(RunConfig::new([op::SELFBALANCE, op::STOP]).host(&mut host).message(message));
         assert_matches!(interp.err, InstrStop::Stop);
@@ -212,7 +214,7 @@ mod tests {
 
     #[test]
     fn basefee_opcode() {
-        let mut host = test_host(BlockEnv { basefee: Word::from(16), ..BlockEnv::default() });
+        let mut host = test_host(BlockEnvExt { basefee: Word::from(16), ..BlockEnvExt::default() });
         let interp =
             run(RunConfig::new([op::BASEFEE, op::STOP]).host(&mut host).spec(SpecId::LONDON));
         assert_matches!(interp.err, InstrStop::Stop);
@@ -223,7 +225,8 @@ mod tests {
     fn blobhash_opcode() {
         let hash = B256::with_last_byte(0x42);
         let mut host = TestHost::default();
-        let tx_env = TxEnv { blob_hashes: Vec::from([b256_to_word(hash)]), ..TxEnv::default() };
+        let tx_env =
+            TxEnvExt { blob_hashes: Vec::from([b256_to_word(hash)]), ..TxEnvExt::default() };
 
         let interp = run(RunConfig::new([op::PUSH0, op::BLOBHASH, op::STOP])
             .host(&mut host)
@@ -242,7 +245,8 @@ mod tests {
 
     #[test]
     fn blobbasefee_opcode() {
-        let mut host = test_host(BlockEnv { blob_basefee: Word::from(17), ..BlockEnv::default() });
+        let mut host =
+            test_host(BlockEnvExt { blob_basefee: Word::from(17), ..BlockEnvExt::default() });
         let interp =
             run(RunConfig::new([op::BLOBBASEFEE, op::STOP]).host(&mut host).spec(SpecId::CANCUN));
         assert_matches!(interp.err, InstrStop::Stop);
@@ -251,7 +255,8 @@ mod tests {
 
     #[test]
     fn slotnum_opcode() {
-        let mut host = test_host(BlockEnv { slot_num: Word::from(18), ..BlockEnv::default() });
+        let mut host =
+            test_host(BlockEnvExt { slot_num: Word::from(18), ..BlockEnvExt::default() });
         let interp =
             run(RunConfig::new([op::SLOTNUM, op::STOP]).host(&mut host).spec(SpecId::AMSTERDAM));
         assert_matches!(interp.err, InstrStop::Stop);

--- a/crates/evm2/src/interpreter/instructions/env.rs
+++ b/crates/evm2/src/interpreter/instructions/env.rs
@@ -169,8 +169,8 @@ pub(crate) fn returndatacopy(cx: _, [memory_offset, data_offset, len]: [Word]) -
 mod tests {
     use crate::{
         SpecId,
-        env::TxEnv,
-        interpreter::{InstrStop, Message, Word, op},
+        env::TxEnvExt,
+        interpreter::{InstrStop, Message, MessageExt, Word, op},
         test_utils::{
             RunConfig, TestHost, TestTypes, assert_stack, neg, push, run, run_stack, stack_code,
         },
@@ -181,14 +181,14 @@ mod tests {
     use core::assert_matches;
 
     fn test_message() -> Message<TestTypes> {
-        Message { gas_limit: 10_000, ..Message::default() }
+        MessageExt { gas_limit: 10_000, ..MessageExt::default() }
     }
 
     #[test]
     fn address_opcode() {
         let address = Address::from([0x11; 20]);
         let mut host = TestHost::default();
-        let message = Message { destination: address, ..test_message() };
+        let message = MessageExt { destination: address, ..test_message() };
         let interp = run(RunConfig::new([op::ADDRESS, op::STOP]).host(&mut host).message(message));
         assert_matches!(interp.err, InstrStop::Stop);
         assert_eq!(interp.stack(), [address_to_word(&address)]);
@@ -226,7 +226,7 @@ mod tests {
     fn origin_opcode() {
         let origin = Address::from([0x22; 20]);
         let mut host = TestHost::default();
-        let tx_env = TxEnv { origin, ..TxEnv::default() };
+        let tx_env = TxEnvExt { origin, ..TxEnvExt::default() };
         let interp = run(RunConfig::new([op::ORIGIN, op::STOP]).host(&mut host).tx_env(tx_env));
         assert_matches!(interp.err, InstrStop::Stop);
         assert_eq!(interp.stack(), [address_to_word(&origin)]);
@@ -236,7 +236,7 @@ mod tests {
     fn caller_opcode() {
         let caller = Address::from([0x33; 20]);
         let mut host = TestHost::default();
-        let message = Message { caller, ..test_message() };
+        let message = MessageExt { caller, ..test_message() };
         let interp = run(RunConfig::new([op::CALLER, op::STOP]).host(&mut host).message(message));
         assert_matches!(interp.err, InstrStop::Stop);
         assert_eq!(interp.stack(), [address_to_word(&caller)]);
@@ -245,7 +245,7 @@ mod tests {
     #[test]
     fn callvalue_opcode() {
         let mut host = TestHost::default();
-        let message = Message { value: Word::from(0xbeef), ..test_message() };
+        let message = MessageExt { value: Word::from(0xbeef), ..test_message() };
         let interp =
             run(RunConfig::new([op::CALLVALUE, op::STOP]).host(&mut host).message(message));
         assert_matches!(interp.err, InstrStop::Stop);
@@ -256,7 +256,7 @@ mod tests {
     fn calldataload_opcode() {
         let input = Bytes::from(Vec::from([1_u8, 2, 3]));
         let mut host = TestHost::default();
-        let message = Message { input, ..test_message() };
+        let message = MessageExt { input, ..test_message() };
 
         let interp = run(RunConfig::new([op::PUSH0, op::CALLDATALOAD, op::STOP])
             .host(&mut host)
@@ -277,7 +277,7 @@ mod tests {
     fn calldatasize_opcode() {
         let input = Bytes::from(Vec::from([1_u8, 2, 3, 4]));
         let mut host = TestHost::default();
-        let message = Message { input, ..test_message() };
+        let message = MessageExt { input, ..test_message() };
         let interp =
             run(RunConfig::new([op::CALLDATASIZE, op::STOP]).host(&mut host).message(message));
         assert_matches!(interp.err, InstrStop::Stop);
@@ -288,7 +288,7 @@ mod tests {
     fn calldatacopy_opcode() {
         let input = Bytes::from(Vec::from([0xaa_u8, 0xbb, 0xcc]));
         let mut host = TestHost::default();
-        let message = Message { input, ..test_message() };
+        let message = MessageExt { input, ..test_message() };
         let mut code = Vec::new();
         push(&mut code, 2);
         push(&mut code, 1);
@@ -363,7 +363,7 @@ mod tests {
     #[test]
     fn gasprice_opcode() {
         let mut host = TestHost::default();
-        let tx_env = TxEnv { gas_price: Word::from(0x1234), ..TxEnv::default() };
+        let tx_env = TxEnvExt { gas_price: Word::from(0x1234), ..TxEnvExt::default() };
         let interp = run(RunConfig::new([op::GASPRICE, op::STOP]).host(&mut host).tx_env(tx_env));
         assert_matches!(interp.err, InstrStop::Stop);
         assert_eq!(interp.stack(), [Word::from(0x1234)]);

--- a/crates/evm2/src/interpreter/instructions/host.rs
+++ b/crates/evm2/src/interpreter/instructions/host.rs
@@ -131,7 +131,7 @@ fn log_common<T: EvmTypesHost>(
 mod tests {
     use crate::{
         SpecId,
-        interpreter::{InstrStop, Message, MessageKind, Word, op},
+        interpreter::{InstrStop, MessageExt, MessageKind, Word, op},
         storage_key::StorageKey,
         test_utils::{RunConfig, TestHost, push, run},
     };
@@ -200,7 +200,7 @@ mod tests {
         push(&mut code, 1);
         code.extend([op::SSTORE, op::STOP]);
         let message =
-            Message { kind: MessageKind::StaticCall, gas_limit: 10_000, ..Default::default() };
+            MessageExt { kind: MessageKind::StaticCall, gas_limit: 10_000, ..Default::default() };
 
         let interp = run(RunConfig::new(code).host(&mut host).message(message));
 
@@ -382,7 +382,7 @@ mod tests {
     fn log0_opcode() {
         let mut host = TestHost::default();
         let address = Address::from([0x11; 20]);
-        let message = Message { destination: address, gas_limit: 10_000, ..Default::default() };
+        let message = MessageExt { destination: address, gas_limit: 10_000, ..Default::default() };
         let interp = run(RunConfig::new(log_code(30, 2, [])).host(&mut host).message(message));
         assert_matches!(interp.err, InstrStop::Stop);
         assert!(interp.stack().is_empty());

--- a/crates/evm2/src/interpreter/instructions/macro_tests.rs
+++ b/crates/evm2/src/interpreter/instructions/macro_tests.rs
@@ -1,6 +1,6 @@
 use crate::{
     BaseEvmConfig, EvmConfig, ExecutionConfig, SpecId,
-    env::BlockEnv,
+    env::BlockEnvExt,
     interpreter::{Host, InstrStop, Interpreter, Word, op},
     test_utils::{RunConfig, TestHost, TestInterpreter, TestTypes, legacy_bytecode, push},
     version::OpcodeConfig,
@@ -124,7 +124,7 @@ fn instruction_macro_no_stack_preamble_attribute() {
 #[test]
 fn instruction_macro_concrete_evm_types_equals_attribute() {
     let mut host = TestHost {
-        block: BlockEnv { number: Word::from(42), ..BlockEnv::default() },
+        block: BlockEnvExt { number: Word::from(42), ..BlockEnvExt::default() },
         ..TestHost::default()
     };
     let interp = run(RunConfig::new([CONCRETE_EQ_OPCODE, op::STOP]).host(&mut host));
@@ -136,7 +136,7 @@ fn instruction_macro_concrete_evm_types_equals_attribute() {
 #[test]
 fn instruction_macro_evm_types_colon_bound_attribute() {
     let mut host = TestHost {
-        block: BlockEnv { number: Word::from(31337), ..BlockEnv::default() },
+        block: BlockEnvExt { number: Word::from(31337), ..BlockEnvExt::default() },
         ..TestHost::default()
     };
     let interp = run(RunConfig::new([TYPE_BOUND_OPCODE, op::STOP]).host(&mut host));
@@ -148,7 +148,7 @@ fn instruction_macro_evm_types_colon_bound_attribute() {
 #[test]
 fn instruction_macro_evm_types_assoc_colon_bound_attribute() {
     let mut host = TestHost {
-        block: BlockEnv { number: Word::from(31337), ..BlockEnv::default() },
+        block: BlockEnvExt { number: Word::from(31337), ..BlockEnvExt::default() },
         ..TestHost::default()
     };
     let interp = run(RunConfig::new([ASSOC_BOUND_OPCODE, op::STOP]).host(&mut host));

--- a/crates/evm2/src/interpreter/instructions/memory.rs
+++ b/crates/evm2/src/interpreter/instructions/memory.rs
@@ -43,8 +43,8 @@ pub(crate) fn mcopy(cx: _, [dst, src, len]: [Word]) -> Result {
 mod tests {
     use crate::{
         ExecutionConfig, SpecId, Version,
-        env::TxEnv,
-        interpreter::{InstrStop, Interpreter, Message, Word, op},
+        env::TxEnvExt,
+        interpreter::{InstrStop, Interpreter, MessageExt, Word, op},
         test_utils::{RunConfig, TestHost, TestTypes, legacy_bytecode, push, run, run_stack},
         version::GasId,
     };
@@ -101,8 +101,8 @@ mod tests {
         code.push(op::MSTORE);
         code.push(op::STOP);
 
-        let tx_env = TxEnv::default();
-        let message = Message { gas_limit: 10_000, ..Message::default() };
+        let tx_env = TxEnvExt::default();
+        let message = MessageExt { gas_limit: 10_000, ..MessageExt::default() };
         let bytecode = legacy_bytecode(code);
         let mut interp = Interpreter::<TestTypes>::new(bytecode, &tx_env, &message);
         let mut host = TestHost::default();
@@ -123,8 +123,8 @@ mod tests {
         code.push(op::MSTORE);
         code.push(op::STOP);
 
-        let tx_env = TxEnv::default();
-        let message = Message { gas_limit: 17, ..Message::default() };
+        let tx_env = TxEnvExt::default();
+        let message = MessageExt { gas_limit: 17, ..MessageExt::default() };
         let bytecode = legacy_bytecode(code);
         let mut interp = Interpreter::<TestTypes>::new(bytecode, &tx_env, &message);
         let mut host = TestHost::default();

--- a/crates/evm2/src/interpreter/instructions/system.rs
+++ b/crates/evm2/src/interpreter/instructions/system.rs
@@ -4,7 +4,8 @@ use crate::{
     EvmFeatures, EvmTypesHost,
     bytecode::Bytecode,
     interpreter::{
-        Gas, Host, InstrStop, InterpreterState, Message, MessageKind, Result, StackMut, Word,
+        Gas, Host, InstrStop, InterpreterState, Message, MessageExt, MessageKind, Result, StackMut,
+        Word,
     },
     utils::{word_to_address, word_to_usize},
     version::GasId,
@@ -199,7 +200,7 @@ fn prepare_call<T: EvmTypesHost>(
         MessageKind::StaticCall => (to, current.destination, Word::ZERO, resolved_code_address),
         _ => unreachable!("invalid call message kind"),
     };
-    *message = Message {
+    *message = MessageExt {
         kind,
         depth: current.depth.saturating_add(1),
         gas_limit,
@@ -329,7 +330,7 @@ fn create_inner<T: EvmTypesHost>(
     gas.spend(gas_limit)?;
 
     let current = state.message();
-    let mut message = Message {
+    let mut message = MessageExt {
         kind: if is_create2 { MessageKind::Create2 } else { MessageKind::Create },
         depth: current.depth.saturating_add(1),
         gas_limit,
@@ -404,7 +405,7 @@ mod tests {
     use crate::{
         SpecId,
         constants::{CALL_DEPTH_LIMIT, MAX_INITCODE_SIZE},
-        interpreter::{InstrStop, Message, MessageKind, MessageResult, Word, op},
+        interpreter::{InstrStop, MessageExt, MessageKind, MessageResultExt, Word, op},
         test_utils::{RunConfig, TestHost, push, push_all, run},
         utils::address_to_word,
     };
@@ -432,7 +433,7 @@ mod tests {
         );
         code.extend([op::CALL, op::STOP]);
 
-        let interp = run(RunConfig::new(code).host(&mut host).message(Message {
+        let interp = run(RunConfig::new(code).host(&mut host).message(MessageExt {
             destination: caller,
             gas_limit: 10_000,
             ..Default::default()
@@ -449,9 +450,9 @@ mod tests {
     fn call_propagates_fatal_child_result() {
         let target = Address::from([0x22; 20]);
         let mut host = TestHost {
-            execute_result: MessageResult {
+            execute_result: MessageResultExt {
                 stop: InstrStop::FatalPrecompileError,
-                ..MessageResult::default()
+                ..MessageResultExt::default()
             },
             ..Default::default()
         };
@@ -524,7 +525,7 @@ mod tests {
         let interp = run(RunConfig::new(code)
             .host(&mut host)
             .spec(SpecId::BERLIN)
-            .message(Message { depth: CALL_DEPTH_LIMIT, ..Default::default() })
+            .message(MessageExt { depth: CALL_DEPTH_LIMIT, ..Default::default() })
             .gas_limit(50_000));
         assert_matches!(interp.err, InstrStop::Stop);
         assert_eq!(interp.stack(), [Word::ZERO]);
@@ -558,7 +559,7 @@ mod tests {
         let interp = run(RunConfig::new(code)
             .host(&mut host)
             .spec(SpecId::TANGERINE)
-            .message(Message { depth: CALL_DEPTH_LIMIT, ..Default::default() })
+            .message(MessageExt { depth: CALL_DEPTH_LIMIT, ..Default::default() })
             .gas_limit(50_000));
         assert_matches!(interp.err, InstrStop::Stop);
         assert_eq!(interp.gas_remaining(), 42_553);
@@ -587,7 +588,7 @@ mod tests {
         let interp = run(RunConfig::new(code)
             .host(&mut host)
             .spec(SpecId::TANGERINE)
-            .message(Message { depth: CALL_DEPTH_LIMIT, ..Default::default() })
+            .message(MessageExt { depth: CALL_DEPTH_LIMIT, ..Default::default() })
             .gas_limit(50_000));
         assert_matches!(interp.err, InstrStop::Stop);
         assert_eq!(interp.stack(), [Word::ZERO]);
@@ -618,7 +619,7 @@ mod tests {
         let interp = run(RunConfig::new(code)
             .host(&mut host)
             .spec(SpecId::TANGERINE)
-            .message(Message { depth: CALL_DEPTH_LIMIT, ..Default::default() })
+            .message(MessageExt { depth: CALL_DEPTH_LIMIT, ..Default::default() })
             .gas_limit(50_000));
         assert_matches!(interp.err, InstrStop::Stop);
         assert_eq!(interp.stack(), [Word::ZERO]);
@@ -675,7 +676,7 @@ mod tests {
 
         let interp = run(RunConfig::new(code)
             .host(&mut host)
-            .message(Message { destination, ..Default::default() })
+            .message(MessageExt { destination, ..Default::default() })
             .gas_limit(20_000));
         assert_matches!(interp.err, InstrStop::Stop);
         assert_eq!(interp.stack(), [Word::from(1)]);
@@ -704,7 +705,7 @@ mod tests {
         );
         code.extend([op::DELEGATECALL, op::STOP]);
 
-        let interp = run(RunConfig::new(code).host(&mut host).message(Message {
+        let interp = run(RunConfig::new(code).host(&mut host).message(MessageExt {
             caller,
             value: Word::from(9),
             gas_limit: 10_000,
@@ -783,10 +784,10 @@ mod tests {
     fn create_opcode() {
         let created = Address::from([0x77; 20]);
         let mut host = TestHost {
-            execute_result: MessageResult {
+            execute_result: MessageResultExt {
                 stop: InstrStop::Return,
                 created_address: Some(created),
-                ..MessageResult::default()
+                ..MessageResultExt::default()
             },
             ..Default::default()
         };
@@ -804,9 +805,9 @@ mod tests {
     #[test]
     fn create_propagates_fatal_child_result() {
         let mut host = TestHost {
-            execute_result: MessageResult {
+            execute_result: MessageResultExt {
                 stop: InstrStop::FatalPrecompileError,
-                ..MessageResult::default()
+                ..MessageResultExt::default()
             },
             ..Default::default()
         };
@@ -824,11 +825,11 @@ mod tests {
     fn create_clears_return_data_on_success() {
         let created = Address::from([0x77; 20]);
         let mut host = TestHost {
-            execute_result: MessageResult {
+            execute_result: MessageResultExt {
                 stop: InstrStop::Return,
                 output: Bytes::from_static(&[0xaa, 0xbb, 0xcc]),
                 created_address: Some(created),
-                ..MessageResult::default()
+                ..MessageResultExt::default()
             },
             ..Default::default()
         };
@@ -844,10 +845,10 @@ mod tests {
     #[test]
     fn create_sets_return_data_on_revert() {
         let mut host = TestHost {
-            execute_result: MessageResult {
+            execute_result: MessageResultExt {
                 stop: InstrStop::Revert,
                 output: Bytes::from_static(&[0xaa, 0xbb]),
-                ..MessageResult::default()
+                ..MessageResultExt::default()
             },
             ..Default::default()
         };
@@ -870,7 +871,7 @@ mod tests {
         let interp = run(RunConfig::new(code)
             .host(&mut host)
             .spec(SpecId::BERLIN)
-            .message(Message { depth: CALL_DEPTH_LIMIT, ..Default::default() })
+            .message(MessageExt { depth: CALL_DEPTH_LIMIT, ..Default::default() })
             .gas_limit(50_000));
         assert_matches!(interp.err, InstrStop::Stop);
         assert_eq!(interp.stack(), [Word::ZERO]);
@@ -895,10 +896,10 @@ mod tests {
     fn create2_opcode() {
         let created = Address::from([0x88; 20]);
         let mut host = TestHost {
-            execute_result: MessageResult {
+            execute_result: MessageResultExt {
                 stop: InstrStop::Return,
                 created_address: Some(created),
-                ..MessageResult::default()
+                ..MessageResultExt::default()
             },
             ..Default::default()
         };
@@ -935,7 +936,7 @@ mod tests {
         push(&mut code, address_to_word(&target));
         code.push(op::SELFDESTRUCT);
 
-        let interp = run(RunConfig::new(code).host(&mut host).message(Message {
+        let interp = run(RunConfig::new(code).host(&mut host).message(MessageExt {
             destination: contract,
             gas_limit: 10_000,
             ..Default::default()

--- a/crates/evm2/src/interpreter/message.rs
+++ b/crates/evm2/src/interpreter/message.rs
@@ -1,6 +1,5 @@
 use crate::{BaseEvmTypes, EvmTypesHost};
 use alloy_primitives::{Address, B256, Bytes, U256};
-use derive_where::derive_where;
 
 /// EVM message kind.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
@@ -29,9 +28,12 @@ impl MessageKind {
     }
 }
 
-/// Frame-local EVM call/create message executed by the interpreter.
-#[derive_where(Clone, Debug, Default, PartialEq, Eq; T::MessageExt)]
-pub struct Message<T: EvmTypesHost = BaseEvmTypes> {
+/// Frame-local EVM call/create message executed by the interpreter for an EVM type family.
+pub type Message<T = BaseEvmTypes> = MessageExt<<T as EvmTypesHost>::MessageExt>;
+
+/// Frame-local EVM call/create message, parameterized by extension data.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct MessageExt<E = ()> {
     /// Message kind.
     pub kind: MessageKind,
     /// Current call depth.
@@ -65,7 +67,7 @@ pub struct Message<T: EvmTypesHost = BaseEvmTypes> {
     /// CREATE2 salt. Ignored for other message kinds.
     pub salt: B256,
     /// EVM type-specific extension data.
-    pub ext: T::MessageExt,
+    pub ext: E,
     #[doc(hidden)] // Not public API. Please use an existing constructor.
     pub _non_exhaustive: (),
 }

--- a/crates/evm2/src/interpreter/mod.rs
+++ b/crates/evm2/src/interpreter/mod.rs
@@ -28,10 +28,10 @@ mod memory;
 pub use memory::Memory;
 
 mod message;
-pub use message::{Message, MessageKind};
+pub use message::{Message, MessageExt, MessageKind};
 
 mod host;
-pub use host::{Host, MessageResult};
+pub use host::{Host, MessageResult, MessageResultExt};
 
 mod runtime;
 pub(crate) use runtime::InterpreterPool;

--- a/crates/evm2/src/lib.rs
+++ b/crates/evm2/src/lib.rs
@@ -20,7 +20,7 @@ pub mod evm;
 pub use evm::config::EvmTypesHost;
 pub use evm::{
     AccountInfo, BlockStateAccumulator, Evm, ExecutedTx, InterpreterRunner, JournalEntry,
-    PendingState, TxResult, TxResultWithState, config,
+    PendingState, TxResult, TxResultExt, TxResultWithState, config,
     config::{
         BaseEvmConfig, BaseEvmConfigSelector, BaseEvmTypes, EvmConfig, EvmConfigSelector, EvmTypes,
         ExecutionConfig,

--- a/crates/evm2/src/test_utils.rs
+++ b/crates/evm2/src/test_utils.rs
@@ -2,11 +2,11 @@ use crate::{
     BaseEvmConfigSelector, EvmFeatures, EvmTypesHost, ExecutionConfig, SpecId,
     bytecode::Bytecode,
     constants::CALL_DEPTH_LIMIT,
-    env::{BlockEnv, TxEnv},
+    env::{BlockEnv, BlockEnvExt, TxEnv, TxEnvExt},
     evm::{AccountLoad, SLoad, SStore, SelfDestructResult},
     interpreter::{
-        Gas, GasTracker, Host, InstrStop, Interpreter, Memory, Message, MessageKind, MessageResult,
-        StackBacking, Word, op,
+        Gas, GasTracker, Host, InstrStop, Interpreter, Memory, Message, MessageExt, MessageKind,
+        MessageResult, MessageResultExt, StackBacking, Word, op,
     },
     storage_key::{StorageKey, StorageKeyMap},
 };
@@ -57,7 +57,7 @@ impl Default for TestHost {
     fn default() -> Self {
         Self {
             spec_id: SpecId::OSAKA,
-            block: BlockEnv::default(),
+            block: BlockEnvExt::default(),
             code_hash: B256::ZERO,
             code: Bytes::new(),
             exists: true,
@@ -69,7 +69,10 @@ impl Default for TestHost {
             original_storage: StorageKeyMap::default(),
             transient_storage: StorageKeyMap::default(),
             logs: Vec::new(),
-            execute_result: MessageResult { stop: InstrStop::Return, ..MessageResult::default() },
+            execute_result: MessageResultExt {
+                stop: InstrStop::Return,
+                ..MessageResultExt::default()
+            },
             selfdestruct_result: SelfDestructResult::default(),
             selfdestruct_error: None,
             calls: Vec::new(),
@@ -193,7 +196,7 @@ impl Host<TestTypes> for TestHost {
     ) -> MessageResult<TestTypes> {
         // Mimics the depth limit enforced by the real host.
         if message.depth > CALL_DEPTH_LIMIT {
-            return MessageResult {
+            return MessageResultExt {
                 stop: InstrStop::CallTooDeep,
                 gas: GasTracker::new(message.gas_limit),
                 ..Default::default()
@@ -311,8 +314,8 @@ impl Default for RunConfig<'_> {
             code: Vec::new(),
             host: None,
             spec_id: SpecId::OSAKA,
-            tx_env: TxEnv::default(),
-            message: Message { gas_limit: 10_000, ..Message::default() },
+            tx_env: TxEnvExt::default(),
+            message: MessageExt { gas_limit: 10_000, ..MessageExt::default() },
             gas_limit: 10_000,
             return_data: Bytes::new(),
         }

--- a/crates/evm2/src/tests.rs
+++ b/crates/evm2/src/tests.rs
@@ -1,8 +1,8 @@
 use crate::{
     BaseEvmTypes, Evm, Precompiles, SpecId,
-    env::{BlockEnv, TxEnv},
+    env::{BlockEnvExt, TxEnvExt},
     evm::{AccountInfo, InMemoryDB},
-    interpreter::{Host, InstrStop, Message, Word, op},
+    interpreter::{Host, InstrStop, MessageExt, Word, op},
     registry::TxRegistry,
     test_utils::{legacy_bytecode, push},
 };
@@ -12,13 +12,14 @@ use alloy_primitives::Address;
 type TestEvm = Evm<'static, BaseEvmTypes>;
 
 fn run_tx(evm: &mut TestEvm, destination: Address, code: impl Into<Vec<u8>>) {
-    let mut message = Message {
+    let mut message = MessageExt {
         destination,
         code_address: destination,
         gas_limit: 100_000,
         ..Default::default()
     };
-    let result = Host::execute_message(evm, &TxEnv::default(), legacy_bytecode(code), &mut message);
+    let result =
+        Host::execute_message(evm, &TxEnvExt::default(), legacy_bytecode(code), &mut message);
     assert!(result.stop.is_success());
 }
 
@@ -27,7 +28,7 @@ fn evm_executes_storage_transaction() {
     let contract = Address::from([0x11; 20]);
     let mut evm = TestEvm::new(
         SpecId::OSAKA,
-        BlockEnv::default(),
+        BlockEnvExt::default(),
         TxRegistry::new(),
         InMemoryDB::default(),
         Precompiles::base(SpecId::OSAKA),
@@ -56,7 +57,7 @@ fn evm_runs_transactions_against_initial_state() {
     database.insert_account_storage(&contract, &Word::from(1), &Word::from(40));
     let mut evm = TestEvm::new(
         SpecId::OSAKA,
-        BlockEnv::default(),
+        BlockEnvExt::default(),
         TxRegistry::new(),
         database,
         Precompiles::base(SpecId::OSAKA),
@@ -106,7 +107,7 @@ fn evm_propagates_child_sstore_negative_refund() {
     database.insert_account_storage(&contract, &Word::from(0), &Word::from(5));
     let mut evm = TestEvm::new(
         SpecId::LONDON,
-        BlockEnv::default(),
+        BlockEnvExt::default(),
         TxRegistry::new(),
         database,
         Precompiles::base(SpecId::LONDON),
@@ -125,7 +126,7 @@ fn evm_propagates_child_sstore_negative_refund() {
     push(&mut parent_code, 50_000); // gas
     parent_code.extend([op::CALL, op::STOP]);
 
-    let mut message = Message {
+    let mut message = MessageExt {
         destination: contract,
         code_address: contract,
         gas_limit: 100_000,
@@ -133,7 +134,7 @@ fn evm_propagates_child_sstore_negative_refund() {
     };
     let result = Host::execute_message(
         &mut evm,
-        &TxEnv::default(),
+        &TxEnvExt::default(),
         legacy_bytecode(parent_code),
         &mut message,
     );
@@ -147,12 +148,12 @@ fn evm_reports_invalid_transaction_execution() {
     let contract = Address::from([0x33; 20]);
     let mut evm = TestEvm::new(
         SpecId::OSAKA,
-        BlockEnv::default(),
+        BlockEnvExt::default(),
         TxRegistry::new(),
         InMemoryDB::default(),
         Precompiles::base(SpecId::OSAKA),
     );
-    let mut message = Message {
+    let mut message = MessageExt {
         destination: contract,
         code_address: contract,
         gas_limit: 100_000,
@@ -160,7 +161,7 @@ fn evm_reports_invalid_transaction_execution() {
     };
     let result = Host::execute_message(
         &mut evm,
-        &TxEnv::default(),
+        &TxEnvExt::default(),
         legacy_bytecode([op::PUSH1, 0x01, op::SSTORE]),
         &mut message,
     );

--- a/crates/inspectors/src/opcode.rs
+++ b/crates/inspectors/src/opcode.rs
@@ -173,8 +173,8 @@ mod tests {
 
         let bytecode = Bytecode::new_legacy(Bytes::from(opcodes));
         let tx_env = TxEnv::<BaseEvmTypes>::default();
-        let message = Message::default();
-        let mut interp = Interpreter::new(bytecode, &tx_env, &message);
+        let message = Message::<BaseEvmTypes>::default();
+        let mut interp = Interpreter::<BaseEvmTypes>::new(bytecode, &tx_env, &message);
 
         for _ in &opcodes {
             opcode_counter.step(&mut interp);
@@ -189,8 +189,8 @@ mod tests {
 
         let bytecode = Bytecode::new_legacy(Bytes::from(opcodes));
         let tx_env = TxEnv::<BaseEvmTypes>::default();
-        let message = Message::default();
-        let mut interp = Interpreter::new(bytecode, &tx_env, &message);
+        let message = Message::<BaseEvmTypes>::default();
+        let mut interp = Interpreter::<BaseEvmTypes>::new(bytecode, &tx_env, &message);
 
         for _ in &opcodes {
             opcode_counter.step(&mut interp);

--- a/crates/inspectors/src/tracing/builder/parity.rs
+++ b/crates/inspectors/src/tracing/builder/parity.rs
@@ -11,7 +11,7 @@ use alloy_rpc_types_eth::TransactionInfo;
 use alloy_rpc_types_trace::parity::*;
 use core::iter::Peekable;
 use evm2::{
-    AccountInfo, EvmTypesHost, SpecId, TxResult, TxResultWithState,
+    AccountInfo, EvmTypesHost, SpecId, TxResultExt, TxResultWithState,
     evm::{DbResult, DynDatabase, PendingState},
 };
 
@@ -148,9 +148,9 @@ impl ParityTraceBuilder {
     /// be filled. Use [ParityTraceBuilder::into_trace_results_with_state] or
     /// [populate_state_diff] to populate the balance and nonce changes for the [StateDiff]
     /// using the database.
-    pub fn into_trace_results<T: EvmTypesHost>(
+    pub fn into_trace_results<E>(
         self,
-        res: &TxResult<T>,
+        res: &TxResultExt<E>,
         trace_types: &HashSet<TraceType>,
     ) -> TraceResults {
         let output = res.output.clone();

--- a/crates/inspectors/src/tracing/js/mod.rs
+++ b/crates/inspectors/src/tracing/js/mod.rs
@@ -29,8 +29,8 @@ use evm2::{
     env::BlockEnv,
     evm::DynDatabase,
     interpreter::{
-        GasTracker, InstrStop, Interpreter, Message, MessageKind, MessageResult, Word,
-        opcode::OpCode,
+        GasTracker, InstrStop, Interpreter, Message, MessageKind, MessageResult, MessageResultExt,
+        Word, opcode::OpCode,
     },
 };
 
@@ -733,9 +733,9 @@ pub enum JsInspectorError {
 
 /// Converts a JavaScript error into a [InstrStop::Revert] [MessageResult].
 #[inline]
-fn js_error_to_revert<T: EvmTypesHost>(err: JsError) -> MessageResult<T> {
+fn js_error_to_revert<E: Default>(err: JsError) -> MessageResultExt<E> {
     let output = err.to_string().as_bytes().to_vec();
-    MessageResult {
+    MessageResultExt {
         stop: InstrStop::Revert,
         output: output.into(),
         gas: GasTracker::new(0),
@@ -810,7 +810,7 @@ mod tests {
         let insp = JsInspector::new(code.to_string(), serde_json::Value::Null).unwrap();
         let mut evm = Evm::<BaseEvmTypes>::new(
             SpecId::CANCUN,
-            evm2::env::BlockEnv::default(),
+            evm2::env::BlockEnvExt::default(),
             ethereum_tx_registry(SpecId::CANCUN),
             db,
             Precompiles::base(SpecId::CANCUN),

--- a/crates/inspectors/src/tracing/mod.rs
+++ b/crates/inspectors/src/tracing/mod.rs
@@ -15,10 +15,10 @@ use alloc::{boxed::Box, vec::Vec};
 use alloy_primitives::{Address, B256, Bytes, Log, U256};
 use core::mem;
 use evm2::{
-    Evm, EvmTypes, EvmTypesHost, Inspector, SpecId,
+    Evm, EvmTypes, Inspector, SpecId,
     evm::JournalEntry,
     interpreter::{
-        Interpreter, Message, MessageKind, MessageResult,
+        Interpreter, Message, MessageKind, MessageResult, MessageResultExt,
         opcode::{OpCode, op},
     },
 };
@@ -373,7 +373,7 @@ impl TracingInspector {
     /// # Panics
     ///
     /// This expects an existing trace [Self::start_trace_on_call]
-    fn fill_trace_on_call_end<T: EvmTypesHost>(&mut self, result: &MessageResult<T>) {
+    fn fill_trace_on_call_end<E>(&mut self, result: &MessageResultExt<E>) {
         let trace_idx = self.pop_trace_idx();
         let trace = &mut self.traces.arena[trace_idx].trace;
 

--- a/crates/inspectors/src/transfer.rs
+++ b/crates/inspectors/src/transfer.rs
@@ -108,7 +108,7 @@ impl<T: EvmTypesHost> Inspector<T> for TransferInspector {
         interp: &mut Interpreter<'_, '_, T>,
         message: &mut Message<T>,
     ) -> Option<MessageResult<T>> {
-        self.on_transfer(message, interp.host());
+        self.on_transfer::<T>(message, interp.host());
         None
     }
 
@@ -117,7 +117,7 @@ impl<T: EvmTypesHost> Inspector<T> for TransferInspector {
         interp: &mut Interpreter<'_, '_, T>,
         message: &mut Message<T>,
     ) -> Option<MessageResult<T>> {
-        self.on_transfer(message, interp.host());
+        self.on_transfer::<T>(message, interp.host());
         None
     }
 

--- a/crates/inspectors/tests/it/compat.rs
+++ b/crates/inspectors/tests/it/compat.rs
@@ -138,7 +138,7 @@ impl Context {
         Self {
             db: CacheDB::new(EmptyDB::default()),
             tx: TxEnv::default(),
-            block: evm_env::BlockEnv::default(),
+            block: evm_env::BlockEnvExt::default(),
             spec: SpecId::OSAKA,
         }
     }

--- a/crates/jit/builtins/src/lib.rs
+++ b/crates/jit/builtins/src/lib.rs
@@ -16,7 +16,7 @@ use alloy_primitives::{Address, B256, Bytes, KECCAK256_EMPTY, Log, LogData, U256
 use core::cmp::min;
 use evm2::{
     bytecode::Bytecode,
-    interpreter::{Host, Message, MessageKind, Word, i256},
+    interpreter::{Host, MessageExt, MessageKind, Word, i256},
     utils::{word_to_usize, word_to_usize_saturated},
     version::{EvmFeatures, GasId},
 };
@@ -681,7 +681,7 @@ pub unsafe extern "C" fn __revmc_builtin_create(
     };
 
     let current = ecx.message();
-    let mut message = Message {
+    let mut message = MessageExt {
         kind: if is_create2 { MessageKind::Create2 } else { MessageKind::Create },
         depth: current.depth.saturating_add(1),
         gas_limit,
@@ -784,7 +784,7 @@ pub unsafe extern "C" fn __revmc_builtin_call(
         }
         CallKind::StaticCall => (to, current.destination, U256::ZERO, resolved_code_address),
     };
-    let mut message = Message {
+    let mut message = MessageExt {
         kind: call_kind.into(),
         depth: current.depth.saturating_add(1),
         gas_limit,
@@ -997,10 +997,10 @@ mod tests {
     use alloy_primitives::Address;
     use evm2::{
         BaseEvmConfigSelector, BaseEvmTypes, Evm, EvmConfigSelector, Precompiles, SpecId,
-        env::{BlockEnv, TxEnv},
+        env::{BlockEnvExt, TxEnvExt},
         ethereum::ethereum_tx_registry,
         evm::{EmptyDB, inspector::Inspector},
-        interpreter::{GasTracker, MessageResult, op},
+        interpreter::{GasTracker, Message, MessageResult, MessageResultExt, op},
     };
     use evm2_jit_context::EvmStack;
 
@@ -1015,9 +1015,9 @@ mod tests {
     impl Default for MessageInspector {
         fn default() -> Self {
             Self {
-                execute_result: MessageResult {
+                execute_result: MessageResultExt {
                     stop: InstrStop::Return,
-                    ..MessageResult::default()
+                    ..MessageResultExt::default()
                 },
                 calls: Vec::new(),
                 creates: Vec::new(),
@@ -1080,7 +1080,7 @@ mod tests {
     fn base_evm(spec_id: SpecId) -> Evm<'static, BaseEvmTypes> {
         Evm::<BaseEvmTypes>::new(
             spec_id,
-            BlockEnv::default(),
+            BlockEnvExt::default(),
             ethereum_tx_registry(spec_id),
             EmptyDB::default(),
             Precompiles::base(spec_id),
@@ -1107,16 +1107,17 @@ mod tests {
         let child_output = Bytes::from_static(&[0xaa, 0xbb, 0xcc]);
         let mut host = base_evm(SpecId::CANCUN);
         host.set_inspector(MessageInspector {
-            execute_result: MessageResult {
+            execute_result: MessageResultExt {
                 stop: InstrStop::Return,
                 gas: GasTracker::new(37),
                 output: child_output.clone(),
-                ..MessageResult::default()
+                ..MessageResultExt::default()
             },
             ..MessageInspector::default()
         });
-        let tx_env = TxEnv::default();
-        let message = Message { gas_limit: 1_000_000, destination: caller, ..Message::default() };
+        let tx_env = TxEnvExt::default();
+        let message =
+            MessageExt { gas_limit: 1_000_000, destination: caller, ..MessageExt::default() };
         let mut interpreter = evm2::interpreter::Interpreter::<BaseEvmTypes>::new(
             Bytecode::new_legacy(Bytes::from_static(&[op::STOP])),
             &tx_env,
@@ -1166,13 +1167,13 @@ mod tests {
         let stack_value = Word::from(0x12);
         let mut host = base_evm(SpecId::CANCUN);
         host.set_inspector(MessageInspector::default());
-        let tx_env = TxEnv::default();
-        let message = Message {
+        let tx_env = TxEnvExt::default();
+        let message = MessageExt {
             gas_limit: 1_000_000,
             destination,
             caller,
             value: Word::from(0x99),
-            ..Message::default()
+            ..MessageExt::default()
         };
         let mut interpreter = evm2::interpreter::Interpreter::<BaseEvmTypes>::new(
             Bytecode::new_legacy(Bytes::from_static(&[op::STOP])),
@@ -1208,13 +1209,13 @@ mod tests {
         let current_value = Word::from(0x99);
         let mut host = base_evm(SpecId::CANCUN);
         host.set_inspector(MessageInspector::default());
-        let tx_env = TxEnv::default();
-        let message = Message {
+        let tx_env = TxEnvExt::default();
+        let message = MessageExt {
             gas_limit: 1_000_000,
             destination,
             caller,
             value: current_value,
-            ..Message::default()
+            ..MessageExt::default()
         };
         let mut interpreter = evm2::interpreter::Interpreter::<BaseEvmTypes>::new(
             Bytecode::new_legacy(Bytes::from_static(&[op::STOP])),
@@ -1249,13 +1250,13 @@ mod tests {
         let caller = Address::from([0x11; 20]);
         let mut host = base_evm(SpecId::CANCUN);
         host.set_inspector(MessageInspector::default());
-        let tx_env = TxEnv::default();
-        let message = Message {
+        let tx_env = TxEnvExt::default();
+        let message = MessageExt {
             gas_limit: 1_000_000,
             destination,
             caller,
             value: Word::from(0x99),
-            ..Message::default()
+            ..MessageExt::default()
         };
         let mut interpreter = evm2::interpreter::Interpreter::<BaseEvmTypes>::new(
             Bytecode::new_legacy(Bytes::from_static(&[op::STOP])),
@@ -1289,16 +1290,16 @@ mod tests {
         let initcode = [op::STOP];
         let mut host = base_evm(SpecId::CANCUN);
         host.set_inspector(MessageInspector {
-            execute_result: MessageResult {
+            execute_result: MessageResultExt {
                 stop: InstrStop::Return,
                 gas: GasTracker::new(11),
                 created_address: Some(created),
-                ..MessageResult::default()
+                ..MessageResultExt::default()
             },
             ..MessageInspector::default()
         });
-        let tx_env = TxEnv::default();
-        let message = Message { gas_limit: 1_000_000, ..Message::default() };
+        let tx_env = TxEnvExt::default();
+        let message = MessageExt { gas_limit: 1_000_000, ..MessageExt::default() };
         let mut interpreter = evm2::interpreter::Interpreter::<BaseEvmTypes>::new(
             Bytecode::new_legacy(Bytes::from_static(&[op::STOP])),
             &tx_env,
@@ -1333,16 +1334,16 @@ mod tests {
         let salt = EvmWord::from(Word::from(0xabcdu64));
         let mut host = base_evm(SpecId::CANCUN);
         host.set_inspector(MessageInspector {
-            execute_result: MessageResult {
+            execute_result: MessageResultExt {
                 stop: InstrStop::Return,
                 gas: GasTracker::new(11),
                 created_address: Some(created),
-                ..MessageResult::default()
+                ..MessageResultExt::default()
             },
             ..MessageInspector::default()
         });
-        let tx_env = TxEnv::default();
-        let message = Message { gas_limit: 1_000_000, ..Message::default() };
+        let tx_env = TxEnvExt::default();
+        let message = MessageExt { gas_limit: 1_000_000, ..MessageExt::default() };
         let mut interpreter = evm2::interpreter::Interpreter::<BaseEvmTypes>::new(
             Bytecode::new_legacy(Bytes::from_static(&[op::STOP])),
             &tx_env,

--- a/crates/jit/codegen/src/tests/runner.rs
+++ b/crates/jit/codegen/src/tests/runner.rs
@@ -2,7 +2,7 @@ use super::*;
 use evm2::{
     BaseEvmConfigSelector, BaseEvmTypes, Evm, Precompiles,
     bytecode::Bytecode,
-    env::{BlockEnv, TxEnv},
+    env::{BlockEnv, BlockEnvExt, TxEnv},
     ethereum::ethereum_tx_registry,
     evm::{AccountInfo, InMemoryDB},
     interpreter::{Gas, InstrStop, Interpreter, Message},
@@ -232,7 +232,7 @@ pub fn def_codemap() -> &'static HashMap<Address, Bytecode> {
 
 fn def_block_env() -> BlockEnv<BaseEvmTypes> {
     let env = def_env();
-    BlockEnv {
+    BlockEnvExt {
         number: env.block.number,
         beneficiary: env.block.coinbase,
         timestamp: env.block.timestamp,

--- a/crates/jit/runtime/src/evm2_evm.rs
+++ b/crates/jit/runtime/src/evm2_evm.rs
@@ -76,10 +76,10 @@ mod tests {
     use evm2::{
         BaseEvmConfigSelector, BaseEvmTypes, Evm, EvmConfigSelector, Precompiles, SpecId,
         bytecode::Bytecode,
-        env::{BlockEnv, TxEnv},
+        env::{BlockEnvExt, TxEnvExt},
         ethereum::ethereum_tx_registry,
         evm::EmptyDB,
-        interpreter::{Message, op},
+        interpreter::{MessageExt, op},
     };
     #[cfg(feature = "llvm")]
     use evm2::{
@@ -206,8 +206,8 @@ mod tests {
         let config = <BaseEvmConfigSelector as EvmConfigSelector<BaseEvmTypes>>::execution_config(
             SpecId::CANCUN,
         );
-        let tx_env = TxEnv::default();
-        let message = Message { gas_limit: 1_000_000, ..Default::default() };
+        let tx_env = TxEnvExt::default();
+        let message = MessageExt { gas_limit: 1_000_000, ..Default::default() };
         let mut interpreter = Interpreter::<BaseEvmTypes>::new(
             Bytecode::new_legacy(Bytes::from_static(&[op::STOP])),
             &tx_env,
@@ -215,7 +215,7 @@ mod tests {
         );
         let mut host = Evm::<BaseEvmTypes>::new(
             SpecId::CANCUN,
-            BlockEnv::default(),
+            BlockEnvExt::default(),
             ethereum_tx_registry(SpecId::CANCUN),
             EmptyDB::default(),
             Precompiles::base(SpecId::CANCUN),
@@ -245,14 +245,15 @@ mod tests {
         let backend = blocking_backend();
         let mut host = Evm::<BaseEvmTypes>::new(
             SpecId::CANCUN,
-            BlockEnv::default(),
+            BlockEnvExt::default(),
             ethereum_tx_registry(SpecId::CANCUN),
             database,
             Precompiles::base(SpecId::CANCUN),
         );
         host.set_interpreter_runner(JitInterpreterRunner::new(backend.clone()));
-        let tx_env = TxEnv::default();
-        let message = Message { gas_limit: 1_000_000, destination: caller, ..Message::default() };
+        let tx_env = TxEnvExt::default();
+        let message =
+            MessageExt { gas_limit: 1_000_000, destination: caller, ..MessageExt::default() };
         let mut code = vec![op::PUSH1, 0x20, op::PUSH0, op::PUSH0, op::PUSH0, op::PUSH0];
         push20(&mut code, target);
         code.extend([
@@ -292,14 +293,15 @@ mod tests {
         let backend = blocking_backend();
         let mut host = Evm::<BaseEvmTypes>::new(
             SpecId::CANCUN,
-            BlockEnv::default(),
+            BlockEnvExt::default(),
             ethereum_tx_registry(SpecId::CANCUN),
             database,
             Precompiles::base(SpecId::CANCUN),
         );
         host.set_interpreter_runner(JitInterpreterRunner::new(backend.clone()));
-        let tx_env = TxEnv::default();
-        let message = Message { gas_limit: 1_000_000, destination: creator, ..Message::default() };
+        let tx_env = TxEnvExt::default();
+        let message =
+            MessageExt { gas_limit: 1_000_000, destination: creator, ..MessageExt::default() };
         let code = [
             op::PUSH10,
             0x60,
@@ -368,18 +370,18 @@ mod tests {
         let backend = blocking_backend();
         let mut host = Evm::<BaseEvmTypes>::new(
             SpecId::CANCUN,
-            BlockEnv::default(),
+            BlockEnvExt::default(),
             ethereum_tx_registry(SpecId::CANCUN),
             database,
             Precompiles::base(SpecId::CANCUN),
         );
         host.set_interpreter_runner(JitInterpreterRunner::new(backend.clone()));
-        let tx_env = TxEnv::default();
-        let message = Message {
+        let tx_env = TxEnvExt::default();
+        let message = MessageExt {
             gas_limit: 1_000_000,
             destination: caller,
             value: Word::from(30),
-            ..Message::default()
+            ..MessageExt::default()
         };
         let code = vec![
             op::PUSH1,
@@ -447,18 +449,18 @@ mod tests {
         let backend = blocking_backend();
         let mut host = Evm::<BaseEvmTypes>::new(
             SpecId::CANCUN,
-            BlockEnv::default(),
+            BlockEnvExt::default(),
             ethereum_tx_registry(SpecId::CANCUN),
             database,
             Precompiles::base(SpecId::CANCUN),
         );
         host.set_interpreter_runner(JitInterpreterRunner::new(backend.clone()));
-        let tx_env = TxEnv::default();
-        let message = Message {
+        let tx_env = TxEnvExt::default();
+        let message = MessageExt {
             gas_limit: 1_000_000,
             destination: caller,
             value: Word::from(30),
-            ..Message::default()
+            ..MessageExt::default()
         };
         let code = vec![
             op::PUSH1,
@@ -505,16 +507,16 @@ mod tests {
         let outer_code = dynamic_call_outer_code();
         let mut input = [0u8; 32];
         input[12..].copy_from_slice(middle.as_slice());
-        let message = Message {
+        let message = MessageExt {
             gas_limit: 0xcd79195900 - 21_368,
             destination: outer,
             caller,
             input: Bytes::copy_from_slice(&input),
             value: Word::from(10),
             code_address: outer,
-            ..Message::default()
+            ..MessageExt::default()
         };
-        let tx_env = TxEnv { gas_price: Word::from(10), ..TxEnv::default() };
+        let tx_env = TxEnvExt { gas_price: Word::from(10), ..TxEnvExt::default() };
 
         let run = |with_jit: bool| {
             let mut database = InMemoryDB::default();
@@ -536,7 +538,7 @@ mod tests {
             let backend = blocking_backend();
             let mut host = Evm::<BaseEvmTypes>::new(
                 SpecId::CANCUN,
-                BlockEnv::default(),
+                BlockEnvExt::default(),
                 ethereum_tx_registry(SpecId::CANCUN),
                 database,
                 Precompiles::base(SpecId::CANCUN),


### PR DESCRIPTION
Expose `BlockEnvExt<E>`, `TxEnvExt<E>`, `MessageExt<E>`, `MessageResultExt<E>`, and `TxResultExt<E>` as the concrete carriers, with the existing names aliasing an `EvmTypesHost` family.

This keeps family-typed APIs while allowing extension values to be constructed without coupling their layout to the full EVM type family.