### PR TITLE
feat(amsterdam): glamsterdam devnet-7 (EIP-2780 runtime gas phase)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
         shell: bash
         run: |
           if [[ "${{ matrix.fixture }}" == "devnet" ]]; then
-            export DEVNET_VERSION="tests-glamsterdam-devnet%40v6.0.0"
+            export DEVNET_VERSION="tests-glamsterdam-devnet%40v7.2.0"
             export DEVNET_TAR="fixtures_glamsterdam-devnet.tar.gz"
             export EVM2_STATETEST_DEVNET_ONLY=1
           fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ If fixtures are already available in another worktree, symlink `test-fixtures`
 to that directory instead of re-downloading them.
 By default it downloads the glamsterdam (Amsterdam) devnet fixtures plus legacy
 Cancun/Constantinople state tests. The devnet release defaults to
-`tests-glamsterdam-devnet@v6.1.1` / `fixtures_glamsterdam-devnet.tar.gz`
+`tests-glamsterdam-devnet@v7.2.0` / `fixtures_glamsterdam-devnet.tar.gz`
 (from the `ethereum/execution-specs` repo, base overridable via `DEVNET_BASE_URL`);
 override `DEVNET_VERSION` and `DEVNET_TAR` to select a different devnet release, or
 clear either to disable devnet. The glamsterdam devnet fixtures cover

