### PR TITLE
feat(evm): add transaction handler hooks

### DIFF
--- a/crates/evm2/src/ethereum/eip1559.rs
+++ b/crates/evm2/src/ethereum/eip1559.rs
@@ -1,7 +1,7 @@
 use super::{
-    access_list_counts, charge_upfront, create_initial_state_gas, effective_gas_price, floor_gas,
+    access_list_counts, create_initial_state_gas, effective_gas_price, floor_gas,
     initial_gas_and_reservoir, initial_message, intrinsic_gas, refund_create_state_gas,
-    rollback_failed_execution, settle_gas, validate_block_gas_limit, validate_chain_id,
+    rollback_failed_execution, validate_block_gas_limit, validate_chain_id,
     validate_create_initcode, validate_floor_gas, validate_gas_price, validate_intrinsic_gas,
     validate_nonce_not_overflow, validate_priority_fee, validate_regular_gas_limit_cap,
     validate_sender, validate_tx_gas_limit_cap, warm_access_list, warm_base_accounts,
@@ -9,7 +9,10 @@ use super::{
 use crate::{
     EvmTypes, TxResult,
     env::TxEnvExt,
-    evm::error_handler,
+    evm::{
+        error_handler,
+        handler::{DefaultTxHandlerHooks, GasSettlement, TxHandlerHooks},
+    },
     interpreter::Host,
     registry::{HandlerResult, TxRequest},
 };
@@ -18,6 +21,13 @@ use alloy_primitives::U256;
 
 /// Executes an EIP-1559 transaction using Ethereum rules.
 pub fn handle<T: EvmTypes>(req: TxRequest<'_, '_, T, TxEip1559>) -> HandlerResult<TxResult<T>> {
+    handle_with_hooks::<T, DefaultTxHandlerHooks>(req)
+}
+
+/// Executes an EIP-1559 transaction using Ethereum rules and custom handler hooks.
+pub fn handle_with_hooks<T: EvmTypes, H: TxHandlerHooks<T>>(
+    req: TxRequest<'_, '_, T, TxEip1559>,
+) -> HandlerResult<TxResult<T>> {
     let caller = req.tx.signer();
     let tx = req.tx.inner();
     let max_fee_per_gas = U256::from(tx.max_fee_per_gas);
@@ -33,7 +43,7 @@ pub fn handle<T: EvmTypes>(req: TxRequest<'_, '_, T, TxEip1559>) -> HandlerResul
     validate_create_initcode(req.host.version(), tx.to, &tx.input)?;
     validate_nonce_not_overflow(tx.nonce)?;
     let (access_list_accounts, access_list_storage_keys) = access_list_counts(&tx.access_list);
-    let intrinsic = intrinsic_gas(
+    let mut intrinsic = intrinsic_gas(
         req.host.version(),
         caller,
         tx.to,
@@ -42,7 +52,8 @@ pub fn handle<T: EvmTypes>(req: TxRequest<'_, '_, T, TxEip1559>) -> HandlerResul
         access_list_storage_keys,
         tx.value,
     );
-    let initial_state_gas = create_initial_state_gas(req.host.version(), tx.to.is_create());
+    let mut initial_state_gas = create_initial_state_gas(req.host.version(), tx.to.is_create());
+    H::adjust_intrinsic_gas(req.host, req.envelope, &mut intrinsic, &mut initial_state_gas)?;
     validate_intrinsic_gas(tx.gas_limit, intrinsic, initial_state_gas)?;
     let floor_gas =
         floor_gas(req.host.version(), &tx.input, access_list_accounts, access_list_storage_keys);
@@ -56,8 +67,8 @@ pub fn handle<T: EvmTypes>(req: TxRequest<'_, '_, T, TxEip1559>) -> HandlerResul
     warm_access_list(req.host, &tx.access_list);
 
     let effective_gas_cost = U256::from(tx.gas_limit) * gas_price;
-    charge_upfront(req.host, caller, effective_gas_cost)?;
     req.host.state.account(&caller, false).map_err(error_handler!(req.host))?.bump_nonce();
+    H::before_execution(req.host, req.envelope, caller, effective_gas_cost)?;
     let execution_checkpoint = req.host.state.checkpoint();
 
     let (gas_limit, reservoir) = initial_gas_and_reservoir(
@@ -80,15 +91,18 @@ pub fn handle<T: EvmTypes>(req: TxRequest<'_, '_, T, TxEip1559>) -> HandlerResul
     rollback_failed_execution(req.host, execution_checkpoint, &mut result);
     refund_create_state_gas(&mut result, initial_state_gas);
 
-    settle_gas(
+    H::settle_transaction(
         req.host,
-        caller,
-        gas_price,
-        tx.gas_limit,
-        floor_gas,
-        initial_state_gas,
-        0,
-        tx.to.is_create(),
-        result,
+        req.envelope,
+        GasSettlement {
+            caller,
+            gas_price,
+            gas_limit: tx.gas_limit,
+            floor_gas,
+            initial_state_gas,
+            state_refund: 0,
+            is_create: tx.to.is_create(),
+            result,
+        },
     )
 }

--- a/crates/evm2/src/ethereum/eip2930.rs
+++ b/crates/evm2/src/ethereum/eip2930.rs
@@ -1,15 +1,18 @@
 use super::{
-    access_list_counts, charge_upfront, create_initial_state_gas, floor_gas,
-    initial_gas_and_reservoir, initial_message, intrinsic_gas, refund_create_state_gas,
-    rollback_failed_execution, settle_gas, validate_block_gas_limit, validate_chain_id,
-    validate_create_initcode, validate_floor_gas, validate_gas_price, validate_intrinsic_gas,
-    validate_nonce_not_overflow, validate_regular_gas_limit_cap, validate_sender,
-    validate_tx_gas_limit_cap, warm_access_list, warm_base_accounts,
+    access_list_counts, create_initial_state_gas, floor_gas, initial_gas_and_reservoir,
+    initial_message, intrinsic_gas, refund_create_state_gas, rollback_failed_execution,
+    validate_block_gas_limit, validate_chain_id, validate_create_initcode, validate_floor_gas,
+    validate_gas_price, validate_intrinsic_gas, validate_nonce_not_overflow,
+    validate_regular_gas_limit_cap, validate_sender, validate_tx_gas_limit_cap, warm_access_list,
+    warm_base_accounts,
 };
 use crate::{
     EvmTypes, TxResult,
     env::TxEnvExt,
-    evm::error_handler,
+    evm::{
+        error_handler,
+        handler::{DefaultTxHandlerHooks, GasSettlement, TxHandlerHooks},
+    },
     interpreter::Host,
     registry::{HandlerResult, TxRequest},
 };
@@ -18,6 +21,13 @@ use alloy_primitives::U256;
 
 /// Executes an EIP-2930 transaction using Ethereum rules.
 pub fn handle<T: EvmTypes>(req: TxRequest<'_, '_, T, TxEip2930>) -> HandlerResult<TxResult<T>> {
+    handle_with_hooks::<T, DefaultTxHandlerHooks>(req)
+}
+
+/// Executes an EIP-2930 transaction using Ethereum rules and custom handler hooks.
+pub fn handle_with_hooks<T: EvmTypes, H: TxHandlerHooks<T>>(
+    req: TxRequest<'_, '_, T, TxEip2930>,
+) -> HandlerResult<TxResult<T>> {
     let caller = req.tx.signer();
     let tx = req.tx.inner();
     let gas_price = U256::from(tx.gas_price);
@@ -29,7 +39,7 @@ pub fn handle<T: EvmTypes>(req: TxRequest<'_, '_, T, TxEip2930>) -> HandlerResul
     validate_create_initcode(req.host.version(), tx.to, &tx.input)?;
     validate_nonce_not_overflow(tx.nonce)?;
     let (access_list_accounts, access_list_storage_keys) = access_list_counts(&tx.access_list);
-    let intrinsic = intrinsic_gas(
+    let mut intrinsic = intrinsic_gas(
         req.host.version(),
         caller,
         tx.to,
@@ -38,7 +48,8 @@ pub fn handle<T: EvmTypes>(req: TxRequest<'_, '_, T, TxEip2930>) -> HandlerResul
         access_list_storage_keys,
         tx.value,
     );
-    let initial_state_gas = create_initial_state_gas(req.host.version(), tx.to.is_create());
+    let mut initial_state_gas = create_initial_state_gas(req.host.version(), tx.to.is_create());
+    H::adjust_intrinsic_gas(req.host, req.envelope, &mut intrinsic, &mut initial_state_gas)?;
     validate_intrinsic_gas(tx.gas_limit, intrinsic, initial_state_gas)?;
     let floor_gas =
         floor_gas(req.host.version(), &tx.input, access_list_accounts, access_list_storage_keys);
@@ -51,8 +62,8 @@ pub fn handle<T: EvmTypes>(req: TxRequest<'_, '_, T, TxEip2930>) -> HandlerResul
     warm_base_accounts(req.host, caller, tx.to);
     warm_access_list(req.host, &tx.access_list);
 
-    charge_upfront(req.host, caller, max_gas_cost)?;
     req.host.state.account(&caller, false).map_err(error_handler!(req.host))?.bump_nonce();
+    H::before_execution(req.host, req.envelope, caller, max_gas_cost)?;
     let execution_checkpoint = req.host.state.checkpoint();
 
     let (gas_limit, reservoir) = initial_gas_and_reservoir(
@@ -75,15 +86,18 @@ pub fn handle<T: EvmTypes>(req: TxRequest<'_, '_, T, TxEip2930>) -> HandlerResul
     rollback_failed_execution(req.host, execution_checkpoint, &mut result);
     refund_create_state_gas(&mut result, initial_state_gas);
 
-    settle_gas(
+    H::settle_transaction(
         req.host,
-        caller,
-        gas_price,
-        tx.gas_limit,
-        floor_gas,
-        initial_state_gas,
-        0,
-        tx.to.is_create(),
-        result,
+        req.envelope,
+        GasSettlement {
+            caller,
+            gas_price,
+            gas_limit: tx.gas_limit,
+            floor_gas,
+            initial_state_gas,
+            state_refund: 0,
+            is_create: tx.to.is_create(),
+            result,
+        },
     )
 }

--- a/crates/evm2/src/ethereum/eip4844.rs
+++ b/crates/evm2/src/ethereum/eip4844.rs
@@ -1,15 +1,18 @@
 use super::{
-    access_list_counts, charge_upfront, create_initial_state_gas, effective_gas_price, floor_gas,
+    access_list_counts, create_initial_state_gas, effective_gas_price, floor_gas,
     initial_gas_and_reservoir, initial_message, intrinsic_gas, rollback_failed_execution,
-    settle_gas, validate_block_gas_limit, validate_chain_id, validate_create_initcode,
-    validate_floor_gas, validate_gas_price, validate_intrinsic_gas, validate_nonce_not_overflow,
-    validate_priority_fee, validate_regular_gas_limit_cap, validate_sender,
-    validate_tx_gas_limit_cap, warm_access_list, warm_base_accounts,
+    validate_block_gas_limit, validate_chain_id, validate_create_initcode, validate_floor_gas,
+    validate_gas_price, validate_intrinsic_gas, validate_nonce_not_overflow, validate_priority_fee,
+    validate_regular_gas_limit_cap, validate_sender, validate_tx_gas_limit_cap, warm_access_list,
+    warm_base_accounts,
 };
 use crate::{
     EvmTypes, TxResult,
     env::TxEnvExt,
-    evm::error_handler,
+    evm::{
+        error_handler,
+        handler::{DefaultTxHandlerHooks, GasSettlement, TxHandlerHooks},
+    },
     interpreter::Host,
     registry::{HandlerError, HandlerResult, TxRequest},
     utils::b256_to_word,
@@ -20,6 +23,13 @@ use alloy_primitives::U256;
 
 /// Executes an EIP-4844 transaction using Ethereum rules.
 pub fn handle<T: EvmTypes>(
+    req: TxRequest<'_, '_, T, TxEip4844Variant>,
+) -> HandlerResult<TxResult<T>> {
+    handle_with_hooks::<T, DefaultTxHandlerHooks>(req)
+}
+
+/// Executes an EIP-4844 transaction using Ethereum rules and custom handler hooks.
+pub fn handle_with_hooks<T: EvmTypes, H: TxHandlerHooks<T>>(
     req: TxRequest<'_, '_, T, TxEip4844Variant>,
 ) -> HandlerResult<TxResult<T>> {
     let caller = req.tx.signer();
@@ -40,7 +50,7 @@ pub fn handle<T: EvmTypes>(
     validate_create_initcode(req.host.version(), tx.to.into(), &tx.input)?;
     validate_nonce_not_overflow(tx.nonce)?;
     let (access_list_accounts, access_list_storage_keys) = access_list_counts(&tx.access_list);
-    let intrinsic = intrinsic_gas(
+    let mut intrinsic = intrinsic_gas(
         req.host.version(),
         caller,
         tx.to.into(),
@@ -49,7 +59,8 @@ pub fn handle<T: EvmTypes>(
         access_list_storage_keys,
         tx.value,
     );
-    let initial_state_gas = create_initial_state_gas(req.host.version(), false);
+    let mut initial_state_gas = create_initial_state_gas(req.host.version(), false);
+    H::adjust_intrinsic_gas(req.host, req.envelope, &mut intrinsic, &mut initial_state_gas)?;
     validate_intrinsic_gas(tx.gas_limit, intrinsic, initial_state_gas)?;
     let floor_gas =
         floor_gas(req.host.version(), &tx.input, access_list_accounts, access_list_storage_keys);
@@ -71,8 +82,8 @@ pub fn handle<T: EvmTypes>(
 
     let effective_gas_cost = U256::from(tx.gas_limit) * gas_price;
     let blob_basefee_cost = blob_gas_cost * req.host.block.blob_basefee;
-    charge_upfront(req.host, caller, effective_gas_cost + blob_basefee_cost)?;
     req.host.state.account(&caller, false).map_err(error_handler!(req.host))?.bump_nonce();
+    H::before_execution(req.host, req.envelope, caller, effective_gas_cost + blob_basefee_cost)?;
     let execution_checkpoint = req.host.state.checkpoint();
 
     // Blob transactions are always calls, never creates.
@@ -104,16 +115,19 @@ pub fn handle<T: EvmTypes>(
     let mut result = req.host.execute_message(&tx_env, bytecode, &mut message);
     rollback_failed_execution(req.host, execution_checkpoint, &mut result);
 
-    settle_gas(
+    H::settle_transaction(
         req.host,
-        caller,
-        gas_price,
-        tx.gas_limit,
-        floor_gas,
-        initial_state_gas,
-        0,
-        false,
-        result,
+        req.envelope,
+        GasSettlement {
+            caller,
+            gas_price,
+            gas_limit: tx.gas_limit,
+            floor_gas,
+            initial_state_gas,
+            state_refund: 0,
+            is_create: false,
+            result,
+        },
     )
 }
 

--- a/crates/evm2/src/ethereum/eip7702.rs
+++ b/crates/evm2/src/ethereum/eip7702.rs
@@ -1,15 +1,17 @@
 use super::{
-    access_list_counts, charge_upfront, effective_gas_price, floor_gas, initial_gas_and_reservoir,
-    initial_message, intrinsic_gas, rollback_failed_execution, settle_gas,
-    validate_block_gas_limit, validate_chain_id, validate_create_initcode, validate_floor_gas,
-    validate_gas_price, validate_intrinsic_gas, validate_nonce_not_overflow, validate_priority_fee,
-    validate_regular_gas_limit_cap, validate_sender, validate_tx_gas_limit_cap, warm_access_list,
-    warm_base_accounts,
+    access_list_counts, effective_gas_price, floor_gas, initial_gas_and_reservoir, initial_message,
+    intrinsic_gas, rollback_failed_execution, validate_block_gas_limit, validate_chain_id,
+    validate_create_initcode, validate_floor_gas, validate_gas_price, validate_intrinsic_gas,
+    validate_nonce_not_overflow, validate_priority_fee, validate_regular_gas_limit_cap,
+    validate_sender, validate_tx_gas_limit_cap, warm_access_list, warm_base_accounts,
 };
 use crate::{
     Evm, EvmFeatures, EvmTypes, TxResult,
     env::TxEnvExt,
-    evm::error_handler,
+    evm::{
+        error_handler,
+        handler::{DefaultTxHandlerHooks, GasSettlement, TxHandlerHooks},
+    },
     interpreter::Host,
     registry::{HandlerError, HandlerResult, TxRequest},
     version::GasId,
@@ -18,6 +20,13 @@ use alloy_primitives::U256;
 
 /// Executes an EIP-7702 transaction using Ethereum rules.
 pub fn handle<T: EvmTypes>(
+    req: TxRequest<'_, '_, T, super::LazyTxEip7702>,
+) -> HandlerResult<TxResult<T>> {
+    handle_with_hooks::<T, DefaultTxHandlerHooks>(req)
+}
+
+/// Executes an EIP-7702 transaction using Ethereum rules and custom handler hooks.
+pub fn handle_with_hooks<T: EvmTypes, H: TxHandlerHooks<T>>(
     req: TxRequest<'_, '_, T, super::LazyTxEip7702>,
 ) -> HandlerResult<TxResult<T>> {
     let caller = req.tx.signer();
@@ -38,7 +47,7 @@ pub fn handle<T: EvmTypes>(
     validate_create_initcode(req.host.version(), tx.to.into(), &tx.input)?;
     validate_nonce_not_overflow(tx.nonce)?;
     let (access_list_accounts, access_list_storage_keys) = access_list_counts(&tx.access_list);
-    let intrinsic = intrinsic_gas(
+    let mut intrinsic = intrinsic_gas(
         req.host.version(),
         caller,
         tx.to.into(),
@@ -49,7 +58,9 @@ pub fn handle<T: EvmTypes>(
     ) + eip7702_authorization_gas(req.host, tx.authorization_list.len());
     // EIP-8037: per-auth state gas (account + bytecode) is charged before execution. Zero before
     // Amsterdam.
-    let initial_state_gas = eip7702_authorization_state_gas(req.host, tx.authorization_list.len());
+    let mut initial_state_gas =
+        eip7702_authorization_state_gas(req.host, tx.authorization_list.len());
+    H::adjust_intrinsic_gas(req.host, req.envelope, &mut intrinsic, &mut initial_state_gas)?;
     validate_intrinsic_gas(tx.gas_limit, intrinsic, initial_state_gas)?;
     let floor_gas =
         floor_gas(req.host.version(), &tx.input, access_list_accounts, access_list_storage_keys);
@@ -63,11 +74,11 @@ pub fn handle<T: EvmTypes>(
     warm_access_list(req.host, &tx.access_list);
 
     let effective_gas_cost = U256::from(tx.gas_limit) * gas_price;
-    charge_upfront(req.host, caller, effective_gas_cost)?;
     req.host.state.account(&caller, false).map_err(error_handler!(req.host))?.bump_nonce();
     let chain_id = req.host.version().chain_id;
     let (state_refund, regular_refund) =
         apply_auth_list(req.host, chain_id, &tx.authorization_list)?;
+    H::before_execution(req.host, req.envelope, caller, effective_gas_cost)?;
     let execution_checkpoint = req.host.state.checkpoint();
 
     // EIP-7702 transactions are always calls, never creates.
@@ -100,16 +111,19 @@ pub fn handle<T: EvmTypes>(
         result.gas.refunded().saturating_add(i64::try_from(regular_refund).unwrap_or(i64::MAX)),
     );
 
-    settle_gas(
+    H::settle_transaction(
         req.host,
-        caller,
-        gas_price,
-        tx.gas_limit,
-        floor_gas,
-        initial_state_gas,
-        state_refund,
-        false,
-        result,
+        req.envelope,
+        GasSettlement {
+            caller,
+            gas_price,
+            gas_limit: tx.gas_limit,
+            floor_gas,
+            initial_state_gas,
+            state_refund,
+            is_create: false,
+            result,
+        },
     )
 }
 

--- a/crates/evm2/src/ethereum/legacy.rs
+++ b/crates/evm2/src/ethereum/legacy.rs
@@ -1,14 +1,17 @@
 use super::{
-    charge_upfront, create_initial_state_gas, floor_gas, initial_gas_and_reservoir,
-    initial_message, intrinsic_gas, refund_create_state_gas, rollback_failed_execution, settle_gas,
-    validate_block_gas_limit, validate_chain_id, validate_create_initcode, validate_floor_gas,
-    validate_gas_price, validate_intrinsic_gas, validate_nonce_not_overflow,
-    validate_regular_gas_limit_cap, validate_sender, validate_tx_gas_limit_cap, warm_base_accounts,
+    create_initial_state_gas, floor_gas, initial_gas_and_reservoir, initial_message, intrinsic_gas,
+    refund_create_state_gas, rollback_failed_execution, validate_block_gas_limit,
+    validate_chain_id, validate_create_initcode, validate_floor_gas, validate_gas_price,
+    validate_intrinsic_gas, validate_nonce_not_overflow, validate_regular_gas_limit_cap,
+    validate_sender, validate_tx_gas_limit_cap, warm_base_accounts,
 };
 use crate::{
     EvmTypes, TxResult,
     env::TxEnvExt,
-    evm::error_handler,
+    evm::{
+        error_handler,
+        handler::{DefaultTxHandlerHooks, GasSettlement, TxHandlerHooks},
+    },
     interpreter::Host,
     registry::{HandlerResult, TxRequest},
 };
@@ -17,6 +20,13 @@ use alloy_primitives::U256;
 
 /// Executes a legacy transaction using Ethereum rules.
 pub fn handle<T: EvmTypes>(req: TxRequest<'_, '_, T, TxLegacy>) -> HandlerResult<TxResult<T>> {
+    handle_with_hooks::<T, DefaultTxHandlerHooks>(req)
+}
+
+/// Executes a legacy transaction using Ethereum rules and custom handler hooks.
+pub fn handle_with_hooks<T: EvmTypes, H: TxHandlerHooks<T>>(
+    req: TxRequest<'_, '_, T, TxLegacy>,
+) -> HandlerResult<TxResult<T>> {
     let caller = req.tx.signer();
     let tx = req.tx.inner();
     let gas_price = U256::from(tx.gas_price);
@@ -27,8 +37,9 @@ pub fn handle<T: EvmTypes>(req: TxRequest<'_, '_, T, TxLegacy>) -> HandlerResult
     validate_block_gas_limit(req.host.version(), tx.gas_limit, req.host.block.gas_limit)?;
     validate_create_initcode(req.host.version(), tx.to, &tx.input)?;
     validate_nonce_not_overflow(tx.nonce)?;
-    let intrinsic = intrinsic_gas(req.host.version(), caller, tx.to, &tx.input, 0, 0, tx.value);
-    let initial_state_gas = create_initial_state_gas(req.host.version(), tx.to.is_create());
+    let mut intrinsic = intrinsic_gas(req.host.version(), caller, tx.to, &tx.input, 0, 0, tx.value);
+    let mut initial_state_gas = create_initial_state_gas(req.host.version(), tx.to.is_create());
+    H::adjust_intrinsic_gas(req.host, req.envelope, &mut intrinsic, &mut initial_state_gas)?;
     validate_intrinsic_gas(tx.gas_limit, intrinsic, initial_state_gas)?;
     let floor_gas = floor_gas(req.host.version(), &tx.input, 0, 0);
     validate_floor_gas(tx.gas_limit, floor_gas)?;
@@ -39,8 +50,8 @@ pub fn handle<T: EvmTypes>(req: TxRequest<'_, '_, T, TxLegacy>) -> HandlerResult
 
     warm_base_accounts(req.host, caller, tx.to);
 
-    charge_upfront(req.host, caller, max_gas_cost)?;
     req.host.state.account(&caller, false).map_err(error_handler!(req.host))?.bump_nonce();
+    H::before_execution(req.host, req.envelope, caller, max_gas_cost)?;
     let execution_checkpoint = req.host.state.checkpoint();
 
     let (gas_limit, reservoir) = initial_gas_and_reservoir(
@@ -63,15 +74,18 @@ pub fn handle<T: EvmTypes>(req: TxRequest<'_, '_, T, TxLegacy>) -> HandlerResult
     rollback_failed_execution(req.host, execution_checkpoint, &mut result);
     refund_create_state_gas(&mut result, initial_state_gas);
 
-    settle_gas(
+    H::settle_transaction(
         req.host,
-        caller,
-        gas_price,
-        tx.gas_limit,
-        floor_gas,
-        initial_state_gas,
-        0,
-        tx.to.is_create(),
-        result,
+        req.envelope,
+        GasSettlement {
+            caller,
+            gas_price,
+            gas_limit: tx.gas_limit,
+            floor_gas,
+            initial_state_gas,
+            state_refund: 0,
+            is_create: tx.to.is_create(),
+            result,
+        },
     )
 }

--- a/crates/evm2/src/ethereum/mod.rs
+++ b/crates/evm2/src/ethereum/mod.rs
@@ -17,7 +17,7 @@ pub use lazy_eip7702::{LazyAuthorization, LazyTxEip7702};
 use crate::{
     Evm, EvmFeatures, EvmTypes, SpecId, TxResult, TxResultExt, Version,
     bytecode::Bytecode,
-    evm::{AccountInfo, StateCheckpoint, error_handler},
+    evm::{AccountInfo, StateCheckpoint, error_handler, handler::GasSettlement},
     interpreter::{
         Message, MessageExt, MessageKind, MessageResult, MessageResultExt, Word,
         gas::{EIP2780_TX_BASE_COST, EIP8038_COLD_ACCOUNT_ACCESS},
@@ -622,30 +622,61 @@ pub const fn refund_create_state_gas<E>(result: &mut MessageResultExt<E>, create
     }
 }
 
-#[allow(clippy::too_many_arguments)]
-/// Applies Ethereum gas refunds, sender reimbursement, and beneficiary rewards.
-pub fn settle_gas<'a, T: EvmTypes>(
+/// Applies the default Ethereum gas refund, sender reimbursement, and beneficiary reward rules.
+pub fn default_settle_gas<'a, T: EvmTypes>(
     host: &mut Evm<'a, T>,
-    caller: Address,
-    gas_price: U256,
-    tx_gas_limit: u64,
-    floor_gas: u64,
-    initial_state_gas: u64,
-    state_refund: u64,
-    is_create: bool,
-    result: MessageResult<T>,
+    settlement: GasSettlement<T>,
 ) -> HandlerResult<TxResult<T>> {
+    let caller = settlement.caller;
+    let gas_price = settlement.gas_price;
+    let gas_limit = settlement.gas_limit;
+    let result = finalize_gas(host, settlement)?;
+    if host.feature(EvmFeatures::FEE_CHARGE) {
+        let gas_used = result.tx_gas_used();
+        let gas_remaining = gas_limit.saturating_sub(gas_used);
+        let caller_refund = U256::from(gas_remaining) * gas_price;
+        host.state
+            .account(&caller, false)
+            .map_err(error_handler!(host))?
+            .add_balance(caller_refund);
+        let beneficiary_gas_price = if host.feature(EvmFeatures::BASE_FEE_CHECK) {
+            gas_price.saturating_sub(host.block.basefee)
+        } else {
+            gas_price
+        };
+        let beneficiary = host.block.beneficiary;
+        let beneficiary_reward = U256::from(gas_used) * beneficiary_gas_price;
+        host.state
+            .account(&beneficiary, false)
+            .map_err(error_handler!(host))?
+            .add_balance(beneficiary_reward);
+    }
+    Ok(result)
+}
+
+/// Finalizes transaction gas accounting.
+pub fn finalize_gas<'a, T: EvmTypes>(
+    host: &mut Evm<'a, T>,
+    settlement: GasSettlement<T>,
+) -> HandlerResult<TxResult<T>> {
+    let GasSettlement {
+        caller: _,
+        gas_price: _,
+        gas_limit: tx_gas_limit,
+        floor_gas,
+        initial_state_gas,
+        state_refund,
+        is_create,
+        result,
+    } = settlement;
     if let Some(code) = host.error_code {
         return Err(HandlerError::Fatal(code));
     }
 
     let max_refund_quotient = u64::from(host.version().gas_params.get(GasId::MaxRefundQuotient));
-    let (gas_remaining, gas_used) =
-        final_tx_gas(&result, tx_gas_limit, max_refund_quotient, floor_gas);
     // Self-contained gas breakdown for the result. `total_gas_spent` is defined so that
-    // `TxResult::tx_gas_used` reproduces the local `gas_used` (used here for the beneficiary
-    // reward). State gas is execution state gas plus the upfront `initial_state_gas`, less the
-    // EIP-7702 per-authorization `state_refund`.
+    // `TxResult::tx_gas_used` reproduces the finalized gas used. State gas is execution state gas
+    // plus the upfront `initial_state_gas`, less the EIP-7702 per-authorization `state_refund`.
     let total_gas_spent =
         tx_gas_limit.saturating_sub(result.gas.remaining()).saturating_sub(result.gas.reservoir());
     let refunded = result.final_refund(tx_gas_limit, max_refund_quotient);
@@ -675,24 +706,6 @@ pub fn settle_gas<'a, T: EvmTypes>(
     let state_gas_spent = (exec_state_gas.saturating_add_unsigned(initial_state_gas).max(0) as u64)
         .saturating_sub(state_refund)
         .saturating_sub(alive_create_refund);
-    if host.feature(EvmFeatures::FEE_CHARGE) {
-        let caller_refund = U256::from(gas_remaining) * gas_price;
-        host.state
-            .account(&caller, false)
-            .map_err(error_handler!(host))?
-            .add_balance(caller_refund);
-        let beneficiary_gas_price = if host.feature(EvmFeatures::BASE_FEE_CHECK) {
-            gas_price.saturating_sub(host.block.basefee)
-        } else {
-            gas_price
-        };
-        let beneficiary = host.block.beneficiary;
-        let beneficiary_reward = U256::from(gas_used) * beneficiary_gas_price;
-        host.state
-            .account(&beneficiary, false)
-            .map_err(error_handler!(host))?
-            .add_balance(beneficiary_reward);
-    }
     Ok(TxResultExt {
         status: result.stop.is_success(),
         total_gas_spent,
@@ -705,21 +718,6 @@ pub fn settle_gas<'a, T: EvmTypes>(
         ext: T::TxResultExt::default(),
         ..TxResultExt::default()
     })
-}
-
-const fn final_tx_gas<E>(
-    result: &MessageResultExt<E>,
-    tx_gas_limit: u64,
-    max_refund_quotient: u64,
-    floor_gas: u64,
-) -> (u64, u64) {
-    let gas_remaining = result.gas_remaining_after_final_refund(tx_gas_limit, max_refund_quotient);
-    let gas_used = result.gas_used_after_final_refund(tx_gas_limit, max_refund_quotient);
-    // EIP-7623 charges at least the calldata floor after applying refunds.
-    if gas_used < floor_gas {
-        return (tx_gas_limit.saturating_sub(floor_gas), floor_gas);
-    }
-    (gas_remaining, gas_used)
 }
 
 /// Returns the account and storage-key counts in an access list.
@@ -837,7 +835,7 @@ mod tests {
         BaseEvmTypes, ExecutionConfig, Precompiles,
         env::{BlockEnvExt, TxEnvExt},
         evm::InMemoryDB,
-        interpreter::{GasTracker, Host, InstrStop, op},
+        interpreter::{Host, InstrStop, op},
         registry::TxRegistry,
     };
     use alloc::vec;
@@ -1066,32 +1064,6 @@ mod tests {
             evm.state.account_info_untracked(&caller).unwrap().unwrap().balance,
             U256::from(100)
         );
-    }
-
-    #[test]
-    fn final_tx_gas_charges_calldata_floor_after_refund() {
-        let result = MessageResult::<BaseEvmTypes> {
-            stop: crate::interpreter::InstrStop::Return,
-            gas: {
-                let mut gas = GasTracker::new_used_gas(100_000, 50_000, 0);
-                gas.set_refunded(10_000);
-                gas
-            },
-            ..MessageResult::<BaseEvmTypes>::default()
-        };
-
-        assert_eq!(final_tx_gas(&result, 100_000, 5, 60_000), (40_000, 60_000));
-    }
-
-    #[test]
-    fn final_tx_gas_preserves_higher_actual_usage() {
-        let result = MessageResult::<BaseEvmTypes> {
-            stop: crate::interpreter::InstrStop::Return,
-            gas: GasTracker::new_used_gas(100_000, 70_000, 0),
-            ..MessageResult::<BaseEvmTypes>::default()
-        };
-
-        assert_eq!(final_tx_gas(&result, 100_000, 5, 60_000), (30_000, 70_000));
     }
 
     #[test]

--- a/crates/evm2/src/evm/handler.rs
+++ b/crates/evm2/src/evm/handler.rs
@@ -1,0 +1,66 @@
+//! Transaction handler extension points.
+
+use crate::{Evm, EvmTypes, TxResult, interpreter::MessageResult, registry::HandlerResult};
+use alloy_primitives::{Address, U256};
+use derive_where::derive_where;
+
+/// Values produced by transaction execution and consumed during gas settlement.
+#[derive_where(Debug)]
+pub struct GasSettlement<T: EvmTypes> {
+    /// Transaction sender.
+    pub caller: Address,
+    /// Effective gas price used for this transaction.
+    pub gas_price: U256,
+    /// Transaction gas limit.
+    pub gas_limit: u64,
+    /// Calldata floor gas.
+    pub floor_gas: u64,
+    /// State gas charged before execution.
+    pub initial_state_gas: u64,
+    /// State gas refunded by pre-execution processing.
+    pub state_refund: u64,
+    /// Whether this is a top-level create transaction.
+    pub is_create: bool,
+    /// Result of executing the top-level message.
+    pub result: MessageResult<T>,
+}
+
+/// Static extension points shared by transaction handlers.
+pub trait TxHandlerHooks<T: EvmTypes>: Sized {
+    /// Adjusts the intrinsic regular and state gas calculated by the standard handler.
+    fn adjust_intrinsic_gas(
+        _host: &mut Evm<'_, T>,
+        _envelope: &T::Tx,
+        _intrinsic: &mut u64,
+        _initial_state_gas: &mut u64,
+    ) -> HandlerResult<()> {
+        Ok(())
+    }
+
+    /// Runs after standard pre-execution state changes and immediately before the execution
+    /// checkpoint is created.
+    fn before_execution(
+        host: &mut Evm<'_, T>,
+        _envelope: &T::Tx,
+        caller: Address,
+        upfront_fee: U256,
+    ) -> HandlerResult<()> {
+        crate::ethereum::charge_upfront(host, caller, upfront_fee)?;
+        Ok(())
+    }
+
+    /// Settles a transaction after execution and rollback handling.
+    fn settle_transaction(
+        host: &mut Evm<'_, T>,
+        _envelope: &T::Tx,
+        gas: GasSettlement<T>,
+    ) -> HandlerResult<TxResult<T>> {
+        crate::ethereum::default_settle_gas(host, gas)
+    }
+}
+
+/// Hooks that preserve the default transaction behavior.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct DefaultTxHandlerHooks;
+
+impl<T: EvmTypes> TxHandlerHooks<T> for DefaultTxHandlerHooks {}

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -142,6 +142,7 @@ use derive_where::derive_where;
 pub mod r#async;
 pub mod config;
 pub mod env;
+pub mod handler;
 pub mod inspector;
 pub mod precompile;
 pub mod registry;

--- a/crates/evm2/src/lib.rs
+++ b/crates/evm2/src/lib.rs
@@ -25,7 +25,7 @@ pub use evm::{
         BaseEvmConfig, BaseEvmConfigSelector, BaseEvmTypes, EvmConfig, EvmConfigSelector, EvmTypes,
         ExecutionConfig,
     },
-    env, inspector, precompile, registry,
+    env, handler, inspector, precompile, registry,
 };
 pub use inspector::{Inspector, NoopInspector};
 


### PR DESCRIPTION
Adds reusable hooks around intrinsic gas calculation, pre-execution state, and gas settlement for all Ethereum transaction handlers. Default hooks preserve the existing Ethereum path, while custom EVM integrations can customize fee policy and gas accounting without copying the handlers.

Tests: `cargo cl`, `cargo nextest run` (2,829 passed), and `cargo docs`.
