### PR TITLE
fix(eest): destroy empty recipient on zero-amount EIP-4895 withdrawal

### DIFF
--- a/crates/eest/src/additional.rs
+++ b/crates/eest/src/additional.rs
@@ -43,7 +43,7 @@ fn run_file(path: PathBuf) -> Result<(), Failed> {
         Some(FixtureKind::Blockchain) => execute_str(
             &path,
             &input,
-            BlockchainConfig::default(),
+            BlockchainConfig { compare_state_root: true, ..Default::default() },
             &NameFilter::default(),
             &mut NoopHook,
         )

--- a/crates/eest/src/blockchaintest/execute.rs
+++ b/crates/eest/src/blockchaintest/execute.rs
@@ -983,8 +983,12 @@ fn increment_balance(
     if current.code_hash.is_zero() {
         current.code_hash = KECCAK256_EMPTY;
     }
+    // EELS `modify_state` destroys an account left empty by the modification, so a zero-amount
+    // withdrawal neither creates its recipient nor keeps a pre-existing empty one alive. The
+    // BAL commit below still runs to record the touched address.
+    let current = (!current.is_empty()).then_some(current);
 
-    let change = AccountStateChange { address, original, current: Some(current) };
+    let change = AccountStateChange { address, original, current };
     commit_state_changes(evm, block_state, &change);
     // Post-block balance updates bypass transaction commit, so record them in the BAL directly.
     evm.overlay_db_mut().bal_context.commit_account_change(

--- a/crates/eest/src/blockchaintest/runner.rs
+++ b/crates/eest/src/blockchaintest/runner.rs
@@ -63,9 +63,12 @@ fn run_file(path: PathBuf) -> Result<(), Failed> {
 }
 
 fn run_file_with_mode(path: PathBuf, mode: ExecutionMode) -> Result<(), Failed> {
-    execute_test_suite(&path, ExecuteConfig { mode, ..Default::default() })
-        .map(|_| ())
-        .map_err(|err| err.to_string().into())
+    execute_test_suite(
+        &path,
+        ExecuteConfig { mode, compare_state_root: true, ..Default::default() },
+    )
+    .map(|_| ())
+    .map_err(|err| err.to_string().into())
 }
 
 #[cfg(feature = "jit")]
@@ -95,9 +98,16 @@ fn run_compiled_file(path: PathBuf, mode: CompiledMode) -> Result<(), Failed> {
 
 #[cfg(feature = "jit")]
 fn run_compiled_files(paths: Vec<PathBuf>, mode: CompiledMode) -> Result<(), Failed> {
-    execute_test_suites(&paths, ExecuteConfig { mode: mode.execution_mode(), ..Default::default() })
-        .map(|_| ())
-        .map_err(|err| err.to_string().into())
+    execute_test_suites(
+        &paths,
+        ExecuteConfig {
+            mode: mode.execution_mode(),
+            compare_state_root: true,
+            ..Default::default()
+        },
+    )
+    .map(|_| ())
+    .map_err(|err| err.to_string().into())
 }
 
 fn should_descend(path: &Path) -> bool {


### PR DESCRIPTION
## Summary

A zero-amount EIP-4895 withdrawal to a nonexistent address materialized a phantom empty account in the database: `increment_balance` in the post-block path did `unwrap_or_default()` and always committed `current: Some(...)`.

Per execution-specs (`modify_state` in the state tracker), an account left empty after a modification is destroyed — so a zero-amount withdrawal must neither create its recipient nor keep a pre-existing empty one alive. This change drops the account when it is empty (Spurious Dragon definition) after the balance increase.

The BAL commit still runs for the `(None, None)` transition, so the touched address is recorded — matching `bal_zero_withdrawal.json`, which expects the recipient in the block access list as a pure touch while staying absent from state.

The block-reward caller of `increment_balance` is unaffected: rewards are always nonzero there, so the result can never be empty and pre-Spurious-Dragon forks keep their behavior.

## Why tests didn't catch it

The nextest harness runs with `compare_state_root: false` and `validate_post_state` only checks accounts the fixture lists. With `compare_state_root` temporarily enabled, `shanghai/eip4895_withdrawals/test_zero_amount.json` fails with a state-root mismatch before this change and passes after it. The CLI replay path (which does compare roots) would have hit this on any real block with a zero-amount withdrawal.

## Testing

- `test_zero_amount.json` passes under state-root comparison with the fix (fails without).
- All 14 fixtures in `amsterdam/.../block_access_lists_eip4895` pass.
- Full EEST suite (32,273 tests): byte-identical failure sets before and after — the same 14 pre-existing failures, none withdrawal-related.

Refs CYCLOPS-581

## Harness hardening

Second commit enables `compare_state_root` in the nextest harness (interpreter, JIT/AOT, and `eest.sh` additional-tests runners), so account-absence violations like this one fail loudly instead of passing vacuously. The full suite passes with it on at no measurable runtime cost. Benches keep it off so root hashing stays out of timed loops.
