### PR TITLE
refactor(db): make get_block_hash return the hash, not an Option

### DIFF
--- a/crates/evm2/src/evm/async.rs
+++ b/crates/evm2/src/evm/async.rs
@@ -427,10 +427,13 @@ pub trait AsyncDatabase: NonStaticAny {
     ) -> impl Future<Output = Result<Word, Self::Error>> + Send + '_;
 
     /// Loads a historical block hash.
+    ///
+    /// Callers only request numbers inside the `BLOCKHASH` window, so a hash the database cannot
+    /// provide is a database failure reported through the error, never a benign miss.
     fn get_block_hash(
         &mut self,
         number: Word,
-    ) -> impl Future<Output = Result<Option<B256>, Self::Error>> + Send + '_;
+    ) -> impl Future<Output = Result<B256, Self::Error>> + Send + '_;
 }
 
 /// Adapter that exposes an [`AsyncDatabase`] through the synchronous [`DynDatabase`] interface.
@@ -514,7 +517,7 @@ impl<D: AsyncDatabase> DynDatabase for AsyncDb<D> {
     }
 
     #[inline]
-    fn get_block_hash(&mut self, number: &Word) -> DbResult<Option<B256>> {
+    fn get_block_hash(&mut self, number: &Word) -> DbResult<B256> {
         let result = {
             let Self { db, .. } = self;
             block_on_current_result(db.get_block_hash(*number))
@@ -1037,8 +1040,8 @@ mod tests {
             Ok(Word::from(9))
         }
 
-        fn get_block_hash(&mut self, _number: &Word) -> Result<Option<B256>, Self::Error> {
-            Ok(None)
+        fn get_block_hash(&mut self, _number: &Word) -> Result<B256, Self::Error> {
+            Ok(B256::ZERO)
         }
     }
 
@@ -1068,8 +1071,8 @@ mod tests {
             Ok(Word::ZERO)
         }
 
-        fn get_block_hash(&mut self, _number: &Word) -> Result<Option<B256>, Self::Error> {
-            Ok(None)
+        fn get_block_hash(&mut self, _number: &Word) -> Result<B256, Self::Error> {
+            Ok(B256::ZERO)
         }
     }
 
@@ -1158,8 +1161,8 @@ mod tests {
             Ok(Word::from(9))
         }
 
-        async fn get_block_hash(&mut self, _number: Word) -> Result<Option<B256>, Self::Error> {
-            Ok(None)
+        async fn get_block_hash(&mut self, _number: Word) -> Result<B256, Self::Error> {
+            Ok(B256::ZERO)
         }
     }
 
@@ -1190,8 +1193,8 @@ mod tests {
             Ok(Word::from(9))
         }
 
-        async fn get_block_hash(&mut self, _number: Word) -> Result<Option<B256>, Self::Error> {
-            Ok(None)
+        async fn get_block_hash(&mut self, _number: Word) -> Result<B256, Self::Error> {
+            Ok(B256::ZERO)
         }
     }
 
@@ -1226,8 +1229,8 @@ mod tests {
             Ok(Word::ZERO)
         }
 
-        async fn get_block_hash(&mut self, _number: Word) -> Result<Option<B256>, Self::Error> {
-            Ok(None)
+        async fn get_block_hash(&mut self, _number: Word) -> Result<B256, Self::Error> {
+            Ok(B256::ZERO)
         }
     }
 
@@ -1272,8 +1275,8 @@ mod tests {
             Err(TestError)
         }
 
-        async fn get_block_hash(&mut self, _number: Word) -> Result<Option<B256>, Self::Error> {
-            Ok(None)
+        async fn get_block_hash(&mut self, _number: Word) -> Result<B256, Self::Error> {
+            Ok(B256::ZERO)
         }
     }
 

--- a/crates/evm2/src/evm/async.rs
+++ b/crates/evm2/src/evm/async.rs
@@ -427,9 +427,6 @@ pub trait AsyncDatabase: NonStaticAny {
     ) -> impl Future<Output = Result<Word, Self::Error>> + Send + '_;
 
     /// Loads a historical block hash.
-    ///
-    /// Callers only request numbers inside the `BLOCKHASH` window, so a hash the database cannot
-    /// provide is a database failure reported through the error, never a benign miss.
     fn get_block_hash(
         &mut self,
         number: Word,

--- a/crates/evm2/src/evm/db/cache.rs
+++ b/crates/evm2/src/evm/db/cache.rs
@@ -345,15 +345,10 @@ impl<ExtDB: DynDatabase> DynDatabase for CacheDB<ExtDB> {
     }
 
     #[inline]
-    fn get_block_hash(&mut self, number: &Word) -> DbResult<Option<B256>> {
+    fn get_block_hash(&mut self, number: &Word) -> DbResult<B256> {
         match self.cache.block_hashes.entry(*number) {
-            Entry::Occupied(entry) => Ok(Some(*entry.get())),
-            Entry::Vacant(entry) => {
-                let Some(hash) = self.db.get_block_hash(number)? else {
-                    return Ok(None);
-                };
-                Ok(Some(*entry.insert(hash)))
-            }
+            Entry::Occupied(entry) => Ok(*entry.get()),
+            Entry::Vacant(entry) => Ok(*entry.insert(self.db.get_block_hash(number)?)),
         }
     }
 
@@ -391,7 +386,7 @@ mod typed {
         }
 
         #[inline]
-        fn get_block_hash(&mut self, number: &Word) -> Result<Option<B256>, Self::Error> {
+        fn get_block_hash(&mut self, number: &Word) -> Result<B256, Self::Error> {
             DynDatabase::get_block_hash(self, number).map_err(|code| DynDatabase::error(self, code))
         }
     }
@@ -412,7 +407,7 @@ mod tests {
     struct CountingDB {
         account: Option<AccountInfo>,
         storage: Word,
-        block_hash: Option<B256>,
+        block_hash: B256,
         account_loads: usize,
         code_loads: usize,
         storage_loads: usize,
@@ -442,7 +437,7 @@ mod tests {
             Ok(self.storage)
         }
 
-        fn get_block_hash(&mut self, _number: &Word) -> Result<Option<B256>, Self::Error> {
+        fn get_block_hash(&mut self, _number: &Word) -> Result<B256, Self::Error> {
             self.block_hash_loads += 1;
             Ok(self.block_hash)
         }
@@ -457,7 +452,7 @@ mod tests {
         let db = CountingDB {
             account: Some(AccountInfo::default().with_code(code.clone())),
             storage: Word::from(4),
-            block_hash: Some(block_hash),
+            block_hash,
             ..CountingDB::default()
         };
         let mut cache = CacheDB::new(crate::evm::Db::new(db));
@@ -476,8 +471,8 @@ mod tests {
         assert_eq!(cache.get_storage(&address, &key).unwrap(), Word::from(4));
         assert_eq!(cache.db.inner().storage_loads, 1);
 
-        assert_eq!(cache.get_block_hash(&Word::from(5)).unwrap(), Some(block_hash));
-        assert_eq!(cache.get_block_hash(&Word::from(5)).unwrap(), Some(block_hash));
+        assert_eq!(cache.get_block_hash(&Word::from(5)).unwrap(), block_hash);
+        assert_eq!(cache.get_block_hash(&Word::from(5)).unwrap(), block_hash);
         assert_eq!(cache.db.inner().block_hash_loads, 1);
     }
 

--- a/crates/evm2/src/evm/db/mod.rs
+++ b/crates/evm2/src/evm/db/mod.rs
@@ -29,7 +29,10 @@ pub trait Database: NonStaticAny {
     fn get_storage(&mut self, address: &Address, key: &Word) -> Result<Word, Self::Error>;
 
     /// Loads a historical block hash.
-    fn get_block_hash(&mut self, number: &Word) -> Result<Option<B256>, Self::Error>;
+    ///
+    /// Callers only request numbers inside the `BLOCKHASH` window, so a hash the database cannot
+    /// provide is a database failure reported through the error, never a benign miss.
+    fn get_block_hash(&mut self, number: &Word) -> Result<B256, Self::Error>;
 }
 
 /// Object-safe database adapter for typed database implementations.
@@ -107,7 +110,7 @@ impl<T: Database> DynDatabase for Db<T> {
     }
 
     #[inline]
-    fn get_block_hash(&mut self, number: &Word) -> DbResult<Option<B256>> {
+    fn get_block_hash(&mut self, number: &Word) -> DbResult<B256> {
         self.db.get_block_hash(number).map_err(|err| self.store_error(err))
     }
 
@@ -135,7 +138,10 @@ pub trait DynDatabase: NonStaticAny {
     fn get_storage(&mut self, address: &Address, key: &Word) -> DbResult<Word>;
 
     /// Loads a historical block hash.
-    fn get_block_hash(&mut self, number: &Word) -> DbResult<Option<B256>>;
+    ///
+    /// Callers only request numbers inside the `BLOCKHASH` window, so a hash the database cannot
+    /// provide is a database failure reported through the error, never a benign miss.
+    fn get_block_hash(&mut self, number: &Word) -> DbResult<B256>;
 
     /// Retrieves the full error for a previously returned error code.
     fn error(&mut self, code: ErrorCode) -> AnyError {
@@ -265,7 +271,7 @@ impl<D: DynDatabase> DynDatabase for DbStats<D> {
     }
 
     #[inline]
-    fn get_block_hash(&mut self, number: &Word) -> DbResult<Option<B256>> {
+    fn get_block_hash(&mut self, number: &Word) -> DbResult<B256> {
         self.counts.get_block_hash += 1;
         self.db.get_block_hash(number)
     }
@@ -321,8 +327,8 @@ impl Database for EmptyDB {
     }
 
     #[inline]
-    fn get_block_hash(&mut self, number: &Word) -> Result<Option<B256>, Self::Error> {
-        Ok(Some(keccak256(number.to_string().as_bytes())))
+    fn get_block_hash(&mut self, number: &Word) -> Result<B256, Self::Error> {
+        Ok(keccak256(number.to_string().as_bytes()))
     }
 }
 
@@ -343,7 +349,7 @@ impl DynDatabase for EmptyDB {
     }
 
     #[inline]
-    fn get_block_hash(&mut self, number: &Word) -> DbResult<Option<B256>> {
+    fn get_block_hash(&mut self, number: &Word) -> DbResult<B256> {
         Db::new(*self).get_block_hash(number)
     }
 }
@@ -369,8 +375,8 @@ mod tests {
             Ok(Word::ZERO)
         }
 
-        fn get_block_hash(&mut self, _number: &Word) -> DbResult<Option<B256>> {
-            Ok(Some(B256::from([*self.value; 32])))
+        fn get_block_hash(&mut self, _number: &Word) -> DbResult<B256> {
+            Ok(B256::from([*self.value; 32]))
         }
     }
 
@@ -379,7 +385,7 @@ mod tests {
         let value = 1;
         let mut erased = boxed_dyn_database(BorrowingDb { value: &value });
 
-        assert_eq!(erased.get_block_hash(&Word::ZERO).unwrap(), Some(B256::from([value; 32])));
+        assert_eq!(erased.get_block_hash(&Word::ZERO).unwrap(), B256::from([value; 32]));
     }
 
     #[test]

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -1760,7 +1760,7 @@ impl<'a, T: EvmTypes> Host<T> for Evm<'a, T> {
         }
     }
 
-    fn block_hash(&mut self, number: &Word) -> Result<Option<B256>, InstrStop> {
+    fn block_hash(&mut self, number: &Word) -> Result<B256, InstrStop> {
         self.state.block_hash(number).map_err(|code| self.store_error(code))
     }
 
@@ -3279,8 +3279,8 @@ mod tests {
                 Err(FailingDbError)
             }
 
-            fn get_block_hash(&mut self, _number: &Word) -> Result<Option<B256>, Self::Error> {
-                Ok(None)
+            fn get_block_hash(&mut self, _number: &Word) -> Result<B256, Self::Error> {
+                Ok(B256::ZERO)
             }
         }
 
@@ -3381,8 +3381,8 @@ mod tests {
                 Ok(Word::ZERO)
             }
 
-            fn get_block_hash(&mut self, _number: &Word) -> Result<Option<B256>, Self::Error> {
-                Ok(None)
+            fn get_block_hash(&mut self, _number: &Word) -> Result<B256, Self::Error> {
+                Ok(B256::ZERO)
             }
         }
 

--- a/crates/evm2/src/evm/registry.rs
+++ b/crates/evm2/src/evm/registry.rs
@@ -405,7 +405,7 @@ mod tests {
             unimplemented!()
         }
 
-        fn block_hash(&mut self, _number: &Word) -> Result<Option<B256>, InstrStop> {
+        fn block_hash(&mut self, _number: &Word) -> Result<B256, InstrStop> {
             unimplemented!()
         }
 

--- a/crates/evm2/src/evm/state/mod.rs
+++ b/crates/evm2/src/evm/state/mod.rs
@@ -232,7 +232,7 @@ impl<'a> State<'a> {
 
     /// Loads a historical block hash.
     #[inline]
-    pub(crate) fn block_hash(&mut self, number: &Word) -> DbResult<Option<B256>> {
+    pub(crate) fn block_hash(&mut self, number: &Word) -> DbResult<B256> {
         self.database.get_block_hash(number)
     }
 

--- a/crates/evm2/src/interpreter/host.rs
+++ b/crates/evm2/src/interpreter/host.rs
@@ -125,7 +125,7 @@ pub trait Host<T: EvmTypesHost> {
     ) -> Result<bool, InstrStop>;
 
     /// Returns a historical block hash.
-    fn block_hash(&mut self, number: &Word) -> Result<Option<B256>, InstrStop>;
+    fn block_hash(&mut self, number: &Word) -> Result<B256, InstrStop>;
 
     /// Loads a persistent storage slot.
     fn sload(

--- a/crates/evm2/src/interpreter/instructions/block.rs
+++ b/crates/evm2/src/interpreter/instructions/block.rs
@@ -1,7 +1,7 @@
 use crate::{
     EvmFeatures,
     constants::BLOCK_HASH_HISTORY,
-    interpreter::{Host, InstrStop, Word},
+    interpreter::{Host, Word},
     utils::{address_to_word, b256_to_word, word_to_usize_saturated},
 };
 use evm2_macros::instruction;
@@ -12,11 +12,7 @@ pub(crate) fn blockhash(cx: _, [number]: [Word]) -> Result<out> {
         if diff == 0 || diff > BLOCK_HASH_HISTORY {
             Word::ZERO
         } else {
-            cx.state
-                .host()
-                .block_hash(number)?
-                .map(b256_to_word)
-                .ok_or(InstrStop::FatalExternalError)?
+            b256_to_word(cx.state.host().block_hash(number)?)
         }
     } else {
         Word::ZERO

--- a/crates/evm2/src/test_utils.rs
+++ b/crates/evm2/src/test_utils.rs
@@ -126,11 +126,11 @@ impl Host<TestTypes> for TestHost {
         Ok(!self.exists && !self.is_touched)
     }
 
-    fn block_hash(&mut self, number: &Word) -> Result<Option<B256>, InstrStop> {
+    fn block_hash(&mut self, number: &Word) -> Result<B256, InstrStop> {
         if self.missing_block_hash {
-            return Ok(None);
+            return Err(InstrStop::FatalExternalError);
         }
-        Ok(Some(B256::with_last_byte(number.wrapping_to::<u8>())))
+        Ok(B256::with_last_byte(number.wrapping_to::<u8>()))
     }
 
     fn sload(

--- a/crates/inspectors/src/tracing/builder/geth.rs
+++ b/crates/inspectors/src/tracing/builder/geth.rs
@@ -602,7 +602,7 @@ mod tests {
             Err(self.error)
         }
 
-        fn get_block_hash(&mut self, _number: &Word) -> DbResult<Option<B256>> {
+        fn get_block_hash(&mut self, _number: &Word) -> DbResult<B256> {
             Err(self.error)
         }
     }

--- a/crates/inspectors/src/tracing/js/bindings.rs
+++ b/crates/inspectors/src/tracing/js/bindings.rs
@@ -1619,8 +1619,8 @@ mod tests {
             Ok(if *address == self.address && *key == self.slot { self.value } else { Word::ZERO })
         }
 
-        fn get_block_hash(&mut self, _number: &Word) -> Result<Option<B256>, Self::Error> {
-            Ok(None)
+        fn get_block_hash(&mut self, _number: &Word) -> Result<B256, Self::Error> {
+            Ok(B256::ZERO)
         }
     }
 

--- a/crates/jit/builtins/src/lib.rs
+++ b/crates/jit/builtins/src/lib.rs
@@ -396,7 +396,7 @@ pub unsafe extern "C" fn __revmc_builtin_blockhash(
 
     if diff <= BLOCK_HASH_HISTORY {
         let requested_number = U256::from(word_to_u64_saturated(requested_number));
-        let hash = ecx.host().block_hash(&requested_number).ok().flatten().ok_or_fatal()?;
+        let hash = ecx.host().block_hash(&requested_number)?;
         *number_ptr = EvmWord::from_be_bytes(hash);
     } else {
         // Too old, return 0

--- a/crates/jit/builtins/src/utils.rs
+++ b/crates/jit/builtins/src/utils.rs
@@ -30,18 +30,6 @@ impl From<InstrStop> for BuiltinError {
     }
 }
 
-/// Extension trait to convert `Option<T>` to `BuiltinResult`.
-pub(crate) trait OkOrFatal<T> {
-    fn ok_or_fatal(self) -> Result<T, BuiltinError>;
-}
-
-impl<T> OkOrFatal<T> for Option<T> {
-    #[inline]
-    fn ok_or_fatal(self) -> Result<T, BuiltinError> {
-        self.ok_or_else(|| InstrStop::FatalExternalError.into())
-    }
-}
-
 #[inline]
 pub(crate) fn require_non_staticcall(ecx: &EvmContext<'_, '_, '_>) -> BuiltinResult {
     if ecx.is_static() {


### PR DESCRIPTION
A missing block hash is a fatal database failure, not a benign miss: callers only request numbers inside the `BLOCKHASH` window, and both the interpreter and the JIT builtin already escalated `None` to `FatalExternalError`. This moves that contract into the database traits.

## Changes

- `Database::get_block_hash`, `DynDatabase::get_block_hash`, and `AsyncDatabase::get_block_hash` return `Result<B256, _>` instead of `Result<Option<B256>, _>`; trait docs state the contract.
- `Host::block_hash` follows (`Result<B256, InstrStop>`), so the `BLOCKHASH` instruction and the JIT `__revmc_builtin_blockhash` drop their `None`-to-fatal mapping (the builtin propagates the host error via `From<InstrStop> for BuiltinError`).
- The now-unused `OkOrFatal` helper trait in `evm2-jit-builtins` is removed.
- `CacheDB`'s cache-miss passthrough collapses to a plain entry insert; `EmptyDB`, `AsyncDb`, `State::block_hash`, and the test stubs across evm2/inspectors are updated.
- The `missing_blockhash_is_fatal` test now exercises the error path through the host instead of the `None` path.

## Testing

- `cargo cl`, nightly fmt, `cargo docs` clean; unit tests 2829/2829.
- Full interpreter EEST run: the failure set is byte-identical with and without this change (verified by stash-diffing the failing-test lists) — the remaining failures are pre-existing on `main` against current fixtures and are addressed by #315.