### PR TITLE
fix(evm): fold streamed state changes into the BAL builder

### DIFF
--- a/crates/eest/src/blockchaintest/execute.rs
+++ b/crates/eest/src/blockchaintest/execute.rs
@@ -986,12 +986,6 @@ fn increment_balance(
 
     let change = AccountStateChange { address, original, current: Some(current) };
     commit_state_changes(evm, block_state, &change);
-    // Post-block balance updates bypass transaction commit, so record them in the BAL directly.
-    evm.overlay_db_mut().bal_context.commit_account_change(
-        change.address,
-        change.original.as_ref(),
-        change.current.as_ref(),
-    );
     Ok(())
 }
 

--- a/crates/evm2/src/evm/bal/bal_context.rs
+++ b/crates/evm2/src/evm/bal/bal_context.rs
@@ -3,12 +3,16 @@
 use super::{AccountBal, Bal, BalError, BlockAccessIndex};
 use crate::{
     AnyError, ErrorCode,
-    evm::state::{Account, AccountInfo, PendingState, StorageOverlay},
+    evm::state::{
+        Account, AccountChangeRef, AccountInfo, AccountInfoRef, PendingState, StateChangeSink,
+        StorageChange, StorageOverlay,
+    },
     interpreter::Word,
 };
 use alloc::sync::Arc;
 use alloy_eip7928::BlockAccessList;
 use alloy_primitives::{Address, map::AddressMap};
+use core::convert::Infallible;
 
 /// Result of an EIP-7928 BAL lookup during a read.
 type BalResult<T> = Result<T, BalError>;
@@ -186,27 +190,6 @@ impl BalContext {
         }
     }
 
-    /// Records an account-info-only change (no storage) into the BAL builder at the current index.
-    ///
-    /// Used for post-block balance updates -- block rewards and withdrawals -- that mutate the
-    /// accepted overlay directly instead of flowing through a transaction commit, so they are not
-    /// captured by the transaction-commit fold. No-op when BAL construction is disabled.
-    #[inline]
-    pub fn commit_account_change(
-        &mut self,
-        address: Address,
-        original: Option<&AccountInfo>,
-        current: Option<&AccountInfo>,
-    ) {
-        let index = self.bal_index;
-        if let Some(bal) = self.bal_builder.as_mut() {
-            let account = bal.accounts.entry(address).or_default();
-            let original = original.cloned().unwrap_or_default();
-            let current = current.cloned().unwrap_or_default();
-            account.account_info.update(index, &original, &current);
-        }
-    }
-
     /// Takes the built BAL, resetting the block access index. Returns `None` when BAL construction
     /// is disabled.
     #[inline]
@@ -304,5 +287,73 @@ impl BalContext {
             return None;
         }
         self.bal_error.take().map(AnyError::new)
+    }
+}
+
+/// Folds streamed state changes into the BAL builder at the current [`BalContext::bal_index`].
+///
+/// This is the sink shape of the [`Self::commit_pending`] fold: changed accounts and storage
+/// slots are
+/// recorded as writes, loaded-but-unchanged ones -- the read callbacks -- as reads. The bytecode
+/// and storage-wipe callbacks need no BAL action: code changes surface through
+/// [`StateChangeSink::account`], and a wiped account's storage surfaces through the storage
+/// callbacks. Every callback is a no-op when BAL construction is disabled.
+impl StateChangeSink for BalContext {
+    type Error = Infallible;
+
+    #[inline]
+    fn account(&mut self, change: AccountChangeRef<'_>) -> Result<(), Self::Error> {
+        let index = self.bal_index;
+        if let Some(bal) = self.bal_builder.as_mut() {
+            let original = change.original.map(AccountInfoRef::to_account_info).unwrap_or_default();
+            let current = change.current.map(AccountInfoRef::to_account_info).unwrap_or_default();
+            bal.accounts
+                .entry(change.address)
+                .or_default()
+                .account_info
+                .update(index, &original, &current);
+        }
+        Ok(())
+    }
+
+    #[inline]
+    fn storage(&mut self, change: StorageChange) -> Result<(), Self::Error> {
+        let index = self.bal_index;
+        if let Some(bal) = self.bal_builder.as_mut() {
+            bal.accounts
+                .entry(change.address)
+                .or_default()
+                .storage
+                .storage
+                .entry(change.key)
+                .or_default()
+                .update(index, &change.original, change.current);
+        }
+        Ok(())
+    }
+
+    #[inline]
+    fn account_read(
+        &mut self,
+        address: Address,
+        _info: Option<AccountInfoRef<'_>>,
+    ) -> Result<(), Self::Error> {
+        if let Some(bal) = self.bal_builder.as_mut() {
+            bal.accounts.entry(address).or_default();
+        }
+        Ok(())
+    }
+
+    #[inline]
+    fn storage_read(
+        &mut self,
+        address: Address,
+        key: Word,
+        _value: Word,
+    ) -> Result<(), Self::Error> {
+        if let Some(bal) = self.bal_builder.as_mut() {
+            bal.accounts.entry(address).or_default().storage.storage.entry(key).or_default();
+        }
+        Ok(())
     }
 }

