### PR TITLE
fix(state): preserve storage originals after wipe

### DIFF
--- a/crates/evm2/src/evm/state/storage.rs
+++ b/crates/evm2/src/evm/state/storage.rs
@@ -194,7 +194,7 @@ impl<'a, 'db> StorageHandle<'a, 'db> {
     pub fn wipe(&mut self) {
         self.storage.wiped = true;
         self.storage.slots.iter_mut().for_each(|(_, slot)| {
-            slot.value = Tracked::new(Word::ZERO);
+            slot.value.set_current(Word::ZERO);
         });
     }
 }


### PR DESCRIPTION
Preserve each wiped storage slot's transaction-boundary original value by updating only its current value to zero.

Linear: https://linear.app/tempoxyz/issue/CYCLOPS-644/cyclops-cyclops-ripple-effect-audit-evm2-8347f63-iteration-23

Validation: `cargo +nightly fmt --all -- --check` and `git diff --check` pass.

Prompted by: @rakita