### PR TITLE
refactor(message): carry bytecode in Message; rename regular gas to execution gas

### DIFF
--- a/crates/eest/src/blockchaintest/execute.rs
+++ b/crates/eest/src/blockchaintest/execute.rs
@@ -433,9 +433,9 @@ fn execute_block(
         }
 
         let transactions = block_transactions(block);
-        // EIP-8037: track regular and state gas separately for the block-header gas check.
+        // EIP-8037: track execution and state gas separately for the block-header gas check.
         let mut cumulative_tx_gas_used = 0u64;
-        let mut block_regular_gas_used = 0u64;
+        let mut block_execution_gas_used = 0u64;
         let mut block_state_gas_used = 0u64;
         let mut receipts = Vec::with_capacity(transactions.len());
         for (transaction_index, raw_tx) in transactions.iter().enumerate() {
@@ -466,16 +466,17 @@ fn execute_block(
 
             // EIP-8037: per-dimension block-level inclusion check (execution-specs
             // `process_transaction`). A transaction is only includable when its gas limit --
-            // capped by the EIP-7825 limit on the regular dimension, uncapped on the state
+            // capped by the EIP-7825 limit on the execution dimension, uncapped on the state
             // dimension -- still fits the block gas remaining on both dimensions.
             if spec.enables(SpecId::AMSTERDAM)
                 && let Some(header) = block_header(block)
             {
                 let block_gas_limit = header.gas_limit.saturating_to::<u64>();
                 let tx_gas_limit = tx.gas_limit();
-                let regular_gas_available = block_gas_limit.saturating_sub(block_regular_gas_used);
+                let execution_gas_available =
+                    block_gas_limit.saturating_sub(block_execution_gas_used);
                 let state_gas_available = block_gas_limit.saturating_sub(block_state_gas_used);
-                if tx_gas_limit.min(evm.version().tx_gas_limit_cap) > regular_gas_available
+                if tx_gas_limit.min(evm.version().tx_gas_limit_cap) > execution_gas_available
                     || tx_gas_limit > state_gas_available
                 {
                     if should_fail {
@@ -486,7 +487,7 @@ fn execute_block(
                         name,
                         TestErrorKind::UnexpectedFailure(format!(
                             "transaction gas limit {tx_gas_limit} exceeds available block gas \
-                             (regular {regular_gas_available}, state {state_gas_available})"
+                             (execution {execution_gas_available}, state {state_gas_available})"
                         )),
                     ));
                 }
@@ -500,8 +501,8 @@ fn execute_block(
                 Ok(result) => {
                     cumulative_tx_gas_used =
                         cumulative_tx_gas_used.saturating_add(result.tx_gas_used());
-                    block_regular_gas_used =
-                        block_regular_gas_used.saturating_add(result.regular_gas_spent());
+                    block_execution_gas_used =
+                        block_execution_gas_used.saturating_add(result.execution_gas_spent());
                     block_state_gas_used =
                         block_state_gas_used.saturating_add(result.state_gas_spent());
                     if compare_receipt_root {
@@ -552,14 +553,14 @@ fn execute_block(
         }
 
         // Validate the block header's gas used against the executed transactions. Under EIP-8037
-        // (Amsterdam+) regular and state gas are tracked separately and the header records their
+        // (Amsterdam+) execution and state gas are tracked separately and the header records their
         // max; earlier forks record the cumulative per-transaction gas used (refunds included).
         // Block-validation failures on a block that expects an exception resolve to a discard,
         // mirroring execution-specs raising `InvalidBlock`.
         if let Some(expected) = block_gas_used(block) {
             let expected = expected.saturating_to::<u64>();
             let actual = if spec.enables(SpecId::AMSTERDAM) {
-                block_regular_gas_used.max(block_state_gas_used)
+                block_execution_gas_used.max(block_state_gas_used)
             } else {
                 cumulative_tx_gas_used
             };

--- a/crates/evm2/examples/custom_evm/tx.rs
+++ b/crates/evm2/examples/custom_evm/tx.rs
@@ -55,13 +55,13 @@ pub fn execute_code(
     let mut message = MessageExt {
         gas_limit: req.tx.gas_limit,
         destination: req.tx.target,
+        code: Bytecode::new_legacy(req.tx.code.clone()),
         code_address: req.tx.target,
         ext: CustomMessageExt { is_system: false },
         ..MessageExt::default()
     };
     let tx_env = TxEnvExt { ext: CustomTxEnvExt { label: "execute-code" }, ..TxEnvExt::default() };
-    let mut result =
-        req.host.execute_message(&tx_env, Bytecode::new_legacy(req.tx.code.clone()), &mut message);
+    let mut result = req.host.execute_message(&tx_env, &mut message);
     result.ext = CustomMessageResultExt { handled_custom_message: true };
     Ok(evm2::TxResult::<CustomTypes> {
         status: result.stop.is_success(),

--- a/crates/evm2/examples/precompile_subcall.rs
+++ b/crates/evm2/examples/precompile_subcall.rs
@@ -17,16 +17,16 @@ const SUBCALL_TARGET: Address = Address::with_last_byte(0xca);
 
 fn main() {
     let mut evm = evm_with_custom_precompile();
-    let parent_code = Bytecode::new_legacy(parent_code());
     let mut message = MessageExt {
         kind: MessageKind::Call,
         gas_limit: 200_000,
         destination: PARENT,
+        code: Bytecode::new_legacy(parent_code()),
         code_address: PARENT,
         ..MessageExt::default()
     };
 
-    let result = Host::execute_message(&mut evm, &TxEnvExt::default(), parent_code, &mut message);
+    let result = Host::execute_message(&mut evm, &TxEnvExt::default(), &mut message);
     assert_eq!(result.stop, InstrStop::Return);
     assert_eq!(result.output.len(), 32);
 
@@ -77,13 +77,14 @@ fn staticcall_precompile(
         caller: message.destination,
         input: message.input.clone(),
         value: U256::ZERO,
+        code: loaded.code,
         code_address: SUBCALL_TARGET,
         caller_is_static: message.caller_is_static
             || matches!(message.kind, MessageKind::StaticCall),
         ..MessageExt::default()
     };
 
-    let result = Host::execute_message(evm, &TxEnvExt::default(), loaded.code, &mut child);
+    let result = Host::execute_message(evm, &TxEnvExt::default(), &mut child);
     gas.merge_child_gas(result.gas, result.stop);
 
     match result.stop {

--- a/crates/evm2/src/ethereum/eip1559.rs
+++ b/crates/evm2/src/ethereum/eip1559.rs
@@ -1,8 +1,9 @@
 use super::{
-    access_list_counts, effective_gas_price, floor_gas, initial_gas_and_reservoir, initial_message,
-    intrinsic_gas, validate_block_gas_limit, validate_chain_id, validate_create_initcode,
-    validate_floor_gas, validate_gas_price, validate_intrinsic_gas, validate_nonce_not_overflow,
-    validate_priority_fee, validate_regular_gas_limit_cap, validate_sender,
+    InitialFrame, access_list_counts, effective_gas_price, floor_gas, initial_gas_and_reservoir,
+    intrinsic_gas, prepare_initial_frame, runtime_oog_result, settle_initial_frame_gas,
+    validate_block_gas_limit, validate_chain_id, validate_create_initcode,
+    validate_execution_gas_limit_cap, validate_floor_gas, validate_gas_price,
+    validate_intrinsic_gas, validate_nonce_not_overflow, validate_priority_fee, validate_sender,
     validate_tx_gas_limit_cap, warm_access_list, warm_base_accounts,
 };
 use crate::{
@@ -12,7 +13,7 @@ use crate::{
         error_handler,
         handler::{DefaultTxHandlerHooks, GasSettlement, TxHandlerHooks},
     },
-    interpreter::Host,
+    interpreter::{GasTracker, Host},
     registry::{HandlerResult, TxRequest},
 };
 use alloy_consensus::TxEip1559;
@@ -65,7 +66,7 @@ pub fn handle_with_hooks<T: EvmTypes, H: TxHandlerHooks<T>>(
         tx.value,
     );
     validate_floor_gas(tx.gas_limit, floor_gas)?;
-    validate_regular_gas_limit_cap(req.host.version(), tx.gas_limit, intrinsic, floor_gas)?;
+    validate_execution_gas_limit_cap(req.host.version(), tx.gas_limit, intrinsic, floor_gas)?;
 
     let max_gas_cost = U256::from(tx.gas_limit) * max_fee_per_gas;
     validate_sender(req.host, caller, tx.nonce, max_gas_cost.saturating_add(tx.value))?;
@@ -77,7 +78,7 @@ pub fn handle_with_hooks<T: EvmTypes, H: TxHandlerHooks<T>>(
     req.host.state.account(&caller, false).map_err(error_handler!(req.host))?.bump_nonce();
     H::before_execution(req.host, req.envelope, caller, effective_gas_cost)?;
 
-    let (gas_limit, reservoir) =
+    let (execution_gas_limit, reservoir) =
         initial_gas_and_reservoir(req.host.version(), tx.gas_limit, intrinsic, initial_state_gas);
     let tx_env = TxEnvExt {
         origin: caller,
@@ -85,12 +86,26 @@ pub fn handle_with_hooks<T: EvmTypes, H: TxHandlerHooks<T>>(
         chain_id: U256::from(req.host.version().chain_id),
         ..TxEnvExt::default()
     };
-    let (bytecode, mut message) = initial_message(
-        req.host, caller, tx.nonce, tx.to, &tx.input, tx.value, gas_limit, reservoir,
-    )?;
-    // Failed execution has already been rolled back to the message's own checkpoint (and halt gas
-    // zeroed) inside `execute_message`, so the result settles directly.
-    let result = req.host.execute_message(&tx_env, bytecode, &mut message);
+    let mut tx_gas =
+        GasTracker::new_with_execution_gas_and_reservoir(execution_gas_limit, reservoir);
+    let result = match prepare_initial_frame(
+        req.host,
+        caller,
+        tx.nonce,
+        tx.to,
+        &tx.input,
+        tx.value,
+        &mut tx_gas,
+    )? {
+        Some(InitialFrame { mut message, charged_state_gas }) => {
+            // Failed execution has already been rolled back to the message's own checkpoint inside
+            // `execute_message`; the settle merges the frame gas into the transaction-level gas.
+            let mut result = req.host.execute_message(&tx_env, &mut message);
+            settle_initial_frame_gas(&mut tx_gas, &mut result, charged_state_gas);
+            result
+        }
+        None => runtime_oog_result(execution_gas_limit, reservoir),
+    };
     H::settle_transaction(
         req.host,
         req.envelope,

--- a/crates/evm2/src/ethereum/eip2930.rs
+++ b/crates/evm2/src/ethereum/eip2930.rs
@@ -1,9 +1,9 @@
 use super::{
-    access_list_counts, floor_gas, initial_gas_and_reservoir, initial_message, intrinsic_gas,
-    validate_block_gas_limit, validate_chain_id, validate_create_initcode, validate_floor_gas,
-    validate_gas_price, validate_intrinsic_gas, validate_nonce_not_overflow,
-    validate_regular_gas_limit_cap, validate_sender, validate_tx_gas_limit_cap, warm_access_list,
-    warm_base_accounts,
+    InitialFrame, access_list_counts, floor_gas, initial_gas_and_reservoir, intrinsic_gas,
+    prepare_initial_frame, runtime_oog_result, settle_initial_frame_gas, validate_block_gas_limit,
+    validate_chain_id, validate_create_initcode, validate_execution_gas_limit_cap,
+    validate_floor_gas, validate_gas_price, validate_intrinsic_gas, validate_nonce_not_overflow,
+    validate_sender, validate_tx_gas_limit_cap, warm_access_list, warm_base_accounts,
 };
 use crate::{
     EvmTypes, TxResult,
@@ -12,7 +12,7 @@ use crate::{
         error_handler,
         handler::{DefaultTxHandlerHooks, GasSettlement, TxHandlerHooks},
     },
-    interpreter::Host,
+    interpreter::{GasTracker, Host},
     registry::{HandlerResult, TxRequest},
 };
 use alloy_consensus::TxEip2930;
@@ -61,7 +61,7 @@ pub fn handle_with_hooks<T: EvmTypes, H: TxHandlerHooks<T>>(
         tx.value,
     );
     validate_floor_gas(tx.gas_limit, floor_gas)?;
-    validate_regular_gas_limit_cap(req.host.version(), tx.gas_limit, intrinsic, floor_gas)?;
+    validate_execution_gas_limit_cap(req.host.version(), tx.gas_limit, intrinsic, floor_gas)?;
 
     let max_gas_cost = U256::from(tx.gas_limit) * gas_price;
     validate_sender(req.host, caller, tx.nonce, max_gas_cost.saturating_add(tx.value))?;
@@ -72,7 +72,7 @@ pub fn handle_with_hooks<T: EvmTypes, H: TxHandlerHooks<T>>(
     req.host.state.account(&caller, false).map_err(error_handler!(req.host))?.bump_nonce();
     H::before_execution(req.host, req.envelope, caller, max_gas_cost)?;
 
-    let (gas_limit, reservoir) =
+    let (execution_gas_limit, reservoir) =
         initial_gas_and_reservoir(req.host.version(), tx.gas_limit, intrinsic, initial_state_gas);
     let tx_env = TxEnvExt {
         origin: caller,
@@ -80,12 +80,26 @@ pub fn handle_with_hooks<T: EvmTypes, H: TxHandlerHooks<T>>(
         chain_id: U256::from(req.host.version().chain_id),
         ..TxEnvExt::default()
     };
-    let (bytecode, mut message) = initial_message(
-        req.host, caller, tx.nonce, tx.to, &tx.input, tx.value, gas_limit, reservoir,
-    )?;
-    // Failed execution has already been rolled back to the message's own checkpoint (and halt gas
-    // zeroed) inside `execute_message`, so the result settles directly.
-    let result = req.host.execute_message(&tx_env, bytecode, &mut message);
+    let mut tx_gas =
+        GasTracker::new_with_execution_gas_and_reservoir(execution_gas_limit, reservoir);
+    let result = match prepare_initial_frame(
+        req.host,
+        caller,
+        tx.nonce,
+        tx.to,
+        &tx.input,
+        tx.value,
+        &mut tx_gas,
+    )? {
+        Some(InitialFrame { mut message, charged_state_gas }) => {
+            // Failed execution has already been rolled back to the message's own checkpoint inside
+            // `execute_message`; the settle merges the frame gas into the transaction-level gas.
+            let mut result = req.host.execute_message(&tx_env, &mut message);
+            settle_initial_frame_gas(&mut tx_gas, &mut result, charged_state_gas);
+            result
+        }
+        None => runtime_oog_result(execution_gas_limit, reservoir),
+    };
     H::settle_transaction(
         req.host,
         req.envelope,

--- a/crates/evm2/src/ethereum/eip4844.rs
+++ b/crates/evm2/src/ethereum/eip4844.rs
@@ -1,8 +1,9 @@
 use super::{
-    access_list_counts, effective_gas_price, floor_gas, initial_gas_and_reservoir, initial_message,
-    intrinsic_gas, validate_block_gas_limit, validate_chain_id, validate_create_initcode,
-    validate_floor_gas, validate_gas_price, validate_intrinsic_gas, validate_nonce_not_overflow,
-    validate_priority_fee, validate_regular_gas_limit_cap, validate_sender,
+    InitialFrame, access_list_counts, effective_gas_price, floor_gas, initial_gas_and_reservoir,
+    intrinsic_gas, prepare_initial_frame, runtime_oog_result, settle_initial_frame_gas,
+    validate_block_gas_limit, validate_chain_id, validate_create_initcode,
+    validate_execution_gas_limit_cap, validate_floor_gas, validate_gas_price,
+    validate_intrinsic_gas, validate_nonce_not_overflow, validate_priority_fee, validate_sender,
     validate_tx_gas_limit_cap, warm_access_list, warm_base_accounts,
 };
 use crate::{
@@ -12,7 +13,7 @@ use crate::{
         error_handler,
         handler::{DefaultTxHandlerHooks, GasSettlement, TxHandlerHooks},
     },
-    interpreter::Host,
+    interpreter::{GasTracker, Host},
     registry::{HandlerError, HandlerResult, TxRequest},
     utils::b256_to_word,
 };
@@ -73,7 +74,7 @@ pub fn handle_with_hooks<T: EvmTypes, H: TxHandlerHooks<T>>(
         tx.value,
     );
     validate_floor_gas(tx.gas_limit, floor_gas)?;
-    validate_regular_gas_limit_cap(req.host.version(), tx.gas_limit, intrinsic, floor_gas)?;
+    validate_execution_gas_limit_cap(req.host.version(), tx.gas_limit, intrinsic, floor_gas)?;
 
     let blob_gas_cost = U256::from(DATA_GAS_PER_BLOB) * U256::from(tx.blob_versioned_hashes.len());
     let max_blob_gas_cost = blob_gas_cost * max_fee_per_blob_gas;
@@ -93,7 +94,7 @@ pub fn handle_with_hooks<T: EvmTypes, H: TxHandlerHooks<T>>(
     req.host.state.account(&caller, false).map_err(error_handler!(req.host))?.bump_nonce();
     H::before_execution(req.host, req.envelope, caller, effective_gas_cost + blob_basefee_cost)?;
 
-    let (gas_limit, reservoir) =
+    let (execution_gas_limit, reservoir) =
         initial_gas_and_reservoir(req.host.version(), tx.gas_limit, intrinsic, initial_state_gas);
     let tx_env = TxEnvExt {
         origin: caller,
@@ -103,19 +104,26 @@ pub fn handle_with_hooks<T: EvmTypes, H: TxHandlerHooks<T>>(
         ext: T::TxEnvExt::default(),
         _non_exhaustive: (),
     };
-    let (bytecode, mut message) = initial_message(
+    let mut tx_gas =
+        GasTracker::new_with_execution_gas_and_reservoir(execution_gas_limit, reservoir);
+    let result = match prepare_initial_frame(
         req.host,
         caller,
         tx.nonce,
         tx.to.into(),
         &tx.input,
         tx.value,
-        gas_limit,
-        reservoir,
-    )?;
-    // Failed execution has already been rolled back to the message's own checkpoint (and halt gas
-    // zeroed) inside `execute_message`, so the result settles directly.
-    let result = req.host.execute_message(&tx_env, bytecode, &mut message);
+        &mut tx_gas,
+    )? {
+        Some(InitialFrame { mut message, charged_state_gas }) => {
+            // Failed execution has already been rolled back to the message's own checkpoint inside
+            // `execute_message`; the settle merges the frame gas into the transaction-level gas.
+            let mut result = req.host.execute_message(&tx_env, &mut message);
+            settle_initial_frame_gas(&mut tx_gas, &mut result, charged_state_gas);
+            result
+        }
+        None => runtime_oog_result(execution_gas_limit, reservoir),
+    };
     H::settle_transaction(
         req.host,
         req.envelope,

--- a/crates/evm2/src/ethereum/eip7702.rs
+++ b/crates/evm2/src/ethereum/eip7702.rs
@@ -1,10 +1,10 @@
 use super::{
-    LazyAuthorization, access_list_counts, effective_gas_price, floor_gas,
-    initial_gas_and_reservoir, initial_message, intrinsic_gas, validate_block_gas_limit,
-    validate_chain_id, validate_create_initcode, validate_floor_gas, validate_gas_price,
-    validate_intrinsic_gas, validate_nonce_not_overflow, validate_priority_fee,
-    validate_regular_gas_limit_cap, validate_sender, validate_tx_gas_limit_cap, warm_access_list,
-    warm_base_accounts,
+    InitialFrame, LazyAuthorization, access_list_counts, effective_gas_price, floor_gas,
+    initial_gas_and_reservoir, intrinsic_gas, prepare_initial_frame, runtime_oog_result,
+    settle_initial_frame_gas, validate_block_gas_limit, validate_chain_id,
+    validate_create_initcode, validate_execution_gas_limit_cap, validate_floor_gas,
+    validate_gas_price, validate_intrinsic_gas, validate_nonce_not_overflow, validate_priority_fee,
+    validate_sender, validate_tx_gas_limit_cap, warm_access_list, warm_base_accounts,
 };
 use crate::{
     Evm, EvmFeatures, EvmTypes, TxResult, Version,
@@ -13,9 +13,7 @@ use crate::{
         error_handler,
         handler::{DefaultTxHandlerHooks, GasSettlement, TxHandlerHooks},
     },
-    interpreter::{
-        GasTracker, Host, InstrStop, MessageResult, MessageResultExt, gas::EIP8038_ACCOUNT_WRITE,
-    },
+    interpreter::{GasTracker, Host, InstrStop, MessageResult, gas::EIP8038_ACCOUNT_WRITE},
     registry::{HandlerError, HandlerResult, TxRequest},
     version::GasId,
 };
@@ -78,7 +76,7 @@ pub fn handle_with_hooks<T: EvmTypes, H: TxHandlerHooks<T>>(
         tx.value,
     );
     validate_floor_gas(tx.gas_limit, floor_gas)?;
-    validate_regular_gas_limit_cap(req.host.version(), tx.gas_limit, intrinsic, floor_gas)?;
+    validate_execution_gas_limit_cap(req.host.version(), tx.gas_limit, intrinsic, floor_gas)?;
 
     let max_gas_cost = U256::from(tx.gas_limit) * max_fee_per_gas;
     validate_sender(req.host, caller, tx.nonce, max_gas_cost.saturating_add(tx.value))?;
@@ -97,9 +95,10 @@ pub fn handle_with_hooks<T: EvmTypes, H: TxHandlerHooks<T>>(
         ..TxEnvExt::default()
     };
 
-    let (regular_gas_limit, reservoir) =
+    let (execution_gas_limit, reservoir) =
         initial_gas_and_reservoir(req.host.version(), tx.gas_limit, intrinsic, initial_state_gas);
-    let mut tx_gas = GasTracker::new_with_regular_gas_and_reservoir(regular_gas_limit, reservoir);
+    let mut tx_gas =
+        GasTracker::new_with_execution_gas_and_reservoir(execution_gas_limit, reservoir);
     // The delegations span `runtime_checkpoint` so a runtime out-of-gas can drop them; the
     // recipient is read only afterwards (at first-frame creation), so it too stays out of the
     // EIP-7928 block access list on an authorization out-of-gas. Pre-Amsterdam nothing rolls
@@ -110,11 +109,11 @@ pub fn handle_with_hooks<T: EvmTypes, H: TxHandlerHooks<T>>(
     // metered on the transaction-level gas tracker as the delegations are applied, stopping at the
     // first unaffordable charge — later authorities are never loaded, keeping them out of the
     // block access list. Pre-Amsterdam the pessimistic per-auth intrinsic charge is refilled
-    // instead and never runs out of gas: an regular refund for each already-existing authority,
+    // instead and never runs out of gas: an execution refund for each already-existing authority,
     // and under EIP-8037 a state refund credited directly back to the reservoir so it stays state
     // gas — per execution-specs `set_delegation` (`state_gas_reservoir += refund`), deliberately
-    // not routed through regular gas first.
-    let (auth_oog, state_refund, regular_refund) = if req.host.feature(EvmFeatures::EIP2780) {
+    // not routed through execution gas first.
+    let (auth_oog, state_refund, execution_refund) = if req.host.feature(EvmFeatures::EIP2780) {
         let mut auth_charges =
             RuntimeAuthCharges::new(req.host.version(), &mut tx_gas, caller, tx.to, tx.value);
         let oog = apply_auth_list(req.host, chain_id, &tx.authorization_list, &mut auth_charges)?;
@@ -122,18 +121,20 @@ pub fn handle_with_hooks<T: EvmTypes, H: TxHandlerHooks<T>>(
     } else {
         let mut auth_refunds = AuthRefunds::new(req.host.version());
         apply_auth_list(req.host, chain_id, &tx.authorization_list, &mut auth_refunds)?;
-        let AuthRefunds { state_refund, regular_refund, .. } = auth_refunds;
+        let AuthRefunds { state_refund, execution_refund, .. } = auth_refunds;
         tx_gas.set_reservoir(tx_gas.reservoir() + state_refund);
-        (false, state_refund, regular_refund)
+        (false, state_refund, execution_refund)
     };
 
-    // Applies the pre-Amsterdam authorization regular refund (zero under EIP-2780) and settles
-    // the transaction with the given authorization state gas on top of the hook-provided
-    // intrinsic state gas (charged upfront, before `runtime_checkpoint`, so it persists on every
-    // exit). Every exit below funnels through here.
-    let settle = |host: &mut Evm<'_, T>, mut result: MessageResult<T>, auth_state_gas: u64| {
+    // Applies the pre-Amsterdam authorization execution refund (zero under EIP-2780) and settles
+    // the transaction with the hook-provided intrinsic state gas (charged upfront, before
+    // `runtime_checkpoint`, so it persists on every exit). Every exit below funnels through here.
+    let settle = |host: &mut Evm<'_, T>, mut result: MessageResult<T>| {
         result.gas.set_refunded(
-            result.gas.refunded().saturating_add(i64::try_from(regular_refund).unwrap_or(i64::MAX)),
+            result
+                .gas
+                .refunded()
+                .saturating_add(i64::try_from(execution_refund).unwrap_or(i64::MAX)),
         );
         H::settle_transaction(
             host,
@@ -143,54 +144,47 @@ pub fn handle_with_hooks<T: EvmTypes, H: TxHandlerHooks<T>>(
                 gas_price,
                 gas_limit: tx.gas_limit,
                 floor_gas,
-                initial_state_gas: initial_state_gas.saturating_add(auth_state_gas),
+                initial_state_gas,
                 state_refund,
                 result,
             },
         )
     };
     // Settles the transaction as an out-of-gas halt when the runtime gas phase (the authorization
-    // charges or the first-frame recipient charge) runs out of gas: reverts the runtime
-    // checkpoint to drop the applied delegations, then consumes all regular gas and returns the
+    // charges or the first-frame recipient charge) runs out of gas: reverts the authorization
+    // checkpoint to drop the applied delegations, then consumes all execution gas and returns the
     // reservoir. Unreachable pre-Amsterdam, where no runtime charge is attempted.
     let settle_oog = |host: &mut Evm<'_, T>| {
         let features = host.version().features;
         host.state.rollback(runtime_checkpoint, features);
-        settle(
-            host,
-            MessageResultExt {
-                stop: InstrStop::OutOfGas,
-                gas: GasTracker::new_spent_with_reservoir(regular_gas_limit, reservoir),
-                ..MessageResultExt::default()
-            },
-            0,
-        )
+        settle(host, runtime_oog_result(execution_gas_limit, reservoir))
     };
 
     if auth_oog {
         return settle_oog(req.host);
     }
-    // State gas charged for the authorizations, carried into the block state-gas accounting.
-    let auth_state_gas = tx_gas.state_gas_spent().max(0) as u64;
-    let (bytecode, mut message) = initial_message(
+    let Some(InitialFrame { mut message, charged_state_gas }) = prepare_initial_frame(
         req.host,
         caller,
         tx.nonce,
         tx.to.into(),
         &tx.input,
         tx.value,
-        tx_gas.remaining(),
-        tx_gas.reservoir(),
-    )?;
-    // Failed execution has already been rolled back to the message's own checkpoint (past the
-    // applied delegations, which stay) inside `execute_message`.
-    let result = req.host.execute_message(&tx_env, bytecode, &mut message);
-    // A depth-0 recipient charge that ran out of gas is part of the runtime gas phase, so it
-    // drops the delegations too.
-    if result.runtime_gas_oog {
+        &mut tx_gas,
+    )?
+    else {
+        // A depth-0 recipient charge that ran out of gas is part of the runtime gas phase, so it
+        // drops the delegations too.
         return settle_oog(req.host);
-    }
-    settle(req.host, result, auth_state_gas)
+    };
+
+    // Failed execution has already been rolled back to the message's own checkpoint (past the
+    // applied delegations, which stay) inside `execute_message`. The settle merges the frame gas
+    // into `tx_gas`, which carries the authorization state gas into the block state-gas
+    // accounting.
+    let mut result = req.host.execute_message(&tx_env, &mut message);
+    settle_initial_frame_gas(&mut tx_gas, &mut result, charged_state_gas);
+    settle(req.host, result)
 }
 
 fn eip7702_authorization_gas<'a, T: EvmTypes>(host: &Evm<'a, T>, authorizations: usize) -> u64 {
@@ -269,7 +263,7 @@ pub trait AuthAccounting {
 /// tracker as the delegations are applied (ethereum/EIPs#11844, #11891).
 ///
 /// Per accepted authority: the new-account state gas when the authority does not exist,
-/// `ACCOUNT_WRITE` regular gas on the first write to the authority's leaf (unless already paid —
+/// `ACCOUNT_WRITE` execution gas on the first write to the authority's leaf (unless already paid —
 /// the sender at inclusion, the recipient of a value-bearing transaction, or a preceding valid
 /// authorization on the same authority), and the net-new delegation-indicator state gas.
 ///
@@ -345,23 +339,23 @@ impl AuthAccounting for RuntimeAuthCharges<'_> {
 
 /// Pre-EIP-2780 accounting: refunds against the pessimistic per-authorization intrinsic charge.
 ///
-/// Follows execution-specs `set_delegation`. The per-authorization state and regular gas charged
+/// Follows execution-specs `set_delegation`. The per-authorization state and execution gas charged
 /// in the intrinsic cost is refilled when it turns out not to be needed: the state refund is
-/// credited to the reservoir (so it stays state gas) and the regular refund is routed through
+/// credited to the reservoir (so it stays state gas) and the execution refund is routed through
 /// the capped refund counter.
 ///
-/// Before EIP-8037 (Prague) there is no state gas: only the per-existing-account regular refund
+/// Before EIP-8037 (Prague) there is no state gas: only the per-existing-account execution refund
 /// applies and rejected authorizations refund nothing.
 #[derive(Clone, Copy, Debug)]
 pub struct AuthRefunds {
     is_eip8037: bool,
     new_account: u64,
     auth_base: u64,
-    regular_per_auth: u64,
+    execution_per_auth: u64,
     /// Accumulated state-gas refund.
     pub state_refund: u64,
-    /// Accumulated regular-gas refund.
-    pub regular_refund: u64,
+    /// Accumulated execution-gas refund.
+    pub execution_refund: u64,
 }
 
 impl AuthRefunds {
@@ -371,9 +365,9 @@ impl AuthRefunds {
             is_eip8037: version.feature(EvmFeatures::EIP8037),
             new_account: version.gas_params.new_account_state_gas(),
             auth_base: u64::from(version.gas_params.get(GasId::TxEip7702PerAuthState)),
-            regular_per_auth: u64::from(version.gas_params.get(GasId::TxEip7702AuthRefund)),
+            execution_per_auth: u64::from(version.gas_params.get(GasId::TxEip7702AuthRefund)),
             state_refund: 0,
-            regular_refund: 0,
+            execution_refund: 0,
         }
     }
 }
@@ -385,15 +379,15 @@ impl AuthAccounting for AuthRefunds {
         // nothing is refunded.
         if self.is_eip8037 {
             self.state_refund = self.state_refund.saturating_add(self.new_account + self.auth_base);
-            self.regular_refund = self.regular_refund.saturating_add(self.regular_per_auth);
+            self.execution_refund = self.execution_refund.saturating_add(self.execution_per_auth);
         }
     }
 
     fn accepted(&mut self, _authority: Address, auth: &AppliedAuth) -> Result<(), InstrStop> {
-        // Existing authority: the worst-case `ACCOUNT_WRITE` regular gas was not needed. This
+        // Existing authority: the worst-case `ACCOUNT_WRITE` execution gas was not needed. This
         // refund applies in every regime (it is the only authorization refund before EIP-8037).
         if auth.existed {
-            self.regular_refund = self.regular_refund.saturating_add(self.regular_per_auth);
+            self.execution_refund = self.execution_refund.saturating_add(self.execution_per_auth);
         }
 
         // The remaining refunds are state gas, which only exists under EIP-8037.

--- a/crates/evm2/src/ethereum/legacy.rs
+++ b/crates/evm2/src/ethereum/legacy.rs
@@ -1,8 +1,9 @@
 use super::{
-    floor_gas, initial_gas_and_reservoir, initial_message, intrinsic_gas, validate_block_gas_limit,
-    validate_chain_id, validate_create_initcode, validate_floor_gas, validate_gas_price,
-    validate_intrinsic_gas, validate_nonce_not_overflow, validate_regular_gas_limit_cap,
-    validate_sender, validate_tx_gas_limit_cap, warm_base_accounts,
+    InitialFrame, floor_gas, initial_gas_and_reservoir, intrinsic_gas, prepare_initial_frame,
+    runtime_oog_result, settle_initial_frame_gas, validate_block_gas_limit, validate_chain_id,
+    validate_create_initcode, validate_execution_gas_limit_cap, validate_floor_gas,
+    validate_gas_price, validate_intrinsic_gas, validate_nonce_not_overflow, validate_sender,
+    validate_tx_gas_limit_cap, warm_base_accounts,
 };
 use crate::{
     EvmTypes, TxResult,
@@ -11,7 +12,7 @@ use crate::{
         error_handler,
         handler::{DefaultTxHandlerHooks, GasSettlement, TxHandlerHooks},
     },
-    interpreter::Host,
+    interpreter::{GasTracker, Host},
     registry::{HandlerResult, TxRequest},
 };
 use alloy_consensus::TxLegacy;
@@ -44,7 +45,7 @@ pub fn handle_with_hooks<T: EvmTypes, H: TxHandlerHooks<T>>(
     validate_intrinsic_gas(tx.gas_limit, intrinsic, initial_state_gas)?;
     let floor_gas = floor_gas(req.host.version(), caller, tx.to, &tx.input, 0, 0, tx.value);
     validate_floor_gas(tx.gas_limit, floor_gas)?;
-    validate_regular_gas_limit_cap(req.host.version(), tx.gas_limit, intrinsic, floor_gas)?;
+    validate_execution_gas_limit_cap(req.host.version(), tx.gas_limit, intrinsic, floor_gas)?;
 
     let max_gas_cost = U256::from(tx.gas_limit) * gas_price;
     validate_sender(req.host, caller, tx.nonce, max_gas_cost.saturating_add(tx.value))?;
@@ -54,7 +55,7 @@ pub fn handle_with_hooks<T: EvmTypes, H: TxHandlerHooks<T>>(
     req.host.state.account(&caller, false).map_err(error_handler!(req.host))?.bump_nonce();
     H::before_execution(req.host, req.envelope, caller, max_gas_cost)?;
 
-    let (gas_limit, reservoir) =
+    let (execution_gas_limit, reservoir) =
         initial_gas_and_reservoir(req.host.version(), tx.gas_limit, intrinsic, initial_state_gas);
     let tx_env = TxEnvExt {
         origin: caller,
@@ -62,12 +63,26 @@ pub fn handle_with_hooks<T: EvmTypes, H: TxHandlerHooks<T>>(
         chain_id: U256::from(req.host.version().chain_id),
         ..TxEnvExt::default()
     };
-    let (bytecode, mut message) = initial_message(
-        req.host, caller, tx.nonce, tx.to, &tx.input, tx.value, gas_limit, reservoir,
-    )?;
-    // Failed execution has already been rolled back to the message's own checkpoint (and halt gas
-    // zeroed) inside `execute_message`, so the result settles directly.
-    let result = req.host.execute_message(&tx_env, bytecode, &mut message);
+    let mut tx_gas =
+        GasTracker::new_with_execution_gas_and_reservoir(execution_gas_limit, reservoir);
+    let result = match prepare_initial_frame(
+        req.host,
+        caller,
+        tx.nonce,
+        tx.to,
+        &tx.input,
+        tx.value,
+        &mut tx_gas,
+    )? {
+        Some(InitialFrame { mut message, charged_state_gas }) => {
+            // Failed execution has already been rolled back to the message's own checkpoint inside
+            // `execute_message`; the settle merges the frame gas into the transaction-level gas.
+            let mut result = req.host.execute_message(&tx_env, &mut message);
+            settle_initial_frame_gas(&mut tx_gas, &mut result, charged_state_gas);
+            result
+        }
+        None => runtime_oog_result(execution_gas_limit, reservoir),
+    };
     H::settle_transaction(
         req.host,
         req.envelope,

--- a/crates/evm2/src/ethereum/mod.rs
+++ b/crates/evm2/src/ethereum/mod.rs
@@ -19,8 +19,8 @@ use crate::{
     bytecode::Bytecode,
     evm::{AccountInfo, error_handler, handler::GasSettlement},
     interpreter::{
-        Message, MessageExt, MessageKind, Word,
-        gas::{EIP2780_TX_BASE_COST, EIP8038_COLD_ACCOUNT_ACCESS},
+        GasTracker, Host, InstrStop, Message, MessageExt, MessageKind, MessageResultExt, Word,
+        gas::{EIP2780_TX_BASE_COST, EIP8038_COLD_ACCOUNT_ACCESS, WARM_STORAGE_READ_COST},
     },
     registry::{HandlerError, HandlerResult, TxRegistry},
     utils::num_words,
@@ -284,7 +284,7 @@ pub fn validate_block_gas_limit(
 /// Validates the transaction gas limit against the active transaction cap.
 pub const fn validate_tx_gas_limit_cap(version: &Version, tx_gas_limit: u64) -> HandlerResult<()> {
     // EIP-7825 caps each transaction gas limit to 2^24 in Osaka. Amsterdam/EIP-8037
-    // replaces this with a regular-gas cap while allowing extra transaction gas to serve as
+    // replaces this with a execution-gas cap while allowing extra transaction gas to serve as
     // the state-gas reservoir.
     let cap = version.tx_gas_limit_cap;
     if !version.feature(EvmFeatures::EIP8037) && tx_gas_limit > cap {
@@ -293,8 +293,8 @@ pub const fn validate_tx_gas_limit_cap(version: &Version, tx_gas_limit: u64) -> 
     Ok(())
 }
 
-/// Validates the regular-gas portion against the active transaction cap.
-pub const fn validate_regular_gas_limit_cap(
+/// Validates the execution-gas portion against the active transaction cap.
+pub const fn validate_execution_gas_limit_cap(
     version: &Version,
     tx_gas_limit: u64,
     intrinsic: u64,
@@ -302,10 +302,10 @@ pub const fn validate_regular_gas_limit_cap(
 ) -> HandlerResult<()> {
     let cap = version.tx_gas_limit_cap;
     if version.feature(EvmFeatures::EIP8037) && tx_gas_limit > cap {
-        let required_regular_gas = if intrinsic > floor_gas { intrinsic } else { floor_gas };
-        if required_regular_gas > cap {
+        let required_execution_gas = if intrinsic > floor_gas { intrinsic } else { floor_gas };
+        if required_execution_gas > cap {
             return Err(HandlerError::TxGasLimitGreaterThanCap {
-                gas_limit: required_regular_gas,
+                gas_limit: required_execution_gas,
                 cap,
             });
         }
@@ -353,13 +353,13 @@ pub const fn validate_nonce_not_overflow(nonce: u64) -> HandlerResult<()> {
     Ok(())
 }
 
-/// Validates that the gas limit covers regular and state intrinsic gas.
+/// Validates that the gas limit covers execution and state intrinsic gas.
 pub const fn validate_intrinsic_gas(
     gas_limit: u64,
     intrinsic: u64,
     initial_state_gas: u64,
 ) -> HandlerResult<()> {
-    // EIP-8037: the gas limit must cover the regular intrinsic gas plus the upfront state gas.
+    // EIP-8037: the gas limit must cover the execution intrinsic gas plus the upfront state gas.
     let required = intrinsic.saturating_add(initial_state_gas);
     if gas_limit < required {
         return Err(HandlerError::IntrinsicGasTooLow { required, got: gas_limit });
@@ -444,15 +444,15 @@ pub fn charge_upfront<'a, T: EvmTypes>(
     Ok(())
 }
 
-/// Returns `(regular_gas_limit, reservoir)` for the first frame.
+/// Returns `(execution_gas_limit, reservoir)` for the first frame.
 ///
 /// `initial_state_gas` is the EIP-8037 state gas charged at the intrinsic phase (the pre-EIP-2780
 /// pessimistic EIP-7702 authorization state gas, or hook-added charges). It is deducted from the
-/// reservoir, spilling into the regular budget when the reservoir is insufficient. It is zero
+/// reservoir, spilling into the execution budget when the reservoir is insufficient. It is zero
 /// without EIP-8037; under EIP-2780 the state-dependent charges are metered at the runtime gas
-/// phase instead. The pre-EIP-2780 EIP-7702 state-gas refund is not an input here: per
-/// execution-specs it is credited directly back to the reservoir after the authorizations are
-/// applied, not applied to regular gas first.
+/// phase instead ([`prepare_initial_frame`]). The pre-EIP-2780 EIP-7702 state-gas refund is not an
+/// input here: per execution-specs it is credited directly back to the reservoir after the
+/// authorizations are applied, not applied to execution gas first.
 pub fn initial_gas_and_reservoir(
     version: &Version,
     tx_gas_limit: u64,
@@ -465,115 +465,213 @@ pub fn initial_gas_and_reservoir(
 
     let cap = version.tx_gas_limit_cap;
     let execution_gas = tx_gas_limit - intrinsic;
-    let mut regular_gas_limit = core::cmp::min(tx_gas_limit, cap).saturating_sub(intrinsic);
-    let mut reservoir = execution_gas - regular_gas_limit;
+    let mut execution_gas_limit = core::cmp::min(tx_gas_limit, cap).saturating_sub(intrinsic);
+    let mut reservoir = execution_gas - execution_gas_limit;
 
     if reservoir >= initial_state_gas {
         reservoir -= initial_state_gas;
     } else {
-        regular_gas_limit -= initial_state_gas - reservoir;
+        execution_gas_limit -= initial_state_gas - reservoir;
         reservoir = 0;
     }
 
-    (regular_gas_limit, reservoir)
+    (execution_gas_limit, reservoir)
 }
 
-#[allow(clippy::too_many_arguments)]
-/// Creates the bytecode and top-level message for a transaction call or create.
-pub fn initial_message<'a, T: EvmTypes>(
+/// The first frame of a transaction, prepared by [`prepare_initial_frame`].
+#[derive(Clone, Debug)]
+pub struct InitialFrame<T: EvmTypes> {
+    /// Top-level call or create message, carrying the resolved bytecode to run.
+    pub message: Message<T>,
+    /// EIP-8037 state gas charged on the transaction-level tracker for the account leaf this
+    /// frame creates (the call recipient's new-account charge or the create target's
+    /// account-creation charge), zero when nothing was charged. Refunded by
+    /// [`settle_initial_frame_gas`] when the frame fails and the leaf is not created.
+    pub charged_state_gas: u64,
+}
+
+/// Completes the EIP-2780 runtime gas phase on the transaction-level `tx_gas` and builds the
+/// first frame — the depth-0 analog of the CALL/CREATE opcodes' account-load-and-charge step.
+///
+/// For a call, the recipient pays the new-account state gas when the call transfers value to an
+/// empty recipient (charged before the delegation resolution, matching the spec's
+/// `prepare_dispatch` order), and a delegated recipient pays the delegation-target access
+/// following the EIP-2929 warm/cold model: the warm cost lands before the target load and the
+/// cold premium after it, with the load gated on `skip_cold_load` (as nested calls do) so a
+/// cold, unafforded target stays out of the EIP-7928 block access list. For a create, the
+/// account-creation state gas is charged when the destination is not already alive (existing,
+/// non-empty), so a create at a pre-existing balance-only account pays nothing for the leaf
+/// (execution-specs `created_target_alive`); nested creates are charged on the parent frame by
+/// the CREATE opcode instead. Earlier versions charge nothing here; a delegated recipient is
+/// still resolved (for free) so the frame runs the delegate's code.
+///
+/// The frame's `gas_limit`/`reservoir` snapshot `tx_gas` after the charges. Returns `None` when
+/// a charge runs out of gas: the transaction stays valid but is included as an out-of-gas halt
+/// without entering execution ([`runtime_oog_result`]).
+pub fn prepare_initial_frame<'a, T: EvmTypes>(
     host: &mut Evm<'a, T>,
     caller: Address,
     nonce: u64,
     to: TxKind,
     input: &Bytes,
     value: U256,
-    gas_limit: u64,
-    reservoir: u64,
-) -> HandlerResult<(Bytecode, Message<T>)> {
-    let r = match to {
+    tx_gas: &mut GasTracker,
+) -> HandlerResult<Option<InitialFrame<T>>> {
+    let mut charged_state_gas = 0;
+    let message = match to {
         TxKind::Call(to) => {
-            let initial_code = initial_call_code(host, to)?;
-            let message = MessageExt {
+            let (recipient_is_empty, mut code) = {
+                let mut account = host.state.account(&to, false).map_err(error_handler!(host))?;
+                // A nonexistent recipient reads as an empty account (EIP-161).
+                let recipient_is_empty = account.get().is_none_or(AccountInfo::is_empty);
+                (recipient_is_empty, account.load_code().map_err(error_handler!(host))?)
+            };
+            let mut code_address = to;
+            let mut disable_precompiles = false;
+            if host.feature(EvmFeatures::EIP2780) && !value.is_zero() && recipient_is_empty {
+                let new_account_state_gas = host.version().gas_params.new_account_state_gas();
+                if tx_gas.spend_state(new_account_state_gas).is_err() {
+                    return Ok(None);
+                }
+                charged_state_gas = new_account_state_gas;
+            }
+            // An empty recipient is never delegated, so the charge above and the resolution below
+            // are mutually exclusive.
+            if host.feature(EvmFeatures::EIP7702)
+                && let Some(delegated_address) = code.eip7702_address()
+            {
+                if host.feature(EvmFeatures::EIP2780) {
+                    // Delegation-target access, EIP-2929 warm/cold: charge the warm access first
+                    // (covered → the target is loaded and enters the block access list), then the
+                    // cold premium after the load. The load is skipped when the cold premium is
+                    // unaffordable, keeping a cold, unafforded target out of the block access
+                    // list.
+                    let cold_additional = host.version().gas_params.cold_account_additional_cost();
+                    if tx_gas.spend(u64::from(WARM_STORAGE_READ_COST)).is_err() {
+                        return Ok(None);
+                    }
+                    let skip_cold_load = tx_gas.remaining() < cold_additional;
+                    let Ok(load) =
+                        Host::load_account(host, &delegated_address, true, skip_cold_load)
+                    else {
+                        return Ok(None);
+                    };
+                    if load.is_cold && tx_gas.spend(cold_additional).is_err() {
+                        return Ok(None);
+                    }
+                    code = load.code;
+                } else {
+                    let mut account = host
+                        .state
+                        .account(&delegated_address, false)
+                        .map_err(error_handler!(host))?;
+                    account.warm();
+                    code = account.load_code().map_err(error_handler!(host))?;
+                }
+                code_address = delegated_address;
+                disable_precompiles = true;
+            }
+            MessageExt {
                 kind: MessageKind::Call,
                 depth: 0,
-                gas_limit,
-                reservoir,
+                gas_limit: tx_gas.remaining(),
+                reservoir: tx_gas.reservoir(),
                 destination: to,
                 caller,
                 input: input.clone(),
                 value,
-                code_address: initial_code.code_address,
-                disable_precompiles: initial_code.disable_precompiles,
+                code,
+                code_address,
+                disable_precompiles,
                 caller_is_static: false,
                 salt: B256::ZERO,
                 ext: T::MessageExt::default(),
                 _non_exhaustive: (),
-            };
-            (initial_code.code, message)
+            }
         }
         TxKind::Create => {
-            let address = caller.create(nonce);
-            let message = MessageExt {
+            let destination = caller.create(nonce);
+            if host.feature(EvmFeatures::EIP8037) {
+                let target_alive = host
+                    .state
+                    .account(&destination, false)
+                    .map_err(error_handler!(host))?
+                    .get()
+                    .is_some_and(|info| !info.is_empty());
+                if !target_alive {
+                    let create_state_gas = host.version().gas_params.create_state_gas();
+                    if tx_gas.spend_state(create_state_gas).is_err() {
+                        return Ok(None);
+                    }
+                    charged_state_gas = create_state_gas;
+                }
+            }
+            MessageExt {
                 kind: MessageKind::Create,
                 depth: 0,
-                gas_limit,
-                reservoir,
-                destination: address,
+                gas_limit: tx_gas.remaining(),
+                reservoir: tx_gas.reservoir(),
+                destination,
                 caller,
                 input: input.clone(),
                 value,
-                code_address: address,
+                code: Bytecode::new_legacy(input.clone()),
+                code_address: destination,
                 disable_precompiles: false,
                 caller_is_static: false,
                 salt: B256::ZERO,
                 ext: T::MessageExt::default(),
                 _non_exhaustive: (),
-            };
-            (Bytecode::new_legacy(input.clone()), message)
+            }
         }
     };
-    debug_assert_eq!(r.1.depth, 0);
-    Ok(r)
+    debug_assert_eq!(message.depth, 0);
+    Ok(Some(InitialFrame { message, charged_state_gas }))
 }
 
-struct InitialCallCode {
-    code: Bytecode,
-    code_address: Address,
-    disable_precompiles: bool,
-}
-
-fn initial_call_code<'a, T: EvmTypes>(
-    host: &mut Evm<'a, T>,
-    to: Address,
-) -> HandlerResult<InitialCallCode> {
-    let code = host
-        .state
-        .account(&to, false)
-        .map_err(error_handler!(host))?
-        .load_code()
-        .map_err(error_handler!(host))?;
-    if host.feature(EvmFeatures::EIP7702)
-        && let Some(delegated_address) = code.eip7702_address()
-    {
-        // Under EIP-2780 the delegation resolution is deferred to the frame
-        // (`apply_eip2780_call_charges`), which meters the delegation-target access and gates its
-        // load on gas so a cold, unafforded target stays out of the EIP-7928 block access list. The
-        // frame swaps in the delegate's code and code_address after the charge; loading the target
-        // here would leak it into the block access list on a runtime out-of-gas.
-        if host.feature(EvmFeatures::EIP2780) {
-            return Ok(InitialCallCode { code, code_address: to, disable_precompiles: true });
+/// Settles the first frame's result into the transaction-level `tx_gas` and writes the settled
+/// tracker back to the result for gas finalization.
+///
+/// All execution gas was forwarded to the frame, so it is first consumed on `tx_gas` and the
+/// frame's settled gas merged back like any parent frame would
+/// ([`GasTracker::merge_child_gas`]). When the frame did not create the account leaf whose state
+/// gas the runtime gas phase charged upfront ([`InitialFrame::charged_state_gas`]), the charge
+/// is refunded in LIFO order ([`GasTracker::refill_reservoir`]), exactly as the CALL/CREATE
+/// opcodes refund their upfront state charges for failed children. Unlike an inner frame's
+/// caller, the transaction ends here: an exceptional halt consumes all execution gas, including
+/// the spilled portion the refill just credited back to `remaining`.
+pub const fn settle_initial_frame_gas<E>(
+    tx_gas: &mut GasTracker,
+    result: &mut MessageResultExt<E>,
+    charged_state_gas: u64,
+) {
+    tx_gas.spend_all();
+    tx_gas.merge_child_gas(result.gas, result.stop);
+    if charged_state_gas != 0 && !result.stop.is_success() {
+        tx_gas.refill_reservoir(charged_state_gas);
+        if result.stop.is_halt() {
+            tx_gas.spend_all();
         }
-        let mut account =
-            host.state.account(&delegated_address, false).map_err(error_handler!(host))?;
-        account.warm();
-        let delegated_code = account.load_code().map_err(error_handler!(host))?;
-        return Ok(InitialCallCode {
-            code: delegated_code,
-            code_address: delegated_address,
-            disable_precompiles: true,
-        });
     }
-    Ok(InitialCallCode { code, code_address: to, disable_precompiles: false })
+    result.gas = *tx_gas;
+}
+
+/// Builds the result for a transaction whose EIP-2780 runtime gas phase ran out of gas
+/// ([`prepare_initial_frame`] returned `None`, or the EIP-7702 authorization charges bailed).
+///
+/// The transaction is valid but cannot afford the state-dependent runtime charges: it is
+/// included as an out-of-gas halt that consumes all execution gas and returns the reservoir,
+/// without entering execution. The phase's partial charges are dropped by rebuilding the
+/// pristine transaction-level gas from `execution_gas_limit` and `reservoir`.
+pub fn runtime_oog_result<E: Default>(
+    execution_gas_limit: u64,
+    reservoir: u64,
+) -> MessageResultExt<E> {
+    MessageResultExt {
+        stop: InstrStop::OutOfGas,
+        gas: GasTracker::new_spent_with_reservoir(execution_gas_limit, reservoir),
+        ..MessageResultExt::default()
+    }
 }
 
 /// Applies the default Ethereum gas refund, sender reimbursement, and beneficiary reward rules.
@@ -635,15 +733,16 @@ pub fn finalize_gas<'a, T: EvmTypes>(
     let refunded = result.final_refund(tx_gas_limit, max_refund_quotient);
     // EIP-7623: when the calldata floor exceeds spent-minus-refund, `TxResult::tx_gas_used`
     // resolves to the floor. `total_gas_spent` stays pre-refund and pre-floor: block-level
-    // regular gas (EIP-7778/EIP-8037) accumulates `tx_gas_used_before_refund` per
+    // execution gas (EIP-7778/EIP-8037) accumulates `tx_gas_used_before_refund` per
     // execution-specs, without the floor clamp.
     //
-    // Execution state gas contributes only on success: a revert/halt rolls back its state changes.
-    // The upfront `initial_state_gas` is added unconditionally — an EIP-7702 execution failure
-    // still leaves the applied delegations (and their state gas) in place.
-    let exec_state_gas = if result.stop.is_success() { result.gas.state_gas_spent() } else { 0 };
-    let state_gas_spent = (exec_state_gas.saturating_add_unsigned(initial_state_gas).max(0) as u64)
-        .saturating_sub(state_refund);
+    // The settled tracker's state gas is self-consistent: a failed frame's state charges were
+    // rolled back before it was merged, while unconditional pre-execution charges (the EIP-7702
+    // authorizations, whose delegations survive an execution failure) remain. The upfront
+    // `initial_state_gas` is likewise added unconditionally.
+    let state_gas_spent =
+        (result.gas.state_gas_spent().saturating_add_unsigned(initial_state_gas).max(0) as u64)
+            .saturating_sub(state_refund);
     Ok(TxResultExt {
         status: result.stop.is_success(),
         total_gas_spent,
@@ -666,7 +765,7 @@ pub fn access_list_counts(access_list: &AccessList) -> (u64, u64) {
 /// Calculates transaction calldata floor gas.
 ///
 /// `caller`/`to`/`value` feed the EIP-2780 floor base (ethereum/EIPs#11836):
-/// under EIP-2780 the floor is anchored on the decomposed regular-gas intrinsic
+/// under EIP-2780 the floor is anchored on the decomposed execution-gas intrinsic
 /// base (`TX_BASE` + `to`-based + `value`-based, the same sum
 /// [`intrinsic_gas`] charges) instead of the flat `TxFloorCostBase`, so the
 /// floor never undercuts the transaction's own intrinsic base.
@@ -753,7 +852,7 @@ pub fn intrinsic_gas(
 }
 
 /// EIP-2780: sum of the sender base, `tx.to`-based, and `tx.value`-based
-/// regular-gas charges. Excludes calldata, access list, authorizations, and
+/// execution-gas charges. Excludes calldata, access list, authorizations, and
 /// initcode pieces which are added by the caller.
 ///
 /// Per execution-specs, a self-transfer (`tx.to == sender`) pays neither the
@@ -1066,22 +1165,24 @@ mod tests {
             Precompiles::base(SpecId::PRAGUE),
         );
 
-        let (bytecode, mut message) = initial_message(
+        let mut tx_gas = GasTracker::new_with_execution_gas_and_reservoir(100_000, 0);
+        let InitialFrame { mut message, charged_state_gas } = prepare_initial_frame(
             &mut evm,
             caller,
             0,
             TxKind::Call(target),
             &Bytes::new(),
             U256::ZERO,
-            100_000,
-            0,
+            &mut tx_gas,
         )
+        .unwrap()
         .unwrap();
         assert_eq!(message.destination, target);
         assert_eq!(message.code_address, delegated);
         assert!(message.disable_precompiles);
+        assert_eq!(charged_state_gas, 0);
 
-        let result = Host::execute_message(&mut evm, &TxEnvExt::default(), bytecode, &mut message);
+        let result = Host::execute_message(&mut evm, &TxEnvExt::default(), &mut message);
 
         assert_eq!(result.stop, InstrStop::Return);
         assert_eq!(result.output.len(), 32);
@@ -1089,7 +1190,7 @@ mod tests {
     }
 
     #[test]
-    fn amsterdam_allows_total_gas_above_osaka_cap_when_regular_gas_fits() {
+    fn amsterdam_allows_total_gas_above_osaka_cap_when_execution_gas_fits() {
         let osaka = Version::base(SpecId::OSAKA);
         let amsterdam = Version::base(SpecId::AMSTERDAM);
         let tx_gas_limit = osaka.tx_gas_limit_cap + 1;
@@ -1105,11 +1206,11 @@ mod tests {
         );
         assert_eq!(validate_tx_gas_limit_cap(amsterdam, tx_gas_limit), Ok(()));
         assert_eq!(
-            validate_regular_gas_limit_cap(amsterdam, tx_gas_limit, intrinsic, floor_gas),
+            validate_execution_gas_limit_cap(amsterdam, tx_gas_limit, intrinsic, floor_gas),
             Ok(())
         );
         assert_eq!(
-            validate_regular_gas_limit_cap(
+            validate_execution_gas_limit_cap(
                 amsterdam,
                 tx_gas_limit,
                 amsterdam.tx_gas_limit_cap + 1,

--- a/crates/evm2/src/evm/handler.rs
+++ b/crates/evm2/src/evm/handler.rs
@@ -19,13 +19,14 @@ pub struct GasSettlement<T: EvmTypes> {
     pub initial_state_gas: u64,
     /// State gas refunded by pre-execution processing.
     pub state_refund: u64,
-    /// Result of executing the top-level message.
+    /// Result of executing the top-level message, carrying the settled transaction-level gas
+    /// ([`settle_initial_frame_gas`](crate::ethereum::settle_initial_frame_gas)).
     pub result: MessageResult<T>,
 }
 
 /// Static extension points shared by transaction handlers.
 pub trait TxHandlerHooks<T: EvmTypes>: Sized {
-    /// Adjusts the intrinsic regular and state gas calculated by the standard handler.
+    /// Adjusts the intrinsic execution and state gas calculated by the standard handler.
     fn adjust_intrinsic_gas(
         _host: &mut Evm<'_, T>,
         _envelope: &T::Tx,

--- a/crates/evm2/src/evm/inspector.rs
+++ b/crates/evm2/src/evm/inspector.rs
@@ -383,7 +383,8 @@ mod tests {
         let bytecode = legacy_bytecode(code);
         let mut message = message.clone();
         message.gas_limit = gas_limit;
-        let result = Host::execute_message(&mut evm, &tx_env, bytecode, &mut message);
+        message.code = bytecode;
+        let result = Host::execute_message(&mut evm, &tx_env, &mut message);
         let inspector = evm.clear_inspector_as::<I>().unwrap();
         (result, inspector, evm)
     }
@@ -647,7 +648,8 @@ mod tests {
         let tx_env = TxEnvExt::default();
         let bytecode = legacy_bytecode(code);
         let mut message = MessageExt { gas_limit: 100_000, ..Default::default() };
-        let result = Host::execute_message(&mut evm, &tx_env, bytecode, &mut message);
+        message.code = bytecode;
+        let result = Host::execute_message(&mut evm, &tx_env, &mut message);
 
         assert_matches!(result.stop, InstrStop::Stop);
         // The redirected call transferred the value to the replacement, not the target.
@@ -948,9 +950,12 @@ mod tests {
         code.push(op::SELFDESTRUCT);
 
         let tx_env = TxEnvExt::default();
-        let bytecode = legacy_bytecode(code);
-        let message = Message::<TestTypes> { gas_limit: 10_000, ..Default::default() };
-        let mut interp = Interpreter::<TestTypes>::new(bytecode, &tx_env, &message);
+        let message = Message::<TestTypes> {
+            gas_limit: 10_000,
+            code: legacy_bytecode(code),
+            ..Default::default()
+        };
+        let mut interp = Interpreter::<TestTypes>::new(&tx_env, &message);
         let config = ExecutionConfig::for_base_spec::<BaseEvmConfigSelector>(SpecId::OSAKA);
         let stop = interp.run_inspect(&config, &mut host, &mut inspector);
 

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -123,7 +123,7 @@ use crate::{
     error::error_unavailable,
     interpreter::{
         Gas, GasTracker, Host, InstrStop, Interpreter, InterpreterPool, Message, MessageKind,
-        MessageResult, MessageResultExt, Word, gas::WARM_STORAGE_READ_COST,
+        MessageResult, MessageResultExt, Word,
     },
     registry::{HandlerError, HandlerResult, TxRegistry},
     trustme,
@@ -1114,17 +1114,16 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
     fn execute_message_impl(
         &mut self,
         tx_env: &TxEnv<T>,
-        bytecode: Bytecode,
         message: &mut Message<T>,
     ) -> MessageResult<T> {
         let mut result = match message.kind {
             MessageKind::Create | MessageKind::Create2 => {
-                self.execute_create_message(tx_env, bytecode, message)
+                self.execute_create_message(tx_env, message)
             }
             MessageKind::Call
             | MessageKind::CallCode
             | MessageKind::DelegateCall
-            | MessageKind::StaticCall => self.execute_call_message(tx_env, bytecode, message),
+            | MessageKind::StaticCall => self.execute_call_message(tx_env, message),
         };
         // Settle the returning frame's gas for its stop reason at this single exit,
         // rather than in each result builder, so every consumer (parent
@@ -1141,12 +1140,11 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
     fn execute_message_inspected<'frame>(
         &mut self,
         tx_env: &'frame TxEnv<T>,
-        bytecode: Bytecode,
         message: &'frame mut Message<T>,
     ) -> MessageResult<T> {
         let _guard = self.enter_execution();
         let Some(inspector) = self.inspector.as_deref_mut() else {
-            return self.execute_message_impl(tx_env, bytecode, message);
+            return self.execute_message_impl(tx_env, message);
         };
         // SAFETY: The inspector is stored in `self`; the execution guard prevents inspector
         // replacement while the hooks are running.
@@ -1170,7 +1168,7 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
                 let frame = top_frame.insert(self.interpreter_pool.pop());
                 // SAFETY: The message outlives the frame, which is returned to the pool below.
                 let frame_message = unsafe { trustme::decouple_lt(&*message) };
-                frame.init(bytecode.clone(), tx_env, frame_message);
+                frame.init(tx_env, frame_message);
                 // SAFETY: `execution_config` points to a private field that host execution does
                 // not replace or mutate, so the pointee remains valid for the lifetime of the
                 // frame.
@@ -1188,8 +1186,7 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
             inspector.call(frame, message)
         };
 
-        let mut result =
-            inspected.unwrap_or_else(|| self.execute_message_impl(tx_env, bytecode, message));
+        let mut result = inspected.unwrap_or_else(|| self.execute_message_impl(tx_env, message));
 
         if is_create {
             inspector.create_end(frame, message, &mut result);
@@ -1208,7 +1205,6 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
     fn execute_create_message(
         &mut self,
         tx_env: &TxEnv<T>,
-        bytecode: Bytecode,
         message: &mut Message<T>,
     ) -> MessageResult<T> {
         if message.depth > CALL_DEPTH_LIMIT {
@@ -1222,20 +1218,6 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
             return Self::error_message_result(stop, message.gas_limit, message.reservoir);
         }
         let checkpoint = self.state.checkpoint();
-        // EIP-2780: capture whether the target leaf is already alive
-        // (existing, non-empty) before creation, so a top-level create at a pre-existing
-        // balance-only account is not charged the account-creation state gas below (no new leaf is
-        // created — execution-specs `created_target_alive`).
-        let target_alive = if self.feature(EvmFeatures::EIP8037) {
-            match self.account_is_alive(&message.destination) {
-                Ok(alive) => alive,
-                Err(stop) => {
-                    return Self::error_message_result(stop, message.gas_limit, message.reservoir);
-                }
-            }
-        } else {
-            false
-        };
         if let Err(stop) = self.create_message_account(message) {
             self.state.rollback(checkpoint, self.features);
             return Self::error_message_result(stop, message.gas_limit, message.reservoir);
@@ -1244,27 +1226,7 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
         message.disable_precompiles = false;
         let input = core::mem::take(&mut message.input);
 
-        // EIP-2780: a top-level create (depth 0) charges the
-        // account-creation state gas at frame entry, conditional on the destination not already
-        // existing (`!target_alive`). Nested creates are charged on the parent frame by the CREATE
-        // opcode instead. The charge is state gas on this frame's tracker, refilled by the frame's
-        // own settle on failure; an unaffordable charge halts the create out-of-gas without running
-        // the initcode, returning the reservoir.
-        let mut frame_gas =
-            GasTracker::new_with_regular_gas_and_reservoir(message.gas_limit, message.reservoir);
-        if message.depth == 0
-            && !target_alive
-            && self.feature(EvmFeatures::EIP8037)
-            && frame_gas.spend_state(self.version().gas_params.create_state_gas()).is_err()
-        {
-            self.state.rollback(checkpoint, self.features);
-            return Self::error_message_result(
-                InstrStop::OutOfGas,
-                message.gas_limit,
-                message.reservoir,
-            );
-        }
-        let stop = self.run_interpreter(bytecode, tx_env, message, frame_gas);
+        let stop = self.run_interpreter(tx_env, message);
         message.input = input;
 
         self.finish_create_message_run(checkpoint, &message.destination, message.gas_limit, stop)
@@ -1304,15 +1266,6 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
         Ok(())
     }
 
-    /// Returns whether the account is alive (exists and is non-empty), matching execution-specs
-    /// `is_account_alive`. Used by EIP-8037 to detect a create at a pre-existing leaf.
-    fn account_is_alive(&mut self, address: &Address) -> Result<bool, InstrStop> {
-        match self.state.account(address, false) {
-            Ok(account) => Ok(account.get().is_some_and(|info| !info.is_empty())),
-            Err(code) => Err(store_error!(self, code)),
-        }
-    }
-
     #[inline(never)]
     fn create_message_account(&mut self, message: &Message<T>) -> Result<(), InstrStop> {
         self.state
@@ -1342,7 +1295,6 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
                     gas: *gas.tracker(),
                     output: Bytes::new(),
                     created_address: None,
-                    runtime_gas_oog: false,
                     ext: T::MessageResultExt::default(),
                     _non_exhaustive: (),
                 };
@@ -1369,7 +1321,6 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
             gas: *gas.tracker(),
             output,
             created_address: stop.is_success().then_some(*address),
-            runtime_gas_oog: false,
             ext: T::MessageResultExt::default(),
             _non_exhaustive: (),
         }
@@ -1400,7 +1351,7 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
         gas.spend(code_deposit_gas)?;
 
         // EIP-8037: hashing the deployed bytecode to compute its code_hash costs
-        // regular keccak word gas, and depositing the code costs state gas. The
+        // execution keccak word gas, and depositing the code costs state gas. The
         // state-gas charge must be the last spend before the journal commit so
         // that any 0→x→0 reservoir refills earlier in the frame are not disturbed.
         if self.feature(EvmFeatures::EIP8037) {
@@ -1418,7 +1369,6 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
     fn execute_call_message(
         &mut self,
         tx_env: &TxEnv<T>,
-        bytecode: Bytecode,
         message: &mut Message<T>,
     ) -> MessageResult<T> {
         if message.depth > CALL_DEPTH_LIMIT {
@@ -1429,35 +1379,6 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
             );
         }
         let checkpoint = self.state.checkpoint();
-        // EIP-2780 top-level (depth-0) execution charges, metered on the frame gas before the
-        // precompile/interpreter split. Read from the recipient's pre-call state (before the value
-        // transfer below) and applied inside the checkpoint, so the delegated-target load it
-        // performs is unwound if the frame later rolls back. For a delegated recipient this also
-        // resolves the delegation (gating the target load on gas), returning the delegate's code
-        // and address so the frame runs the delegate's code.
-        let mut frame_gas =
-            GasTracker::new_with_regular_gas_and_reservoir(message.gas_limit, message.reservoir);
-        let mut bytecode = bytecode;
-        match self.apply_eip2780_call_charges(message, &mut frame_gas) {
-            Ok(Some((delegate_code, delegate_address))) => {
-                message.code_address = delegate_address;
-                message.disable_precompiles = true;
-                bytecode = delegate_code;
-            }
-            Ok(None) => {}
-            Err(()) => {
-                self.state.rollback(checkpoint, self.features);
-                let mut result = Self::error_message_result(
-                    InstrStop::OutOfGas,
-                    message.gas_limit,
-                    message.reservoir,
-                );
-                // Signal a runtime gas-phase out-of-gas so the EIP-7702 handler can revert the
-                // delegations applied before the frame (ethereum/EIPs#11844).
-                result.runtime_gas_oog = true;
-                return result;
-            }
-        }
         // EIP-161 state clearing depends on zero-value direct call targets being touched.
         let transfers_balance = matches!(
             message.kind,
@@ -1483,77 +1404,12 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
         }
 
         if self.contains_precompile(message) {
-            return self.execute_call_precompile(checkpoint, message, frame_gas);
+            return self.execute_call_precompile(checkpoint, message);
         }
 
-        let stop = self.run_interpreter(bytecode, tx_env, message, frame_gas);
+        let stop = self.run_interpreter(tx_env, message);
 
         self.finish_call_message_run(checkpoint, stop)
-    }
-
-    /// Applies the EIP-2780 top-level (depth-0) execution charges for a call to
-    /// `message.destination`, metered on the frame `gas`:
-    /// - `new_account_state_gas` of state gas when the recipient is empty (EIP-161) and the call
-    ///   transfers value (charged before delegation resolution, per execution-specs
-    ///   `prepare_dispatch`), and
-    /// - the delegation-target access following the EIP-2929 warm/cold model when the recipient
-    ///   carries an EIP-7702 delegation.
-    ///
-    /// The delegation-target access is charged as a warm access first and the cold premium after
-    /// the target is loaded, and the load is gated on `skip_cold_load` (as nested calls do): a
-    /// frame that cannot afford the cold access never loads the target, so it stays out of the
-    /// EIP-7928 block access list. On success the delegated recipient's resolved code and
-    /// address are returned so the caller runs the delegate's code; `Err(())` signals a runtime
-    /// out-of-gas. A no-op returning `Ok(None)` off the depth-0 EIP-2780 path.
-    fn apply_eip2780_call_charges(
-        &mut self,
-        message: &Message<T>,
-        gas: &mut GasTracker,
-    ) -> Result<Option<(Bytecode, Address)>, ()> {
-        if message.depth != 0 || !self.feature(EvmFeatures::EIP2780) {
-            return Ok(None);
-        }
-        let dest = message.destination;
-        // A nonexistent recipient reads as an empty account (EIP-161).
-        let recipient_is_empty = match self.state.account_info_untracked(&dest) {
-            Ok(info) => info.as_ref().is_none_or(AccountInfo::is_empty),
-            Err(_) => return Ok(None),
-        };
-        // Empty recipient + value transfer: pay the new account leaf's state gas. Checked before
-        // the delegation resolution, matching the spec's `prepare_dispatch` order.
-        if !message.value.is_zero() && recipient_is_empty {
-            if gas.spend_state(self.version().gas_params.new_account_state_gas()).is_err() {
-                return Err(());
-            }
-            // An empty recipient is never delegated.
-            return Ok(None);
-        }
-        if recipient_is_empty {
-            return Ok(None);
-        }
-        // Resolve the recipient's delegation designator (the recipient is the warm tx target; its
-        // stored code must be loaded to read the designator).
-        let delegated = match self.state.account(&dest, false) {
-            Ok(mut acc) => acc.load_code().ok().and_then(|code| code.eip7702_address()),
-            Err(_) => None,
-        };
-        let Some(delegated) = delegated else {
-            return Ok(None);
-        };
-        // Delegation-target access, EIP-2929 warm/cold: charge the warm access first (covered → the
-        // target is loaded and enters the block access list), then the cold premium after the load.
-        // The load is skipped when the cold premium is unaffordable, keeping a cold, unafforded
-        // target out of the block access list.
-        let cold_additional = self.version().gas_params.cold_account_additional_cost();
-        if gas.spend(u64::from(WARM_STORAGE_READ_COST)).is_err() {
-            return Err(());
-        }
-        let skip_cold_load = gas.remaining() < cold_additional;
-        let load = self.load_account(&delegated, true, skip_cold_load).map_err(|_| ())?;
-        if load.is_cold && gas.spend(cold_additional).is_err() {
-            return Err(());
-        }
-        Ok(Some((load.code, delegated)))
     }
 
     #[inline(never)]
@@ -1561,10 +1417,9 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
         &mut self,
         checkpoint: StateCheckpoint,
         message: &Message<T>,
-        mut gas: GasTracker,
     ) -> MessageResult<T> {
-        // `gas` is the frame tracker built by the caller with the inherited reservoir and
-        // any EIP-2780 depth-0 charge already applied; the precompile only adds regular gas.
+        let mut gas =
+            GasTracker::new_with_execution_gas_and_reservoir(message.gas_limit, message.reservoir);
         let logs_len = self.state.logs().len();
         let execution = self.execute_precompile(message, &mut gas);
         let logs = self.state.logs()[logs_len..].to_vec();
@@ -1592,7 +1447,6 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
             gas,
             output,
             created_address: None,
-            runtime_gas_oog: false,
             ext: T::MessageResultExt::default(),
             _non_exhaustive: (),
         }
@@ -1616,7 +1470,6 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
             gas: *child_gas.tracker(),
             output,
             created_address: None,
-            runtime_gas_oog: false,
             ext: T::MessageResultExt::default(),
             _non_exhaustive: (),
         }
@@ -1630,7 +1483,7 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
     ) -> MessageResult<T> {
         MessageResultExt {
             stop,
-            gas: GasTracker::new_with_regular_gas_and_reservoir(gas_remaining, reservoir),
+            gas: GasTracker::new_with_execution_gas_and_reservoir(gas_remaining, reservoir),
             ..MessageResultExt::default()
         }
     }
@@ -1638,21 +1491,13 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
     #[inline(never)]
     fn run_interpreter<'frame>(
         &mut self,
-        bytecode: Bytecode,
         tx_env: &'frame TxEnv<T>,
         message: &'frame Message<T>,
-        frame_gas: GasTracker,
     ) -> InstrStop {
         let mut interp: Box<Interpreter<'frame, 'a, T>> = self.interpreter_pool.pop();
         let _guard = self.enter_execution();
         let interp_ref = interp.as_mut();
-        interp_ref.init(bytecode, tx_env, message);
-        // Adopt the caller's frame tracker, which carries the EIP-2780 depth-0 charges
-        // already applied; it is otherwise identical to the one `init` derived (same
-        // regular limit and inherited reservoir). A later revert/halt unwinds the state
-        // charge via the existing `rollback_state_gas` reconciliation, like any in-frame
-        // state gas.
-        *interp_ref.gas_mut().tracker_mut() = frame_gas;
+        interp_ref.init(tx_env, message);
         // SAFETY: `execution_config` points to a private field that host execution does not
         // replace or mutate, so the pointee remains valid here.
         let execution_config = unsafe { trustme::decouple_lt(&self.execution_config) };
@@ -1816,16 +1661,11 @@ impl<'a, T: EvmTypes> Host<T> for Evm<'a, T> {
     }
 
     #[inline]
-    fn execute_message(
-        &mut self,
-        tx_env: &TxEnv<T>,
-        bytecode: Bytecode,
-        message: &mut Message<T>,
-    ) -> MessageResult<T> {
+    fn execute_message(&mut self, tx_env: &TxEnv<T>, message: &mut Message<T>) -> MessageResult<T> {
         if self.inspector.is_some() {
-            return self.execute_message_inspected(tx_env, bytecode, message);
+            return self.execute_message_inspected(tx_env, message);
         }
-        self.execute_message_impl(tx_env, bytecode, message)
+        self.execute_message_impl(tx_env, message)
     }
 
     fn selfdestruct(
@@ -2128,16 +1968,13 @@ mod tests {
         );
         evm.set_interpreter_runner(TestInterpreterRunner { stop, calls: Arc::clone(&calls) });
         let tx_env = TxEnvExt::default();
-        let message = MessageExt { gas_limit: 30_000, ..Default::default() };
+        let message = MessageExt {
+            gas_limit: 30_000,
+            code: Bytecode::new_legacy(Bytes::copy_from_slice(bytecode)),
+            ..Default::default()
+        };
 
-        let frame_gas =
-            GasTracker::new_with_regular_gas_and_reservoir(message.gas_limit, message.reservoir);
-        let stop = evm.run_interpreter(
-            Bytecode::new_legacy(Bytes::copy_from_slice(bytecode)),
-            &tx_env,
-            &message,
-            frame_gas,
-        );
+        let stop = evm.run_interpreter(&tx_env, &message);
 
         assert_eq!(calls.load(Ordering::Relaxed), 1);
         stop
@@ -2194,6 +2031,7 @@ mod tests {
             caller: Address::ZERO,
             input: Bytes::new(),
             value: U256::ZERO,
+            code: Bytecode::default(),
             code_address: address,
             disable_precompiles: false,
             caller_is_static: false,
@@ -2231,12 +2069,7 @@ mod tests {
         evm.set_inspector(LogInspector::default());
         let mut message = precompile_message(TEST_PRECOMPILE);
 
-        let result = Host::execute_message(
-            &mut evm,
-            &TxEnvExt::default(),
-            Bytecode::new_legacy(Bytes::new()),
-            &mut message,
-        );
+        let result = Host::execute_message(&mut evm, &TxEnvExt::default(), &mut message);
 
         assert_eq!(result.stop, InstrStop::Return);
         let inspector = evm.clear_inspector_as::<LogInspector>().unwrap();
@@ -2317,7 +2150,9 @@ mod tests {
             ..MessageExt::default()
         };
 
-        let result = Host::execute_message(&mut evm, &TxEnvExt::default(), bytecode, &mut message);
+        message.code = bytecode;
+
+        let result = Host::execute_message(&mut evm, &TxEnvExt::default(), &mut message);
 
         assert_eq!(result.stop, InstrStop::FatalPrecompileError);
         assert_eq!(evm.error_code(), Some(ErrorCode::FATAL_PRECOMPILE));
@@ -2372,7 +2207,9 @@ mod tests {
             ..MessageExt::default()
         };
 
-        let result = Host::execute_message(&mut evm, &TxEnvExt::default(), bytecode, &mut message);
+        message.code = bytecode;
+
+        let result = Host::execute_message(&mut evm, &TxEnvExt::default(), &mut message);
 
         assert_eq!(result.stop, InstrStop::Stop);
         assert!(evm.error_code().is_none());
@@ -2629,12 +2466,10 @@ mod tests {
             Precompiles::base(SpecId::OSAKA),
         );
         evm.set_inspector(AccessingInspector { access });
-        let message = MessageExt::default();
+        let mut message = MessageExt::default();
         let tx_env = TxEnvExt::default();
-        let bytecode = Bytecode::new_legacy(Bytes::from_static(&[op::STOP]));
-        let frame_gas =
-            GasTracker::new_with_regular_gas_and_reservoir(message.gas_limit, message.reservoir);
-        let _ = evm.run_interpreter(bytecode, &tx_env, &message, frame_gas);
+        message.code = Bytecode::new_legacy(Bytes::from_static(&[op::STOP]));
+        let _ = evm.run_interpreter(&tx_env, &message);
     }
 
     #[test]
@@ -2655,13 +2490,11 @@ mod tests {
             Precompiles::base(SpecId::OSAKA),
         );
         evm.set_inspector(ReadingInspector {});
-        let message = MessageExt::default();
+        let mut message = MessageExt::default();
         let tx_env = TxEnvExt::default();
-        let bytecode = Bytecode::new_legacy(Bytes::from_static(&[op::STOP]));
+        message.code = Bytecode::new_legacy(Bytes::from_static(&[op::STOP]));
 
-        let frame_gas =
-            GasTracker::new_with_regular_gas_and_reservoir(message.gas_limit, message.reservoir);
-        let _ = evm.run_interpreter(bytecode, &tx_env, &message, frame_gas);
+        let _ = evm.run_interpreter(&tx_env, &message);
     }
 
     #[test]
@@ -2713,12 +2546,10 @@ mod tests {
             Precompiles::base(SpecId::OSAKA),
         );
         evm.set_inspector(BlockReplacingInspector);
-        let message = MessageExt::default();
+        let mut message = MessageExt::default();
         let tx_env = TxEnvExt::default();
-        let bytecode = Bytecode::new_legacy(Bytes::from_static(&[op::STOP]));
-        let frame_gas =
-            GasTracker::new_with_regular_gas_and_reservoir(message.gas_limit, message.reservoir);
-        let _ = evm.run_interpreter(bytecode, &tx_env, &message, frame_gas);
+        message.code = Bytecode::new_legacy(Bytes::from_static(&[op::STOP]));
+        let _ = evm.run_interpreter(&tx_env, &message);
         assert_eq!(evm.block().number, Word::from(123));
         assert_eq!(evm.block().timestamp, Word::from(124));
     }
@@ -2748,12 +2579,10 @@ mod tests {
             Precompiles::base(SpecId::OSAKA),
         );
         evm.set_inspector(ConfigReplacingInspector);
-        let message = MessageExt::default();
+        let mut message = MessageExt::default();
         let tx_env = TxEnvExt::default();
-        let bytecode = Bytecode::new_legacy(Bytes::from_static(&[op::STOP]));
-        let frame_gas =
-            GasTracker::new_with_regular_gas_and_reservoir(message.gas_limit, message.reservoir);
-        let _ = evm.run_interpreter(bytecode, &tx_env, &message, frame_gas);
+        message.code = Bytecode::new_legacy(Bytes::from_static(&[op::STOP]));
+        let _ = evm.run_interpreter(&tx_env, &message);
     }
 
     #[derive(Clone, Copy)]
@@ -2806,21 +2635,11 @@ mod tests {
             ),
             TopLevelInspectorHook::Call => {
                 let mut message = MessageExt { kind: MessageKind::Call, ..Default::default() };
-                let _ = Host::execute_message(
-                    &mut evm,
-                    &TxEnvExt::default(),
-                    Bytecode::default(),
-                    &mut message,
-                );
+                let _ = Host::execute_message(&mut evm, &TxEnvExt::default(), &mut message);
             }
             TopLevelInspectorHook::Create => {
                 let mut message = MessageExt { kind: MessageKind::Create, ..Default::default() };
-                let _ = Host::execute_message(
-                    &mut evm,
-                    &TxEnvExt::default(),
-                    Bytecode::default(),
-                    &mut message,
-                );
+                let _ = Host::execute_message(&mut evm, &TxEnvExt::default(), &mut message);
             }
         }
     }
@@ -2874,6 +2693,7 @@ mod tests {
             caller: Address::with_last_byte(0x7a),
             input: Bytes::from_static(b"message input"),
             value: U256::from(99),
+            code: Bytecode::default(),
             code_address: address,
             disable_precompiles: false,
             caller_is_static: false,
@@ -3232,7 +3052,9 @@ mod tests {
             ..MessageExt::default()
         };
 
-        let result = Host::execute_message(&mut evm, &TxEnvExt::default(), bytecode, &mut message);
+        message.code = bytecode;
+
+        let result = Host::execute_message(&mut evm, &TxEnvExt::default(), &mut message);
         assert!(result.stop.is_success());
     }
 
@@ -3296,7 +3118,9 @@ mod tests {
             ..MessageExt::default()
         };
 
-        let result = Host::execute_message(&mut evm, &TxEnvExt::default(), bytecode, &mut message);
+        message.code = bytecode;
+
+        let result = Host::execute_message(&mut evm, &TxEnvExt::default(), &mut message);
 
         assert_eq!(result.stop, InstrStop::FatalExternalError);
         let error_code = evm.error_code().unwrap();
@@ -3325,7 +3149,9 @@ mod tests {
             ..MessageExt::default()
         };
 
-        let result = Host::execute_message(&mut evm, &TxEnvExt::default(), bytecode, &mut message);
+        message.code = bytecode;
+
+        let result = Host::execute_message(&mut evm, &TxEnvExt::default(), &mut message);
 
         assert_eq!(result.stop, InstrStop::OutOfGas);
         assert!(!evm.state.storage(&contract).is_warm(&key));
@@ -3407,12 +3233,8 @@ mod tests {
             ..MessageExt::default()
         };
 
-        let result = Host::execute_message(
-            &mut evm,
-            &TxEnvExt::default(),
-            selfdestruct_to_code(&target),
-            &mut message,
-        );
+        message.code = selfdestruct_to_code(&target);
+        let result = Host::execute_message(&mut evm, &TxEnvExt::default(), &mut message);
 
         assert_eq!(result.stop, InstrStop::OutOfGas);
         assert_eq!(target_reads.load(Ordering::SeqCst), 0);
@@ -3441,7 +3263,9 @@ mod tests {
         let code =
             Bytecode::new_legacy(Bytes::from_static(&[op::PUSH1, 1, op::PUSH1, 0, op::RETURN]));
 
-        let result = Host::execute_message(&mut evm, &TxEnvExt::default(), code, &mut message);
+        message.code = code;
+
+        let result = Host::execute_message(&mut evm, &TxEnvExt::default(), &mut message);
         assert!(result.stop.is_success());
 
         evm.state.finalize_transaction_(Version::base(SpecId::FRONTIER));
@@ -3474,7 +3298,9 @@ mod tests {
         let code =
             Bytecode::new_legacy(Bytes::from_static(&[op::PUSH1, 1, op::PUSH1, 0, op::RETURN]));
 
-        let result = Host::execute_message(&mut evm, &TxEnvExt::default(), code, &mut message);
+        message.code = code;
+
+        let result = Host::execute_message(&mut evm, &TxEnvExt::default(), &mut message);
         assert_eq!(result.stop, InstrStop::OutOfGas);
         assert!(result.output.is_empty());
 
@@ -3516,7 +3342,9 @@ mod tests {
             op::RETURN,
         ]));
 
-        let result = Host::execute_message(&mut evm, &TxEnvExt::default(), code, &mut message);
+        message.code = code;
+
+        let result = Host::execute_message(&mut evm, &TxEnvExt::default(), &mut message);
 
         assert_eq!(result.stop, InstrStop::CreateContractStartingWithEF);
         assert!(result.output.is_empty());
@@ -3551,7 +3379,9 @@ mod tests {
             op::RETURN,
         ]));
 
-        let result = Host::execute_message(&mut evm, &TxEnvExt::default(), code, &mut message);
+        message.code = code;
+
+        let result = Host::execute_message(&mut evm, &TxEnvExt::default(), &mut message);
 
         assert_eq!(result.stop, InstrStop::CreateContractSizeLimit);
         assert!(result.output.is_empty());
@@ -3578,12 +3408,7 @@ mod tests {
             ..MessageExt::default()
         };
 
-        let result = Host::execute_message(
-            &mut evm,
-            &TxEnvExt::default(),
-            Bytecode::default(),
-            &mut message,
-        );
+        let result = Host::execute_message(&mut evm, &TxEnvExt::default(), &mut message);
         assert!(result.stop.is_success());
 
         evm.state.finalize_transaction_(Version::base(SpecId::SPURIOUS_DRAGON));
@@ -3618,12 +3443,7 @@ mod tests {
             ..MessageExt::default()
         };
 
-        let result = Host::execute_message(
-            &mut evm,
-            &TxEnvExt::default(),
-            Bytecode::default(),
-            &mut message,
-        );
+        let result = Host::execute_message(&mut evm, &TxEnvExt::default(), &mut message);
         assert!(result.stop.is_success());
 
         evm.state.finalize_transaction_(Version::base(SpecId::SPURIOUS_DRAGON));
@@ -3689,12 +3509,7 @@ mod tests {
             ..MessageExt::default()
         };
 
-        let result = Host::execute_message(
-            &mut evm,
-            &TxEnvExt::default(),
-            Bytecode::default(),
-            &mut message,
-        );
+        let result = Host::execute_message(&mut evm, &TxEnvExt::default(), &mut message);
         assert!(result.stop.is_success());
 
         let version = *evm.version();

--- a/crates/evm2/src/evm/registry.rs
+++ b/crates/evm2/src/evm/registry.rs
@@ -326,7 +326,6 @@ mod tests {
     use super::*;
     use crate::{
         BaseEvmConfigSelector, EvmFeatures, EvmTypesHost, SpecId,
-        bytecode::Bytecode,
         env::{BlockEnv, BlockEnvExt, TxEnv},
         evm::{AccountLoad, SLoad, SStore, SelfDestructResult},
         interpreter::{Host, InstrStop, Message, MessageResult, Word},
@@ -443,7 +442,6 @@ mod tests {
         fn execute_message(
             &mut self,
             _tx_env: &TxEnv<TestTypes>,
-            _bytecode: Bytecode,
             _message: &mut Message<TestTypes>,
         ) -> MessageResult<TestTypes> {
             unimplemented!()

--- a/crates/evm2/src/evm/system.rs
+++ b/crates/evm2/src/evm/system.rs
@@ -12,8 +12,8 @@ use super::{SendEvmRef, r#async};
 use crate::{
     EvmTypes,
     env::TxEnvExt,
-    ethereum::initial_message,
-    interpreter::Host,
+    ethereum::{InitialFrame, prepare_initial_frame, runtime_oog_result, settle_initial_frame_gas},
+    interpreter::{GasTracker, Host},
     registry::{HandlerError, HandlerResult},
     version::{EvmFeatures, GasId},
 };
@@ -31,7 +31,7 @@ pub const SYSTEM_CALL_GAS_LIMIT: u64 = 30_000_000;
 /// Upper bound on the number of new storage slots a single system call is expected to write.
 ///
 /// EIP-8037 (Amsterdam) sizes the system-call state-gas reservoir as this many `SSTORE` new-slot
-/// state charges; state gas beyond the reservoir spills into the regular gas budget.
+/// state charges; state gas beyond the reservoir spills into the execution gas budget.
 pub const SYSTEM_MAX_SSTORES_PER_CALL: u64 = 16;
 
 /// EIP-4788 beacon roots system contract address.
@@ -145,17 +145,24 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
         } else {
             0
         };
-        let (bytecode, mut message) = initial_message(
+        let mut tx_gas =
+            GasTracker::new_with_execution_gas_and_reservoir(SYSTEM_CALL_GAS_LIMIT, reservoir);
+        let result = match prepare_initial_frame(
             self,
             caller,
             0,
             TxKind::Call(system_contract_address),
             &data,
             U256::ZERO,
-            SYSTEM_CALL_GAS_LIMIT,
-            reservoir,
-        )?;
-        let result = Host::execute_message(self, &tx_env, bytecode, &mut message);
+            &mut tx_gas,
+        )? {
+            Some(InitialFrame { mut message, charged_state_gas }) => {
+                let mut result = Host::execute_message(self, &tx_env, &mut message);
+                settle_initial_frame_gas(&mut tx_gas, &mut result, charged_state_gas);
+                result
+            }
+            None => runtime_oog_result(SYSTEM_CALL_GAS_LIMIT, reservoir),
+        };
         if let Some(code) = self.error_code {
             return Err(HandlerError::Fatal(code));
         }

--- a/crates/evm2/src/evm/tx.rs
+++ b/crates/evm2/src/evm/tx.rs
@@ -21,7 +21,7 @@ pub type TxResult<T = crate::BaseEvmTypes> = TxResultExt<<T as EvmTypesHost>::Tx
 pub struct TxResultExt<E = ()> {
     /// Whether execution succeeded.
     pub status: bool,
-    /// Total gas spent (regular + state) before refund. The receipt gas-used value is
+    /// Total gas spent (execution + state) before refund. The receipt gas-used value is
     /// [`Self::tx_gas_used`].
     pub total_gas_spent: u64,
     /// State gas consumed by the transaction (EIP-8037): storage creation, account creation, code
@@ -58,22 +58,22 @@ impl<E> TxResultExt<E> {
         if spent_sub_refunded > self.floor_gas { spent_sub_refunded } else { self.floor_gas }
     }
 
-    /// Returns this transaction's regular (non-state) block gas:
+    /// Returns this transaction's execution (non-state) block gas:
     /// `max(total_gas_spent - state_gas_spent, floor_gas)`, pre-refund.
     ///
     /// Together with [`Self::state_gas_spent()`] this is the per-transaction split that callers add
-    /// to the block's separate regular- and state-gas counters (EIP-8037 + EIP-7778). The
+    /// to the block's separate execution- and state-gas counters (EIP-8037 + EIP-7778). The
     /// EIP-7623 calldata floor is not discounted by state gas, so it binds against the
-    /// regular component (ethereum/EIPs#11836); the refund still only affects
+    /// execution component (ethereum/EIPs#11836); the refund still only affects
     /// [`Self::tx_gas_used`].
     #[inline]
-    pub const fn regular_gas_spent(&self) -> u64 {
-        let regular = self.total_gas_spent.saturating_sub(self.state_gas_spent);
-        if regular > self.floor_gas { regular } else { self.floor_gas }
+    pub const fn execution_gas_spent(&self) -> u64 {
+        let execution = self.total_gas_spent.saturating_sub(self.state_gas_spent);
+        if execution > self.floor_gas { execution } else { self.floor_gas }
     }
 
     /// Returns this transaction's state gas (EIP-8037) — the stored `state_gas_spent` field,
-    /// exposed as the counterpart to [`Self::regular_gas_spent`] for the per-transaction
+    /// exposed as the counterpart to [`Self::execution_gas_spent`] for the per-transaction
     /// block-gas split.
     #[inline]
     pub const fn state_gas_spent(&self) -> u64 {
@@ -303,10 +303,10 @@ mod tests {
         // Floor inactive: tx_gas_used = total_gas_spent - refunded, refund is effective.
         let r = result(100_000, 30_000, 8_000, 21_000);
         assert_eq!(r.tx_gas_used(), 92_000);
-        // Per-tx split: regular + state == total.
-        assert_eq!(r.regular_gas_spent(), 70_000);
+        // Per-tx split: execution + state == total.
+        assert_eq!(r.execution_gas_spent(), 70_000);
         assert_eq!(r.state_gas_spent(), 30_000);
-        assert_eq!(r.regular_gas_spent() + r.state_gas_spent(), r.total_gas_spent);
+        assert_eq!(r.execution_gas_spent() + r.state_gas_spent(), r.total_gas_spent);
     }
 
     #[test]

--- a/crates/evm2/src/interpreter/gas.rs
+++ b/crates/evm2/src/interpreter/gas.rs
@@ -97,7 +97,7 @@ pub(crate) const EIP7702_AUTH_TUPLE_BYTES: u32 = 101;
 /// ecRecover precompile base cost, charged once per EIP-7702 authorization to
 /// recover the authority. Matches `secp256k1::ECRECOVER_BASE`.
 pub(crate) const EIP7702_ECRECOVER_COST: u32 = 3000;
-/// `REGULAR_PER_AUTH_BASE_COST`: the state-independent regular-gas base charged per EIP-7702
+/// `REGULAR_PER_AUTH_BASE_COST`: the state-independent execution-gas base charged per EIP-7702
 /// authorization at the intrinsic phase under EIP-2780 (ethereum/EIPs#11844).
 ///
 /// Equals `AUTH_TUPLE_BYTES * TX_DATA_TOKEN_FLOOR + PRECOMPILE_ECRECOVER + COLD_ACCOUNT_ACCESS +
@@ -117,16 +117,16 @@ pub(crate) const EIP8038_EIP7702_PER_AUTH_BASE_REGULAR: u32 = EIP7702_AUTH_TUPLE
 // Active alongside EIP-8037 / EIP-8038 starting at the Amsterdam hardfork.
 /// Reduced intrinsic base charged to `tx.sender` (execution-specs `TX_BASE`).
 pub(crate) const EIP2780_TX_BASE_COST: u32 = 12_000;
-/// Regular gas cost of the EIP-7708 transfer log emitted for every nonzero-value
+/// Execution gas cost of the EIP-7708 transfer log emitted for every nonzero-value
 /// transfer to a different account: `GAS_LOG + 3 * GAS_LOG_TOPIC + 32 *
 /// GAS_LOG_DATA_PER_BYTE = 375 + 1_125 + 256 = 1_756`.
 pub(crate) const EIP2780_TRANSFER_LOG_COST: u32 = 1_756;
-/// Additional intrinsic regular-gas charge for a value-bearing (non-create,
+/// Additional intrinsic execution-gas charge for a value-bearing (non-create,
 /// non-self) transaction (execution-specs `TX_VALUE_COST`), on top of
 /// [`EIP2780_TRANSFER_LOG_COST`].
 pub(crate) const EIP2780_TX_VALUE_COST: u32 = 4_244;
 
-/// Tracks regular, state, and refunded gas.
+/// Tracks execution, state, and refunded gas.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
 pub struct GasTracker {
     remaining: u64,
@@ -139,11 +139,11 @@ pub struct GasTracker {
     /// previously charged the 0→x portion). The net is reconciled on frame
     /// return by [`Self::merge_child_gas`].
     state_gas_spent: i64,
-    /// State gas drawn from regular gas (`remaining`) because the reservoir was
+    /// State gas drawn from execution gas (`remaining`) because the reservoir was
     /// empty (EIP-8037's `state_gas_from_gas_left`).
     ///
     /// Incremented by [`Self::spend_state`] whenever a state-gas charge spills
-    /// out of the reservoir into regular gas. On frame rollback (revert or halt)
+    /// out of the reservoir into execution gas. On frame rollback (revert or halt)
     /// the spilled portion is credited back to `remaining` in last-in-first-out
     /// order by [`Self::rollback_state_gas`]; on success it is propagated to the
     /// parent frame so a later parent rollback can return it.
@@ -152,15 +152,15 @@ pub struct GasTracker {
 }
 
 impl GasTracker {
-    /// Creates a gas tracker with `limit` regular gas.
+    /// Creates a gas tracker with `limit` execution gas.
     #[inline]
     pub const fn new(limit: u64) -> Self {
         Self::from_parts(limit, limit, 0)
     }
 
-    /// Creates a gas tracker with regular gas and a state gas reservoir.
+    /// Creates a gas tracker with execution gas and a state gas reservoir.
     #[inline]
-    pub const fn new_with_regular_gas_and_reservoir(limit: u64, reservoir: u64) -> Self {
+    pub const fn new_with_execution_gas_and_reservoir(limit: u64, reservoir: u64) -> Self {
         Self::from_parts(limit, limit, reservoir)
     }
 
@@ -189,13 +189,13 @@ impl GasTracker {
         Self::from_parts(gas_limit, gas_limit - used_gas, reservoir)
     }
 
-    /// Returns remaining regular gas.
+    /// Returns remaining execution gas.
     #[inline]
     pub const fn remaining(&self) -> u64 {
         self.remaining
     }
 
-    /// Sets remaining regular gas.
+    /// Sets remaining execution gas.
     #[inline]
     pub const fn set_remaining(&mut self, val: u64) {
         self.remaining = val;
@@ -237,7 +237,7 @@ impl GasTracker {
         self.state_gas_spent = self.state_gas_spent.saturating_add(delta);
     }
 
-    /// Returns state gas drawn from regular gas because the reservoir was empty
+    /// Returns state gas drawn from execution gas because the reservoir was empty
     /// (EIP-8037's `state_gas_from_gas_left`). See the field docs.
     #[inline]
     pub const fn state_gas_spilled(&self) -> u64 {
@@ -247,7 +247,7 @@ impl GasTracker {
     /// Adds `delta` to the spilled state gas, saturating.
     ///
     /// Used to merge a successful child frame's spilled state gas into this
-    /// frame, since it is now backed by the merged regular gas.
+    /// frame, since it is now backed by the merged execution gas.
     #[inline]
     pub const fn add_state_gas_spilled(&mut self, delta: u64) {
         self.state_gas_spilled = self.state_gas_spilled.saturating_add(delta);
@@ -265,7 +265,7 @@ impl GasTracker {
         self.refunded = val;
     }
 
-    /// Returns spent regular gas.
+    /// Returns spent execution gas.
     #[inline]
     pub const fn spent(&self) -> u64 {
         self.gas_limit.saturating_sub(self.remaining)
@@ -277,13 +277,13 @@ impl GasTracker {
         self.spent().saturating_sub(self.refunded as u64)
     }
 
-    /// Sets spent regular gas.
+    /// Sets spent execution gas.
     #[inline]
     pub const fn set_spent(&mut self, spent: u64) {
         self.remaining = self.gas_limit.saturating_sub(spent);
     }
 
-    /// Spends regular gas.
+    /// Spends execution gas.
     #[doc(alias = "record_cost")]
     #[doc(alias = "record_regular_cost")]
     #[doc(alias = "record_cost_unsafe")]
@@ -350,7 +350,7 @@ impl GasTracker {
     /// slot restored to its original zero value (0→x→0), or a failed CREATE's
     /// upfront charge — the corresponding state gas is restored directly rather
     /// than routed through the capped refund counter. Because charges deduct from
-    /// the reservoir first and from regular gas (`remaining`) last, the refill
+    /// the reservoir first and from execution gas (`remaining`) last, the refill
     /// credits the pool charged last first: `remaining` is credited up to
     /// `state_gas_spilled` (decrementing it by the same amount) and any remainder
     /// tops up the reservoir.
@@ -385,7 +385,7 @@ impl GasTracker {
     ///
     /// A failing frame rolls back its state changes, so its state gas is refilled
     /// in LIFO order ([`Self::rollback_state_gas`]) and the execution refund counter
-    /// is dropped; an exceptional halt additionally consumes the frame's regular
+    /// is dropped; an exceptional halt additionally consumes the frame's execution
     /// gas. On success the gas is left as-is. Applied once when a frame returns, so
     /// every consumer — the parent [`Self::merge_child_gas`], top-level accounting,
     /// and inspectors — reads the same settled gas.
@@ -403,8 +403,8 @@ impl GasTracker {
     /// Merges a returning child frame's (already [settled](Self::settle_gas)) gas
     /// into this (parent) frame, per the child's `stop` reason.
     ///
-    /// - **Unused regular gas** returns to the parent only on success or revert; a halt consumes
-    ///   the child's regular gas (already zeroed when settled).
+    /// - **Unused execution gas** returns to the parent only on success or revert; a halt consumes
+    ///   the child's execution gas (already zeroed when settled).
     /// - **The reservoir** is a shared state-gas pool the child inherited at call time, so the
     ///   parent always adopts the child's value — which settling restored to the inherited amount
     ///   on revert/halt, leaving it untouched.
@@ -423,14 +423,14 @@ impl GasTracker {
         }
     }
 
-    /// Spends all remaining regular gas.
+    /// Spends all remaining execution gas.
     #[inline]
     pub const fn spend_all(&mut self) {
         self.remaining = 0;
     }
 }
 
-/// Remaining regular gas threaded through dispatch calls.
+/// Remaining execution gas threaded through dispatch calls.
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
 #[repr(transparent)]
@@ -444,19 +444,19 @@ impl RemainingGas {
         Self(remaining)
     }
 
-    /// Returns remaining regular gas.
+    /// Returns remaining execution gas.
     #[inline]
     pub(crate) const fn get(self) -> u64 {
         self.0
     }
 
-    /// Sets remaining regular gas.
+    /// Sets remaining execution gas.
     #[inline]
     pub(crate) const fn set(&mut self, remaining: u64) {
         self.0 = remaining;
     }
 
-    /// Spends regular gas.
+    /// Spends execution gas.
     #[inline(always)]
     pub(crate) const fn spend(&mut self, cost: u64) -> Result {
         let remaining = self.0;
@@ -479,17 +479,17 @@ pub struct Gas {
 }
 
 impl Gas {
-    /// Creates gas with `limit` regular gas.
+    /// Creates gas with `limit` execution gas.
     #[inline]
     pub const fn new(limit: u64) -> Self {
         Self { tracker: GasTracker::new(limit), memory: MemoryGas::new() }
     }
 
-    /// Creates gas with regular gas and a state gas reservoir.
+    /// Creates gas with execution gas and a state gas reservoir.
     #[inline]
-    pub const fn new_with_regular_gas_and_reservoir(limit: u64, reservoir: u64) -> Self {
+    pub const fn new_with_execution_gas_and_reservoir(limit: u64, reservoir: u64) -> Self {
         Self {
-            tracker: GasTracker::new_with_regular_gas_and_reservoir(limit, reservoir),
+            tracker: GasTracker::new_with_execution_gas_and_reservoir(limit, reservoir),
             memory: MemoryGas::new(),
         }
     }
@@ -527,13 +527,13 @@ impl Gas {
         &mut self.memory
     }
 
-    /// Returns remaining regular gas.
+    /// Returns remaining execution gas.
     #[inline]
     pub const fn remaining(&self) -> u64 {
         self.tracker.remaining()
     }
 
-    /// Sets remaining regular gas.
+    /// Sets remaining execution gas.
     #[inline]
     pub const fn set_remaining(&mut self, remaining: u64) {
         self.tracker.set_remaining(remaining);
@@ -575,7 +575,7 @@ impl Gas {
         self.tracker.add_state_gas_spent(delta);
     }
 
-    /// Returns state gas drawn from regular gas because the reservoir was empty
+    /// Returns state gas drawn from execution gas because the reservoir was empty
     /// (EIP-8037). See [`GasTracker::state_gas_spilled`].
     #[inline]
     pub const fn state_gas_spilled(&self) -> u64 {
@@ -607,7 +607,7 @@ impl Gas {
         self.set_refunded(refund);
     }
 
-    /// Returns spent regular gas.
+    /// Returns spent execution gas.
     #[inline]
     pub const fn spent(&self) -> u64 {
         self.tracker.spent()
@@ -619,13 +619,13 @@ impl Gas {
         self.tracker.used()
     }
 
-    /// Sets spent regular gas.
+    /// Sets spent execution gas.
     #[inline]
     pub const fn set_spent(&mut self, spent: u64) {
         self.tracker.set_spent(spent);
     }
 
-    /// Spends regular gas or returns out of gas.
+    /// Spends execution gas or returns out of gas.
     #[doc(alias = "record_cost")]
     #[doc(alias = "record_regular_cost")]
     #[doc(alias = "record_cost_unsafe")]
@@ -668,7 +668,7 @@ impl Gas {
         self.tracker.merge_child_gas(child, stop);
     }
 
-    /// Spends all remaining regular gas.
+    /// Spends all remaining execution gas.
     #[inline]
     pub const fn spend_all(&mut self) {
         self.tracker.spend_all();
@@ -713,15 +713,15 @@ mod tests {
 
     #[test]
     fn test_spend_state() {
-        let mut gas = Gas::new_with_regular_gas_and_reservoir(1000, 500);
+        let mut gas = Gas::new_with_execution_gas_and_reservoir(1000, 500);
         assert!(gas.spend_state(200).is_ok());
         assert_eq!((gas.reservoir(), gas.remaining(), gas.state_gas_spent()), (300, 1000, 200));
 
-        let mut gas = Gas::new_with_regular_gas_and_reservoir(1000, 500);
+        let mut gas = Gas::new_with_execution_gas_and_reservoir(1000, 500);
         assert!(gas.spend_state(500).is_ok());
         assert_eq!((gas.reservoir(), gas.remaining(), gas.state_gas_spent()), (0, 1000, 500));
 
-        let mut gas = Gas::new_with_regular_gas_and_reservoir(1000, 300);
+        let mut gas = Gas::new_with_execution_gas_and_reservoir(1000, 300);
         assert!(gas.spend_state(500).is_ok());
         assert_eq!((gas.reservoir(), gas.remaining(), gas.state_gas_spent()), (0, 800, 500));
 
@@ -729,20 +729,20 @@ mod tests {
         assert!(gas.spend_state(200).is_ok());
         assert_eq!((gas.reservoir(), gas.remaining(), gas.state_gas_spent()), (0, 800, 200));
 
-        let mut gas = Gas::new_with_regular_gas_and_reservoir(100, 50);
+        let mut gas = Gas::new_with_execution_gas_and_reservoir(100, 50);
         assert!(gas.spend_state(0).is_ok());
         assert_eq!((gas.reservoir(), gas.remaining(), gas.state_gas_spent()), (50, 100, 0));
 
-        let mut gas = Gas::new_with_regular_gas_and_reservoir(100, 50);
+        let mut gas = Gas::new_with_execution_gas_and_reservoir(100, 50);
         assert_matches!(gas.spend_state(200), Err(InstrStop::OutOfGas));
 
-        let mut gas = Gas::new_with_regular_gas_and_reservoir(2000, 1000);
+        let mut gas = Gas::new_with_execution_gas_and_reservoir(2000, 1000);
         assert!(gas.spend_state(100).is_ok());
         assert!(gas.spend_state(200).is_ok());
         assert!(gas.spend_state(150).is_ok());
         assert_eq!(gas.state_gas_spent(), 450);
 
-        let mut gas = Gas::new_with_regular_gas_and_reservoir(500, 300);
+        let mut gas = Gas::new_with_execution_gas_and_reservoir(500, 300);
         assert!(gas.spend_state(150).is_ok());
         assert_eq!((gas.reservoir(), gas.remaining()), (150, 500));
         assert!(gas.spend_state(200).is_ok());
@@ -757,7 +757,7 @@ mod tests {
         assert_matches!(gas.spend_state(100), Err(InstrStop::OutOfGas));
         assert_eq!(gas.state_gas_spent(), 0);
 
-        let mut gas = Gas::new_with_regular_gas_and_reservoir(30, 20);
+        let mut gas = Gas::new_with_execution_gas_and_reservoir(30, 20);
         assert_matches!(gas.spend_state(100), Err(InstrStop::OutOfGas));
         assert_eq!(gas.state_gas_spent(), 0);
         assert_eq!(gas.reservoir(), 20);
@@ -766,11 +766,11 @@ mod tests {
     #[test]
     fn test_spend_state_tracks_spilled() {
         // No spill while the reservoir covers the charge.
-        let mut gas = Gas::new_with_regular_gas_and_reservoir(1000, 500);
+        let mut gas = Gas::new_with_execution_gas_and_reservoir(1000, 500);
         assert!(gas.spend_state(300).is_ok());
         assert_eq!((gas.state_gas_spilled(), gas.reservoir()), (0, 200));
 
-        // Spilling the remainder into regular gas records it.
+        // Spilling the remainder into execution gas records it.
         assert!(gas.spend_state(500).is_ok());
         assert_eq!((gas.state_gas_spilled(), gas.reservoir(), gas.remaining()), (300, 0, 700));
 
@@ -781,8 +781,8 @@ mod tests {
 
     #[test]
     fn test_rollback_state_gas_no_spill() {
-        // Pure-reservoir spend: unwind restores the reservoir, leaving regular gas alone.
-        let mut gas = Gas::new_with_regular_gas_and_reservoir(1000, 500);
+        // Pure-reservoir spend: unwind restores the reservoir, leaving execution gas alone.
+        let mut gas = Gas::new_with_execution_gas_and_reservoir(1000, 500);
         assert!(gas.spend_state(300).is_ok());
         gas.tracker_mut().rollback_state_gas();
         assert_eq!(
@@ -793,9 +793,9 @@ mod tests {
 
     #[test]
     fn test_rollback_state_gas_with_spill() {
-        // Reservoir exhausted then spilled: unwind returns the spill to regular gas
+        // Reservoir exhausted then spilled: unwind returns the spill to execution gas
         // and restores the reservoir to its frame-start value.
-        let mut gas = Gas::new_with_regular_gas_and_reservoir(1000, 200);
+        let mut gas = Gas::new_with_execution_gas_and_reservoir(1000, 200);
         assert!(gas.spend_state(500).is_ok());
         assert_eq!((gas.reservoir(), gas.remaining(), gas.state_gas_spilled()), (0, 700, 300));
         gas.tracker_mut().rollback_state_gas();
@@ -807,17 +807,17 @@ mod tests {
 
     #[test]
     fn test_refill_reservoir_lifo() {
-        // Refill credits the spilled (regular-gas) portion first, remainder to reservoir.
-        let mut gas = Gas::new_with_regular_gas_and_reservoir(1000, 200);
+        // Refill credits the spilled (execution-gas) portion first, remainder to reservoir.
+        let mut gas = Gas::new_with_execution_gas_and_reservoir(1000, 200);
         assert!(gas.spend_state(500).is_ok()); // spill 300, reservoir 0, remaining 700
         assert_eq!((gas.reservoir(), gas.remaining(), gas.state_gas_spilled()), (0, 700, 300));
-        // Refund 200: less than the 300 spilled, so it all returns to regular gas.
+        // Refund 200: less than the 300 spilled, so it all returns to execution gas.
         gas.refill_reservoir(200);
         assert_eq!(
             (gas.reservoir(), gas.remaining(), gas.state_gas_spent(), gas.state_gas_spilled()),
             (0, 900, 300, 100)
         );
-        // Refund 250: 100 returns to regular gas (draining the spill), 150 to the reservoir.
+        // Refund 250: 100 returns to execution gas (draining the spill), 150 to the reservoir.
         gas.refill_reservoir(250);
         assert_eq!(
             (gas.reservoir(), gas.remaining(), gas.state_gas_spent(), gas.state_gas_spilled()),
@@ -826,7 +826,7 @@ mod tests {
 
         // With no spill recorded, the refill lands entirely in the reservoir and may
         // drive `state_gas_spent` negative (charge made by a parent frame).
-        let mut gas = Gas::new_with_regular_gas_and_reservoir(1000, 100);
+        let mut gas = Gas::new_with_execution_gas_and_reservoir(1000, 100);
         gas.refill_reservoir(300);
         assert_eq!(
             (gas.reservoir(), gas.remaining(), gas.state_gas_spent(), gas.state_gas_spilled()),
@@ -836,9 +836,9 @@ mod tests {
 
     #[test]
     fn test_rollback_state_gas_after_refill() {
-        // A partial refill returns part of the spill to regular gas; unwind still
+        // A partial refill returns part of the spill to execution gas; unwind still
         // restores the original split.
-        let mut gas = Gas::new_with_regular_gas_and_reservoir(1000, 200);
+        let mut gas = Gas::new_with_execution_gas_and_reservoir(1000, 200);
         assert!(gas.spend_state(500).is_ok()); // spill 300, reservoir 0, remaining 700
         gas.refill_reservoir(100); // LIFO: remaining 800, spilled 200, reservoir 0
         assert_eq!((gas.reservoir(), gas.remaining(), gas.state_gas_spilled()), (0, 800, 200));
@@ -851,7 +851,7 @@ mod tests {
 
     #[test]
     fn test_spend_state_zero_remaining_with_reservoir() {
-        let mut gas = Gas::new_with_regular_gas_and_reservoir(0, 500);
+        let mut gas = Gas::new_with_execution_gas_and_reservoir(0, 500);
         assert!(gas.spend_state(200).is_ok());
         assert_eq!((gas.reservoir(), gas.remaining(), gas.state_gas_spent()), (300, 0, 200));
 

--- a/crates/evm2/src/interpreter/host.rs
+++ b/crates/evm2/src/interpreter/host.rs
@@ -1,7 +1,6 @@
 use super::{GasTracker, InstrStop, Message, Result, Word};
 use crate::{
     BaseEvmTypes, EvmFeatures, EvmTypesHost, SpecId,
-    bytecode::Bytecode,
     env::{BlockEnv, TxEnv},
     evm::{AccountLoad, SLoad, SStore, SelfDestructResult},
 };
@@ -26,11 +25,6 @@ pub struct MessageResultExt<E = ()> {
     pub output: Bytes,
     /// Created address for successful create messages.
     pub created_address: Option<Address>,
-    /// EIP-2780: whether a depth-0 runtime gas-phase charge (the recipient's new-account state gas
-    /// or delegation-target access) ran out of gas before the frame executed. The EIP-7702 handler
-    /// treats this as a runtime out-of-gas: it reverts the applied delegations and includes the
-    /// transaction as an out-of-gas halt. Always `false` off the depth-0 path.
-    pub runtime_gas_oog: bool,
     /// EVM type-specific extension data.
     pub ext: E,
     #[doc(hidden)] // Not public API. Please use an existing constructor.
@@ -153,13 +147,9 @@ pub trait Host<T: EvmTypesHost> {
     /// Records an emitted log.
     fn log(&mut self, log: Log);
 
-    /// Executes a message inside this host.
-    fn execute_message(
-        &mut self,
-        tx_env: &TxEnv<T>,
-        bytecode: Bytecode,
-        message: &mut Message<T>,
-    ) -> MessageResult<T>;
+    /// Executes a message inside this host. The message carries the bytecode to run
+    /// ([`MessageExt::code`](super::MessageExt::code)).
+    fn execute_message(&mut self, tx_env: &TxEnv<T>, message: &mut Message<T>) -> MessageResult<T>;
 
     /// Registers the current contract for self-destruction.
     fn selfdestruct(

--- a/crates/evm2/src/interpreter/instructions/host.rs
+++ b/crates/evm2/src/interpreter/instructions/host.rs
@@ -62,7 +62,7 @@ pub(crate) fn sstore(cx: _, [key, value]: [Word]) -> Result {
 
     // EIP-8037 / Amsterdam: creating a new storage slot (original == present == 0,
     // new != 0) also consumes state gas from the reservoir before spilling into
-    // regular gas.
+    // execution gas.
     if cx.state.feature(EvmFeatures::EIP8037) {
         cx.gas.spend_state(cx.state.gas_params().sstore_state_gas(&state_load))?;
 
@@ -296,7 +296,7 @@ mod tests {
         assert_matches!(interp.err, InstrStop::Stop);
         // Regular: PUSH1(3)·2 + SSTORE warm (100 static + EIP-8038 STORAGE_WRITE
         // 10_000 set) = 10_106.
-        // State gas (64 × 1530 = 97_920) spills into regular gas (no reservoir).
+        // State gas (64 × 1530 = 97_920) spills into execution gas (no reservoir).
         assert_eq!(interp.state_gas_spent(), 97_920);
         assert_eq!(interp.gas_remaining(), 200_000 - 10_106 - 97_920);
     }

--- a/crates/evm2/src/interpreter/instructions/macro_tests.rs
+++ b/crates/evm2/src/interpreter/instructions/macro_tests.rs
@@ -79,9 +79,9 @@ const fn macro_opcode_config() -> OpcodeConfig<TestTypes> {
 fn run(config: RunConfig<'_>) -> TestInterpreter {
     let execution_config = ExecutionConfig::<TestTypes>::for_config::<MacroConfig>();
     let RunConfig { code, host, spec_id, tx_env, mut message, gas_limit, return_data } = config;
-    let bytecode = legacy_bytecode(code);
+    message.code = legacy_bytecode(code);
     message.gas_limit = gas_limit;
-    let mut inner = Interpreter::<TestTypes>::new(bytecode, &tx_env, &message);
+    let mut inner = Interpreter::<TestTypes>::new(&tx_env, &message);
     *inner.return_data_mut() = return_data;
     let mut default_host = TestHost::default();
     let host = host.unwrap_or(&mut default_host);

--- a/crates/evm2/src/interpreter/instructions/memory.rs
+++ b/crates/evm2/src/interpreter/instructions/memory.rs
@@ -102,9 +102,9 @@ mod tests {
         code.push(op::STOP);
 
         let tx_env = TxEnvExt::default();
-        let message = MessageExt { gas_limit: 10_000, ..MessageExt::default() };
-        let bytecode = legacy_bytecode(code);
-        let mut interp = Interpreter::<TestTypes>::new(bytecode, &tx_env, &message);
+        let message =
+            MessageExt { gas_limit: 10_000, code: legacy_bytecode(code), ..MessageExt::default() };
+        let mut interp = Interpreter::<TestTypes>::new(&tx_env, &message);
         let mut host = TestHost::default();
         let err = interp.run(&config, &mut host);
 
@@ -124,9 +124,9 @@ mod tests {
         code.push(op::STOP);
 
         let tx_env = TxEnvExt::default();
-        let message = MessageExt { gas_limit: 17, ..MessageExt::default() };
-        let bytecode = legacy_bytecode(code);
-        let mut interp = Interpreter::<TestTypes>::new(bytecode, &tx_env, &message);
+        let message =
+            MessageExt { gas_limit: 17, code: legacy_bytecode(code), ..MessageExt::default() };
+        let mut interp = Interpreter::<TestTypes>::new(&tx_env, &message);
         let mut host = TestHost::default();
         let err = interp.run(&config, &mut host);
 

--- a/crates/evm2/src/interpreter/instructions/system.rs
+++ b/crates/evm2/src/interpreter/instructions/system.rs
@@ -3,9 +3,10 @@
 use crate::{
     EvmFeatures, EvmTypesHost,
     bytecode::Bytecode,
+    constants::CALL_DEPTH_LIMIT,
     interpreter::{
         Gas, Host, InstrStop, InterpreterState, Message, MessageExt, MessageKind, Result, StackMut,
-        Word,
+        Word, derive_create_destination,
     },
     utils::{word_to_address, word_to_usize},
     version::GasId,
@@ -151,7 +152,6 @@ fn prepare_call<T: EvmTypesHost>(
     state: &mut InterpreterState<'_, '_, T>,
     kind: MessageKind,
     message: &mut Message<T>,
-    code: &mut Bytecode,
     return_memory_range: &mut Range<usize>,
 ) -> Result<u64> {
     let has_value = match kind {
@@ -209,6 +209,7 @@ fn prepare_call<T: EvmTypesHost>(
         caller,
         input,
         value: call_value,
+        code: loaded_code,
         code_address,
         disable_precompiles,
         caller_is_static: state.is_static(),
@@ -216,7 +217,6 @@ fn prepare_call<T: EvmTypesHost>(
         ext: T::MessageExt::default(),
         _non_exhaustive: (),
     };
-    *code = loaded_code;
     *return_memory_range = prepared_return_memory_range;
 
     Ok(new_account_state_gas)
@@ -230,20 +230,12 @@ fn call_inner<T: EvmTypesHost>(
     kind: MessageKind,
 ) -> Result {
     let mut message = Message::<T>::default();
-    let mut code = Bytecode::default();
     let mut return_memory_range = 0..0;
-    let new_account_state_gas = prepare_call(
-        stack.reborrow(),
-        gas,
-        state,
-        kind,
-        &mut message,
-        &mut code,
-        &mut return_memory_range,
-    )?;
+    let new_account_state_gas =
+        prepare_call(stack.reborrow(), gas, state, kind, &mut message, &mut return_memory_range)?;
 
     let tx_env = state.tx();
-    let mut result = state.host().execute_message(tx_env, code, &mut message);
+    let mut result = state.host().execute_message(tx_env, &mut message);
     if result.stop.is_fatal() {
         return Err(result.stop);
     }
@@ -317,39 +309,30 @@ fn create_inner<T: EvmTypesHost>(
     };
     gas.spend(create_cost)?;
 
-    // Build the message up front (minus the child gas split, filled in below).
+    let kind = if is_create2 { MessageKind::Create2 } else { MessageKind::Create };
     let current = state.message();
-    let mut message = MessageExt {
-        kind: if is_create2 { MessageKind::Create2 } else { MessageKind::Create },
-        depth: current.depth.saturating_add(1),
-        gas_limit: 0,
-        reservoir: 0,
-        // Derived below into the yet-to-be-created contract address.
-        destination: Address::ZERO,
-        caller: current.destination,
-        input,
-        value,
-        code_address: current.destination,
-        disable_precompiles: false,
-        // CREATE is rejected in a static context (see `require_non_staticcall`).
-        caller_is_static: false,
-        salt: salt.map(|salt| B256::from(salt.to_be_bytes())).unwrap_or_default(),
-        ext: T::MessageExt::default(),
-        _non_exhaustive: (),
-    };
+    let caller = current.destination;
+    let depth = current.depth.saturating_add(1);
+    let salt = salt.map(|salt| B256::from(salt.to_be_bytes())).unwrap_or_default();
 
-    // Derive the created contract address once and record it in `destination`. CREATE needs the
-    // creator's (pre-bump) nonce; the caller is the currently-executing contract, already warm and
-    // in the access list, so this read is neutral. CREATE2 needs no nonce. The same load feeds the
-    // EIP-8037 balance/nonce checks below, so it is only performed when one of the two needs it.
+    // Derive the created contract address once. CREATE needs the creator's (pre-bump) nonce; the
+    // caller is the currently-executing contract, already warm and in the access list, so this read
+    // is neutral. CREATE2 needs no nonce. The same load feeds the EIP-8037 balance/nonce checks
+    // below, so it is only performed when one of the two needs it.
     let caller_info = if is_create2 && !state.feature(EvmFeatures::EIP8037) {
         None
     } else {
-        Some(state.host().load_account(&message.caller, false, false)?)
+        Some(state.host().load_account(&caller, false, false)?)
     };
-    message.derive_destination(caller_info.as_ref().map_or(0, |info| info.nonce));
+    let destination = derive_create_destination(
+        kind,
+        &caller,
+        &salt,
+        &input,
+        caller_info.as_ref().map_or(0, |info| info.nonce),
+    );
 
-    // EIP-8037 (ethereum/EIPs#11858): charge the CREATE account-creation state gas on this frame
+    // EIP-8037: charge the CREATE account-creation state gas on this frame
     // before the child gas/reservoir split, conditional on the destination not already existing.
     // The single destination read decides the charge (and warms the address); a create at a
     // pre-existing leaf pays nothing, so its child is not shortchanged by an unneeded spill. The
@@ -357,13 +340,16 @@ fn create_inner<T: EvmTypesHost>(
     // create-failure path after `execute_message`).
     let mut charged_create_state_gas = false;
     if let Some(caller_info) = caller_info.filter(|_| state.feature(EvmFeatures::EIP8037)) {
-        // Only decide the account-creation charge once the endowment and nonce pre-checks pass: a
-        // create that early-fails on those never accesses the destination, so reading it here would
-        // leak it into the EIP-7928 block access list. The early-fail itself (pushing 0) is handled
-        // by the child frame below.
-        if caller_info.balance >= message.value && caller_info.nonce != u64::MAX {
+        // Only decide the account-creation charge once the depth, endowment, and nonce pre-checks
+        // pass: a create that early-fails on those never accesses the destination, so reading it
+        // here would leak it into the EIP-7928 block access list (and warm the address). The
+        // early-fail itself (pushing 0) is handled by the child frame below.
+        if depth <= CALL_DEPTH_LIMIT
+            && caller_info.balance >= value
+            && caller_info.nonce != u64::MAX
+        {
             let features = state.version().features;
-            if state.host().target_is_empty_for_new_account_gas(&message.destination, features)? {
+            if state.host().target_is_empty_for_new_account_gas(&destination, features)? {
                 gas.spend_state(state.gas_params().create_state_gas())?;
                 charged_create_state_gas = true;
             }
@@ -375,18 +361,33 @@ fn create_inner<T: EvmTypesHost>(
         gas.remaining()
     };
     gas.spend(gas_limit)?;
-    message.gas_limit = gas_limit;
-    message.reservoir = gas.reservoir();
 
-    let bytecode = crate::bytecode::Bytecode::new_legacy(message.input.clone());
     let tx_env = state.tx();
-    let mut result = state.host().execute_message(tx_env, bytecode, &mut message);
+    let mut message = MessageExt {
+        kind,
+        depth,
+        gas_limit,
+        reservoir: gas.reservoir(),
+        destination,
+        caller,
+        code: Bytecode::new_legacy(input.clone()),
+        input,
+        value,
+        code_address: caller,
+        disable_precompiles: false,
+        // CREATE is rejected in a static context (see `require_non_staticcall`).
+        caller_is_static: false,
+        salt,
+        ext: T::MessageExt::default(),
+        _non_exhaustive: (),
+    };
+    let mut result = state.host().execute_message(tx_env, &mut message);
     if result.stop.is_fatal() {
         return Err(result.stop);
     }
     gas.merge_child_gas(result.gas, result.stop);
 
-    // EIP-8037 (ethereum/EIPs#11858): when the opcode charged the conditional `create_state_gas`
+    // EIP-8037: when the opcode charged the conditional `create_state_gas`
     // and the create then fails to deploy (revert, halt, or an early-fail leaving
     // `created_address == None` — depth, out-of-funds, nonce overflow), no new account leaf is
     // created, so refund the charge to the reservoir via `refill_reservoir` (matching 0→x→0 storage
@@ -907,6 +908,25 @@ mod tests {
         assert_eq!(interp.stack(), [Word::ZERO]);
         assert_eq!(interp.gas_remaining(), 17_991);
         assert!(host.calls.is_empty());
+    }
+
+    #[test]
+    fn create_too_deep_skips_destination_read_eip8037() {
+        // EIP-8037: a create failing the depth pre-check must not access the destination —
+        // the read would leak the address into the EIP-7928 block access list.
+        let mut host = TestHost { exists: false, ..Default::default() };
+        let mut code = Vec::new();
+        push_all(&mut code, [Word::ZERO, Word::ZERO, Word::ZERO]);
+        code.extend([op::CREATE, op::STOP]);
+
+        let interp = run(RunConfig::new(code)
+            .host(&mut host)
+            .spec(SpecId::AMSTERDAM)
+            .message(MessageExt { depth: CALL_DEPTH_LIMIT, ..Default::default() })
+            .gas_limit(50_000));
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.stack(), [Word::ZERO]);
+        assert!(host.new_account_checks.is_empty());
     }
 
     #[test]

--- a/crates/evm2/src/interpreter/message.rs
+++ b/crates/evm2/src/interpreter/message.rs
@@ -1,4 +1,4 @@
-use crate::{BaseEvmTypes, EvmTypesHost};
+use crate::{BaseEvmTypes, EvmTypesHost, bytecode::Bytecode};
 use alloy_primitives::{Address, B256, Bytes, U256, keccak256};
 
 /// EVM message kind.
@@ -60,6 +60,12 @@ pub struct MessageExt<E = ()> {
     pub input: Bytes,
     /// Value transferred with the message.
     pub value: U256,
+    /// Bytecode this frame executes: the code at [`MessageExt::code_address`] (the resolved
+    /// delegate's code for an EIP-7702 delegated call), or the initcode for create messages.
+    ///
+    /// Resolved by the message's producer when it is constructed, so frames never load accounts
+    /// for code.
+    pub code: Bytecode,
     /// Address whose code is being executed. This can differ from `destination` for `CALLCODE`,
     /// `DELEGATECALL`, and EIP-7702 delegated-code execution.
     pub code_address: Address,
@@ -77,25 +83,21 @@ pub struct MessageExt<E = ()> {
     pub _non_exhaustive: (),
 }
 
-impl<E> MessageExt<E> {
-    /// Returns the keccak256 hash of the init code ([`MessageExt::input`]).
-    ///
-    /// Only meaningful for create messages, where `input` holds the initcode.
-    #[inline]
-    pub fn init_code_hash_slow(&self) -> B256 {
-        keccak256(self.input.as_ref())
-    }
-
-    /// Derives this create message's contract address and stores it in [`MessageExt::destination`].
-    ///
-    /// `nonce` is the creator's nonce and is only used by the `CREATE` scheme; `CREATE2` derives
-    /// the address from the salt and [`MessageExt::init_code_hash_slow`]. Called once when the
-    /// create message is constructed.
-    #[inline]
-    pub fn derive_destination(&mut self, nonce: u64) {
-        self.destination = match self.kind {
-            MessageKind::Create2 => self.caller.create2(self.salt, self.init_code_hash_slow()),
-            _ => self.caller.create(nonce),
-        };
+/// Derives the contract address a create message deploys to, i.e. its
+/// [`destination`](MessageExt::destination).
+///
+/// `nonce` is the creator's (pre-bump) nonce and is only used by the `CREATE` scheme; `CREATE2`
+/// derives the address from `salt` and the initcode hash instead.
+#[inline]
+pub fn derive_create_destination(
+    kind: MessageKind,
+    caller: &Address,
+    salt: &B256,
+    init_code: &[u8],
+    nonce: u64,
+) -> Address {
+    match kind {
+        MessageKind::Create2 => caller.create2(salt, keccak256(init_code)),
+        _ => caller.create(nonce),
     }
 }

--- a/crates/evm2/src/interpreter/mod.rs
+++ b/crates/evm2/src/interpreter/mod.rs
@@ -28,7 +28,7 @@ mod memory;
 pub use memory::Memory;
 
 mod message;
-pub use message::{Message, MessageExt, MessageKind};
+pub use message::{Message, MessageExt, MessageKind, derive_create_destination};
 
 mod host;
 pub use host::{Host, MessageResult, MessageResultExt};

--- a/crates/evm2/src/interpreter/runtime.rs
+++ b/crates/evm2/src/interpreter/runtime.rs
@@ -75,27 +75,23 @@ impl<T: EvmTypesHost> Default for Interpreter<'_, '_, T> {
 }
 
 impl<'frame, 'host, T: EvmTypesHost> Interpreter<'frame, 'host, T> {
-    /// Creates an interpreter from analyzed bytecode, a transaction-global environment, and a
-    /// frame-local message.
-    pub fn new(bytecode: Bytecode, tx_env: &'frame TxEnv<T>, message: &'frame Message<T>) -> Self {
+    /// Creates an interpreter from a transaction-global environment and a frame-local message,
+    /// which carries the bytecode to run.
+    pub fn new(tx_env: &'frame TxEnv<T>, message: &'frame Message<T>) -> Self {
         let mut interp = Self::default();
-        interp.init(bytecode, tx_env, message);
+        interp.init(tx_env, message);
         interp
     }
 
     /// Initializes this interpreter for a new frame, retaining reusable allocations.
-    pub(crate) fn init(
-        &mut self,
-        bytecode: Bytecode,
-        tx_env: &'frame TxEnv<T>,
-        message: &'frame Message<T>,
-    ) {
+    pub(crate) fn init(&mut self, tx_env: &'frame TxEnv<T>, message: &'frame Message<T>) {
+        let bytecode = message.code.clone();
         let gas_limit = message.gas_limit;
         let is_static = message.caller_is_static || matches!(message.kind, MessageKind::StaticCall);
         self.pc = bytecode.original_byte_slice().as_ptr();
         self.bytecode = bytecode;
         self.stack_len = 0;
-        self.gas = Gas::new_with_regular_gas_and_reservoir(gas_limit, message.reservoir);
+        self.gas = Gas::new_with_execution_gas_and_reservoir(gas_limit, message.reservoir);
         self.memory.clear();
         self.result = Ok(());
         self.output = 0..0;

--- a/crates/evm2/src/test_utils.rs
+++ b/crates/evm2/src/test_utils.rs
@@ -51,6 +51,7 @@ pub(crate) struct TestHost {
     pub(crate) calls: Vec<Message<TestTypes>>,
     pub(crate) call_static_flags: Vec<bool>,
     pub(crate) selfdestructs: Vec<(Address, Address, bool)>,
+    pub(crate) new_account_checks: Vec<Address>,
 }
 
 impl Default for TestHost {
@@ -78,6 +79,7 @@ impl Default for TestHost {
             calls: Vec::new(),
             call_static_flags: Vec::new(),
             selfdestructs: Vec::new(),
+            new_account_checks: Vec::new(),
         }
     }
 }
@@ -118,9 +120,10 @@ impl Host<TestTypes> for TestHost {
 
     fn target_is_empty_for_new_account_gas(
         &mut self,
-        _address: &Address,
+        address: &Address,
         features: EvmFeatures,
     ) -> Result<bool, InstrStop> {
+        self.new_account_checks.push(*address);
         if features.contains(EvmFeatures::EIP161) {
             return Ok(!self.exists || self.is_empty);
         }
@@ -192,7 +195,6 @@ impl Host<TestTypes> for TestHost {
     fn execute_message(
         &mut self,
         _tx_env: &TxEnv<TestTypes>,
-        _bytecode: Bytecode,
         message: &mut Message<TestTypes>,
     ) -> MessageResult<TestTypes> {
         // Mimics the depth limit enforced by the real host.
@@ -325,9 +327,9 @@ impl Default for RunConfig<'_> {
 
 pub(crate) fn run(config: RunConfig<'_>) -> TestInterpreter {
     let RunConfig { code, host, spec_id, tx_env, mut message, gas_limit, return_data } = config;
-    let bytecode = legacy_bytecode(code);
+    message.code = legacy_bytecode(code);
     message.gas_limit = gas_limit;
-    let mut inner = Interpreter::<TestTypes>::new(bytecode, &tx_env, &message);
+    let mut inner = Interpreter::<TestTypes>::new(&tx_env, &message);
     *inner.return_data_mut() = return_data;
     let mut default_host = TestHost::default();
     let host = host.unwrap_or(&mut default_host);

--- a/crates/evm2/src/tests.rs
+++ b/crates/evm2/src/tests.rs
@@ -18,8 +18,8 @@ fn run_tx(evm: &mut TestEvm, destination: Address, code: impl Into<Vec<u8>>) {
         gas_limit: 100_000,
         ..Default::default()
     };
-    let result =
-        Host::execute_message(evm, &TxEnvExt::default(), legacy_bytecode(code), &mut message);
+    message.code = legacy_bytecode(code);
+    let result = Host::execute_message(evm, &TxEnvExt::default(), &mut message);
     assert!(result.stop.is_success());
 }
 
@@ -132,12 +132,8 @@ fn evm_propagates_child_sstore_negative_refund() {
         gas_limit: 100_000,
         ..Default::default()
     };
-    let result = Host::execute_message(
-        &mut evm,
-        &TxEnvExt::default(),
-        legacy_bytecode(parent_code),
-        &mut message,
-    );
+    message.code = legacy_bytecode(parent_code);
+    let result = Host::execute_message(&mut evm, &TxEnvExt::default(), &mut message);
 
     assert!(result.stop.is_success());
     assert_eq!(result.gas.refunded(), 0);
@@ -159,12 +155,8 @@ fn evm_reports_invalid_transaction_execution() {
         gas_limit: 100_000,
         ..Default::default()
     };
-    let result = Host::execute_message(
-        &mut evm,
-        &TxEnvExt::default(),
-        legacy_bytecode([op::PUSH1, 0x01, op::SSTORE]),
-        &mut message,
-    );
+    message.code = legacy_bytecode([op::PUSH1, 0x01, op::SSTORE]);
+    let result = Host::execute_message(&mut evm, &TxEnvExt::default(), &mut message);
 
     assert_eq!(result.stop, InstrStop::StackUnderflow);
 }

--- a/crates/evm2/src/version/gas_params.rs
+++ b/crates/evm2/src/version/gas_params.rs
@@ -167,11 +167,11 @@ gas_ids! {
     /// EIP-7702 transaction state gas per authorization.
     TxEip7702PerAuthState;
 
-    /// EIP-2780 regular gas cost of the EIP-7708 transfer log on a nonzero-value transfer.
+    /// EIP-2780 execution gas cost of the EIP-7708 transfer log on a nonzero-value transfer.
     TxTransferLogCost;
     /// EIP-2780 additional intrinsic charge for a value-bearing non-create, non-self transaction.
     TxValueCost;
-    /// EIP-2780/EIP-8038 regular gas cost of a top-level CREATE access.
+    /// EIP-2780/EIP-8038 execution gas cost of a top-level CREATE access.
     TxCreateAccessCost;
 
     // Reserved custom gas parameter slots.
@@ -530,11 +530,11 @@ mod tests {
         assert_eq!(amsterdam.get(GasId::ColdAccountAdditionalCost), 2900);
         assert_eq!(amsterdam.get(GasId::TransferValueCost), 10_300);
         // CALL folds the account-write surcharge into CALL_VALUE, so a new target
-        // adds no extra regular gas (only NEW_ACCOUNT state gas).
+        // adds no extra execution gas (only NEW_ACCOUNT state gas).
         assert_eq!(amsterdam.get(GasId::NewAccountCost), 0);
         assert_eq!(amsterdam.get(GasId::SstoreSetWithoutLoadCost), 10_000);
         assert_eq!(amsterdam.get(GasId::SstoreClearingSlotRefund), 12_480);
-        // EIP-2780/Amsterdam intrinsic per-auth regular gas: the state-independent
+        // EIP-2780/Amsterdam intrinsic per-auth execution gas: the state-independent
         // REGULAR_PER_AUTH_BASE_COST = 101*16 + 3000 + 3000 + 2*100 = 7_816 (the ACCOUNT_WRITE
         // and state-gas remainder is charged at the runtime gas phase).
         assert_eq!(amsterdam.get(GasId::TxEip7702PerEmptyAccountCost), 7_816);

--- a/crates/evm2/src/version/mod.rs
+++ b/crates/evm2/src/version/mod.rs
@@ -778,8 +778,8 @@ evm_versions! {
             // floor-tokens count.
             TxFloorZeroByteMultiplier: NON_ZERO_BYTE_MULTIPLIER_ISTANBUL,
             TxAccessListFloorByteMultiplier: EIP7981_ACCESS_LIST_FLOOR_BYTE_MULTIPLIER,
-            // EIP-7702 under EIP-8037: per-authorization regular-gas refund. The
-            // intrinsic per-auth regular charge bundles a worst-case
+            // EIP-7702 under EIP-8037: per-authorization execution-gas refund. The
+            // intrinsic per-auth execution charge bundles a worst-case
             // `ACCOUNT_WRITE`; when the authority leaf already exists (or the auth
             // EIP-2780 (ethereum/EIPs#11844): the per-auth `ACCOUNT_WRITE` and
             // state gas are charged conditionally at the runtime gas phase, per
@@ -816,7 +816,7 @@ evm_versions! {
             ColdStorageCost: EIP8038_COLD_STORAGE_ACCESS_ADDITIONAL,
             // CALL_VALUE = ACCOUNT_WRITE + CALL_STIPEND. A value-bearing CALL already
             // pays the ACCOUNT_WRITE surcharge here, so creating the target charges
-            // no extra regular gas — only the NEW_ACCOUNT state gas (hence
+            // no extra execution gas — only the NEW_ACCOUNT state gas (hence
             // `NewAccountCost` is zero). SELFDESTRUCT has no such bundled charge, so
             // it still pays a separate ACCOUNT_WRITE when sending balance to an empty
             // account (execution-specs `selfdestruct`).
@@ -826,12 +826,12 @@ evm_versions! {
             // SSTORE write surcharge / refunds = STORAGE_WRITE.
             SstoreSetWithoutLoadCost: EIP8038_STORAGE_WRITE,
             SstoreResetWithoutColdLoadCost: EIP8038_STORAGE_WRITE,
-            // SSTORE 0→x→0 regular refund only; the state-gas portion is restored
+            // SSTORE 0→x→0 execution refund only; the state-gas portion is restored
             // directly to the reservoir via `sstore_state_gas_refill`.
             SstoreSetRefund: EIP8038_STORAGE_WRITE,
             SstoreResetRefund: EIP8038_STORAGE_WRITE,
             SstoreClearingSlotRefund: EIP8038_STORAGE_CLEAR_REFUND,
-            // CREATE / CREATE2 regular-gas access cost (CREATE opcodes and create txns).
+            // CREATE / CREATE2 execution-gas access cost (CREATE opcodes and create txns).
             Create: EIP8038_CREATE_ACCESS,
             TxCreateCost: EIP8038_CREATE_ACCESS,
             // EIP-7981: charge access-list data at 64 gas per byte (20 bytes per

--- a/crates/inspectors/src/opcode.rs
+++ b/crates/inspectors/src/opcode.rs
@@ -171,10 +171,12 @@ mod tests {
 
         let opcodes = [op::ADD, op::ADD, op::ADD, op::BYTE];
 
-        let bytecode = Bytecode::new_legacy(Bytes::from(opcodes));
         let tx_env = TxEnv::<BaseEvmTypes>::default();
-        let message = Message::<BaseEvmTypes>::default();
-        let mut interp = Interpreter::<BaseEvmTypes>::new(bytecode, &tx_env, &message);
+        let message = Message::<BaseEvmTypes> {
+            code: Bytecode::new_legacy(Bytes::from(opcodes)),
+            ..Message::<BaseEvmTypes>::default()
+        };
+        let mut interp = Interpreter::<BaseEvmTypes>::new(&tx_env, &message);
 
         for _ in &opcodes {
             opcode_counter.step(&mut interp);
@@ -187,10 +189,12 @@ mod tests {
 
         let opcodes = [op::PUSH1, op::PUSH1, op::ADD, op::PUSH1, op::SSTORE, op::STOP];
 
-        let bytecode = Bytecode::new_legacy(Bytes::from(opcodes));
         let tx_env = TxEnv::<BaseEvmTypes>::default();
-        let message = Message::<BaseEvmTypes>::default();
-        let mut interp = Interpreter::<BaseEvmTypes>::new(bytecode, &tx_env, &message);
+        let message = Message::<BaseEvmTypes> {
+            code: Bytecode::new_legacy(Bytes::from(opcodes)),
+            ..Message::<BaseEvmTypes>::default()
+        };
+        let mut interp = Interpreter::<BaseEvmTypes>::new(&tx_env, &message);
 
         for _ in &opcodes {
             opcode_counter.step(&mut interp);

--- a/crates/jit/builtins/src/lib.rs
+++ b/crates/jit/builtins/src/lib.rs
@@ -16,8 +16,8 @@ use alloy_primitives::{Address, B256, Bytes, KECCAK256_EMPTY, Log, LogData, U256
 use core::cmp::min;
 use evm2::{
     bytecode::Bytecode,
-    constants::BLOCK_HASH_HISTORY,
-    interpreter::{Host, MessageExt, MessageKind, Word, i256},
+    constants::{BLOCK_HASH_HISTORY, CALL_DEPTH_LIMIT},
+    interpreter::{Host, MessageExt, MessageKind, Word, derive_create_destination, i256},
     utils::{word_to_usize, word_to_usize_saturated},
     version::{EvmFeatures, GasId},
 };
@@ -668,46 +668,39 @@ pub unsafe extern "C" fn __revmc_builtin_create(
     } else {
         B256::ZERO
     };
-    // Build the message up front (minus the child gas split, filled in below).
+    let kind = if is_create2 { MessageKind::Create2 } else { MessageKind::Create };
     let current = ecx.message();
-    let mut message = MessageExt {
-        kind: if is_create2 { MessageKind::Create2 } else { MessageKind::Create },
-        depth: current.depth.saturating_add(1),
-        gas_limit: 0,
-        reservoir: 0,
-        // Derived below into the yet-to-be-created contract address.
-        destination: Address::ZERO,
-        caller: current.destination,
-        input: code,
-        value: value.to_u256(),
-        code_address: current.destination,
-        disable_precompiles: false,
-        caller_is_static: false,
-        salt,
-        ext: (),
-        _non_exhaustive: (),
-    };
+    let caller = current.destination;
+    let depth = current.depth.saturating_add(1);
+    let value = value.to_u256();
 
-    // Derive the created contract address once and record it in `destination` (mirrors the
-    // interpreter's `create` opcode). CREATE needs the creator's (pre-bump) nonce; the caller is the
-    // currently-executing contract, already warm. CREATE2 needs no nonce. The same load feeds the
-    // EIP-8037 balance/nonce checks below, so it is only performed when one of the two needs it.
+    // Derive the created contract address once (mirrors the interpreter's `create` opcode). CREATE
+    // needs the creator's (pre-bump) nonce; the caller is the currently-executing contract, already
+    // warm. CREATE2 needs no nonce. The same load feeds the EIP-8037 balance/nonce checks below, so
+    // it is only performed when one of the two needs it.
     let caller_info = if is_create2 && !ecx.enables(EvmFeatures::EIP8037) {
         None
     } else {
-        Some(ecx.host().load_account(&message.caller, false, false)?)
+        Some(ecx.host().load_account(&caller, false, false)?)
     };
-    message.derive_destination(caller_info.as_ref().map_or(0, |info| info.nonce));
+    let destination = derive_create_destination(
+        kind,
+        &caller,
+        &salt,
+        &code,
+        caller_info.as_ref().map_or(0, |info| info.nonce),
+    );
 
-    // EIP-8037 (ethereum/EIPs#11858): charge the CREATE account-creation state gas before the child
-    // gas split, conditional on the destination not already existing (and on the endowment/nonce
-    // pre-checks passing, so an early-failing create leaves the destination out of the block access
-    // list).
+    // EIP-8037: charge the CREATE account-creation state gas before the child
+    // gas split, conditional on the destination not already existing (and on the depth, endowment,
+    // and nonce pre-checks passing, so an early-failing create leaves the destination out of the
+    // block access list).
     let mut charged_create_state_gas = false;
     if let Some(caller_info) = caller_info.filter(|_| ecx.enables(EvmFeatures::EIP8037))
-        && caller_info.balance >= message.value
+        && depth <= CALL_DEPTH_LIMIT
+        && caller_info.balance >= value
         && caller_info.nonce != u64::MAX
-        && ecx.host().target_is_empty_for_new_account_gas(&message.destination, version.features)?
+        && ecx.host().target_is_empty_for_new_account_gas(&destination, version.features)?
     {
         ecx.gas.spend_state(version.gas_params.create_state_gas())?;
         charged_create_state_gas = true;
@@ -718,14 +711,28 @@ pub unsafe extern "C" fn __revmc_builtin_create(
         gas_limit = version.gas_params.call_stipend_reduction(gas_limit);
     }
     ecx.gas.spend(gas_limit)?;
-    message.gas_limit = gas_limit;
-    message.reservoir = ecx.gas.reservoir();
 
-    let bytecode = Bytecode::new_legacy(message.input.clone());
     let tx_env = ecx.tx_env();
-    let mut result = ecx.host().execute_message(tx_env, bytecode, &mut message);
+    let mut message = MessageExt {
+        kind,
+        depth,
+        gas_limit,
+        reservoir: ecx.gas.reservoir(),
+        destination,
+        caller,
+        code: Bytecode::new_legacy(code.clone()),
+        input: code,
+        value,
+        code_address: caller,
+        disable_precompiles: false,
+        caller_is_static: false,
+        salt,
+        ext: (),
+        _non_exhaustive: (),
+    };
+    let mut result = ecx.host().execute_message(tx_env, &mut message);
     ecx.gas.merge_child_gas(result.gas, result.stop);
-    // EIP-8037 (ethereum/EIPs#11858): refund the conditional create state gas when the create fails
+    // EIP-8037: refund the conditional create state gas when the create fails
     // to deploy (no new account leaf is created).
     let create_failed = result.created_address.is_none() || !result.stop.is_success();
     if charged_create_state_gas && create_failed {
@@ -819,6 +826,7 @@ pub unsafe extern "C" fn __revmc_builtin_call(
         caller,
         input,
         value: call_value,
+        code: loaded_code,
         code_address,
         disable_precompiles,
         caller_is_static: ecx.is_static(),
@@ -828,7 +836,7 @@ pub unsafe extern "C" fn __revmc_builtin_call(
     };
 
     let tx_env = ecx.tx_env();
-    let mut result = ecx.host().execute_message(tx_env, loaded_code, &mut message);
+    let mut result = ecx.host().execute_message(tx_env, &mut message);
     ecx.gas.merge_child_gas(result.gas, result.stop);
     if new_account_state_gas != 0 && !result.stop.is_success() {
         ecx.gas.refill_reservoir(new_account_state_gas);
@@ -1142,13 +1150,14 @@ mod tests {
             ..MessageInspector::default()
         });
         let tx_env = TxEnvExt::default();
-        let message =
-            MessageExt { gas_limit: 1_000_000, destination: caller, ..MessageExt::default() };
-        let mut interpreter = evm2::interpreter::Interpreter::<BaseEvmTypes>::new(
-            Bytecode::new_legacy(Bytes::from_static(&[op::STOP])),
-            &tx_env,
-            &message,
-        );
+        let message = MessageExt {
+            gas_limit: 1_000_000,
+            destination: caller,
+            code: Bytecode::new_legacy(Bytes::from_static(&[op::STOP])),
+            ..MessageExt::default()
+        };
+        let mut interpreter =
+            evm2::interpreter::Interpreter::<BaseEvmTypes>::new(&tx_env, &message);
 
         {
             let mut frame = prepare_frame(&mut interpreter, &mut host);
@@ -1199,13 +1208,11 @@ mod tests {
             destination,
             caller,
             value: Word::from(0x99),
+            code: Bytecode::new_legacy(Bytes::from_static(&[op::STOP])),
             ..MessageExt::default()
         };
-        let mut interpreter = evm2::interpreter::Interpreter::<BaseEvmTypes>::new(
-            Bytecode::new_legacy(Bytes::from_static(&[op::STOP])),
-            &tx_env,
-            &message,
-        );
+        let mut interpreter =
+            evm2::interpreter::Interpreter::<BaseEvmTypes>::new(&tx_env, &message);
 
         {
             let mut frame = prepare_frame(&mut interpreter, &mut host);
@@ -1241,13 +1248,11 @@ mod tests {
             destination,
             caller,
             value: current_value,
+            code: Bytecode::new_legacy(Bytes::from_static(&[op::STOP])),
             ..MessageExt::default()
         };
-        let mut interpreter = evm2::interpreter::Interpreter::<BaseEvmTypes>::new(
-            Bytecode::new_legacy(Bytes::from_static(&[op::STOP])),
-            &tx_env,
-            &message,
-        );
+        let mut interpreter =
+            evm2::interpreter::Interpreter::<BaseEvmTypes>::new(&tx_env, &message);
 
         {
             let mut frame = prepare_frame(&mut interpreter, &mut host);
@@ -1282,13 +1287,11 @@ mod tests {
             destination,
             caller,
             value: Word::from(0x99),
+            code: Bytecode::new_legacy(Bytes::from_static(&[op::STOP])),
             ..MessageExt::default()
         };
-        let mut interpreter = evm2::interpreter::Interpreter::<BaseEvmTypes>::new(
-            Bytecode::new_legacy(Bytes::from_static(&[op::STOP])),
-            &tx_env,
-            &message,
-        );
+        let mut interpreter =
+            evm2::interpreter::Interpreter::<BaseEvmTypes>::new(&tx_env, &message);
 
         {
             let mut frame = prepare_frame(&mut interpreter, &mut host);
@@ -1325,12 +1328,13 @@ mod tests {
             ..MessageInspector::default()
         });
         let tx_env = TxEnvExt::default();
-        let message = MessageExt { gas_limit: 1_000_000, ..MessageExt::default() };
-        let mut interpreter = evm2::interpreter::Interpreter::<BaseEvmTypes>::new(
-            Bytecode::new_legacy(Bytes::from_static(&[op::STOP])),
-            &tx_env,
-            &message,
-        );
+        let message = MessageExt {
+            gas_limit: 1_000_000,
+            code: Bytecode::new_legacy(Bytes::from_static(&[op::STOP])),
+            ..MessageExt::default()
+        };
+        let mut interpreter =
+            evm2::interpreter::Interpreter::<BaseEvmTypes>::new(&tx_env, &message);
 
         {
             let mut frame = prepare_frame(&mut interpreter, &mut host);
@@ -1369,12 +1373,13 @@ mod tests {
             ..MessageInspector::default()
         });
         let tx_env = TxEnvExt::default();
-        let message = MessageExt { gas_limit: 1_000_000, ..MessageExt::default() };
-        let mut interpreter = evm2::interpreter::Interpreter::<BaseEvmTypes>::new(
-            Bytecode::new_legacy(Bytes::from_static(&[op::STOP])),
-            &tx_env,
-            &message,
-        );
+        let message = MessageExt {
+            gas_limit: 1_000_000,
+            code: Bytecode::new_legacy(Bytes::from_static(&[op::STOP])),
+            ..MessageExt::default()
+        };
+        let mut interpreter =
+            evm2::interpreter::Interpreter::<BaseEvmTypes>::new(&tx_env, &message);
 
         {
             let mut frame = prepare_frame(&mut interpreter, &mut host);

--- a/crates/jit/codegen/src/tests/runner.rs
+++ b/crates/jit/codegen/src/tests/runner.rs
@@ -393,11 +393,8 @@ fn with_evm_context_and_host_mut<
     if let Some(modify_message) = modify_message {
         modify_message(&mut message);
     }
-    let mut interpreter = Interpreter::<BaseEvmTypes>::new(
-        Bytecode::new_legacy(Bytes::copy_from_slice(bytecode)),
-        &tx_env,
-        &message,
-    );
+    message.code = Bytecode::new_legacy(Bytes::copy_from_slice(bytecode));
+    let mut interpreter = Interpreter::<BaseEvmTypes>::new(&tx_env, &message);
     interpreter.prepare_run(config.base_spec_id(), config.version(), host);
 
     let (mut ecx, stack, stack_len) = EvmContext::from_interpreter_with_stack(&mut interpreter);
@@ -511,11 +508,8 @@ fn run_compiled_test_case_with_context(
         modify_message(&mut message);
     }
     message.caller_is_static = is_static;
-    let mut interpreter = Interpreter::<BaseEvmTypes>::new(
-        Bytecode::new_legacy(Bytes::copy_from_slice(bytecode)),
-        &tx_env,
-        &message,
-    );
+    message.code = Bytecode::new_legacy(Bytes::copy_from_slice(bytecode));
+    let mut interpreter = Interpreter::<BaseEvmTypes>::new(&tx_env, &message);
     let mut int_host = prepare_host(spec_id);
     let int_stop = interpreter.run(&config, &mut int_host);
     let int_result = int_stop;

--- a/crates/jit/runtime/src/evm2_evm.rs
+++ b/crates/jit/runtime/src/evm2_evm.rs
@@ -207,12 +207,12 @@ mod tests {
             SpecId::CANCUN,
         );
         let tx_env = TxEnvExt::default();
-        let message = MessageExt { gas_limit: 1_000_000, ..Default::default() };
-        let mut interpreter = Interpreter::<BaseEvmTypes>::new(
-            Bytecode::new_legacy(Bytes::from_static(&[op::STOP])),
-            &tx_env,
-            &message,
-        );
+        let message = MessageExt {
+            gas_limit: 1_000_000,
+            code: Bytecode::new_legacy(Bytes::from_static(&[op::STOP])),
+            ..Default::default()
+        };
+        let mut interpreter = Interpreter::<BaseEvmTypes>::new(&tx_env, &message);
         let mut host = Evm::<BaseEvmTypes>::new(
             SpecId::CANCUN,
             BlockEnvExt::default(),
@@ -252,7 +252,7 @@ mod tests {
         );
         host.set_interpreter_runner(JitInterpreterRunner::new(backend.clone()));
         let tx_env = TxEnvExt::default();
-        let message =
+        let mut message =
             MessageExt { gas_limit: 1_000_000, destination: caller, ..MessageExt::default() };
         let mut code = vec![op::PUSH1, 0x20, op::PUSH0, op::PUSH0, op::PUSH0, op::PUSH0];
         push20(&mut code, target);
@@ -270,8 +270,8 @@ mod tests {
             op::PUSH0,
             op::RETURN,
         ]);
-        let mut interpreter =
-            Interpreter::<BaseEvmTypes>::new(Bytecode::new_legacy(code.into()), &tx_env, &message);
+        message.code = Bytecode::new_legacy(code.into());
+        let mut interpreter = Interpreter::<BaseEvmTypes>::new(&tx_env, &message);
 
         assert_eq!(
             run_interpreter(&backend, &config, &mut interpreter, &mut host),
@@ -300,7 +300,7 @@ mod tests {
         );
         host.set_interpreter_runner(JitInterpreterRunner::new(backend.clone()));
         let tx_env = TxEnvExt::default();
-        let message =
+        let mut message =
             MessageExt { gas_limit: 1_000_000, destination: creator, ..MessageExt::default() };
         let code = [
             op::PUSH10,
@@ -331,11 +331,8 @@ mod tests {
             op::PUSH0,
             op::RETURN,
         ];
-        let mut interpreter = Interpreter::<BaseEvmTypes>::new(
-            Bytecode::new_legacy(Bytes::copy_from_slice(&code)),
-            &tx_env,
-            &message,
-        );
+        message.code = Bytecode::new_legacy(Bytes::copy_from_slice(&code));
+        let mut interpreter = Interpreter::<BaseEvmTypes>::new(&tx_env, &message);
 
         assert_eq!(
             run_interpreter(&backend, &config, &mut interpreter, &mut host),
@@ -377,7 +374,7 @@ mod tests {
         );
         host.set_interpreter_runner(JitInterpreterRunner::new(backend.clone()));
         let tx_env = TxEnvExt::default();
-        let message = MessageExt {
+        let mut message = MessageExt {
             gas_limit: 1_000_000,
             destination: caller,
             value: Word::from(30),
@@ -401,11 +398,8 @@ mod tests {
             op::PUSH0,
             op::RETURN,
         ];
-        let mut interpreter = Interpreter::<BaseEvmTypes>::new(
-            Bytecode::new_legacy(Bytes::copy_from_slice(&code)),
-            &tx_env,
-            &message,
-        );
+        message.code = Bytecode::new_legacy(Bytes::copy_from_slice(&code));
+        let mut interpreter = Interpreter::<BaseEvmTypes>::new(&tx_env, &message);
 
         assert_eq!(
             run_interpreter(&backend, &config, &mut interpreter, &mut host),
@@ -456,7 +450,7 @@ mod tests {
         );
         host.set_interpreter_runner(JitInterpreterRunner::new(backend.clone()));
         let tx_env = TxEnvExt::default();
-        let message = MessageExt {
+        let mut message = MessageExt {
             gas_limit: 1_000_000,
             destination: caller,
             value: Word::from(30),
@@ -480,11 +474,8 @@ mod tests {
             op::STATICCALL,
             op::STOP,
         ];
-        let mut interpreter = Interpreter::<BaseEvmTypes>::new(
-            Bytecode::new_legacy(Bytes::copy_from_slice(&code)),
-            &tx_env,
-            &message,
-        );
+        message.code = Bytecode::new_legacy(Bytes::copy_from_slice(&code));
+        let mut interpreter = Interpreter::<BaseEvmTypes>::new(&tx_env, &message);
 
         assert_eq!(
             run_interpreter(&backend, &config, &mut interpreter, &mut host),
@@ -513,6 +504,7 @@ mod tests {
             caller,
             input: Bytes::copy_from_slice(&input),
             value: Word::from(10),
+            code: Bytecode::new_legacy(Bytes::copy_from_slice(&outer_code)),
             code_address: outer,
             ..MessageExt::default()
         };
@@ -548,11 +540,7 @@ mod tests {
             if with_jit {
                 host.set_interpreter_runner(JitInterpreterRunner::new(backend.clone()));
             }
-            let mut interpreter = Interpreter::<BaseEvmTypes>::new(
-                Bytecode::new_legacy(Bytes::copy_from_slice(&outer_code)),
-                &tx_env,
-                &message,
-            );
+            let mut interpreter = Interpreter::<BaseEvmTypes>::new(&tx_env, &message);
             let stop = if with_jit {
                 run_interpreter(&backend, &config, &mut interpreter, &mut host).unwrap()
             } else {


### PR DESCRIPTION
Stacked on #315 (base: `glam-devnet-7`). Moves the `execute_message`/`Message` refactors and the gas-dimension rename out of the devnet-7 PR — they are not devnet-7 spec changes. The final tree is byte-identical to what `glam-devnet-7` contained before the split.

## Commits

- **refactor(message): carry bytecode in Message; EIP-8037 create depth check** — the message producer resolves the bytecode a frame executes (delegate code for EIP-7702 calls, initcode for creates) into `Message.code`, so `execute_message` and the interpreter no longer thread a separate bytecode argument; the EIP-2780 first-frame runtime charges move out of frame entry into `prepare_initial_frame` on the handler side. Also checks the call-depth limit alongside the EIP-8037 endowment/nonce pre-checks before reading the destination in `CREATE`/`CREATE2` — a too-deep create previously read (and charged) the destination, leaking it into the EIP-7928 block access list and warm set. Mirrored in the JIT builtin; regression test asserts the read is skipped.
- **refactor(create): build the create Message at its execute_message call site** — replaces `MessageExt::derive_destination`/`init_code_hash_slow` with a standalone `derive_create_destination` so the created address can be derived before the message exists; the interpreter create opcode and the JIT create builtin construct the fully-populated `Message` right before `execute_message`, dropping the placeholder fields and the mutate-after-build dance.
- **refactor(gas): rename the regular gas dimension to execution gas** — across `GasTracker`, the transaction handlers, block gas accounting, and docs (`TxResult::regular_gas_spent` → `execution_gas_spent`). No functional change.

## Testing

- Head tree is identical to the pre-split `glam-devnet-7` head (`git diff` is empty), which passed the full devnet v7.2.0 suites.
- Each intermediate commit builds, passes `cargo fmt --check`, and the unit/ee-test suite.