--- a/crates/evm2/src/evm/db/cache.rs
+++ b/crates/evm2/src/evm/db/cache.rs
@@ -112,6 +112,9 @@ impl<ExtDB> CacheDB<ExtDB> {
     }
 
     /// Applies borrowed state changes to this cache.
+    ///
+    /// When BAL construction is enabled, the visited changes and reads are also folded into the
+    /// BAL builder at the current block access index, matching [`Self::commit_pending`].
     #[inline]
     pub fn commit_source<S: StateChangeSource>(&mut self, source: &S) {
         let Ok(()) = source.visit(self);
@@ -225,23 +228,29 @@ impl<ExtDB> CacheDB<ExtDB> {
     }
 }
 
+/// Applies streamed changes to the cache and forwards every callback to [`BalContext`]'s own sink
+/// impl, so a visited source folds into the BAL builder exactly like [`CacheDB::commit_pending`]
+/// when construction is enabled.
 impl<ExtDB> StateChangeSink for CacheDB<ExtDB> {
     type Error = Infallible;
 
     #[inline]
     fn bytecode(&mut self, code_hash: B256, code: &Bytecode) -> Result<(), Self::Error> {
+        self.bal_context.bytecode(code_hash, code)?;
         self.cache.contracts.insert(code_hash, code.clone());
         Ok(())
     }
 
     #[inline]
     fn storage_wipe(&mut self, address: Address) -> Result<(), Self::Error> {
+        self.bal_context.storage_wipe(address)?;
         self.cache.storage.entry(address).or_default().wipe();
         Ok(())
     }
 
     #[inline]
     fn storage(&mut self, change: StorageChange) -> Result<(), Self::Error> {
+        self.bal_context.storage(change)?;
         let storage = self.cache.storage.entry(change.address).or_default();
         if storage.wiped && change.current.is_zero() {
             storage.slots.remove(&change.key);
@@ -253,6 +262,7 @@ impl<ExtDB> StateChangeSink for CacheDB<ExtDB> {
 
     #[inline]
     fn account(&mut self, change: AccountChangeRef<'_>) -> Result<(), Self::Error> {
+        self.bal_context.account(change)?;
         match change.current {
             Some(info) => self.insert_account_info(&change.address, info.to_account_info()),
             None => {
@@ -261,6 +271,25 @@ impl<ExtDB> StateChangeSink for CacheDB<ExtDB> {
             }
         }
         Ok(())
+    }
+
+    #[inline]
+    fn account_read(
+        &mut self,
+        address: Address,
+        info: Option<AccountInfoRef<'_>>,
+    ) -> Result<(), Self::Error> {
+        self.bal_context.account_read(address, info)
+    }
+
+    #[inline]
+    fn storage_read(
+        &mut self,
+        address: Address,
+        key: Word,
+        value: Word,
+    ) -> Result<(), Self::Error> {
+        self.bal_context.storage_read(address, key, value)
     }
 }
 
@@ -405,7 +434,7 @@ mod tests {
         interpreter::op,
     };
     use alloc::{string::ToString, sync::Arc, vec};
-    use alloy_eip7928::{BalanceChange, StorageChange};
+    use alloy_eip7928::{BalanceChange, NonceChange, StorageChange};
     use alloy_primitives::Bytes;
 
     #[derive(Debug, Default)]
@@ -561,6 +590,60 @@ mod tests {
         let missing = Address::with_last_byte(2);
         let account = cache.get_account(&missing).unwrap().unwrap();
         assert_eq!(account.balance, Word::from(100));
+    }
+
+    #[test]
+    fn sink_visit_folds_changes_into_bal_builder() {
+        let address = Address::with_last_byte(1);
+        let read_address = Address::with_last_byte(2);
+
+        let mut cache = InMemoryDB::default();
+        cache.bal_context.enable_bal_builder();
+        cache.bal_context.set_bal_index(BlockAccessIndex::new(3));
+
+        // One changed account with a changed slot and a loaded-but-unchanged slot, plus one
+        // loaded-but-unchanged account.
+        let mut pending = PendingState::default();
+        pending.insert_account(
+            address,
+            None,
+            Some(AccountInfo::default().with_nonce(1).with_balance(Word::from(100))),
+        );
+        pending.insert_storage(address, Word::from(5), Word::ZERO, Word::from(42));
+        pending.insert_storage(address, Word::from(6), Word::from(7), Word::from(7));
+        pending.insert_account(
+            read_address,
+            Some(AccountInfo::default()),
+            Some(AccountInfo::default()),
+        );
+
+        cache.commit_source(&pending);
+
+        // The visit applied the changes to the cache...
+        assert_eq!(cache.account_info(&address).unwrap().nonce, 1);
+        assert_eq!(cache.cache.storage[&address].slots[&Word::from(5)], Word::from(42));
+
+        // ...and folded the same writes and reads into the BAL builder.
+        let bal = cache.bal_context.take_bal_builder().unwrap();
+        let account = bal.accounts.get(&address).unwrap();
+        assert_eq!(
+            account.account_info.nonce.changes,
+            vec![NonceChange::new(BlockAccessIndex::new(3), 1)]
+        );
+        assert_eq!(
+            account.account_info.balance.changes,
+            vec![BalanceChange::new(BlockAccessIndex::new(3), Word::from(100))]
+        );
+        assert_eq!(
+            account.storage.storage.get(&Word::from(5)).unwrap().changes,
+            vec![StorageChange::new(BlockAccessIndex::new(3), Word::from(42))]
+        );
+        // Loaded-but-unchanged entries surface as reads: present, with no writes.
+        assert!(account.storage.storage.get(&Word::from(6)).unwrap().is_empty());
+        let read_account = bal.accounts.get(&read_address).unwrap();
+        assert!(read_account.account_info.nonce.is_empty());
+        assert!(read_account.account_info.balance.is_empty());
+        assert!(read_account.storage.storage.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Motivation

`impl<ExtDB> StateChangeSink for CacheDB<ExtDB>` applied visited changes to the cache but never touched `bal_context`, so any source streamed through `commit_source` or a `Tee` over `overlay_db_mut()` bypassed EIP-7928 BAL construction — unlike `commit_pending`, which folds into the builder.

## Solution

- Implement `StateChangeSink` on `BalContext` itself: the sink shape of the `commit_pending` fold. `account`/`storage` record writes at the current block access index through the same `AccountInfoBal::update` / `BalChanges::update` paths; `account_read`/`storage_read` record reads (entry with no writes). `bytecode` and `storage_wipe` need no BAL action: code changes surface through the `account` callback and wiped storage surfaces through the storage callbacks.
- Forward every `CacheDB` sink callback to `bal_context` before applying it to the cache, including new `account_read`/`storage_read` overrides (previously default no-ops).
- Remove the eest workaround that manually called `commit_account_change` after streaming post-block rewards/withdrawals — the sink now folds that change itself. `BalContext::commit_account_change` had no other callers, so it is removed.

Added `sink_visit_folds_changes_into_bal_builder`: visits a `PendingState` through `commit_source` and asserts the builder records nonce/balance/slot writes and read-only entries at the set index.

The transaction accept path is unaffected (it folds through the inherent `CacheDB::commit`), so nothing double-records.

## Verification

`cargo cl` clean, workspace tests pass (2830), and the EEST fixture failure set is byte-identical to the baseline (the 28 known stale devnet-6 fixture mismatches).