--- a/crates/eest/src/blockchaintest/runner.rs
+++ b/crates/eest/src/blockchaintest/runner.rs
@@ -183,6 +183,10 @@ pub(crate) const IGNORED_TESTS: &[&str] = &[
     "frontier/validation/header/block_gas_limit_below_minimum.json",
     "london/validation/header/invalid_header.json",
     "shanghai/eip4895_withdrawals/withdrawals/withdrawals_root.json",
+    // The same tests under the EEST main suite's flat `test_*` naming.
+    "frontier/validation/test_gas_limit_below_minimum.json",
+    "london/validation/test_invalid_header.json",
+    "shanghai/eip4895_withdrawals/test_withdrawals_root.json",
 
     // Prague request/deposit fixtures validate EL request extraction and system-contract block processing.
     "prague/eip6110_deposits",

--- a/crates/eest/src/execute.rs
+++ b/crates/eest/src/execute.rs
@@ -602,7 +602,9 @@ fn build_tx(
         gas_limit,
         nonce,
         value,
-        chain_id,
+        // An explicit per-transaction chain id overrides the environment chain id (v7 fixtures set
+        // it, including for type-0 transactions, to exercise `INVALID_CHAINID`).
+        chain_id: raw.chain_id.or(chain_id),
         gas_price: raw.gas_price,
         max_fee_per_gas: raw.max_fee_per_gas,
         max_priority_fee_per_gas: raw.max_priority_fee_per_gas,

--- a/crates/eest/src/execute.rs
+++ b/crates/eest/src/execute.rs
@@ -602,8 +602,6 @@ fn build_tx(
         gas_limit,
         nonce,
         value,
-        // An explicit per-transaction chain id overrides the environment chain id (v7 fixtures set
-        // it, including for type-0 transactions, to exercise `INVALID_CHAINID`).
         chain_id: raw.chain_id.or(chain_id),
         gas_price: raw.gas_price,
         max_fee_per_gas: raw.max_fee_per_gas,

--- a/crates/eest/src/types.rs
+++ b/crates/eest/src/types.rs
@@ -85,6 +85,11 @@ pub struct TransactionParts {
     /// Explicit transaction type.
     #[serde(rename = "type")]
     pub tx_type: Option<u8>,
+    /// Explicit transaction chain id. When present it overrides the environment chain id, so a
+    /// fixture can model a transaction whose chain id differs from the network's (expected to be
+    /// rejected with `INVALID_CHAINID`), including for type-0 transactions.
+    #[serde(default)]
+    pub chain_id: Option<U256>,
     /// Input data variants.
     pub data: Vec<Bytes>,
     /// Gas limit variants.

--- a/crates/evm2/src/constants.rs
+++ b/crates/evm2/src/constants.rs
@@ -5,48 +5,48 @@ use alloy_primitives::{B256, b256};
 /// Maximum deployed contract bytecode size.
 ///
 /// EIP-170 - Contract code size limit.
-pub(crate) const MAX_CODE_SIZE: usize = 0x6000;
+pub const MAX_CODE_SIZE: usize = 0x6000;
 
 /// Maximum contract creation initcode size.
 ///
 /// EIP-3860 - Limit and meter initcode.
-pub(crate) const MAX_INITCODE_SIZE: usize = 2 * MAX_CODE_SIZE;
+pub const MAX_INITCODE_SIZE: usize = 2 * MAX_CODE_SIZE;
 
 /// Maximum deployed contract bytecode size since Amsterdam.
 ///
 /// EIP-7954 raises the EIP-170 limit to 0x10000 (64 KiB); initcode stays at twice
 /// the code size (execution-specs `MAX_CODE_SIZE` / `MAX_INIT_CODE_SIZE`).
-pub(crate) const MAX_CODE_SIZE_AMSTERDAM: usize = 0x10000;
+pub const MAX_CODE_SIZE_AMSTERDAM: usize = 0x10000;
 
 /// Maximum contract creation initcode size since Amsterdam.
-pub(crate) const MAX_INITCODE_SIZE_AMSTERDAM: usize = 2 * MAX_CODE_SIZE_AMSTERDAM;
+pub const MAX_INITCODE_SIZE_AMSTERDAM: usize = 2 * MAX_CODE_SIZE_AMSTERDAM;
 
 /// Cancun blob base fee update fraction.
-pub(crate) const BLOB_BASE_FEE_UPDATE_FRACTION_CANCUN: u64 = 3_338_477;
+pub const BLOB_BASE_FEE_UPDATE_FRACTION_CANCUN: u64 = 3_338_477;
 
 /// Prague blob base fee update fraction.
-pub(crate) const BLOB_BASE_FEE_UPDATE_FRACTION_PRAGUE: u64 = 5_007_716;
+pub const BLOB_BASE_FEE_UPDATE_FRACTION_PRAGUE: u64 = 5_007_716;
 
 /// Maximum message call depth.
-pub(crate) const CALL_DEPTH_LIMIT: u16 = 1024;
+pub const CALL_DEPTH_LIMIT: u16 = 1024;
 
 /// Maximum EVM stack height.
-pub(crate) const STACK_LIMIT: usize = 1024;
+pub const STACK_LIMIT: usize = 1024;
 
 /// Number of recent block hashes available to the `BLOCKHASH` opcode.
-pub(crate) const BLOCK_HASH_HISTORY: u64 = 256;
+pub const BLOCK_HASH_HISTORY: u64 = 256;
 
 /// EIP-7702 version magic.
-pub(crate) const EIP7702_MAGIC: u16 = 0xEF01;
+pub const EIP7702_MAGIC: u16 = 0xEF01;
 /// EIP-7702 version magic bytes.
-pub(crate) const EIP7702_MAGIC_BYTES: &[u8] = &EIP7702_MAGIC.to_be_bytes();
+pub const EIP7702_MAGIC_BYTES: &[u8] = &EIP7702_MAGIC.to_be_bytes();
 /// EIP-7702 version.
-pub(crate) const EIP7702_VERSION: u8 = 0;
+pub const EIP7702_VERSION: u8 = 0;
 /// EIP-7702 bytecode length.
 ///
 /// 2 (magic) + 1 (version) + 20 (address) = 23 bytes.
-pub(crate) const EIP7702_BYTECODE_LEN: usize = 23;
+pub const EIP7702_BYTECODE_LEN: usize = 23;
 
 /// EIP-7708 ETH transfer log topic.
-pub(crate) const EIP7708_TRANSFER_TOPIC: B256 =
+pub const EIP7708_TRANSFER_TOPIC: B256 =
     b256!("ddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef");

--- a/crates/evm2/src/ethereum/eip1559.rs
+++ b/crates/evm2/src/ethereum/eip1559.rs
@@ -1,7 +1,6 @@
 use super::{
-    access_list_counts, charge_upfront, create_initial_state_gas, effective_gas_price, floor_gas,
-    initial_gas_and_reservoir, initial_message, intrinsic_gas, refund_create_state_gas,
-    rollback_failed_execution, settle_gas, validate_block_gas_limit, validate_chain_id,
+    access_list_counts, charge_upfront, effective_gas_price, floor_gas, initial_gas_and_reservoir,
+    initial_message, intrinsic_gas, settle_gas, validate_block_gas_limit, validate_chain_id,
     validate_create_initcode, validate_floor_gas, validate_gas_price, validate_intrinsic_gas,
     validate_nonce_not_overflow, validate_priority_fee, validate_regular_gas_limit_cap,
     validate_sender, validate_tx_gas_limit_cap, warm_access_list, warm_base_accounts,
@@ -42,10 +41,17 @@ pub fn handle<T: EvmTypes>(req: TxRequest<'_, '_, T, TxEip1559>) -> HandlerResul
         access_list_storage_keys,
         tx.value,
     );
-    let initial_state_gas = create_initial_state_gas(req.host.version(), tx.to.is_create());
-    validate_intrinsic_gas(tx.gas_limit, intrinsic, initial_state_gas)?;
-    let floor_gas =
-        floor_gas(req.host.version(), &tx.input, access_list_accounts, access_list_storage_keys);
+    // EIP-2780: state-dependent gas is charged at the runtime gas phase, not the intrinsic phase.
+    validate_intrinsic_gas(tx.gas_limit, intrinsic, 0)?;
+    let floor_gas = floor_gas(
+        req.host.version(),
+        caller,
+        tx.to,
+        &tx.input,
+        access_list_accounts,
+        access_list_storage_keys,
+        tx.value,
+    );
     validate_floor_gas(tx.gas_limit, floor_gas)?;
     validate_regular_gas_limit_cap(req.host.version(), tx.gas_limit, intrinsic, floor_gas)?;
 
@@ -58,15 +64,9 @@ pub fn handle<T: EvmTypes>(req: TxRequest<'_, '_, T, TxEip1559>) -> HandlerResul
     let effective_gas_cost = U256::from(tx.gas_limit) * gas_price;
     charge_upfront(req.host, caller, effective_gas_cost)?;
     req.host.state.account(&caller, false).map_err(error_handler!(req.host))?.bump_nonce();
-    let execution_checkpoint = req.host.state.checkpoint();
 
-    let (gas_limit, reservoir) = initial_gas_and_reservoir(
-        req.host.version(),
-        tx.gas_limit,
-        intrinsic,
-        initial_state_gas,
-        0,
-    );
+    let (gas_limit, reservoir) =
+        initial_gas_and_reservoir(req.host.version(), tx.gas_limit, intrinsic, 0, 0);
     let tx_env = TxEnv {
         origin: caller,
         gas_price,
@@ -76,19 +76,8 @@ pub fn handle<T: EvmTypes>(req: TxRequest<'_, '_, T, TxEip1559>) -> HandlerResul
     let (bytecode, mut message) = initial_message(
         req.host, caller, tx.nonce, tx.to, &tx.input, tx.value, gas_limit, reservoir,
     )?;
-    let mut result = req.host.execute_message(&tx_env, bytecode, &mut message);
-    rollback_failed_execution(req.host, execution_checkpoint, &mut result);
-    refund_create_state_gas(&mut result, initial_state_gas);
-
-    settle_gas(
-        req.host,
-        caller,
-        gas_price,
-        tx.gas_limit,
-        floor_gas,
-        initial_state_gas,
-        0,
-        tx.to.is_create(),
-        result,
-    )
+    // Failed execution has already been rolled back to the message's own checkpoint (and halt gas
+    // zeroed) inside `execute_message`, so the result settles directly.
+    let result = req.host.execute_message(&tx_env, bytecode, &mut message);
+    settle_gas(req.host, caller, gas_price, tx.gas_limit, floor_gas, 0, 0, result)
 }

--- a/crates/evm2/src/ethereum/eip1559.rs
+++ b/crates/evm2/src/ethereum/eip1559.rs
@@ -78,7 +78,7 @@ pub fn handle_with_hooks<T: EvmTypes, H: TxHandlerHooks<T>>(
     H::before_execution(req.host, req.envelope, caller, effective_gas_cost)?;
 
     let (gas_limit, reservoir) =
-        initial_gas_and_reservoir(req.host.version(), tx.gas_limit, intrinsic, initial_state_gas, 0);
+        initial_gas_and_reservoir(req.host.version(), tx.gas_limit, intrinsic, initial_state_gas);
     let tx_env = TxEnvExt {
         origin: caller,
         gas_price,

--- a/crates/evm2/src/ethereum/eip2930.rs
+++ b/crates/evm2/src/ethereum/eip2930.rs
@@ -1,7 +1,6 @@
 use super::{
-    access_list_counts, charge_upfront, create_initial_state_gas, floor_gas,
-    initial_gas_and_reservoir, initial_message, intrinsic_gas, refund_create_state_gas,
-    rollback_failed_execution, settle_gas, validate_block_gas_limit, validate_chain_id,
+    access_list_counts, charge_upfront, floor_gas, initial_gas_and_reservoir, initial_message,
+    intrinsic_gas, settle_gas, validate_block_gas_limit, validate_chain_id,
     validate_create_initcode, validate_floor_gas, validate_gas_price, validate_intrinsic_gas,
     validate_nonce_not_overflow, validate_regular_gas_limit_cap, validate_sender,
     validate_tx_gas_limit_cap, warm_access_list, warm_base_accounts,
@@ -38,10 +37,17 @@ pub fn handle<T: EvmTypes>(req: TxRequest<'_, '_, T, TxEip2930>) -> HandlerResul
         access_list_storage_keys,
         tx.value,
     );
-    let initial_state_gas = create_initial_state_gas(req.host.version(), tx.to.is_create());
-    validate_intrinsic_gas(tx.gas_limit, intrinsic, initial_state_gas)?;
-    let floor_gas =
-        floor_gas(req.host.version(), &tx.input, access_list_accounts, access_list_storage_keys);
+    // EIP-2780: state-dependent gas is charged at the runtime gas phase, not the intrinsic phase.
+    validate_intrinsic_gas(tx.gas_limit, intrinsic, 0)?;
+    let floor_gas = floor_gas(
+        req.host.version(),
+        caller,
+        tx.to,
+        &tx.input,
+        access_list_accounts,
+        access_list_storage_keys,
+        tx.value,
+    );
     validate_floor_gas(tx.gas_limit, floor_gas)?;
     validate_regular_gas_limit_cap(req.host.version(), tx.gas_limit, intrinsic, floor_gas)?;
 
@@ -53,15 +59,9 @@ pub fn handle<T: EvmTypes>(req: TxRequest<'_, '_, T, TxEip2930>) -> HandlerResul
 
     charge_upfront(req.host, caller, max_gas_cost)?;
     req.host.state.account(&caller, false).map_err(error_handler!(req.host))?.bump_nonce();
-    let execution_checkpoint = req.host.state.checkpoint();
 
-    let (gas_limit, reservoir) = initial_gas_and_reservoir(
-        req.host.version(),
-        tx.gas_limit,
-        intrinsic,
-        initial_state_gas,
-        0,
-    );
+    let (gas_limit, reservoir) =
+        initial_gas_and_reservoir(req.host.version(), tx.gas_limit, intrinsic, 0, 0);
     let tx_env = TxEnv {
         origin: caller,
         gas_price,
@@ -71,19 +71,8 @@ pub fn handle<T: EvmTypes>(req: TxRequest<'_, '_, T, TxEip2930>) -> HandlerResul
     let (bytecode, mut message) = initial_message(
         req.host, caller, tx.nonce, tx.to, &tx.input, tx.value, gas_limit, reservoir,
     )?;
-    let mut result = req.host.execute_message(&tx_env, bytecode, &mut message);
-    rollback_failed_execution(req.host, execution_checkpoint, &mut result);
-    refund_create_state_gas(&mut result, initial_state_gas);
-
-    settle_gas(
-        req.host,
-        caller,
-        gas_price,
-        tx.gas_limit,
-        floor_gas,
-        initial_state_gas,
-        0,
-        tx.to.is_create(),
-        result,
-    )
+    // Failed execution has already been rolled back to the message's own checkpoint (and halt gas
+    // zeroed) inside `execute_message`, so the result settles directly.
+    let result = req.host.execute_message(&tx_env, bytecode, &mut message);
+    settle_gas(req.host, caller, gas_price, tx.gas_limit, floor_gas, 0, 0, result)
 }

--- a/crates/evm2/src/ethereum/eip2930.rs
+++ b/crates/evm2/src/ethereum/eip2930.rs
@@ -73,7 +73,7 @@ pub fn handle_with_hooks<T: EvmTypes, H: TxHandlerHooks<T>>(
     H::before_execution(req.host, req.envelope, caller, max_gas_cost)?;
 
     let (gas_limit, reservoir) =
-        initial_gas_and_reservoir(req.host.version(), tx.gas_limit, intrinsic, initial_state_gas, 0);
+        initial_gas_and_reservoir(req.host.version(), tx.gas_limit, intrinsic, initial_state_gas);
     let tx_env = TxEnvExt {
         origin: caller,
         gas_price,

--- a/crates/evm2/src/ethereum/eip4844.rs
+++ b/crates/evm2/src/ethereum/eip4844.rs
@@ -1,10 +1,9 @@
 use super::{
-    access_list_counts, charge_upfront, create_initial_state_gas, effective_gas_price, floor_gas,
-    initial_gas_and_reservoir, initial_message, intrinsic_gas, rollback_failed_execution,
-    settle_gas, validate_block_gas_limit, validate_chain_id, validate_create_initcode,
-    validate_floor_gas, validate_gas_price, validate_intrinsic_gas, validate_nonce_not_overflow,
-    validate_priority_fee, validate_regular_gas_limit_cap, validate_sender,
-    validate_tx_gas_limit_cap, warm_access_list, warm_base_accounts,
+    access_list_counts, charge_upfront, effective_gas_price, floor_gas, initial_gas_and_reservoir,
+    initial_message, intrinsic_gas, settle_gas, validate_block_gas_limit, validate_chain_id,
+    validate_create_initcode, validate_floor_gas, validate_gas_price, validate_intrinsic_gas,
+    validate_nonce_not_overflow, validate_priority_fee, validate_regular_gas_limit_cap,
+    validate_sender, validate_tx_gas_limit_cap, warm_access_list, warm_base_accounts,
 };
 use crate::{
     EvmTypes, TxResult,
@@ -49,10 +48,18 @@ pub fn handle<T: EvmTypes>(
         access_list_storage_keys,
         tx.value,
     );
-    let initial_state_gas = create_initial_state_gas(req.host.version(), false);
-    validate_intrinsic_gas(tx.gas_limit, intrinsic, initial_state_gas)?;
-    let floor_gas =
-        floor_gas(req.host.version(), &tx.input, access_list_accounts, access_list_storage_keys);
+    // Blob transactions are always calls; EIP-2780 charges any state-dependent gas at the runtime
+    // gas phase, so no state gas is charged at the intrinsic phase.
+    validate_intrinsic_gas(tx.gas_limit, intrinsic, 0)?;
+    let floor_gas = floor_gas(
+        req.host.version(),
+        caller,
+        tx.to.into(),
+        &tx.input,
+        access_list_accounts,
+        access_list_storage_keys,
+        tx.value,
+    );
     validate_floor_gas(tx.gas_limit, floor_gas)?;
     validate_regular_gas_limit_cap(req.host.version(), tx.gas_limit, intrinsic, floor_gas)?;
 
@@ -73,16 +80,9 @@ pub fn handle<T: EvmTypes>(
     let blob_basefee_cost = blob_gas_cost * req.host.block.blob_basefee;
     charge_upfront(req.host, caller, effective_gas_cost + blob_basefee_cost)?;
     req.host.state.account(&caller, false).map_err(error_handler!(req.host))?.bump_nonce();
-    let execution_checkpoint = req.host.state.checkpoint();
 
-    // Blob transactions are always calls, never creates.
-    let (gas_limit, reservoir) = initial_gas_and_reservoir(
-        req.host.version(),
-        tx.gas_limit,
-        intrinsic,
-        initial_state_gas,
-        0,
-    );
+    let (gas_limit, reservoir) =
+        initial_gas_and_reservoir(req.host.version(), tx.gas_limit, intrinsic, 0, 0);
     let tx_env = TxEnv {
         origin: caller,
         gas_price,
@@ -101,20 +101,10 @@ pub fn handle<T: EvmTypes>(
         gas_limit,
         reservoir,
     )?;
-    let mut result = req.host.execute_message(&tx_env, bytecode, &mut message);
-    rollback_failed_execution(req.host, execution_checkpoint, &mut result);
-
-    settle_gas(
-        req.host,
-        caller,
-        gas_price,
-        tx.gas_limit,
-        floor_gas,
-        initial_state_gas,
-        0,
-        false,
-        result,
-    )
+    // Failed execution has already been rolled back to the message's own checkpoint (and halt gas
+    // zeroed) inside `execute_message`, so the result settles directly.
+    let result = req.host.execute_message(&tx_env, bytecode, &mut message);
+    settle_gas(req.host, caller, gas_price, tx.gas_limit, floor_gas, 0, 0, result)
 }
 
 fn validate_blob_fee(max_fee_per_blob_gas: U256, blob_basefee: U256) -> HandlerResult<()> {

--- a/crates/evm2/src/ethereum/eip4844.rs
+++ b/crates/evm2/src/ethereum/eip4844.rs
@@ -94,7 +94,7 @@ pub fn handle_with_hooks<T: EvmTypes, H: TxHandlerHooks<T>>(
     H::before_execution(req.host, req.envelope, caller, effective_gas_cost + blob_basefee_cost)?;
 
     let (gas_limit, reservoir) =
-        initial_gas_and_reservoir(req.host.version(), tx.gas_limit, intrinsic, initial_state_gas, 0);
+        initial_gas_and_reservoir(req.host.version(), tx.gas_limit, intrinsic, initial_state_gas);
     let tx_env = TxEnvExt {
         origin: caller,
         gas_price,

--- a/crates/evm2/src/ethereum/eip7702.rs
+++ b/crates/evm2/src/ethereum/eip7702.rs
@@ -1,20 +1,20 @@
 use super::{
     access_list_counts, charge_upfront, effective_gas_price, floor_gas, initial_gas_and_reservoir,
-    initial_message, intrinsic_gas, rollback_failed_execution, settle_gas,
-    validate_block_gas_limit, validate_chain_id, validate_create_initcode, validate_floor_gas,
-    validate_gas_price, validate_intrinsic_gas, validate_nonce_not_overflow, validate_priority_fee,
-    validate_regular_gas_limit_cap, validate_sender, validate_tx_gas_limit_cap, warm_access_list,
-    warm_base_accounts,
+    initial_message, intrinsic_gas, settle_gas, validate_block_gas_limit, validate_chain_id,
+    validate_create_initcode, validate_floor_gas, validate_gas_price, validate_intrinsic_gas,
+    validate_nonce_not_overflow, validate_priority_fee, validate_regular_gas_limit_cap,
+    validate_sender, validate_tx_gas_limit_cap, warm_access_list, warm_base_accounts,
 };
 use crate::{
     Evm, EvmFeatures, EvmTypes, TxResult,
     env::TxEnv,
     evm::error_handler,
-    interpreter::Host,
+    interpreter::{GasTracker, Host, InstrStop, MessageResult, gas::EIP8038_ACCOUNT_WRITE},
     registry::{HandlerError, HandlerResult, TxRequest},
     version::GasId,
 };
-use alloy_primitives::U256;
+use alloc::vec::Vec;
+use alloy_primitives::{Address, U256};
 
 /// Executes an EIP-7702 transaction using Ethereum rules.
 pub fn handle<T: EvmTypes>(
@@ -47,12 +47,20 @@ pub fn handle<T: EvmTypes>(
         access_list_storage_keys,
         tx.value,
     ) + eip7702_authorization_gas(req.host, tx.authorization_list.len());
-    // EIP-8037: per-auth state gas (account + bytecode) is charged before execution. Zero before
-    // Amsterdam.
-    let initial_state_gas = eip7702_authorization_state_gas(req.host, tx.authorization_list.len());
-    validate_intrinsic_gas(tx.gas_limit, intrinsic, initial_state_gas)?;
-    let floor_gas =
-        floor_gas(req.host.version(), &tx.input, access_list_accounts, access_list_storage_keys);
+    // EIP-2780 (ethereum/EIPs#11844): the per-auth state-dependent charges are applied at the
+    // runtime gas phase, so no state gas is charged at the intrinsic phase (pre-Amsterdam there is
+    // none either). A transaction that passes the intrinsic check but cannot afford the runtime
+    // charges is included as an out-of-gas halt rather than rejected.
+    validate_intrinsic_gas(tx.gas_limit, intrinsic, 0)?;
+    let floor_gas = floor_gas(
+        req.host.version(),
+        caller,
+        tx.to.into(),
+        &tx.input,
+        access_list_accounts,
+        access_list_storage_keys,
+        tx.value,
+    );
     validate_floor_gas(tx.gas_limit, floor_gas)?;
     validate_regular_gas_limit_cap(req.host.version(), tx.gas_limit, intrinsic, floor_gas)?;
 
@@ -66,24 +74,90 @@ pub fn handle<T: EvmTypes>(
     charge_upfront(req.host, caller, effective_gas_cost)?;
     req.host.state.account(&caller, false).map_err(error_handler!(req.host))?.bump_nonce();
     let chain_id = req.host.version().chain_id;
+    let tx_env =
+        TxEnv { origin: caller, gas_price, chain_id: U256::from(chain_id), ..TxEnv::default() };
+
+    if req.host.feature(EvmFeatures::EIP2780) {
+        // EIP-2780 runtime gas phase (ethereum/EIPs#11844): the authorization charges are metered on
+        // a transaction-level gas tracker as the delegations are applied, stopping at the first
+        // unaffordable charge — later authorities are never loaded, keeping them out of the EIP-7928
+        // block access list. The delegations span `auth_checkpoint` so a runtime out-of-gas can drop
+        // them, and the recipient is read only afterwards (at first-frame creation), so it too stays
+        // out of the block access list on an authorization out-of-gas.
+        let (regular_gas_limit, reservoir) =
+            initial_gas_and_reservoir(req.host.version(), tx.gas_limit, intrinsic, 0, 0);
+        let mut tx_gas =
+            GasTracker::new_with_regular_gas_and_reservoir(regular_gas_limit, reservoir);
+        let auth_checkpoint = req.host.state.checkpoint();
+
+        // Includes the transaction as an out-of-gas halt when the runtime gas phase (the
+        // authorization charges or the first-frame recipient charge) runs out of gas: reverts the
+        // authorization checkpoint to drop the applied delegations, then consumes all regular gas
+        // and returns the reservoir. Called at either out-of-gas exit.
+        let tx_gas_limit = tx.gas_limit;
+        let oog_halt = |host: &mut Evm<'_, T>| -> HandlerResult<TxResult<T>> {
+            let features = host.version().features;
+            host.state.rollback(auth_checkpoint, features);
+            let result = MessageResult {
+                stop: InstrStop::OutOfGas,
+                gas: GasTracker::new_spent_with_reservoir(regular_gas_limit, reservoir),
+                ..MessageResult::default()
+            };
+            settle_gas(host, caller, gas_price, tx_gas_limit, floor_gas, 0, 0, result)
+        };
+
+        if apply_auth_list_runtime(
+            req.host,
+            chain_id,
+            &tx.authorization_list,
+            caller,
+            tx.to,
+            tx.value,
+            &mut tx_gas,
+        )? {
+            return oog_halt(req.host);
+        }
+
+        // State gas charged for the authorizations, carried into the block state-gas accounting.
+        let auth_state_gas = tx_gas.state_gas_spent().max(0) as u64;
+        let (bytecode, mut message) = initial_message(
+            req.host,
+            caller,
+            tx.nonce,
+            tx.to.into(),
+            &tx.input,
+            tx.value,
+            tx_gas.remaining(),
+            tx_gas.reservoir(),
+        )?;
+        // Failed execution has already been rolled back to the message's own checkpoint (past the
+        // applied delegations, which stay) inside `execute_message`.
+        let result = req.host.execute_message(&tx_env, bytecode, &mut message);
+
+        // A depth-0 recipient charge that ran out of gas is part of the runtime gas phase, so it
+        // drops the delegations too.
+        if result.runtime_gas_oog {
+            return oog_halt(req.host);
+        }
+
+        return settle_gas(
+            req.host,
+            caller,
+            gas_price,
+            tx.gas_limit,
+            floor_gas,
+            auth_state_gas,
+            0,
+            result,
+        );
+    }
+
+    // Pre-Amsterdam (no EIP-2780): the pessimistic per-auth intrinsic charge with a regular refund
+    // for each already-existing authority.
     let (state_refund, regular_refund) =
         apply_auth_list(req.host, chain_id, &tx.authorization_list)?;
-    let execution_checkpoint = req.host.state.checkpoint();
-
-    // EIP-7702 transactions are always calls, never creates.
-    let (gas_limit, reservoir) = initial_gas_and_reservoir(
-        req.host.version(),
-        tx.gas_limit,
-        intrinsic,
-        initial_state_gas,
-        state_refund,
-    );
-    let tx_env = TxEnv {
-        origin: caller,
-        gas_price,
-        chain_id: U256::from(req.host.version().chain_id),
-        ..TxEnv::default()
-    };
+    let (gas_limit, reservoir) =
+        initial_gas_and_reservoir(req.host.version(), tx.gas_limit, intrinsic, 0, state_refund);
     let (bytecode, mut message) = initial_message(
         req.host,
         caller,
@@ -94,23 +168,14 @@ pub fn handle<T: EvmTypes>(
         gas_limit,
         reservoir,
     )?;
+    // Failed execution has already been rolled back to the message's own checkpoint inside
+    // `execute_message`.
     let mut result = req.host.execute_message(&tx_env, bytecode, &mut message);
-    rollback_failed_execution(req.host, execution_checkpoint, &mut result);
     result.gas.set_refunded(
         result.gas.refunded().saturating_add(i64::try_from(regular_refund).unwrap_or(i64::MAX)),
     );
 
-    settle_gas(
-        req.host,
-        caller,
-        gas_price,
-        tx.gas_limit,
-        floor_gas,
-        initial_state_gas,
-        state_refund,
-        false,
-        result,
-    )
+    settle_gas(req.host, caller, gas_price, tx.gas_limit, floor_gas, 0, state_refund, result)
 }
 
 fn eip7702_authorization_gas<'a, T: EvmTypes>(host: &Evm<'a, T>, authorizations: usize) -> u64 {
@@ -118,17 +183,8 @@ fn eip7702_authorization_gas<'a, T: EvmTypes>(host: &Evm<'a, T>, authorizations:
     (authorizations as u64).saturating_mul(per_auth)
 }
 
-/// EIP-8037 per-authorization state gas (account + bytecode) charged before execution. Zero before
-/// Amsterdam.
-const fn eip7702_authorization_state_gas<'a, T: EvmTypes>(
-    host: &Evm<'a, T>,
-    authorizations: usize,
-) -> u64 {
-    (authorizations as u64).saturating_mul(host.version().gas_params.eip7702_auth_state_gas())
-}
-
-/// Outcome of applying one accepted EIP-7702 authorization, carrying the facts needed to compute
-/// its gas refunds (execution-specs `set_delegation`).
+/// Outcome of validating one EIP-7702 authorization, carrying the facts needed to compute its gas
+/// charges (execution-specs `set_delegation`).
 struct AppliedAuth {
     /// Whether the authority account already existed when this authorization was processed.
     existed: bool,
@@ -141,15 +197,14 @@ struct AppliedAuth {
     clearing: bool,
 }
 
-/// Validates one authorization against current state and, if accepted, applies the delegation
-/// (setting code and bumping the nonce). Returns `Some` for an accepted authorization or `None` for
-/// a rejected one. Mirrors execution-specs `validate_authorization` + the per-auth body of
-/// `set_delegation`.
-fn apply_one_auth<'a, T: EvmTypes>(
+/// Validates one authorization against current state without applying it. Returns
+/// `Some((authority, facts))` for an accepted authorization or `None` for a rejected one. Mirrors
+/// execution-specs `validate_authorization`.
+fn validate_one_auth<'a, T: EvmTypes>(
     host: &mut Evm<'a, T>,
     chain_id: u64,
     authorization: &super::LazyAuthorization,
-) -> HandlerResult<Option<AppliedAuth>> {
+) -> HandlerResult<Option<(Address, AppliedAuth)>> {
     if !authorization.chain_id().is_zero() && authorization.chain_id() != &U256::from(chain_id) {
         return Ok(None);
     }
@@ -175,8 +230,100 @@ fn apply_one_auth<'a, T: EvmTypes>(
     }
     let delegated_before_tx = account.original_code().map_err(error_handler!(host))?.is_eip7702();
     let clearing = authorization.address().is_zero();
-    account.set_delegation(*authorization.address());
-    Ok(Some(AppliedAuth { existed, delegated_before_tx, delegated_now, clearing }))
+    Ok(Some((authority, AppliedAuth { existed, delegated_before_tx, delegated_now, clearing })))
+}
+
+/// Validates and, if accepted, applies one authorization (setting code and bumping the nonce).
+/// Returns `Some` for an accepted authorization or `None` for a rejected one.
+fn apply_one_auth<'a, T: EvmTypes>(
+    host: &mut Evm<'a, T>,
+    chain_id: u64,
+    authorization: &super::LazyAuthorization,
+) -> HandlerResult<Option<AppliedAuth>> {
+    let Some((authority, auth)) = validate_one_auth(host, chain_id, authorization)? else {
+        return Ok(None);
+    };
+    host.state
+        .account(&authority, false)
+        .map_err(error_handler!(host))?
+        .set_delegation(*authorization.address());
+    Ok(Some(auth))
+}
+
+/// Applies the EIP-7702 authorization list under EIP-2780, metering the state-dependent charges on
+/// the transaction-level `gas` as the delegations are applied (ethereum/EIPs#11844, #11891).
+///
+/// Per accepted authority: the new-account state gas when the authority does not exist,
+/// `ACCOUNT_WRITE` regular gas on the first write to the authority's leaf (unless already paid — the
+/// sender at inclusion, the recipient of a value-bearing transaction, or a preceding valid
+/// authorization on the same authority), and the net-new delegation-indicator state gas.
+///
+/// The charges are recorded as the authorizations are applied, so the phase stops at the first
+/// unaffordable charge without loading the remaining authorities. Rejected authorizations charge
+/// nothing (the intrinsic `REGULAR_PER_AUTH_BASE_COST` already covers their work) and are not
+/// refunded. Returns whether the authorization processing ran out of gas.
+#[allow(clippy::too_many_arguments)]
+fn apply_auth_list_runtime<'a, T: EvmTypes>(
+    host: &mut Evm<'a, T>,
+    chain_id: u64,
+    authorizations: &[super::LazyAuthorization],
+    caller: Address,
+    recipient: Address,
+    value: U256,
+    gas: &mut GasTracker,
+) -> HandlerResult<bool> {
+    let new_account_state_gas = host.version().gas_params.new_account_state_gas();
+    let delegation_bytes_state_gas =
+        u64::from(host.version().gas_params.get(GasId::TxEip7702PerAuthState));
+    let account_write_cost = u64::from(EIP8038_ACCOUNT_WRITE);
+
+    // Accounts whose leaf write this transaction has already paid for: the sender at inclusion
+    // (priced into `TX_BASE`) and the recipient of a value-bearing transaction (priced into
+    // `TX_VALUE_COST`).
+    let mut written = Vec::new();
+    written.push(caller);
+    if !value.is_zero() {
+        written.push(recipient);
+    }
+    // Net-new delegation bytes are charged at most once per authority (covering a set-clear-set
+    // sequence within one transaction).
+    let mut charged_delegation_bytes: Vec<Address> = Vec::new();
+
+    for authorization in authorizations {
+        let Some((authority, auth)) = validate_one_auth(host, chain_id, authorization)? else {
+            continue;
+        };
+
+        // Non-existent authority: pay for the new account leaf's state bytes.
+        if !auth.existed && gas.spend_state(new_account_state_gas).is_err() {
+            return Ok(true);
+        }
+        // First write to the authority's leaf within the transaction pays `ACCOUNT_WRITE`.
+        if !written.contains(&authority) {
+            if gas.spend(account_write_cost).is_err() {
+                return Ok(true);
+            }
+            written.push(authority);
+        }
+        // Net-new delegation bytes: the 23-byte designator written into a previously empty slot.
+        if !auth.clearing
+            && !auth.delegated_now
+            && !auth.delegated_before_tx
+            && !charged_delegation_bytes.contains(&authority)
+        {
+            if gas.spend_state(delegation_bytes_state_gas).is_err() {
+                return Ok(true);
+            }
+            charged_delegation_bytes.push(authority);
+        }
+
+        host.state
+            .account(&authority, false)
+            .map_err(error_handler!(host))?
+            .set_delegation(*authorization.address());
+    }
+
+    Ok(false)
 }
 
 /// Applies the EIP-7702 authorization list and returns `(state_refund, regular_refund)`.

--- a/crates/evm2/src/ethereum/eip7702.rs
+++ b/crates/evm2/src/ethereum/eip7702.rs
@@ -1,18 +1,21 @@
 use super::{
-    access_list_counts, effective_gas_price, floor_gas, initial_gas_and_reservoir, initial_message,
-    intrinsic_gas, validate_block_gas_limit, validate_chain_id, validate_create_initcode,
-    validate_floor_gas, validate_gas_price, validate_intrinsic_gas, validate_nonce_not_overflow,
-    validate_priority_fee, validate_regular_gas_limit_cap, validate_sender,
-    validate_tx_gas_limit_cap, warm_access_list, warm_base_accounts,
+    LazyAuthorization, access_list_counts, effective_gas_price, floor_gas,
+    initial_gas_and_reservoir, initial_message, intrinsic_gas, validate_block_gas_limit,
+    validate_chain_id, validate_create_initcode, validate_floor_gas, validate_gas_price,
+    validate_intrinsic_gas, validate_nonce_not_overflow, validate_priority_fee,
+    validate_regular_gas_limit_cap, validate_sender, validate_tx_gas_limit_cap, warm_access_list,
+    warm_base_accounts,
 };
 use crate::{
-    Evm, EvmFeatures, EvmTypes, TxResult,
+    Evm, EvmFeatures, EvmTypes, TxResult, Version,
     env::TxEnvExt,
     evm::{
         error_handler,
         handler::{DefaultTxHandlerHooks, GasSettlement, TxHandlerHooks},
     },
-    interpreter::{GasTracker, Host, InstrStop, MessageResultExt, gas::EIP8038_ACCOUNT_WRITE},
+    interpreter::{
+        GasTracker, Host, InstrStop, MessageResult, MessageResultExt, gas::EIP8038_ACCOUNT_WRITE,
+    },
     registry::{HandlerError, HandlerResult, TxRequest},
     version::GasId,
 };
@@ -94,88 +97,45 @@ pub fn handle_with_hooks<T: EvmTypes, H: TxHandlerHooks<T>>(
         ..TxEnvExt::default()
     };
 
-    if req.host.feature(EvmFeatures::EIP2780) {
-        // EIP-2780 runtime gas phase (ethereum/EIPs#11844): the authorization charges are metered on
-        // a transaction-level gas tracker as the delegations are applied, stopping at the first
-        // unaffordable charge — later authorities are never loaded, keeping them out of the EIP-7928
-        // block access list. The delegations span `auth_checkpoint` so a runtime out-of-gas can drop
-        // them, and the recipient is read only afterwards (at first-frame creation), so it too stays
-        // out of the block access list on an authorization out-of-gas.
-        let (regular_gas_limit, reservoir) = initial_gas_and_reservoir(
-            req.host.version(),
-            tx.gas_limit,
-            intrinsic,
-            initial_state_gas,
-            0,
+    let (regular_gas_limit, reservoir) =
+        initial_gas_and_reservoir(req.host.version(), tx.gas_limit, intrinsic, initial_state_gas);
+    let mut tx_gas = GasTracker::new_with_regular_gas_and_reservoir(regular_gas_limit, reservoir);
+    // The delegations span `runtime_checkpoint` so a runtime out-of-gas can drop them; the
+    // recipient is read only afterwards (at first-frame creation), so it too stays out of the
+    // EIP-7928 block access list on an authorization out-of-gas. Pre-Amsterdam nothing rolls
+    // the checkpoint back.
+    let runtime_checkpoint = req.host.state.checkpoint();
+
+    // The authorization gas phase. Under EIP-2780 (ethereum/EIPs#11844) the runtime charges are
+    // metered on the transaction-level gas tracker as the delegations are applied, stopping at the
+    // first unaffordable charge — later authorities are never loaded, keeping them out of the
+    // block access list. Pre-Amsterdam the pessimistic per-auth intrinsic charge is refilled
+    // instead and never runs out of gas: an regular refund for each already-existing authority,
+    // and under EIP-8037 a state refund credited directly back to the reservoir so it stays state
+    // gas — per execution-specs `set_delegation` (`state_gas_reservoir += refund`), deliberately
+    // not routed through regular gas first.
+    let (auth_oog, state_refund, regular_refund) = if req.host.feature(EvmFeatures::EIP2780) {
+        let mut auth_charges =
+            RuntimeAuthCharges::new(req.host.version(), &mut tx_gas, caller, tx.to, tx.value);
+        let oog = apply_auth_list(req.host, chain_id, &tx.authorization_list, &mut auth_charges)?;
+        (oog, 0, 0)
+    } else {
+        let mut auth_refunds = AuthRefunds::new(req.host.version());
+        apply_auth_list(req.host, chain_id, &tx.authorization_list, &mut auth_refunds)?;
+        let AuthRefunds { state_refund, regular_refund, .. } = auth_refunds;
+        tx_gas.set_reservoir(tx_gas.reservoir() + state_refund);
+        (false, state_refund, regular_refund)
+    };
+
+    // Applies the pre-Amsterdam authorization regular refund (zero under EIP-2780) and settles
+    // the transaction with the given authorization state gas. Every exit below funnels through
+    // here.
+    let settle = |host: &mut Evm<'_, T>, mut result: MessageResult<T>, auth_state_gas: u64| {
+        result.gas.set_refunded(
+            result.gas.refunded().saturating_add(i64::try_from(regular_refund).unwrap_or(i64::MAX)),
         );
-        let mut tx_gas =
-            GasTracker::new_with_regular_gas_and_reservoir(regular_gas_limit, reservoir);
-        let auth_checkpoint = req.host.state.checkpoint();
-
-        // Includes the transaction as an out-of-gas halt when the runtime gas phase (the
-        // authorization charges or the first-frame recipient charge) runs out of gas: reverts the
-        // authorization checkpoint to drop the applied delegations, then consumes all regular gas
-        // and returns the reservoir. Called at either out-of-gas exit.
-        let tx_gas_limit = tx.gas_limit;
-        let oog_halt = |host: &mut Evm<'_, T>| -> HandlerResult<TxResult<T>> {
-            let features = host.version().features;
-            host.state.rollback(auth_checkpoint, features);
-            let result = MessageResultExt {
-                stop: InstrStop::OutOfGas,
-                gas: GasTracker::new_spent_with_reservoir(regular_gas_limit, reservoir),
-                ..MessageResultExt::default()
-            };
-            H::settle_transaction(
-                host,
-                envelope,
-                GasSettlement {
-                    caller,
-                    gas_price,
-                    gas_limit: tx_gas_limit,
-                    floor_gas,
-                    initial_state_gas: 0,
-                    state_refund: 0,
-                    result,
-                },
-            )
-        };
-
-        if apply_auth_list_runtime(
-            req.host,
-            chain_id,
-            &tx.authorization_list,
-            caller,
-            tx.to,
-            tx.value,
-            &mut tx_gas,
-        )? {
-            return oog_halt(req.host);
-        }
-
-        // State gas charged for the authorizations, carried into the block state-gas accounting.
-        let auth_state_gas = tx_gas.state_gas_spent().max(0) as u64;
-        let (bytecode, mut message) = initial_message(
-            req.host,
-            caller,
-            tx.nonce,
-            tx.to.into(),
-            &tx.input,
-            tx.value,
-            tx_gas.remaining(),
-            tx_gas.reservoir(),
-        )?;
-        // Failed execution has already been rolled back to the message's own checkpoint (past the
-        // applied delegations, which stay) inside `execute_message`.
-        let result = req.host.execute_message(&tx_env, bytecode, &mut message);
-
-        // A depth-0 recipient charge that ran out of gas is part of the runtime gas phase, so it
-        // drops the delegations too.
-        if result.runtime_gas_oog {
-            return oog_halt(req.host);
-        }
-
-        return H::settle_transaction(
-            req.host,
+        H::settle_transaction(
+            host,
             envelope,
             GasSettlement {
                 caller,
@@ -183,23 +143,34 @@ pub fn handle_with_hooks<T: EvmTypes, H: TxHandlerHooks<T>>(
                 gas_limit: tx.gas_limit,
                 floor_gas,
                 initial_state_gas: auth_state_gas,
-                state_refund: 0,
+                state_refund,
                 result,
             },
-        );
-    }
+        )
+    };
+    // Settles the transaction as an out-of-gas halt when the runtime gas phase (the authorization
+    // charges or the first-frame recipient charge) runs out of gas: reverts the runtime
+    // checkpoint to drop the applied delegations, then consumes all regular gas and returns the
+    // reservoir. Unreachable pre-Amsterdam, where no runtime charge is attempted.
+    let settle_oog = |host: &mut Evm<'_, T>| {
+        let features = host.version().features;
+        host.state.rollback(runtime_checkpoint, features);
+        settle(
+            host,
+            MessageResultExt {
+                stop: InstrStop::OutOfGas,
+                gas: GasTracker::new_spent_with_reservoir(regular_gas_limit, reservoir),
+                ..MessageResultExt::default()
+            },
+            0,
+        )
+    };
 
-    // Pre-Amsterdam (no EIP-2780): the pessimistic per-auth intrinsic charge with a regular refund
-    // for each already-existing authority.
-    let (state_refund, regular_refund) =
-        apply_auth_list(req.host, chain_id, &tx.authorization_list)?;
-    let (gas_limit, reservoir) = initial_gas_and_reservoir(
-        req.host.version(),
-        tx.gas_limit,
-        intrinsic,
-        initial_state_gas,
-        state_refund,
-    );
+    if auth_oog {
+        return settle_oog(req.host);
+    }
+    // State gas charged for the authorizations, carried into the block state-gas accounting.
+    let auth_state_gas = tx_gas.state_gas_spent().max(0) as u64;
     let (bytecode, mut message) = initial_message(
         req.host,
         caller,
@@ -207,29 +178,18 @@ pub fn handle_with_hooks<T: EvmTypes, H: TxHandlerHooks<T>>(
         tx.to.into(),
         &tx.input,
         tx.value,
-        gas_limit,
-        reservoir,
+        tx_gas.remaining(),
+        tx_gas.reservoir(),
     )?;
-    // Failed execution has already been rolled back to the message's own checkpoint inside
-    // `execute_message`.
-    let mut result = req.host.execute_message(&tx_env, bytecode, &mut message);
-    result.gas.set_refunded(
-        result.gas.refunded().saturating_add(i64::try_from(regular_refund).unwrap_or(i64::MAX)),
-    );
-
-    H::settle_transaction(
-        req.host,
-        envelope,
-        GasSettlement {
-            caller,
-            gas_price,
-            gas_limit: tx.gas_limit,
-            floor_gas,
-            initial_state_gas: 0,
-            state_refund,
-            result,
-        },
-    )
+    // Failed execution has already been rolled back to the message's own checkpoint (past the
+    // applied delegations, which stay) inside `execute_message`.
+    let result = req.host.execute_message(&tx_env, bytecode, &mut message);
+    // A depth-0 recipient charge that ran out of gas is part of the runtime gas phase, so it
+    // drops the delegations too.
+    if result.runtime_gas_oog {
+        return settle_oog(req.host);
+    }
+    settle(req.host, result, auth_state_gas)
 }
 
 fn eip7702_authorization_gas<'a, T: EvmTypes>(host: &Evm<'a, T>, authorizations: usize) -> u64 {
@@ -239,25 +199,26 @@ fn eip7702_authorization_gas<'a, T: EvmTypes>(host: &Evm<'a, T>, authorizations:
 
 /// Outcome of validating one EIP-7702 authorization, carrying the facts needed to compute its gas
 /// charges (execution-specs `set_delegation`).
-struct AppliedAuth {
+#[derive(Clone, Copy, Debug)]
+pub struct AppliedAuth {
     /// Whether the authority account already existed when this authorization was processed.
-    existed: bool,
+    pub existed: bool,
     /// Whether the authority's code was a valid delegation at the start of the transaction.
-    delegated_before_tx: bool,
+    pub delegated_before_tx: bool,
     /// Whether the authority's code was a valid delegation when this authorization was processed
     /// (i.e. as left by an earlier authorization for the same authority in this transaction).
-    delegated_now: bool,
+    pub delegated_now: bool,
     /// Whether this authorization clears the delegation (target is the zero address).
-    clearing: bool,
+    pub clearing: bool,
 }
 
 /// Validates one authorization against current state without applying it. Returns
 /// `Some((authority, facts))` for an accepted authorization or `None` for a rejected one. Mirrors
 /// execution-specs `validate_authorization`.
-fn validate_one_auth<'a, T: EvmTypes>(
+pub fn validate_one_auth<'a, T: EvmTypes>(
     host: &mut Evm<'a, T>,
     chain_id: u64,
-    authorization: &super::LazyAuthorization,
+    authorization: &LazyAuthorization,
 ) -> HandlerResult<Option<(Address, AppliedAuth)>> {
     if !authorization.chain_id().is_zero() && authorization.chain_id() != &U256::from(chain_id) {
         return Ok(None);
@@ -287,161 +248,205 @@ fn validate_one_auth<'a, T: EvmTypes>(
     Ok(Some((authority, AppliedAuth { existed, delegated_before_tx, delegated_now, clearing })))
 }
 
-/// Validates and, if accepted, applies one authorization (setting code and bumping the nonce).
-/// Returns `Some` for an accepted authorization or `None` for a rejected one.
-fn apply_one_auth<'a, T: EvmTypes>(
-    host: &mut Evm<'a, T>,
-    chain_id: u64,
-    authorization: &super::LazyAuthorization,
-) -> HandlerResult<Option<AppliedAuth>> {
-    let Some((authority, auth)) = validate_one_auth(host, chain_id, authorization)? else {
-        return Ok(None);
-    };
-    host.state
-        .account(&authority, false)
-        .map_err(error_handler!(host))?
-        .set_delegation(*authorization.address());
-    Ok(Some(auth))
+/// Gas accounting for one regime of [`apply_auth_list`].
+///
+/// The loop validates each authorization and applies the accepted ones; the accounting decides
+/// what each outcome costs or refunds. [`RuntimeAuthCharges`] meters the EIP-2780 runtime charges
+/// and can abort the list, [`AuthRefunds`] accumulates the pessimistic-intrinsic refunds and never
+/// fails; handlers with their own authorization pricing supply their own implementation.
+pub trait AuthAccounting {
+    /// Called for a rejected authorization before moving to the next entry.
+    fn rejected(&mut self);
+
+    /// Called for an accepted authorization before its delegation is applied. Returning
+    /// out-of-gas aborts the list: the delegation is not applied and no later authority is
+    /// loaded.
+    fn accepted(&mut self, authority: Address, auth: &AppliedAuth) -> Result<(), InstrStop>;
 }
 
-/// Applies the EIP-7702 authorization list under EIP-2780, metering the state-dependent charges on
-/// the transaction-level `gas` as the delegations are applied (ethereum/EIPs#11844, #11891).
+/// EIP-2780 runtime accounting: meters the state-dependent charges on the transaction-level gas
+/// tracker as the delegations are applied (ethereum/EIPs#11844, #11891).
 ///
 /// Per accepted authority: the new-account state gas when the authority does not exist,
-/// `ACCOUNT_WRITE` regular gas on the first write to the authority's leaf (unless already paid — the
-/// sender at inclusion, the recipient of a value-bearing transaction, or a preceding valid
+/// `ACCOUNT_WRITE` regular gas on the first write to the authority's leaf (unless already paid —
+/// the sender at inclusion, the recipient of a value-bearing transaction, or a preceding valid
 /// authorization on the same authority), and the net-new delegation-indicator state gas.
 ///
-/// The charges are recorded as the authorizations are applied, so the phase stops at the first
-/// unaffordable charge without loading the remaining authorities. Rejected authorizations charge
-/// nothing (the intrinsic `REGULAR_PER_AUTH_BASE_COST` already covers their work) and are not
-/// refunded. Returns whether the authorization processing ran out of gas.
-#[allow(clippy::too_many_arguments)]
-fn apply_auth_list_runtime<'a, T: EvmTypes>(
-    host: &mut Evm<'a, T>,
-    chain_id: u64,
-    authorizations: &[super::LazyAuthorization],
-    caller: Address,
-    recipient: Address,
-    value: U256,
-    gas: &mut GasTracker,
-) -> HandlerResult<bool> {
-    let new_account_state_gas = host.version().gas_params.new_account_state_gas();
-    let delegation_bytes_state_gas =
-        u64::from(host.version().gas_params.get(GasId::TxEip7702PerAuthState));
-    let account_write_cost = u64::from(EIP8038_ACCOUNT_WRITE);
+/// Rejected authorizations charge nothing (the intrinsic `REGULAR_PER_AUTH_BASE_COST` already
+/// covers their work) and are not refunded.
+#[derive(Debug)]
+pub struct RuntimeAuthCharges<'g> {
+    gas: &'g mut GasTracker,
+    new_account_state_gas: u64,
+    delegation_bytes_state_gas: u64,
+    account_write_cost: u64,
+    /// Accounts whose leaf write this transaction has already paid for.
+    written: Vec<Address>,
+    /// Authorities whose net-new delegation bytes were already charged; the charge applies at most
+    /// once per authority (covering a set-clear-set sequence within one transaction).
+    charged_delegation_bytes: Vec<Address>,
+}
 
-    // Accounts whose leaf write this transaction has already paid for: the sender at inclusion
-    // (priced into `TX_BASE`) and the recipient of a value-bearing transaction (priced into
-    // `TX_VALUE_COST`).
-    let mut written = Vec::new();
-    written.push(caller);
-    if !value.is_zero() {
-        written.push(recipient);
+impl<'g> RuntimeAuthCharges<'g> {
+    /// Creates the runtime accounting for a transaction from `caller` to `recipient` carrying
+    /// `value`. The sender's leaf write is priced into `TX_BASE` and the value-bearing recipient's
+    /// into `TX_VALUE_COST`, so neither pays `ACCOUNT_WRITE` again.
+    pub fn new(
+        version: &Version,
+        gas: &'g mut GasTracker,
+        caller: Address,
+        recipient: Address,
+        value: U256,
+    ) -> Self {
+        let mut written = Vec::new();
+        written.push(caller);
+        if !value.is_zero() {
+            written.push(recipient);
+        }
+        Self {
+            gas,
+            new_account_state_gas: version.gas_params.new_account_state_gas(),
+            delegation_bytes_state_gas: u64::from(
+                version.gas_params.get(GasId::TxEip7702PerAuthState),
+            ),
+            account_write_cost: u64::from(EIP8038_ACCOUNT_WRITE),
+            written,
+            charged_delegation_bytes: Vec::new(),
+        }
     }
-    // Net-new delegation bytes are charged at most once per authority (covering a set-clear-set
-    // sequence within one transaction).
-    let mut charged_delegation_bytes: Vec<Address> = Vec::new();
+}
 
-    for authorization in authorizations {
-        let Some((authority, auth)) = validate_one_auth(host, chain_id, authorization)? else {
-            continue;
-        };
+impl AuthAccounting for RuntimeAuthCharges<'_> {
+    fn rejected(&mut self) {}
 
+    fn accepted(&mut self, authority: Address, auth: &AppliedAuth) -> Result<(), InstrStop> {
         // Non-existent authority: pay for the new account leaf's state bytes.
-        if !auth.existed && gas.spend_state(new_account_state_gas).is_err() {
-            return Ok(true);
+        if !auth.existed {
+            self.gas.spend_state(self.new_account_state_gas)?;
         }
         // First write to the authority's leaf within the transaction pays `ACCOUNT_WRITE`.
-        if !written.contains(&authority) {
-            if gas.spend(account_write_cost).is_err() {
-                return Ok(true);
-            }
-            written.push(authority);
+        if !self.written.contains(&authority) {
+            self.gas.spend(self.account_write_cost)?;
+            self.written.push(authority);
         }
         // Net-new delegation bytes: the 23-byte designator written into a previously empty slot.
         if !auth.clearing
             && !auth.delegated_now
             && !auth.delegated_before_tx
-            && !charged_delegation_bytes.contains(&authority)
+            && !self.charged_delegation_bytes.contains(&authority)
         {
-            if gas.spend_state(delegation_bytes_state_gas).is_err() {
-                return Ok(true);
-            }
-            charged_delegation_bytes.push(authority);
+            self.gas.spend_state(self.delegation_bytes_state_gas)?;
+            self.charged_delegation_bytes.push(authority);
         }
-
-        host.state
-            .account(&authority, false)
-            .map_err(error_handler!(host))?
-            .set_delegation(*authorization.address());
+        Ok(())
     }
-
-    Ok(false)
 }
 
-/// Applies the EIP-7702 authorization list and returns `(state_refund, regular_refund)`.
+/// Pre-EIP-2780 accounting: refunds against the pessimistic per-authorization intrinsic charge.
 ///
-/// Follows execution-specs `set_delegation`. The per-authorization state and regular gas charged in
-/// the intrinsic cost is refilled when it turns out not to be needed: the state refund is credited
-/// to the reservoir (so it stays state gas) and the regular refund is routed through the capped
-/// refund counter.
+/// Follows execution-specs `set_delegation`. The per-authorization state and regular gas charged
+/// in the intrinsic cost is refilled when it turns out not to be needed: the state refund is
+/// credited to the reservoir (so it stays state gas) and the regular refund is routed through
+/// the capped refund counter.
 ///
 /// Before EIP-8037 (Prague) there is no state gas: only the per-existing-account regular refund
 /// applies and rejected authorizations refund nothing.
-fn apply_auth_list<'a, T: EvmTypes>(
-    host: &mut Evm<'a, T>,
-    chain_id: u64,
-    authorizations: &[super::LazyAuthorization],
-) -> HandlerResult<(u64, u64)> {
-    let is_eip8037 = host.feature(EvmFeatures::EIP8037);
-    let new_account = host.version().gas_params.new_account_state_gas();
-    let auth_base = u64::from(host.version().gas_params.get(GasId::TxEip7702PerAuthState));
-    let regular_per_auth = u64::from(host.version().gas_params.get(GasId::TxEip7702AuthRefund));
+#[derive(Clone, Copy, Debug)]
+pub struct AuthRefunds {
+    is_eip8037: bool,
+    new_account: u64,
+    auth_base: u64,
+    regular_per_auth: u64,
+    /// Accumulated state-gas refund.
+    pub state_refund: u64,
+    /// Accumulated regular-gas refund.
+    pub regular_refund: u64,
+}
 
-    let mut state_refund = 0u64;
-    let mut regular_refund = 0u64;
-    for authorization in authorizations {
-        let Some(auth) = apply_one_auth(host, chain_id, authorization)? else {
-            // Rejected authorization. Under EIP-8037 its full intrinsic state gas (account +
-            // bytecode) refills the reservoir and the speculative account write is refunded;
-            // before EIP-8037 nothing is refunded.
-            if is_eip8037 {
-                state_refund = state_refund.saturating_add(new_account + auth_base);
-                regular_refund = regular_refund.saturating_add(regular_per_auth);
-            }
-            continue;
-        };
+impl AuthRefunds {
+    /// Creates refund accounting with `version`'s authorization prices.
+    pub fn new(version: &Version) -> Self {
+        Self {
+            is_eip8037: version.feature(EvmFeatures::EIP8037),
+            new_account: version.gas_params.new_account_state_gas(),
+            auth_base: u64::from(version.gas_params.get(GasId::TxEip7702PerAuthState)),
+            regular_per_auth: u64::from(version.gas_params.get(GasId::TxEip7702AuthRefund)),
+            state_refund: 0,
+            regular_refund: 0,
+        }
+    }
+}
 
+impl AuthAccounting for AuthRefunds {
+    fn rejected(&mut self) {
+        // Rejected authorization. Under EIP-8037 its full intrinsic state gas (account + bytecode)
+        // refills the reservoir and the speculative account write is refunded; before EIP-8037
+        // nothing is refunded.
+        if self.is_eip8037 {
+            self.state_refund = self.state_refund.saturating_add(self.new_account + self.auth_base);
+            self.regular_refund = self.regular_refund.saturating_add(self.regular_per_auth);
+        }
+    }
+
+    fn accepted(&mut self, _authority: Address, auth: &AppliedAuth) -> Result<(), InstrStop> {
         // Existing authority: the worst-case `ACCOUNT_WRITE` regular gas was not needed. This
         // refund applies in every regime (it is the only authorization refund before EIP-8037).
         if auth.existed {
-            regular_refund = regular_refund.saturating_add(regular_per_auth);
+            self.regular_refund = self.regular_refund.saturating_add(self.regular_per_auth);
         }
 
         // The remaining refunds are state gas, which only exists under EIP-8037.
-        if !is_eip8037 {
-            continue;
+        if !self.is_eip8037 {
+            return Ok(());
         }
 
         let mut refund = 0u64;
         // Existing authority: its `NEW_ACCOUNT` state gas was not needed.
         if auth.existed {
-            refund += new_account;
+            refund += self.new_account;
         }
         // Bytecode (`AUTH_BASE`) refunds.
         if auth.clearing {
-            refund += auth_base;
+            refund += self.auth_base;
             // Clearing a delegation freshly installed earlier in this transaction refills the
             // bytecode state gas a second time.
             if auth.delegated_now && !auth.delegated_before_tx {
-                refund += auth_base;
+                refund += self.auth_base;
             }
         } else if auth.delegated_now || auth.delegated_before_tx {
-            refund += auth_base;
+            refund += self.auth_base;
         }
-        state_refund = state_refund.saturating_add(refund);
+        self.state_refund = self.state_refund.saturating_add(refund);
+        Ok(())
     }
+}
 
-    Ok((state_refund, regular_refund))
+/// Validates and applies an EIP-7702 authorization list, driving `accounting` with each
+/// per-authorization outcome.
+///
+/// Each authorization is validated against current state ([`validate_one_auth`]); the accounting
+/// is told about rejected entries and charges (or accumulates refunds) for accepted ones before
+/// their delegation is applied. An accounting out-of-gas aborts the list without loading the
+/// remaining authorities — keeping them out of the EIP-7928 block access list — and returns
+/// `true`; the caller is responsible for rolling back the partially applied delegations.
+pub fn apply_auth_list<'a, T: EvmTypes>(
+    host: &mut Evm<'a, T>,
+    chain_id: u64,
+    authorizations: &[LazyAuthorization],
+    accounting: &mut impl AuthAccounting,
+) -> HandlerResult<bool> {
+    for authorization in authorizations {
+        let Some((authority, auth)) = validate_one_auth(host, chain_id, authorization)? else {
+            accounting.rejected();
+            continue;
+        };
+        if accounting.accepted(authority, &auth).is_err() {
+            return Ok(true);
+        }
+        host.state
+            .account(&authority, false)
+            .map_err(error_handler!(host))?
+            .set_delegation(*authorization.address());
+    }
+    Ok(false)
 }

--- a/crates/evm2/src/ethereum/eip7702.rs
+++ b/crates/evm2/src/ethereum/eip7702.rs
@@ -128,8 +128,9 @@ pub fn handle_with_hooks<T: EvmTypes, H: TxHandlerHooks<T>>(
     };
 
     // Applies the pre-Amsterdam authorization regular refund (zero under EIP-2780) and settles
-    // the transaction with the given authorization state gas. Every exit below funnels through
-    // here.
+    // the transaction with the given authorization state gas on top of the hook-provided
+    // intrinsic state gas (charged upfront, before `runtime_checkpoint`, so it persists on every
+    // exit). Every exit below funnels through here.
     let settle = |host: &mut Evm<'_, T>, mut result: MessageResult<T>, auth_state_gas: u64| {
         result.gas.set_refunded(
             result.gas.refunded().saturating_add(i64::try_from(regular_refund).unwrap_or(i64::MAX)),
@@ -142,7 +143,7 @@ pub fn handle_with_hooks<T: EvmTypes, H: TxHandlerHooks<T>>(
                 gas_price,
                 gas_limit: tx.gas_limit,
                 floor_gas,
-                initial_state_gas: auth_state_gas,
+                initial_state_gas: initial_state_gas.saturating_add(auth_state_gas),
                 state_refund,
                 result,
             },

--- a/crates/evm2/src/ethereum/legacy.rs
+++ b/crates/evm2/src/ethereum/legacy.rs
@@ -55,7 +55,7 @@ pub fn handle_with_hooks<T: EvmTypes, H: TxHandlerHooks<T>>(
     H::before_execution(req.host, req.envelope, caller, max_gas_cost)?;
 
     let (gas_limit, reservoir) =
-        initial_gas_and_reservoir(req.host.version(), tx.gas_limit, intrinsic, initial_state_gas, 0);
+        initial_gas_and_reservoir(req.host.version(), tx.gas_limit, intrinsic, initial_state_gas);
     let tx_env = TxEnvExt {
         origin: caller,
         gas_price,

--- a/crates/evm2/src/ethereum/legacy.rs
+++ b/crates/evm2/src/ethereum/legacy.rs
@@ -1,8 +1,7 @@
 use super::{
-    charge_upfront, create_initial_state_gas, floor_gas, initial_gas_and_reservoir,
-    initial_message, intrinsic_gas, refund_create_state_gas, rollback_failed_execution, settle_gas,
-    validate_block_gas_limit, validate_chain_id, validate_create_initcode, validate_floor_gas,
-    validate_gas_price, validate_intrinsic_gas, validate_nonce_not_overflow,
+    charge_upfront, floor_gas, initial_gas_and_reservoir, initial_message, intrinsic_gas,
+    settle_gas, validate_block_gas_limit, validate_chain_id, validate_create_initcode,
+    validate_floor_gas, validate_gas_price, validate_intrinsic_gas, validate_nonce_not_overflow,
     validate_regular_gas_limit_cap, validate_sender, validate_tx_gas_limit_cap, warm_base_accounts,
 };
 use crate::{
@@ -28,9 +27,10 @@ pub fn handle<T: EvmTypes>(req: TxRequest<'_, '_, T, TxLegacy>) -> HandlerResult
     validate_create_initcode(req.host.version(), tx.to, &tx.input)?;
     validate_nonce_not_overflow(tx.nonce)?;
     let intrinsic = intrinsic_gas(req.host.version(), caller, tx.to, &tx.input, 0, 0, tx.value);
-    let initial_state_gas = create_initial_state_gas(req.host.version(), tx.to.is_create());
-    validate_intrinsic_gas(tx.gas_limit, intrinsic, initial_state_gas)?;
-    let floor_gas = floor_gas(req.host.version(), &tx.input, 0, 0);
+    // EIP-2780: create-transaction and EIP-7702 state gas is charged at the runtime gas phase, so
+    // no state gas is charged at the intrinsic phase.
+    validate_intrinsic_gas(tx.gas_limit, intrinsic, 0)?;
+    let floor_gas = floor_gas(req.host.version(), caller, tx.to, &tx.input, 0, 0, tx.value);
     validate_floor_gas(tx.gas_limit, floor_gas)?;
     validate_regular_gas_limit_cap(req.host.version(), tx.gas_limit, intrinsic, floor_gas)?;
 
@@ -41,15 +41,9 @@ pub fn handle<T: EvmTypes>(req: TxRequest<'_, '_, T, TxLegacy>) -> HandlerResult
 
     charge_upfront(req.host, caller, max_gas_cost)?;
     req.host.state.account(&caller, false).map_err(error_handler!(req.host))?.bump_nonce();
-    let execution_checkpoint = req.host.state.checkpoint();
 
-    let (gas_limit, reservoir) = initial_gas_and_reservoir(
-        req.host.version(),
-        tx.gas_limit,
-        intrinsic,
-        initial_state_gas,
-        0,
-    );
+    let (gas_limit, reservoir) =
+        initial_gas_and_reservoir(req.host.version(), tx.gas_limit, intrinsic, 0, 0);
     let tx_env = TxEnv {
         origin: caller,
         gas_price,
@@ -59,19 +53,8 @@ pub fn handle<T: EvmTypes>(req: TxRequest<'_, '_, T, TxLegacy>) -> HandlerResult
     let (bytecode, mut message) = initial_message(
         req.host, caller, tx.nonce, tx.to, &tx.input, tx.value, gas_limit, reservoir,
     )?;
-    let mut result = req.host.execute_message(&tx_env, bytecode, &mut message);
-    rollback_failed_execution(req.host, execution_checkpoint, &mut result);
-    refund_create_state_gas(&mut result, initial_state_gas);
-
-    settle_gas(
-        req.host,
-        caller,
-        gas_price,
-        tx.gas_limit,
-        floor_gas,
-        initial_state_gas,
-        0,
-        tx.to.is_create(),
-        result,
-    )
+    // Failed execution has already been rolled back to the message's own checkpoint (and halt gas
+    // zeroed) inside `execute_message`, so the result settles directly.
+    let result = req.host.execute_message(&tx_env, bytecode, &mut message);
+    settle_gas(req.host, caller, gas_price, tx.gas_limit, floor_gas, 0, 0, result)
 }

--- a/crates/evm2/src/ethereum/mod.rs
+++ b/crates/evm2/src/ethereum/mod.rs
@@ -17,7 +17,7 @@ pub use lazy_eip7702::{LazyAuthorization, LazyTxEip7702};
 use crate::{
     Evm, EvmFeatures, EvmTypes, EvmTypesHost, SpecId, TxResult, Version,
     bytecode::Bytecode,
-    evm::{AccountInfo, StateCheckpoint, error_handler},
+    evm::{AccountInfo, error_handler},
     interpreter::{
         Message, MessageKind, MessageResult, Word,
         gas::{EIP2780_TX_BASE_COST, EIP8038_COLD_ACCOUNT_ACCESS},
@@ -444,21 +444,6 @@ pub fn charge_upfront<'a, T: EvmTypes>(
     Ok(())
 }
 
-/// Returns the EIP-8037 `initial_state_gas` charged before execution for `is_create` transactions
-/// (the top-level create's `create_state_gas`). Zero without EIP-8037 or for non-create calls.
-///
-/// This is the create transaction's contribution to execution-specs `IntrinsicGas.state`; the
-/// EIP-7702 authorization contribution is computed separately in the EIP-7702 handler. Keeping the
-/// state-gas intrinsic distinct from the regular intrinsic ([`intrinsic_gas`]) mirrors the spec,
-/// which tracks `IntrinsicGas.regular` and `.state` separately.
-pub const fn create_initial_state_gas(version: &Version, is_create: bool) -> u64 {
-    if version.feature(EvmFeatures::EIP8037) && is_create {
-        version.gas_params.create_state_gas()
-    } else {
-        0
-    }
-}
-
 /// Returns `(regular_gas_limit, reservoir)` for the first frame.
 ///
 /// `initial_state_gas` is the EIP-8037 state gas charged before execution (top-level create state
@@ -578,6 +563,14 @@ fn initial_call_code<'a, T: EvmTypes>(
     if host.feature(EvmFeatures::EIP7702)
         && let Some(delegated_address) = code.eip7702_address()
     {
+        // Under EIP-2780 the delegation resolution is deferred to the frame
+        // (`apply_eip2780_call_charges`), which meters the delegation-target access and gates its
+        // load on gas so a cold, unafforded target stays out of the EIP-7928 block access list. The
+        // frame swaps in the delegate's code and code_address after the charge; loading the target
+        // here would leak it into the block access list on a runtime out-of-gas.
+        if host.feature(EvmFeatures::EIP2780) {
+            return Ok(InitialCallCode { code, code_address: to, disable_precompiles: true });
+        }
         let mut account =
             host.state.account(&delegated_address, false).map_err(error_handler!(host))?;
         account.warm();
@@ -591,40 +584,6 @@ fn initial_call_code<'a, T: EvmTypes>(
     Ok(InitialCallCode { code, code_address: to, disable_precompiles: false })
 }
 
-/// Rolls back failed top-level execution and normalizes halt gas.
-pub fn rollback_failed_execution<'a, T: EvmTypes>(
-    host: &mut Evm<'a, T>,
-    checkpoint: StateCheckpoint,
-    result: &mut MessageResult<T>,
-) {
-    if !result.stop.is_success() {
-        let features = host.version().features;
-        host.state.rollback(checkpoint, features);
-        if result.stop.is_halt() {
-            result.gas.set_remaining(0);
-        }
-    }
-}
-
-/// EIP-8037: refunds a top-level CREATE's intrinsic `create_state_gas` back to the reservoir when
-/// no new account leaf ends up created.
-///
-/// The charge was deducted upfront in [`initial_gas_and_reservoir`] (an unbalanced reservoir
-/// reduction, not a `spend_state`), so the inverse is an unbalanced reservoir add. It is refunded
-/// when the deployment failed (a reverted or halted deployment is rolled back, so the state gas was
-/// never actually consumed) or when it succeeded at a pre-existing alive (balance-only) target (no
-/// new leaf was created — execution-specs `created_target_alive`). No-op when `create_state_gas` is
-/// zero (non-create or pre-Amsterdam).
-pub const fn refund_create_state_gas<T: EvmTypesHost>(
-    result: &mut MessageResult<T>,
-    create_state_gas: u64,
-) {
-    if create_state_gas != 0 && (!result.stop.is_success() || result.created_target_was_alive) {
-        let reservoir = result.gas.reservoir().saturating_add(create_state_gas);
-        result.gas.set_reservoir(reservoir);
-    }
-}
-
 #[allow(clippy::too_many_arguments)]
 /// Applies Ethereum gas refunds, sender reimbursement, and beneficiary rewards.
 pub fn settle_gas<'a, T: EvmTypes>(
@@ -635,7 +594,6 @@ pub fn settle_gas<'a, T: EvmTypes>(
     floor_gas: u64,
     initial_state_gas: u64,
     state_refund: u64,
-    is_create: bool,
     result: MessageResult<T>,
 ) -> HandlerResult<TxResult<T>> {
     if let Some(code) = host.error_code {
@@ -647,8 +605,9 @@ pub fn settle_gas<'a, T: EvmTypes>(
         final_tx_gas(&result, tx_gas_limit, max_refund_quotient, floor_gas);
     // Self-contained gas breakdown for the result. `total_gas_spent` is defined so that
     // `TxResult::tx_gas_used` reproduces the local `gas_used` (used here for the beneficiary
-    // reward). State gas is execution state gas plus the upfront `initial_state_gas`, less the
-    // EIP-7702 per-authorization `state_refund`.
+    // reward). State gas is execution state gas plus the upfront `initial_state_gas` (the EIP-7702
+    // authorization state gas charged before the first frame), less the pre-Amsterdam per-auth
+    // `state_refund`.
     let total_gas_spent =
         tx_gas_limit.saturating_sub(result.gas.remaining()).saturating_sub(result.gas.reservoir());
     let refunded = result.final_refund(tx_gas_limit, max_refund_quotient);
@@ -656,28 +615,13 @@ pub fn settle_gas<'a, T: EvmTypes>(
     // resolves to the floor. `total_gas_spent` stays pre-refund and pre-floor: block-level
     // regular gas (EIP-7778/EIP-8037) accumulates `tx_gas_used_before_refund` per
     // execution-specs, without the floor clamp.
+    //
     // Execution state gas contributes only on success: a revert/halt rolls back its state changes.
-    // A failed top-level CREATE additionally unwinds its intrinsic `create_state_gas` (refunded to
-    // the reservoir by `refund_create_state_gas`), so it nets out of the block state gas.
-    let exec_state_gas = if result.stop.is_success() {
-        result.gas.state_gas_spent()
-    } else if is_create {
-        -(initial_state_gas as i64)
-    } else {
-        0
-    };
-    // A top-level CREATE that succeeds at a pre-existing alive target refunds its upfront
-    // `create_state_gas` (already credited to the reservoir by `refund_create_state_gas`), so it
-    // must not count toward block state gas either.
-    let alive_create_refund =
-        if is_create && result.stop.is_success() && result.created_target_was_alive {
-            initial_state_gas
-        } else {
-            0
-        };
+    // The upfront `initial_state_gas` is added unconditionally — an EIP-7702 execution failure
+    // still leaves the applied delegations (and their state gas) in place.
+    let exec_state_gas = if result.stop.is_success() { result.gas.state_gas_spent() } else { 0 };
     let state_gas_spent = (exec_state_gas.saturating_add_unsigned(initial_state_gas).max(0) as u64)
-        .saturating_sub(state_refund)
-        .saturating_sub(alive_create_refund);
+        .saturating_sub(state_refund);
     if host.feature(EvmFeatures::FEE_CHARGE) {
         let caller_refund = U256::from(gas_remaining) * gas_price;
         host.state
@@ -731,11 +675,20 @@ pub fn access_list_counts(access_list: &AccessList) -> (u64, u64) {
 }
 
 /// Calculates transaction calldata floor gas.
+///
+/// `caller`/`to`/`value` feed the EIP-2780 floor base (ethereum/EIPs#11836):
+/// under EIP-2780 the floor is anchored on the decomposed regular-gas intrinsic
+/// base (`TX_BASE` + `to`-based + `value`-based, the same sum
+/// [`intrinsic_gas`] charges) instead of the flat `TxFloorCostBase`, so the
+/// floor never undercuts the transaction's own intrinsic base.
 pub fn floor_gas(
     version: &Version,
+    caller: Address,
+    to: TxKind,
     input: &Bytes,
     access_list_accounts: u64,
     access_list_storage_keys: u64,
+    value: U256,
 ) -> u64 {
     if !version.feature(EvmFeatures::EIP7623) {
         return 0;
@@ -759,7 +712,15 @@ pub fn floor_gas(
     let non_zero_data_len = input.len() as u64 - zero_data_len;
     tokens += zero_data_len * zero_multiplier + non_zero_data_len * non_zero_multiplier;
 
-    params.get(GasId::TxFloorCostBase) as u64 + tokens * floor_cost_per_token
+    // EIP-2780 (ethereum/EIPs#11836): anchor the floor on the decomposed
+    // intrinsic base instead of the flat `TxFloorCostBase`.
+    let base = if version.feature(EvmFeatures::EIP2780) {
+        let is_self_transfer = matches!(to, TxKind::Call(t) if t == caller);
+        eip2780_base_to_value_gas(version, to.is_create(), is_self_transfer, value)
+    } else {
+        params.get(GasId::TxFloorCostBase) as u64
+    };
+    base + tokens * floor_cost_per_token
 }
 
 /// Calculates intrinsic transaction gas.
@@ -951,33 +912,49 @@ mod tests {
     #[test]
     fn floor_gas_charges_prague_calldata_tokens() {
         let input = Bytes::from_static(&[0, 1, 2]);
+        let sender = Address::with_last_byte(0xaa);
+        let to = TxKind::Call(Address::ZERO);
         let mut prague_without_eip7623 = Version::new(SpecId::PRAGUE);
         prague_without_eip7623.features.remove(EvmFeatures::EIP7623);
 
-        assert_eq!(floor_gas(Version::base(SpecId::SHANGHAI), &input, 0, 0), 0);
-        assert_eq!(floor_gas(Version::base(SpecId::PRAGUE), &input, 0, 0), 21_000 + 9 * 10);
-        assert_eq!(floor_gas(&prague_without_eip7623, &input, 0, 0), 0);
+        assert_eq!(
+            floor_gas(Version::base(SpecId::SHANGHAI), sender, to, &input, 0, 0, U256::ZERO),
+            0
+        );
+        assert_eq!(
+            floor_gas(Version::base(SpecId::PRAGUE), sender, to, &input, 0, 0, U256::ZERO),
+            21_000 + 9 * 10
+        );
+        assert_eq!(floor_gas(&prague_without_eip7623, sender, to, &input, 0, 0, U256::ZERO), 0);
     }
 
     #[test]
     fn floor_gas_charges_amsterdam_access_list_tokens() {
         let input = Bytes::from(vec![1; 1000]);
+        let sender = Address::with_last_byte(0xaa);
+        // A plain value-less call to a different address: EIP-2780
+        // (ethereum/EIPs#11836) anchors the floor base on the decomposed
+        // intrinsic base `TX_BASE + COLD_ACCOUNT_ACCESS` (12,000 + 3,000)
+        // instead of the flat `TxFloorCostBase`.
+        let to = TxKind::Call(Address::ZERO);
 
         assert_eq!(
-            floor_gas(Version::base(SpecId::AMSTERDAM), &input, 1, 1),
-            // EIP-2780: the floor base drops from 21,000 to TX_BASE (12,000).
-            12_000 + (1000 * 4 + 80 + 128) * 16
+            floor_gas(Version::base(SpecId::AMSTERDAM), sender, to, &input, 1, 1, U256::ZERO),
+            15_000 + (1000 * 4 + 80 + 128) * 16
         );
 
         // EIP-7976: amsterdam weights zero calldata bytes the same as non-zero
         // bytes in the floor (4 tokens each), unlike EIP-7623 (zero = 1 token).
         let zero_input = Bytes::from(vec![0; 1000]);
         assert_eq!(
-            floor_gas(Version::base(SpecId::AMSTERDAM), &zero_input, 1, 1),
-            12_000 + (1000 * 4 + 80 + 128) * 16
+            floor_gas(Version::base(SpecId::AMSTERDAM), sender, to, &zero_input, 1, 1, U256::ZERO),
+            15_000 + (1000 * 4 + 80 + 128) * 16
         );
         // Prague keeps the EIP-7623 split: zero bytes count as one token each.
-        assert_eq!(floor_gas(Version::base(SpecId::PRAGUE), &zero_input, 0, 0), 21_000 + 1000 * 10);
+        assert_eq!(
+            floor_gas(Version::base(SpecId::PRAGUE), sender, to, &zero_input, 0, 0, U256::ZERO),
+            21_000 + 1000 * 10
+        );
     }
 
     #[test]

--- a/crates/evm2/src/ethereum/mod.rs
+++ b/crates/evm2/src/ethereum/mod.rs
@@ -446,22 +446,18 @@ pub fn charge_upfront<'a, T: EvmTypes>(
 
 /// Returns `(regular_gas_limit, reservoir)` for the first frame.
 ///
-/// `initial_state_gas` is the EIP-8037 state gas charged before execution (top-level create state
-/// gas and EIP-7702 authorization state gas). It is deducted from the reservoir, spilling into the
-/// regular budget when the reservoir is insufficient. `state_refund` is the EIP-7702 state-gas
-/// refund, credited directly back to the reservoir so it stays state gas. Both are zero without
-/// EIP-8037.
-///
-/// `initial_state_gas` and `state_refund` are kept as separate arguments deliberately: per
-/// execution-specs the state refund is added to the state-gas reservoir (`set_delegation` does
-/// `state_gas_reservoir += refund`), not applied to regular gas first. Folding them into a single
-/// regular-first refund — as an earlier note suggested — would diverge from the spec.
+/// `initial_state_gas` is the EIP-8037 state gas charged at the intrinsic phase (the pre-EIP-2780
+/// pessimistic EIP-7702 authorization state gas, or hook-added charges). It is deducted from the
+/// reservoir, spilling into the regular budget when the reservoir is insufficient. It is zero
+/// without EIP-8037; under EIP-2780 the state-dependent charges are metered at the runtime gas
+/// phase instead. The pre-EIP-2780 EIP-7702 state-gas refund is not an input here: per
+/// execution-specs it is credited directly back to the reservoir after the authorizations are
+/// applied, not applied to regular gas first.
 pub fn initial_gas_and_reservoir(
     version: &Version,
     tx_gas_limit: u64,
     intrinsic: u64,
     initial_state_gas: u64,
-    state_refund: u64,
 ) -> (u64, u64) {
     if !version.feature(EvmFeatures::EIP8037) {
         return (tx_gas_limit - intrinsic, 0);
@@ -478,10 +474,6 @@ pub fn initial_gas_and_reservoir(
         regular_gas_limit -= initial_state_gas - reservoir;
         reservoir = 0;
     }
-
-    // EIP-7702 state-gas refund for existing authorities goes directly to the reservoir so it
-    // stays state gas rather than being routed through the capped regular refund counter.
-    reservoir += state_refund;
 
     (regular_gas_limit, reservoir)
 }

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -1436,8 +1436,8 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
         // precompile/interpreter split. Read from the recipient's pre-call state (before the value
         // transfer below) and applied inside the checkpoint, so the delegated-target load it
         // performs is unwound if the frame later rolls back. For a delegated recipient this also
-        // resolves the delegation (gating the target load on gas), returning the delegate's code and
-        // address so the frame runs the delegate's code.
+        // resolves the delegation (gating the target load on gas), returning the delegate's code
+        // and address so the frame runs the delegate's code.
         let mut frame_gas =
             GasTracker::new_with_regular_gas_and_reservoir(message.gas_limit, message.reservoir);
         let mut bytecode = bytecode;
@@ -1502,12 +1502,12 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
     /// - the delegation-target access following the EIP-2929 warm/cold model when the recipient
     ///   carries an EIP-7702 delegation.
     ///
-    /// The delegation-target access is charged as a warm access first and the cold premium after the
-    /// target is loaded, and the load is gated on `skip_cold_load` (as nested calls do): a frame
-    /// that cannot afford the cold access never loads the target, so it stays out of the EIP-7928
-    /// block access list. On success the delegated recipient's resolved code and address are
-    /// returned so the caller runs the delegate's code; `Err(())` signals a runtime out-of-gas.
-    /// A no-op returning `Ok(None)` off the depth-0 EIP-2780 path.
+    /// The delegation-target access is charged as a warm access first and the cold premium after
+    /// the target is loaded, and the load is gated on `skip_cold_load` (as nested calls do): a
+    /// frame that cannot afford the cold access never loads the target, so it stays out of the
+    /// EIP-7928 block access list. On success the delegated recipient's resolved code and
+    /// address are returned so the caller runs the delegate's code; `Err(())` signals a runtime
+    /// out-of-gas. A no-op returning `Ok(None)` off the depth-0 EIP-2780 path.
     fn apply_eip2780_call_charges(
         &mut self,
         message: &Message<T>,
@@ -1785,7 +1785,7 @@ impl<'a, T: EvmTypes> Host<T> for Evm<'a, T> {
         skip_cold_load: bool,
     ) -> Result<SStore, InstrStop> {
         let eip2929 = self.feature(EvmFeatures::EIP2929);
-        // EIP-8037 (ethereum/EIPs#11854): SSTORE must cover the slot's access cost before the
+        // EIP-8037: SSTORE must cover the slot's access cost before the
         // implicit storage read. When the cold access is unaffordable the read is skipped, so the
         // slot stays out of the EIP-7928 block access list (the warm-read cost has already been
         // paid by the instruction, so an affordable warm slot is still read on OOG).

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -123,7 +123,7 @@ use crate::{
     error::error_unavailable,
     interpreter::{
         Gas, GasTracker, Host, InstrStop, Interpreter, InterpreterPool, Message, MessageKind,
-        MessageResult, Word, gas::EIP8038_COLD_ACCOUNT_ACCESS,
+        MessageResult, Word, gas::WARM_STORAGE_READ_COST,
     },
     registry::{HandlerError, HandlerResult, TxRegistry},
     trustme,
@@ -1245,9 +1245,10 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
             return Self::error_message_result(stop, message.gas_limit, message.reservoir);
         }
         let checkpoint = self.state.checkpoint();
-        // EIP-8037: capture whether the target leaf was already alive (existing, non-empty) before
-        // creation, so a successful create at a pre-existing balance-only account can refund the
-        // upfront NEW_ACCOUNT state gas (execution-specs `created_target_alive`).
+        // EIP-2780 (ethereum/EIPs#11858): capture whether the target leaf is already alive
+        // (existing, non-empty) before creation, so a top-level create at a pre-existing
+        // balance-only account is not charged the account-creation state gas below (no new leaf is
+        // created — execution-specs `created_target_alive`).
         let target_alive = if self.feature(EvmFeatures::EIP8037) {
             match self.account_is_alive(&message.destination) {
                 Ok(alive) => alive,
@@ -1266,20 +1267,30 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
         message.disable_precompiles = false;
         let input = core::mem::take(&mut message.input);
 
-        // Creates pay their NEW_ACCOUNT-equivalent state gas upfront via the tx-level
-        // `initial_state_gas`, so the create frame starts from the inherited gas as-is.
-        let frame_gas =
+        // EIP-2780 (ethereum/EIPs#11858): a top-level create (depth 0) charges the
+        // account-creation state gas at frame entry, conditional on the destination not already
+        // existing (`!target_alive`). Nested creates are charged on the parent frame by the CREATE
+        // opcode instead. The charge is state gas on this frame's tracker, refilled by the frame's
+        // own settle on failure; an unaffordable charge halts the create out-of-gas without running
+        // the initcode, returning the reservoir.
+        let mut frame_gas =
             GasTracker::new_with_regular_gas_and_reservoir(message.gas_limit, message.reservoir);
+        if message.depth == 0
+            && !target_alive
+            && self.feature(EvmFeatures::EIP8037)
+            && frame_gas.spend_state(self.version().gas_params.create_state_gas()).is_err()
+        {
+            self.state.rollback(checkpoint, self.features);
+            return Self::error_message_result(
+                InstrStop::OutOfGas,
+                message.gas_limit,
+                message.reservoir,
+            );
+        }
         let stop = self.run_interpreter(bytecode, tx_env, message, frame_gas);
         message.input = input;
 
-        self.finish_create_message_run(
-            checkpoint,
-            &message.destination,
-            message.gas_limit,
-            stop,
-            target_alive,
-        )
+        self.finish_create_message_run(checkpoint, &message.destination, message.gas_limit, stop)
     }
 
     #[inline(never)]
@@ -1351,7 +1362,6 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
         address: &Address,
         gas_limit: u64,
         stop: InstrStop,
-        target_alive: bool,
     ) -> MessageResult<T> {
         let interp = self.interpreter_pool.last_mut().unwrap();
         let mut gas = interp.gas();
@@ -1364,7 +1374,7 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
                     gas: *gas.tracker(),
                     output,
                     created_address: None,
-                    created_target_was_alive: false,
+                    runtime_gas_oog: false,
                     ext: T::MessageResultExt::default(),
                     _non_exhaustive: (),
                 };
@@ -1388,7 +1398,7 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
             gas: *gas.tracker(),
             output,
             created_address: stop.is_success().then_some(*address),
-            created_target_was_alive: stop.is_success() && target_alive,
+            runtime_gas_oog: false,
             ext: T::MessageResultExt::default(),
             _non_exhaustive: (),
         }
@@ -1458,12 +1468,35 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
             );
         }
         let checkpoint = self.state.checkpoint();
-        // EIP-2780 top-level execution charges, computed from the recipient's
-        // pre-call state (before the value transfer below) and applied to the frame
-        // gas before the precompile/interpreter split. Computed inside the checkpoint
-        // so the delegated-target warming it performs is unwound if the frame later
-        // rolls back.
-        let eip2780_charges = self.eip2780_call_charges(message);
+        // EIP-2780 top-level (depth-0) execution charges, metered on the frame gas before the
+        // precompile/interpreter split. Read from the recipient's pre-call state (before the value
+        // transfer below) and applied inside the checkpoint, so the delegated-target load it
+        // performs is unwound if the frame later rolls back. For a delegated recipient this also
+        // resolves the delegation (gating the target load on gas), returning the delegate's code and
+        // address so the frame runs the delegate's code.
+        let mut frame_gas =
+            GasTracker::new_with_regular_gas_and_reservoir(message.gas_limit, message.reservoir);
+        let mut bytecode = bytecode;
+        match self.apply_eip2780_call_charges(message, &mut frame_gas) {
+            Ok(Some((delegate_code, delegate_address))) => {
+                message.code_address = delegate_address;
+                message.disable_precompiles = true;
+                bytecode = delegate_code;
+            }
+            Ok(None) => {}
+            Err(()) => {
+                self.state.rollback(checkpoint, self.features);
+                let mut result = Self::error_message_result(
+                    InstrStop::OutOfGas,
+                    message.gas_limit,
+                    message.reservoir,
+                );
+                // Signal a runtime gas-phase out-of-gas so the EIP-7702 handler can revert the
+                // delegations applied before the frame (ethereum/EIPs#11844).
+                result.runtime_gas_oog = true;
+                return result;
+            }
+        }
         // EIP-161 state clearing depends on zero-value direct call targets being touched.
         let transfers_balance = matches!(
             message.kind,
@@ -1488,28 +1521,6 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
             self.log_eip7708_transfer(&message.caller, &message.destination, &message.value);
         }
 
-        // EIP-2780: apply the depth-0 execution charges to the frame gas here, before the
-        // precompile/interpreter split, so both paths share one charge site (mirroring
-        // execution-specs `process_message`, where the top-frame charge precedes the
-        // code-vs-precompile dispatch). The charge is frame-level state gas: it is recorded
-        // on the tracker for EIP-8037 block accounting and refilled on failure by
-        // `settle_gas`. A frame that cannot afford it halts before running; the rollback
-        // unwinds the value transfer and its EIP-7708 log. Off the depth-0 path the charges
-        // are zero, so this is a no-op spend.
-        let mut frame_gas =
-            GasTracker::new_with_regular_gas_and_reservoir(message.gas_limit, message.reservoir);
-        let (eip2780_regular, eip2780_state) = eip2780_charges;
-        if frame_gas.spend(eip2780_regular).is_err()
-            || frame_gas.spend_state(eip2780_state).is_err()
-        {
-            self.state.rollback(checkpoint, self.features);
-            return Self::error_message_result(
-                InstrStop::OutOfGas,
-                message.gas_limit,
-                message.reservoir,
-            );
-        }
-
         if self.contains_precompile(message) {
             return self.execute_call_precompile(checkpoint, message, frame_gas);
         }
@@ -1519,51 +1530,69 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
         self.finish_call_message_run(checkpoint, stop)
     }
 
-    /// Computes the EIP-2780 top-level (depth-0) execution charges for a call to
-    /// `message.destination`, from the recipient's pre-call state:
-    /// - a regular-gas `COLD_ACCOUNT_ACCESS` surcharge when the recipient carries an EIP-7702
-    ///   delegation, and
+    /// Applies the EIP-2780 top-level (depth-0) execution charges for a call to
+    /// `message.destination`, metered on the frame `gas`:
     /// - `new_account_state_gas` of state gas when the recipient is empty (EIP-161) and the call
-    ///   transfers value.
+    ///   transfers value (charged before delegation resolution, per execution-specs
+    ///   `prepare_dispatch`), and
+    /// - the delegation-target access following the EIP-2929 warm/cold model when the recipient
+    ///   carries an EIP-7702 delegation.
     ///
-    /// Returns `(regular, state)`, both zero unless EIP-2780 is active at depth 0.
-    fn eip2780_call_charges(&mut self, message: &Message<T>) -> (u64, u64) {
+    /// The delegation-target access is charged as a warm access first and the cold premium after the
+    /// target is loaded, and the load is gated on `skip_cold_load` (as nested calls do): a frame
+    /// that cannot afford the cold access never loads the target, so it stays out of the EIP-7928
+    /// block access list. On success the delegated recipient's resolved code and address are
+    /// returned so the caller runs the delegate's code; `Err(())` signals a runtime out-of-gas.
+    /// A no-op returning `Ok(None)` off the depth-0 EIP-2780 path.
+    fn apply_eip2780_call_charges(
+        &mut self,
+        message: &Message<T>,
+        gas: &mut GasTracker,
+    ) -> Result<Option<(Bytecode, Address)>, ()> {
         if message.depth != 0 || !self.feature(EvmFeatures::EIP2780) {
-            return (0, 0);
+            return Ok(None);
         }
         let dest = message.destination;
         // A nonexistent recipient reads as an empty account (EIP-161).
         let recipient_is_empty = match self.state.account_info_untracked(&dest) {
             Ok(info) => info.as_ref().is_none_or(AccountInfo::is_empty),
-            Err(_) => return (0, 0),
+            Err(_) => return Ok(None),
         };
-        // EIP-2780: a delegated recipient is charged an extra COLD_ACCOUNT_ACCESS
-        // of regular gas, and the delegation target is warmed for subsequent
-        // access (matching execution-specs' `accessed_addresses.add`). The
-        // recipient's stored code must be loaded — the warmed tx-target overlay
-        // entry may not carry the code bytes needed to read the designator. An
-        // empty recipient is never delegated, so skip the load to avoid touching
-        // an otherwise-untouched account.
-        let delegated = if recipient_is_empty {
-            None
-        } else {
-            match self.state.account(&dest, false) {
-                Ok(mut acc) => acc.load_code().ok().and_then(|code| code.eip7702_address()),
-                Err(_) => None,
+        // Empty recipient + value transfer: pay the new account leaf's state gas. Checked before
+        // the delegation resolution, matching the spec's `prepare_dispatch` order.
+        if !message.value.is_zero() && recipient_is_empty {
+            if gas.spend_state(self.version().gas_params.new_account_state_gas()).is_err() {
+                return Err(());
             }
+            // An empty recipient is never delegated.
+            return Ok(None);
+        }
+        if recipient_is_empty {
+            return Ok(None);
+        }
+        // Resolve the recipient's delegation designator (the recipient is the warm tx target; its
+        // stored code must be loaded to read the designator).
+        let delegated = match self.state.account(&dest, false) {
+            Ok(mut acc) => acc.load_code().ok().and_then(|code| code.eip7702_address()),
+            Err(_) => None,
         };
-        let regular = if let Some(delegated) = delegated {
-            let _ = self.state.account(&delegated, false).map(|mut a| a.warm());
-            u64::from(EIP8038_COLD_ACCOUNT_ACCESS)
-        } else {
-            0
+        let Some(delegated) = delegated else {
+            return Ok(None);
         };
-        let state = if !message.value.is_zero() && recipient_is_empty {
-            self.version().gas_params.new_account_state_gas()
-        } else {
-            0
-        };
-        (regular, state)
+        // Delegation-target access, EIP-2929 warm/cold: charge the warm access first (covered → the
+        // target is loaded and enters the block access list), then the cold premium after the load.
+        // The load is skipped when the cold premium is unaffordable, keeping a cold, unafforded
+        // target out of the block access list.
+        let cold_additional = self.version().gas_params.cold_account_additional_cost();
+        if gas.spend(u64::from(WARM_STORAGE_READ_COST)).is_err() {
+            return Err(());
+        }
+        let skip_cold_load = gas.remaining() < cold_additional;
+        let load = self.load_account(&delegated, true, skip_cold_load).map_err(|_| ())?;
+        if load.is_cold && gas.spend(cold_additional).is_err() {
+            return Err(());
+        }
+        Ok(Some((load.code, delegated)))
     }
 
     #[inline(never)]
@@ -1602,7 +1631,7 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
             gas,
             output,
             created_address: None,
-            created_target_was_alive: false,
+            runtime_gas_oog: false,
             ext: T::MessageResultExt::default(),
             _non_exhaustive: (),
         }
@@ -1626,7 +1655,7 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
             gas: *child_gas.tracker(),
             output,
             created_address: None,
-            created_target_was_alive: false,
+            runtime_gas_oog: false,
             ext: T::MessageResultExt::default(),
             _non_exhaustive: (),
         }
@@ -1739,6 +1768,7 @@ impl<'a, T: EvmTypes> Host<T> for Evm<'a, T> {
         };
         Ok(AccountLoad {
             balance: info.balance,
+            nonce: info.nonce,
             code_hash: if exists { info.code_hash } else { B256::ZERO },
             code,
             exists,
@@ -1788,11 +1818,14 @@ impl<'a, T: EvmTypes> Host<T> for Evm<'a, T> {
         address: &Address,
         key: &Word,
         value: &Word,
-        _skip_cold_load: bool,
+        skip_cold_load: bool,
     ) -> Result<SStore, InstrStop> {
         let eip2929 = self.feature(EvmFeatures::EIP2929);
-        // TODO: glam-devnet-7 fix this and we should use skip_cold_load.
-        let mut slot = match self.state.storage(address).into_slot(*key, false) {
+        // EIP-8037 (ethereum/EIPs#11854): SSTORE must cover the slot's access cost before the
+        // implicit storage read. When the cold access is unaffordable the read is skipped, so the
+        // slot stays out of the EIP-7928 block access list (the warm-read cost has already been
+        // paid by the instruction, so an affordable warm slot is still read on OOG).
+        let mut slot = match self.state.storage(address).into_slot(*key, skip_cold_load) {
             Ok(slot) => slot,
             Err(ErrorCode::COLD_LOAD_SKIPPED) => return Err(InstrStop::OutOfGas),
             Err(code) => return Err(self.store_error(code)),
@@ -1912,6 +1945,8 @@ impl<'a, T: EvmTypes> Host<T> for Evm<'a, T> {
 pub struct AccountLoad {
     /// Account balance.
     pub balance: Word,
+    /// Account nonce.
+    pub nonce: u64,
     /// Account code hash.
     pub code_hash: B256,
     /// Account bytecode.

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -1157,27 +1157,9 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
         // replacement while the hooks are running.
         let inspector = unsafe { trustme::decouple_lt_mut(inspector) };
 
+        // `destination` already holds the create's contract address (set when the message was
+        // constructed), so the create hook observes it directly.
         let is_create = matches!(message.kind, MessageKind::Create | MessageKind::Create2);
-        if is_create {
-            // Derive the destination early so that the create hook can observe it; execution
-            // re-derives it together with its semantic checks.
-            let nonce = if message.depth > 0 {
-                match self.state.account_info_untracked(&message.caller) {
-                    Ok(info) => info.map_or(0, |info| info.nonce),
-                    Err(code) => {
-                        let stop = self.store_error(code);
-                        return Self::error_message_result(
-                            stop,
-                            message.gas_limit,
-                            message.reservoir,
-                        );
-                    }
-                }
-            } else {
-                0
-            };
-            message.destination = Self::derive_create_address(&bytecode, message, nonce);
-        }
 
         let mut top_frame: Option<Box<Interpreter<'frame, 'a, T>>> = None;
         let frame = match self.current_frame {
@@ -1241,11 +1223,11 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
                 message.reservoir,
             );
         }
-        if let Err(stop) = self.prepare_create_message(&bytecode, message) {
+        if let Err(stop) = self.prepare_create_message(message) {
             return Self::error_message_result(stop, message.gas_limit, message.reservoir);
         }
         let checkpoint = self.state.checkpoint();
-        // EIP-2780 (ethereum/EIPs#11858): capture whether the target leaf is already alive
+        // EIP-2780: capture whether the target leaf is already alive
         // (existing, non-empty) before creation, so a top-level create at a pre-existing
         // balance-only account is not charged the account-creation state gas below (no new leaf is
         // created — execution-specs `created_target_alive`).
@@ -1267,7 +1249,7 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
         message.disable_precompiles = false;
         let input = core::mem::take(&mut message.input);
 
-        // EIP-2780 (ethereum/EIPs#11858): a top-level create (depth 0) charges the
+        // EIP-2780: a top-level create (depth 0) charges the
         // account-creation state gas at frame entry, conditional on the destination not already
         // existing (`!target_alive`). Nested creates are charged on the parent frame by the CREATE
         // opcode instead. The charge is state gas on this frame's tracker, refilled by the frame's
@@ -1294,11 +1276,7 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
     }
 
     #[inline(never)]
-    fn prepare_create_message(
-        &mut self,
-        bytecode: &Bytecode,
-        message: &mut Message<T>,
-    ) -> Result<(), InstrStop> {
+    fn prepare_create_message(&mut self, message: &mut Message<T>) -> Result<(), InstrStop> {
         let info = if message.value > 0 || message.depth > 0 {
             self.state
                 .account_info_untracked(&message.caller)
@@ -1317,13 +1295,8 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
             return Err(InstrStop::Return);
         }
 
-        // When an inspector is installed, the destination is already derived for the create hook,
-        // and inspector mutations of it are respected.
-        if self.inspector.is_none() {
-            message.destination =
-                Self::derive_create_address(bytecode, message, info.map_or(0, |info| info.nonce));
-        }
-
+        // `destination` already holds the contract address (derived when the message was
+        // constructed); warm it before running the initcode.
         let _ = self.state.account(&message.destination, false).map(|mut a| a.warm());
 
         if message.depth > 0
@@ -1441,16 +1414,6 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
             }
         }
         Ok(())
-    }
-
-    /// Derives the destination address for a create message.
-    fn derive_create_address(bytecode: &Bytecode, message: &Message<T>, nonce: u64) -> Address {
-        match message.kind {
-            MessageKind::Create if message.depth == 0 => message.destination,
-            MessageKind::Create => message.caller.create(nonce),
-            MessageKind::Create2 => message.caller.create2(message.salt, bytecode.hash_slow()),
-            _ => unreachable!("invalid create message kind"),
-        }
     }
 
     #[inline(never)]

--- a/crates/evm2/src/evm/state/journal.rs
+++ b/crates/evm2/src/evm/state/journal.rs
@@ -6,7 +6,7 @@ use alloy_primitives::Address;
 
 /// State checkpoint for reverting state changes.
 #[allow(missing_copy_implementations)]
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct StateCheckpoint {
     /// Revert journal length at the checkpoint.
     pub(crate) journal_len: usize,

--- a/crates/evm2/src/evm/system.rs
+++ b/crates/evm2/src/evm/system.rs
@@ -50,11 +50,11 @@ pub const CONSOLIDATION_REQUEST_ADDRESS: Address =
 
 /// EIP-8282 builder deposit request system contract address (request type `0x03`).
 pub const BUILDER_DEPOSIT_REQUEST_ADDRESS: Address =
-    address!("0x0000884d2AA32eAa155F59A2f24eFa73D9008282");
+    address!("0x0000BFF46984E3725691FA540A8C7589300D8282");
 
 /// EIP-8282 builder exit request system contract address (request type `0x04`).
 pub const BUILDER_EXIT_REQUEST_ADDRESS: Address =
-    address!("0x000014574A74c805590AFF9499fc7A690f008282");
+    address!("0x000064D678505AD48F8CCB093BC65613800E8282");
 
 /// System transaction input for [`Evm::system_call`].
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/crates/evm2/src/evm/tx.rs
+++ b/crates/evm2/src/evm/tx.rs
@@ -55,14 +55,17 @@ impl<T: EvmTypesHost> TxResult<T> {
         if spent_sub_refunded > self.floor_gas { spent_sub_refunded } else { self.floor_gas }
     }
 
-    /// Returns this transaction's regular (non-state) gas: `total_gas_spent - state_gas_spent`,
-    /// pre-refund (refund and floor only affect [`Self::tx_gas_used`]).
+    /// Returns this transaction's regular (non-state) block gas:
+    /// `max(total_gas_spent - state_gas_spent, floor_gas)`, pre-refund.
     ///
     /// Together with [`Self::state_gas_spent()`] this is the per-transaction split that callers add
-    /// to the block's separate regular- and state-gas counters (EIP-8037 + EIP-7778).
+    /// to the block's separate regular- and state-gas counters (EIP-8037 + EIP-7778). The EIP-7623
+    /// calldata floor is not discounted by state gas, so it binds against the regular component
+    /// (ethereum/EIPs#11836); the refund still only affects [`Self::tx_gas_used`].
     #[inline]
     pub const fn regular_gas_spent(&self) -> u64 {
-        self.total_gas_spent.saturating_sub(self.state_gas_spent)
+        let regular = self.total_gas_spent.saturating_sub(self.state_gas_spent);
+        if regular > self.floor_gas { regular } else { self.floor_gas }
     }
 
     /// Returns this transaction's state gas (EIP-8037) — the stored `state_gas_spent` field,

--- a/crates/evm2/src/evm/tx.rs
+++ b/crates/evm2/src/evm/tx.rs
@@ -62,9 +62,10 @@ impl<E> TxResultExt<E> {
     /// `max(total_gas_spent - state_gas_spent, floor_gas)`, pre-refund.
     ///
     /// Together with [`Self::state_gas_spent()`] this is the per-transaction split that callers add
-    /// to the block's separate regular- and state-gas counters (EIP-8037 + EIP-7778). The EIP-7623
-    /// calldata floor is not discounted by state gas, so it binds against the regular component
-    /// (ethereum/EIPs#11836); the refund still only affects [`Self::tx_gas_used`].
+    /// to the block's separate regular- and state-gas counters (EIP-8037 + EIP-7778). The
+    /// EIP-7623 calldata floor is not discounted by state gas, so it binds against the
+    /// regular component (ethereum/EIPs#11836); the refund still only affects
+    /// [`Self::tx_gas_used`].
     #[inline]
     pub const fn regular_gas_spent(&self) -> u64 {
         let regular = self.total_gas_spent.saturating_sub(self.state_gas_spent);
@@ -72,8 +73,8 @@ impl<E> TxResultExt<E> {
     }
 
     /// Returns this transaction's state gas (EIP-8037) — the stored `state_gas_spent` field,
-    /// exposed as the counterpart to [`Self::regular_gas_spent`] for the per-transaction block-gas
-    /// split.
+    /// exposed as the counterpart to [`Self::regular_gas_spent`] for the per-transaction
+    /// block-gas split.
     #[inline]
     pub const fn state_gas_spent(&self) -> u64 {
         self.state_gas_spent

--- a/crates/evm2/src/interpreter/gas.rs
+++ b/crates/evm2/src/interpreter/gas.rs
@@ -97,19 +97,20 @@ pub(crate) const EIP7702_AUTH_TUPLE_BYTES: u32 = 101;
 /// ecRecover precompile base cost, charged once per EIP-7702 authorization to
 /// recover the authority. Matches `secp256k1::ECRECOVER_BASE`.
 pub(crate) const EIP7702_ECRECOVER_COST: u32 = 3000;
-/// Regular-gas portion of the EIP-7702 per-auth cost under EIP-8038/Amsterdam.
+/// `REGULAR_PER_AUTH_BASE_COST`: the state-independent regular-gas base charged per EIP-7702
+/// authorization at the intrinsic phase under EIP-2780 (ethereum/EIPs#11844).
 ///
-/// Per execution-specs, the regular per-auth charge is
-/// `ACCOUNT_WRITE + REGULAR_PER_AUTH_BASE_COST`, where
-/// `REGULAR_PER_AUTH_BASE_COST = AUTH_TUPLE_BYTES * TX_DATA_TOKEN_FLOOR
-/// + PRECOMPILE_ECRECOVER + COLD_ACCOUNT_ACCESS + 2 * WARM_ACCESS`.
-/// Evaluates to `8,000 + (101*16 + 3,000 + 3,000 + 200) = 8,000 + 7,816 = 15,816`.
-/// (The per-auth state gas — `NEW_ACCOUNT + AUTH_BASE` — is charged separately.)
-pub(crate) const EIP8038_EIP7702_PER_EMPTY_ACCOUNT_REGULAR: u32 = EIP8038_ACCOUNT_WRITE
-    + (EIP7702_AUTH_TUPLE_BYTES * TOTAL_COST_FLOOR_PER_TOKEN_AMSTERDAM
-        + EIP7702_ECRECOVER_COST
-        + EIP8038_COLD_ACCOUNT_ACCESS
-        + 2 * WARM_STORAGE_READ_COST);
+/// Equals `AUTH_TUPLE_BYTES * TX_DATA_TOKEN_FLOOR + PRECOMPILE_ECRECOVER + COLD_ACCOUNT_ACCESS +
+/// 2 * WARM_ACCESS` = `101*16 + 3,000 + 3,000 + 200 = 7,816`. Covers the authorization's calldata,
+/// the ECDSA recovery, the authority's cold access, and the warm writes every authorization
+/// performs. The state-dependent remainder (`ACCOUNT_WRITE` and the new-account and
+/// delegation-bytes state gas) is charged at the runtime gas phase, only for the authorities that
+/// incur it.
+pub(crate) const EIP8038_EIP7702_PER_AUTH_BASE_REGULAR: u32 = EIP7702_AUTH_TUPLE_BYTES
+    * TOTAL_COST_FLOOR_PER_TOKEN_AMSTERDAM
+    + EIP7702_ECRECOVER_COST
+    + EIP8038_COLD_ACCOUNT_ACCESS
+    + 2 * WARM_STORAGE_READ_COST;
 
 // EIP-2780: Reduce intrinsic transaction gas. Replaces the legacy 21,000 base
 // with a decomposed model (sender base + `tx.to`-based + `tx.value`-based).

--- a/crates/evm2/src/interpreter/host.rs
+++ b/crates/evm2/src/interpreter/host.rs
@@ -24,11 +24,11 @@ pub struct MessageResult<T: EvmTypesHost = BaseEvmTypes> {
     pub output: Bytes,
     /// Created address for successful create messages.
     pub created_address: Option<Address>,
-    /// EIP-8037: for a create message, whether the target address was already alive (existing and
-    /// non-empty) before creation. When a create at such an address succeeds, the upfront
-    /// `NEW_ACCOUNT` state gas is refunded because no new account leaf was created. Always `false`
-    /// for call messages and fresh-target creates.
-    pub created_target_was_alive: bool,
+    /// EIP-2780: whether a depth-0 runtime gas-phase charge (the recipient's new-account state gas
+    /// or delegation-target access) ran out of gas before the frame executed. The EIP-7702 handler
+    /// treats this as a runtime out-of-gas: it reverts the applied delegations and includes the
+    /// transaction as an out-of-gas halt. Always `false` off the depth-0 path.
+    pub runtime_gas_oog: bool,
     /// EVM type-specific extension data.
     pub ext: T::MessageResultExt,
     #[doc(hidden)] // Not public API. Please use an existing constructor.

--- a/crates/evm2/src/interpreter/instructions/system.rs
+++ b/crates/evm2/src/interpreter/instructions/system.rs
@@ -315,50 +315,16 @@ fn create_inner<T: EvmTypesHost>(
         state.gas_params().get(GasId::Create).into()
     };
     gas.spend(create_cost)?;
-    // EIP-8037 (ethereum/EIPs#11858): charge the CREATE account-creation state gas on this frame
-    // before the child gas/reservoir split, conditional on the destination not already existing.
-    // The single destination read decides the charge (and warms the address); a create at a
-    // pre-existing leaf pays nothing, so its child is not shortchanged by an unneeded spill. The
-    // charge is refunded via `refill_reservoir` if the create fails to deploy (see the
-    // create-failure path after `execute_message`).
-    let mut charged_create_state_gas = false;
-    if state.feature(EvmFeatures::EIP8037) {
-        let caller = state.message().destination;
-        let caller_info = state.host().load_account(&caller, false, false)?;
-        // Only decide the account-creation charge once the endowment and nonce pre-checks pass: a
-        // create that early-fails on those never accesses the destination, so reading it here would
-        // leak it into the EIP-7928 block access list. The early-fail itself (pushing 0) is handled
-        // by the child frame below.
-        if caller_info.balance >= value && caller_info.nonce != u64::MAX {
-            let created_address = if is_create2 {
-                let init_code_hash =
-                    crate::bytecode::Bytecode::new_legacy(input.clone()).hash_slow();
-                let salt = B256::from(salt.expect("create2 salt").to_be_bytes());
-                caller.create2(salt, init_code_hash)
-            } else {
-                caller.create(caller_info.nonce)
-            };
-            let features = state.version().features;
-            if state.host().target_is_empty_for_new_account_gas(&created_address, features)? {
-                gas.spend_state(state.gas_params().create_state_gas())?;
-                charged_create_state_gas = true;
-            }
-        }
-    }
-    let gas_limit = if state.feature(EvmFeatures::EIP150) {
-        state.gas_params().call_stipend_reduction(gas.remaining())
-    } else {
-        gas.remaining()
-    };
-    gas.spend(gas_limit)?;
 
+    // Build the message up front (minus the child gas split, filled in below).
     let current = state.message();
     let mut message = Message {
         kind: if is_create2 { MessageKind::Create2 } else { MessageKind::Create },
         depth: current.depth.saturating_add(1),
-        gas_limit,
-        reservoir: gas.reservoir(),
-        destination: current.destination,
+        gas_limit: 0,
+        reservoir: 0,
+        // Derived below into the yet-to-be-created contract address.
+        destination: Address::ZERO,
         caller: current.destination,
         input,
         value,
@@ -370,6 +336,48 @@ fn create_inner<T: EvmTypesHost>(
         ext: T::MessageExt::default(),
         _non_exhaustive: (),
     };
+
+    // Derive the created contract address once and record it in `destination`. CREATE needs the
+    // creator's (pre-bump) nonce; the caller is the currently-executing contract, already warm and
+    // in the access list, so this read is neutral. CREATE2 needs no nonce. The same load feeds the
+    // EIP-8037 balance/nonce checks below, so it is only performed when one of the two needs it.
+    let caller_info = if is_create2 && !state.feature(EvmFeatures::EIP8037) {
+        None
+    } else {
+        Some(state.host().load_account(&message.caller, false, false)?)
+    };
+    message.destination =
+        message.created_address(caller_info.as_ref().map_or(0, |info| info.nonce));
+
+    // EIP-8037 (ethereum/EIPs#11858): charge the CREATE account-creation state gas on this frame
+    // before the child gas/reservoir split, conditional on the destination not already existing.
+    // The single destination read decides the charge (and warms the address); a create at a
+    // pre-existing leaf pays nothing, so its child is not shortchanged by an unneeded spill. The
+    // charge is refunded via `refill_reservoir` if the create fails to deploy (see the
+    // create-failure path after `execute_message`).
+    let mut charged_create_state_gas = false;
+    if let Some(caller_info) = caller_info.filter(|_| state.feature(EvmFeatures::EIP8037)) {
+        // Only decide the account-creation charge once the endowment and nonce pre-checks pass: a
+        // create that early-fails on those never accesses the destination, so reading it here would
+        // leak it into the EIP-7928 block access list. The early-fail itself (pushing 0) is handled
+        // by the child frame below.
+        if caller_info.balance >= message.value && caller_info.nonce != u64::MAX {
+            let features = state.version().features;
+            if state.host().target_is_empty_for_new_account_gas(&message.destination, features)? {
+                gas.spend_state(state.gas_params().create_state_gas())?;
+                charged_create_state_gas = true;
+            }
+        }
+    }
+    let gas_limit = if state.feature(EvmFeatures::EIP150) {
+        state.gas_params().call_stipend_reduction(gas.remaining())
+    } else {
+        gas.remaining()
+    };
+    gas.spend(gas_limit)?;
+    message.gas_limit = gas_limit;
+    message.reservoir = gas.reservoir();
+
     let bytecode = crate::bytecode::Bytecode::new_legacy(message.input.clone());
     let tx_env = state.tx();
     let mut result = state.host().execute_message(tx_env, bytecode, &mut message);

--- a/crates/evm2/src/interpreter/instructions/system.rs
+++ b/crates/evm2/src/interpreter/instructions/system.rs
@@ -346,8 +346,7 @@ fn create_inner<T: EvmTypesHost>(
     } else {
         Some(state.host().load_account(&message.caller, false, false)?)
     };
-    message.destination =
-        message.created_address(caller_info.as_ref().map_or(0, |info| info.nonce));
+    message.derive_destination(caller_info.as_ref().map_or(0, |info| info.nonce));
 
     // EIP-8037 (ethereum/EIPs#11858): charge the CREATE account-creation state gas on this frame
     // before the child gas/reservoir split, conditional on the destination not already existing.

--- a/crates/evm2/src/interpreter/instructions/system.rs
+++ b/crates/evm2/src/interpreter/instructions/system.rs
@@ -315,11 +315,35 @@ fn create_inner<T: EvmTypesHost>(
         state.gas_params().get(GasId::Create).into()
     };
     gas.spend(create_cost)?;
-    // EIP-8037: charge the upfront CREATE state gas on this frame before the
-    // child gas/reservoir split. Refunded via `refill_reservoir` if the child
-    // fails to deploy (see the create-failure path after `execute_message`).
+    // EIP-8037 (ethereum/EIPs#11858): charge the CREATE account-creation state gas on this frame
+    // before the child gas/reservoir split, conditional on the destination not already existing.
+    // The single destination read decides the charge (and warms the address); a create at a
+    // pre-existing leaf pays nothing, so its child is not shortchanged by an unneeded spill. The
+    // charge is refunded via `refill_reservoir` if the create fails to deploy (see the
+    // create-failure path after `execute_message`).
+    let mut charged_create_state_gas = false;
     if state.feature(EvmFeatures::EIP8037) {
-        gas.spend_state(state.gas_params().create_state_gas())?;
+        let caller = state.message().destination;
+        let caller_info = state.host().load_account(&caller, false, false)?;
+        // Only decide the account-creation charge once the endowment and nonce pre-checks pass: a
+        // create that early-fails on those never accesses the destination, so reading it here would
+        // leak it into the EIP-7928 block access list. The early-fail itself (pushing 0) is handled
+        // by the child frame below.
+        if caller_info.balance >= value && caller_info.nonce != u64::MAX {
+            let created_address = if is_create2 {
+                let init_code_hash =
+                    crate::bytecode::Bytecode::new_legacy(input.clone()).hash_slow();
+                let salt = B256::from(salt.expect("create2 salt").to_be_bytes());
+                caller.create2(salt, init_code_hash)
+            } else {
+                caller.create(caller_info.nonce)
+            };
+            let features = state.version().features;
+            if state.host().target_is_empty_for_new_account_gas(&created_address, features)? {
+                gas.spend_state(state.gas_params().create_state_gas())?;
+                charged_create_state_gas = true;
+            }
+        }
     }
     let gas_limit = if state.feature(EvmFeatures::EIP150) {
         state.gas_params().call_stipend_reduction(gas.remaining())
@@ -354,14 +378,13 @@ fn create_inner<T: EvmTypesHost>(
     }
     gas.merge_child_gas(result.gas, result.stop);
 
-    // EIP-8037: the CREATE/CREATE2 opcode charged `create_state_gas` upfront on
-    // this frame's tracker. Refund it to the reservoir via `refill_reservoir`
-    // (matching 0→x→0 storage restoration) when no new account leaf ends up
-    // created: either the create failed to deploy (revert, halt, or early-fail
-    // paths that leave `created_address == None` — depth, out-of-funds, nonce
-    // overflow), or it succeeded at a pre-existing alive (balance-only) target.
+    // EIP-8037 (ethereum/EIPs#11858): when the opcode charged the conditional `create_state_gas`
+    // and the create then fails to deploy (revert, halt, or an early-fail leaving
+    // `created_address == None` — depth, out-of-funds, nonce overflow), no new account leaf is
+    // created, so refund the charge to the reservoir via `refill_reservoir` (matching 0→x→0 storage
+    // restoration). A successful deployment keeps the charge; an alive target was never charged.
     let create_failed = result.created_address.is_none() || !result.stop.is_success();
-    if (create_failed || result.created_target_was_alive) && state.feature(EvmFeatures::EIP8037) {
+    if charged_create_state_gas && create_failed {
         gas.refill_reservoir(state.gas_params().create_state_gas());
     }
     // EIP-211 exposes CREATE failure data only for REVERT; other failures clear returndata.

--- a/crates/evm2/src/interpreter/message.rs
+++ b/crates/evm2/src/interpreter/message.rs
@@ -80,20 +80,20 @@ impl<T: EvmTypesHost> Message<T> {
     ///
     /// Only meaningful for create messages, where `input` holds the initcode.
     #[inline]
-    pub fn init_code_hash(&self) -> B256 {
+    pub fn init_code_hash_slow(&self) -> B256 {
         keccak256(self.input.as_ref())
     }
 
-    /// Derives the address that this create message deploys to.
+    /// Derives this create message's contract address and stores it in [`Message::destination`].
     ///
     /// `nonce` is the creator's nonce and is only used by the `CREATE` scheme; `CREATE2` derives
-    /// the address from the salt and [`Message::init_code_hash`]. The result is written into
-    /// [`Message::destination`] when the message is constructed.
+    /// the address from the salt and [`Message::init_code_hash_slow`]. Called once when the create
+    /// message is constructed.
     #[inline]
-    pub fn created_address(&self, nonce: u64) -> Address {
-        match self.kind {
-            MessageKind::Create2 => self.caller.create2(self.salt, self.init_code_hash()),
+    pub fn derive_destination(&mut self, nonce: u64) {
+        self.destination = match self.kind {
+            MessageKind::Create2 => self.caller.create2(self.salt, self.init_code_hash_slow()),
             _ => self.caller.create(nonce),
-        }
+        };
     }
 }

--- a/crates/evm2/src/interpreter/message.rs
+++ b/crates/evm2/src/interpreter/message.rs
@@ -1,5 +1,5 @@
 use crate::{BaseEvmTypes, EvmTypesHost};
-use alloy_primitives::{Address, B256, Bytes, U256};
+use alloy_primitives::{Address, B256, Bytes, U256, keccak256};
 use derive_where::derive_where;
 
 /// EVM message kind.
@@ -45,7 +45,12 @@ pub struct Message<T: EvmTypesHost = BaseEvmTypes> {
     /// [`GasTracker::merge_child_gas`](crate::interpreter::GasTracker::merge_child_gas).
     /// Zero for non-Amsterdam execution.
     pub reservoir: u64,
-    /// Account whose context is being executed.
+    /// The account this message targets.
+    ///
+    /// Its meaning depends on [`Message::kind`]: for call-family messages it is the account whose
+    /// context is executed; for `CREATE`/`CREATE2` it is the address of the yet-to-be-created
+    /// contract, derived when the message is constructed (from the creator and nonce, or from the
+    /// salt and init-code hash).
     pub destination: Address,
     /// Immediate caller.
     pub caller: Address,
@@ -68,4 +73,27 @@ pub struct Message<T: EvmTypesHost = BaseEvmTypes> {
     pub ext: T::MessageExt,
     #[doc(hidden)] // Not public API. Please use an existing constructor.
     pub _non_exhaustive: (),
+}
+
+impl<T: EvmTypesHost> Message<T> {
+    /// Returns the keccak256 hash of the init code ([`Message::input`]).
+    ///
+    /// Only meaningful for create messages, where `input` holds the initcode.
+    #[inline]
+    pub fn init_code_hash(&self) -> B256 {
+        keccak256(self.input.as_ref())
+    }
+
+    /// Derives the address that this create message deploys to.
+    ///
+    /// `nonce` is the creator's nonce and is only used by the `CREATE` scheme; `CREATE2` derives
+    /// the address from the salt and [`Message::init_code_hash`]. The result is written into
+    /// [`Message::destination`] when the message is constructed.
+    #[inline]
+    pub fn created_address(&self, nonce: u64) -> Address {
+        match self.kind {
+            MessageKind::Create2 => self.caller.create2(self.salt, self.init_code_hash()),
+            _ => self.caller.create(nonce),
+        }
+    }
 }

--- a/crates/evm2/src/interpreter/message.rs
+++ b/crates/evm2/src/interpreter/message.rs
@@ -50,9 +50,9 @@ pub struct MessageExt<E = ()> {
     /// The account this message targets.
     ///
     /// Its meaning depends on [`MessageExt::kind`]: for call-family messages it is the account
-    /// whose context is executed; for `CREATE`/`CREATE2` it is the address of the yet-to-be-created
-    /// contract, derived when the message is constructed (from the creator and nonce, or from the
-    /// salt and init-code hash).
+    /// whose context is executed; for `CREATE`/`CREATE2` it is the address of the
+    /// yet-to-be-created contract, derived when the message is constructed (from the creator
+    /// and nonce, or from the salt and init-code hash).
     pub destination: Address,
     /// Immediate caller.
     pub caller: Address,

--- a/crates/evm2/src/lib.rs
+++ b/crates/evm2/src/lib.rs
@@ -8,7 +8,7 @@ extern crate self as evm2;
 extern crate alloc;
 
 pub mod bytecode;
-pub(crate) mod constants;
+pub mod constants;
 mod error;
 pub mod ethereum;
 pub mod interpreter;

--- a/crates/evm2/src/test_utils.rs
+++ b/crates/evm2/src/test_utils.rs
@@ -99,6 +99,7 @@ impl Host<TestTypes> for TestHost {
         }
         Ok(AccountLoad {
             balance: address.into_word().into(),
+            nonce: 0,
             code_hash: self.code_hash,
             code: if load_code {
                 Bytecode::new_legacy(self.code.clone())

--- a/crates/evm2/src/version/gas_params.rs
+++ b/crates/evm2/src/version/gas_params.rs
@@ -534,9 +534,11 @@ mod tests {
         assert_eq!(amsterdam.get(GasId::NewAccountCost), 0);
         assert_eq!(amsterdam.get(GasId::SstoreSetWithoutLoadCost), 10_000);
         assert_eq!(amsterdam.get(GasId::SstoreClearingSlotRefund), 12_480);
-        // EIP-8038/Amsterdam per-auth regular gas: ACCOUNT_WRITE + REGULAR_PER_AUTH_BASE_COST
-        // = 8000 + (101*16 + 3000 + 3000 + 2*100) = 15_816.
-        assert_eq!(amsterdam.get(GasId::TxEip7702PerEmptyAccountCost), 15_816);
+        // EIP-2780/Amsterdam intrinsic per-auth regular gas: the state-independent
+        // REGULAR_PER_AUTH_BASE_COST = 101*16 + 3000 + 3000 + 2*100 = 7_816 (the ACCOUNT_WRITE
+        // and state-gas remainder is charged at the runtime gas phase).
+        assert_eq!(amsterdam.get(GasId::TxEip7702PerEmptyAccountCost), 7_816);
+        assert_eq!(amsterdam.get(GasId::TxEip7702AuthRefund), 0);
         assert_eq!(amsterdam.get(GasId::SstoreSetState), 64 * 1530);
         assert_eq!(amsterdam.get(GasId::TxEip7702PerAuthState), 23 * 1530);
         assert_eq!(amsterdam.get(GasId::TxAccessListAddressCost), 3000 + 20 * 64);

--- a/crates/evm2/src/version/mod.rs
+++ b/crates/evm2/src/version/mod.rs
@@ -775,11 +775,13 @@ evm_versions! {
             // EIP-7702 under EIP-8037: per-authorization regular-gas refund. The
             // intrinsic per-auth regular charge bundles a worst-case
             // `ACCOUNT_WRITE`; when the authority leaf already exists (or the auth
-            // is rejected) that account write is not needed and is refunded to the
-            // regular refund counter (execution-specs `set_delegation`). The
-            // state-gas portions come from `NewAccountState` (per-account) and
-            // `TxEip7702PerAuthState` (per-bytecode, AUTH_BASE_BYTES × CPSB).
-            TxEip7702AuthRefund: EIP8038_ACCOUNT_WRITE,
+            // EIP-2780 (ethereum/EIPs#11844): the per-auth `ACCOUNT_WRITE` and
+            // state gas are charged conditionally at the runtime gas phase, per
+            // authority that incurs them, so the pessimistic per-auth intrinsic
+            // refund no longer applies. `TxEip7702PerAuthState` (per-bytecode,
+            // AUTH_BASE_BYTES × CPSB) is the runtime net-new delegation-bytes
+            // charge; the new-account state gas comes from `NewAccountState`.
+            TxEip7702AuthRefund: 0,
             TxEip7702PerAuthState: 23 * AMSTERDAM_CPSB,
 
             // EIP-8038: State-access gas cost update (ethereum/EIPs#11802;
@@ -831,9 +833,11 @@ evm_versions! {
             // sets each per-item base to COLD_*_ACCESS (3,000).
             TxAccessListAddressCost: EIP8038_ACCESS_LIST_ADDRESS_COST + 20 * EIP7981_ACCESS_LIST_DATA_COST_PER_BYTE,
             TxAccessListStorageKeyCost: EIP8038_ACCESS_LIST_STORAGE_KEY_COST + 32 * EIP7981_ACCESS_LIST_DATA_COST_PER_BYTE,
-            // EIP-7702 regular-gas per-auth cost shifts with ACCOUNT_WRITE /
-            // COLD_ACCOUNT_ACCESS (7,500 -> 9,200).
-            TxEip7702PerEmptyAccountCost: EIP8038_EIP7702_PER_EMPTY_ACCOUNT_REGULAR,
+            // EIP-2780 (ethereum/EIPs#11844): the intrinsic per-auth charge is
+            // the state-independent `REGULAR_PER_AUTH_BASE_COST` (7,816) only;
+            // the ACCOUNT_WRITE and state-gas remainder is charged at the runtime
+            // gas phase per authority.
+            TxEip7702PerEmptyAccountCost: EIP8038_EIP7702_PER_AUTH_BASE_REGULAR,
 
             // EIP-2780: Reduce intrinsic transaction gas. The `to`- and
             // `value`-based intrinsic charges. ACCOUNT_WRITE / CREATE_ACCESS

--- a/crates/jit/builtins/src/lib.rs
+++ b/crates/jit/builtins/src/lib.rs
@@ -699,7 +699,7 @@ pub unsafe extern "C" fn __revmc_builtin_create(
     } else {
         Some(ecx.host().load_account(&message.caller, false, false)?)
     };
-    message.destination = message.created_address(caller_info.as_ref().map_or(0, |info| info.nonce));
+    message.derive_destination(caller_info.as_ref().map_or(0, |info| info.nonce));
 
     // EIP-8037 (ethereum/EIPs#11858): charge the CREATE account-creation state gas before the child
     // gas split, conditional on the destination not already existing (and on the endowment/nonce

--- a/crates/jit/builtins/src/lib.rs
+++ b/crates/jit/builtins/src/lib.rs
@@ -16,6 +16,7 @@ use alloy_primitives::{Address, B256, Bytes, KECCAK256_EMPTY, Log, LogData, U256
 use core::cmp::min;
 use evm2::{
     bytecode::Bytecode,
+    constants::BLOCK_HASH_HISTORY,
     interpreter::{Host, MessageExt, MessageKind, Word, i256},
     utils::{word_to_usize, word_to_usize_saturated},
     version::{EvmFeatures, GasId},
@@ -390,9 +391,6 @@ pub unsafe extern "C" fn __revmc_builtin_blockhash(
         *number_ptr = EvmWord::ZERO;
         return Ok(());
     }
-
-    // BLOCK_HASH_HISTORY is 256
-    const BLOCK_HASH_HISTORY: u64 = 256;
 
     if diff <= BLOCK_HASH_HISTORY {
         let requested_number = U256::from(word_to_u64_saturated(requested_number));

--- a/crates/jit/builtins/src/lib.rs
+++ b/crates/jit/builtins/src/lib.rs
@@ -664,8 +664,32 @@ pub unsafe extern "C" fn __revmc_builtin_create(
         version.gas_params.get(GasId::Create).into()
     };
     ecx.gas.spend(create_cost)?;
+    let salt = if is_create2 {
+        pop!(sp; salt);
+        B256::from(salt.to_be_bytes())
+    } else {
+        B256::ZERO
+    };
+    // EIP-8037 (ethereum/EIPs#11858): charge the CREATE account-creation state gas before the child
+    // gas split, conditional on the destination not already existing (and on the endowment/nonce
+    // pre-checks passing, so an early-failing create leaves the destination out of the block access
+    // list). Mirrors the interpreter's `create` opcode.
+    let mut charged_create_state_gas = false;
     if ecx.enables(EvmFeatures::EIP8037) {
-        ecx.gas.spend_state(version.gas_params.create_state_gas())?;
+        let caller = ecx.message().destination;
+        let caller_info = ecx.host().load_account(&caller, false, false)?;
+        if caller_info.balance >= value.to_u256() && caller_info.nonce != u64::MAX {
+            let created_address = if is_create2 {
+                let init_code_hash = Bytecode::new_legacy(code.clone()).hash_slow();
+                caller.create2(salt, init_code_hash)
+            } else {
+                caller.create(caller_info.nonce)
+            };
+            if ecx.host().target_is_empty_for_new_account_gas(&created_address, version.features)? {
+                ecx.gas.spend_state(version.gas_params.create_state_gas())?;
+                charged_create_state_gas = true;
+            }
+        }
     }
 
     let mut gas_limit = ecx.gas.remaining();
@@ -673,12 +697,6 @@ pub unsafe extern "C" fn __revmc_builtin_create(
         gas_limit = version.gas_params.call_stipend_reduction(gas_limit);
     }
     ecx.gas.spend(gas_limit)?;
-    let salt = if is_create2 {
-        pop!(sp; salt);
-        B256::from(salt.to_be_bytes())
-    } else {
-        B256::ZERO
-    };
 
     let current = ecx.message();
     let mut message = Message {
@@ -701,9 +719,11 @@ pub unsafe extern "C" fn __revmc_builtin_create(
     let tx_env = ecx.tx_env();
     let mut result = ecx.host().execute_message(tx_env, bytecode, &mut message);
     ecx.gas.merge_child_gas(result.gas, result.stop);
+    // EIP-8037 (ethereum/EIPs#11858): refund the conditional create state gas when the create fails
+    // to deploy (no new account leaf is created).
     let create_failed = result.created_address.is_none() || !result.stop.is_success();
-    if (create_failed || result.created_target_was_alive) && ecx.enables(EvmFeatures::EIP8037) {
-        ecx.gas.refill_reservoir(ecx.gas_params().create_state_gas());
+    if charged_create_state_gas && create_failed {
+        ecx.gas.refill_reservoir(version.gas_params.create_state_gas());
     }
 
     let address = EvmWord::from(result.created_address_for_parent());

--- a/crates/jit/builtins/src/lib.rs
+++ b/crates/jit/builtins/src/lib.rs
@@ -670,41 +670,15 @@ pub unsafe extern "C" fn __revmc_builtin_create(
     } else {
         B256::ZERO
     };
-    // EIP-8037 (ethereum/EIPs#11858): charge the CREATE account-creation state gas before the child
-    // gas split, conditional on the destination not already existing (and on the endowment/nonce
-    // pre-checks passing, so an early-failing create leaves the destination out of the block access
-    // list). Mirrors the interpreter's `create` opcode.
-    let mut charged_create_state_gas = false;
-    if ecx.enables(EvmFeatures::EIP8037) {
-        let caller = ecx.message().destination;
-        let caller_info = ecx.host().load_account(&caller, false, false)?;
-        if caller_info.balance >= value.to_u256() && caller_info.nonce != u64::MAX {
-            let created_address = if is_create2 {
-                let init_code_hash = Bytecode::new_legacy(code.clone()).hash_slow();
-                caller.create2(salt, init_code_hash)
-            } else {
-                caller.create(caller_info.nonce)
-            };
-            if ecx.host().target_is_empty_for_new_account_gas(&created_address, version.features)? {
-                ecx.gas.spend_state(version.gas_params.create_state_gas())?;
-                charged_create_state_gas = true;
-            }
-        }
-    }
-
-    let mut gas_limit = ecx.gas.remaining();
-    if ecx.enables(EvmFeatures::EIP150) {
-        gas_limit = version.gas_params.call_stipend_reduction(gas_limit);
-    }
-    ecx.gas.spend(gas_limit)?;
-
+    // Build the message up front (minus the child gas split, filled in below).
     let current = ecx.message();
     let mut message = Message {
         kind: if is_create2 { MessageKind::Create2 } else { MessageKind::Create },
         depth: current.depth.saturating_add(1),
-        gas_limit,
-        reservoir: ecx.gas.reservoir(),
-        destination: current.destination,
+        gas_limit: 0,
+        reservoir: 0,
+        // Derived below into the yet-to-be-created contract address.
+        destination: Address::ZERO,
         caller: current.destination,
         input: code,
         value: value.to_u256(),
@@ -715,6 +689,40 @@ pub unsafe extern "C" fn __revmc_builtin_create(
         ext: (),
         _non_exhaustive: (),
     };
+
+    // Derive the created contract address once and record it in `destination` (mirrors the
+    // interpreter's `create` opcode). CREATE needs the creator's (pre-bump) nonce; the caller is the
+    // currently-executing contract, already warm. CREATE2 needs no nonce. The same load feeds the
+    // EIP-8037 balance/nonce checks below, so it is only performed when one of the two needs it.
+    let caller_info = if is_create2 && !ecx.enables(EvmFeatures::EIP8037) {
+        None
+    } else {
+        Some(ecx.host().load_account(&message.caller, false, false)?)
+    };
+    message.destination = message.created_address(caller_info.as_ref().map_or(0, |info| info.nonce));
+
+    // EIP-8037 (ethereum/EIPs#11858): charge the CREATE account-creation state gas before the child
+    // gas split, conditional on the destination not already existing (and on the endowment/nonce
+    // pre-checks passing, so an early-failing create leaves the destination out of the block access
+    // list).
+    let mut charged_create_state_gas = false;
+    if let Some(caller_info) = caller_info.filter(|_| ecx.enables(EvmFeatures::EIP8037))
+        && caller_info.balance >= message.value
+        && caller_info.nonce != u64::MAX
+        && ecx.host().target_is_empty_for_new_account_gas(&message.destination, version.features)?
+    {
+        ecx.gas.spend_state(version.gas_params.create_state_gas())?;
+        charged_create_state_gas = true;
+    }
+
+    let mut gas_limit = ecx.gas.remaining();
+    if ecx.enables(EvmFeatures::EIP150) {
+        gas_limit = version.gas_params.call_stipend_reduction(gas_limit);
+    }
+    ecx.gas.spend(gas_limit)?;
+    message.gas_limit = gas_limit;
+    message.reservoir = ecx.gas.reservoir();
+
     let bytecode = Bytecode::new_legacy(message.input.clone());
     let tx_env = ecx.tx_env();
     let mut result = ecx.host().execute_message(tx_env, bytecode, &mut message);

--- a/scripts/setup_test_fixtures.py
+++ b/scripts/setup_test_fixtures.py
@@ -41,10 +41,10 @@ DEVNET_BASE_URL = os.environ.get(
     "DEVNET_BASE_URL",
     "https://github.com/ethereum/execution-specs/releases/download",
 )
-# Default fork-specific devnet fixtures: glamsterdam (Amsterdam) devnet-6. Downloaded by default so
+# Default fork-specific devnet fixtures: glamsterdam (Amsterdam) devnet-7. Downloaded by default so
 # the Amsterdam tests run without extra configuration; override DEVNET_VERSION/DEVNET_TAR to select a
 # different devnet release. The version is a URL path component, so the `@` is percent-encoded.
-DEFAULT_DEVNET_VERSION = "tests-glamsterdam-devnet%40v6.1.1"
+DEFAULT_DEVNET_VERSION = "tests-glamsterdam-devnet%40v7.2.0"
 DEFAULT_DEVNET_TAR = "fixtures_glamsterdam-devnet.tar.gz"
 LEGACY_URL = (
     f"https://github.com/ethereum/tests/archive/refs/tags/{LEGACY_VERSION}.tar.gz"


### PR DESCRIPTION
Aligns Amsterdam to the **glamsterdam devnet-7** spec and the `tests-glamsterdam-devnet@v7.2.0` fixtures. All Amsterdam `state_tests` and `blockchain_tests` pass (interpreter + JIT + AOT); no regressions in earlier-fork state suites or the unit/ee-test suite.

Ports bluealloy/revm#3795 to evm2's architecture.

## EIP-2780 runtime gas phase (ethereum/EIPs#11844)

State-dependent transaction charges move from the intrinsic phase to a runtime phase applied as the first frame is entered. Running out of gas there is an **included out-of-gas halt** consuming all regular gas, not a transaction rejection.

- **Create transactions**: account-creation state gas is charged at the create frame's entry (`execute_create_message`), conditional on the destination not already existing. The intrinsic `create_state_gas` and its refund path are removed.
- **EIP-7702**: the intrinsic per-auth charge drops to the state-independent `REGULAR_PER_AUTH_BASE_COST` (7,816); `ACCOUNT_WRITE`, new-account, and delegation-bytes state gas are charged per authority at runtime on a transaction-level `GasTracker` (the `RuntimeAuthCharges` accounting), stopping at the first unaffordable charge. A runtime out-of-gas reverts the applied delegations and includes the tx as an OOG halt.
- **Delegated recipient (depth 0)**: resolution is deferred into the frame (`apply_eip2780_call_charges`) and the target load is gated on gas (`skip_cold_load`, as nested calls do), so a cold, unafforded target stays out of the EIP-7928 block access list. `MessageResult::runtime_gas_oog` signals a recipient-charge OOG back to the 7702 handler so it drops the delegations too.

The CALL/CREATE runtime charges live in the shared `execute_call_message` / `execute_create_message` (gated on `depth == 0` + feature, not tx type), so **all transaction types** get them; only the authorization-specific charges are in the 7702 handler.

## Devnet-7 spec alignment

- **ethereum/EIPs#11836**: calldata floor anchored on the decomposed intrinsic base instead of flat `TX_BASE`.
- **ethereum/EIPs#11891**: 7702 `ACCOUNT_WRITE` charged once per authority, skipped when already paid (sender / value-recipient / a preceding valid authorization).
- **ethereum/EIPs#11858**: `CREATE`/`CREATE2` account-creation state gas charged conditionally at access (endowment/nonce pre-check + a single destination read), refilled on failure. Mirrored in the JIT builtin.
- **ethereum/EIPs#11854**: `SSTORE` covers the slot's access cost before the implicit read; an unaffordable cold access skips the read (`Evm::sstore` now honors `skip_cold_load`).
- **EIP-8282**: builder deposit/exit system-contract addresses updated.
- **EIP-7623** floor binds the block regular-gas component (`TxResult::regular_gas_spent = max(total - state, floor)`).

## Cleanups

- Remove the superseded devnet-6 create accounting (`create_initial_state_gas`, `refund_create_state_gas`, `MessageResult::created_target_was_alive`, `settle_gas`'s `is_create` path).
- Remove `rollback_failed_execution`: failed execution is already rolled back to the message's own checkpoint (and halt gas zeroed) inside `execute_message`, so it was redundant.

## Follow-up refactors

- **Message construction**: `Message` now carries its `destination` — the CREATE/CREATE2 address is derived when the message is constructed (`Message::derive_destination`) instead of being re-derived at frame entry.
- **EIP-7702 authorization unification**: both gas regimes share one `apply_auth_list` loop (validate → account → apply) driven by an `AuthAccounting` strategy — `RuntimeAuthCharges` (EIP-2780 runtime metering, abortable mid-list) and `AuthRefunds` (pre-Amsterdam pessimistic-intrinsic refunds, owning the EIP-8037 gating). The handler tail funnels every exit through a single `settle` closure (`settle_oog` for the runtime OOG halts), and `initial_gas_and_reservoir` loses its always-zero `state_refund` parameter — the pre-Amsterdam state refund is credited straight to the reservoir at the call site, matching execution-specs `set_delegation`. Crate constants are now `pub`.

The `Message`-carries-bytecode refactor (with the EIP-8037 create depth check) and the regular→execution gas rename are split out into the stacked PR #329.

## Fixtures / harness

- Bump devnet fixtures to v7.2.0 (setup script, CI, `AGENTS.md`).
- eest: honor an explicit per-transaction `chainId` (v7 fixtures test type-0 `INVALID_CHAINID`).

## Testing

- Amsterdam `state_tests`: 406/406; `blockchain_tests`: 657/657.
- JIT + AOT Amsterdam state suites pass on v7.2.0.
- Unit + ee-tests: 2829/2829; Prague/Osaka/Cancun/Berlin/London/Shanghai state suites unchanged.

Two revm changes were no-ops in evm2: EIP-7708 (already implemented) and `JournalEntry::CodeChange` recording prior code (evm2's `AccountChange` already snapshots the full prior `AccountInfo`).

