### PR TITLE
fix(interpreter): tighten set_pc bounds assert to exclusive

### DIFF
--- a/crates/evm2/src/interpreter/dispatch/table/mod.rs
+++ b/crates/evm2/src/interpreter/dispatch/table/mod.rs
@@ -162,7 +162,10 @@ fn finish_run<T: EvmTypesHost>(
     loop_state: imp::LoopState,
 ) -> InstrStop {
     cold_path();
-    state.set_pc_stack_len(pc.as_ptr(), stack_len);
+    // The NULL `pc` is only a loop-exit sentinel; never publish it.
+    let pc =
+        if pc.as_ptr().is_null() { state.bytecode().as_slice().as_ptr() } else { pc.as_ptr() };
+    state.set_pc_stack_len(pc, stack_len);
     imp::finish_loop(state.gas_mut(), loop_state);
     state.result().unwrap_err()
 }

--- a/crates/evm2/src/interpreter/dispatch/table/mod.rs
+++ b/crates/evm2/src/interpreter/dispatch/table/mod.rs
@@ -163,8 +163,7 @@ fn finish_run<T: EvmTypesHost>(
 ) -> InstrStop {
     cold_path();
     // The NULL `pc` is only a loop-exit sentinel; never publish it.
-    let pc =
-        if pc.as_ptr().is_null() { state.bytecode().as_slice().as_ptr() } else { pc.as_ptr() };
+    let pc = if pc.as_ptr().is_null() { state.bytecode().as_slice().as_ptr() } else { pc.as_ptr() };
     state.set_pc_stack_len(pc, stack_len);
     imp::finish_loop(state.gas_mut(), loop_state);
     state.result().unwrap_err()

--- a/crates/evm2/src/interpreter/runtime.rs
+++ b/crates/evm2/src/interpreter/runtime.rs
@@ -146,11 +146,11 @@ impl<'frame, 'host, T: EvmTypesHost> Interpreter<'frame, 'host, T> {
     ///
     /// # Panics
     ///
-    /// Panics if `pc` is greater than the active bytecode length.
+    /// Panics if `pc` is out of bounds of the active bytecode.
     #[inline]
     pub fn set_pc(&mut self, pc: usize) {
         let bytecode = self.bytecode.bytes_slice();
-        assert!(pc <= bytecode.len());
+        assert!(pc < bytecode.len());
         self.pc = unsafe { bytecode.as_ptr().add(pc) };
     }
 


### PR DESCRIPTION
Related to CYCLOPS-643.

`Interpreter::set_pc` asserted `pc <= bytecode.len()`, allowing a one-past-the-end program counter. Since `opcode()` dereferences `pc` unconditionally, `pc == len` would be UB on the next dispatch. Change the assert to `pc < bytecode.len()` and update the doc comment accordingly.

Additionally, `finish_run` no longer publishes the NULL `pc` used as the dispatch-loop exit sentinel: when the sentinel is seen, the published pc is reset to the start of the active bytecode before `set_pc_stack_len`, so the interpreter state never holds a null program counter.