### PR TITLE
fix(eest): validate parent block hashes

### DIFF
--- a/crates/eest/src/blockchaintest/error.rs
+++ b/crates/eest/src/blockchaintest/error.rs
@@ -72,6 +72,14 @@ pub(crate) enum TestErrorKind {
         /// Gas used computed from executing the block's transactions.
         actual: u64,
     },
+    /// Block header does not link to the previously accepted block.
+    #[error("parent block hash mismatch: header {got}, expected {expected}")]
+    ParentBlockHashMismatch {
+        /// Parent hash declared in the block header.
+        got: alloy_primitives::B256,
+        /// Hash of the previously accepted block.
+        expected: alloy_primitives::B256,
+    },
     /// Recomputed post-block state root does not match the block header.
     #[error("state root mismatch: got {got}, expected {expected}")]
     StateRootMismatch {

--- a/crates/eest/src/blockchaintest/execute.rs
+++ b/crates/eest/src/blockchaintest/execute.rs
@@ -402,6 +402,20 @@ fn execute_block(
     }
 
     let result = (|| -> Result<BlockResolution, TestError> {
+        if let Some(header) = block_header(block)
+            && let Some(expected) = *parent_block_hash
+            && header.parent_hash != expected
+        {
+            if should_fail {
+                return Ok(BlockResolution::Discard);
+            }
+            return Err(TestError::case(
+                path,
+                name,
+                TestErrorKind::ParentBlockHashMismatch { got: header.parent_hash, expected },
+            ));
+        }
+
         if let Err(err) = pre_block_system_calls(
             &mut evm,
             &mut block_state,
@@ -1339,6 +1353,117 @@ mod tests {
         .unwrap_err();
 
         assert!(matches!(error.kind, super::TestErrorKind::ReceiptRootMismatch { .. }));
+    }
+
+    #[test]
+    fn rejects_block_with_wrong_parent_hash() {
+        use super::{
+            super::types::{
+                Block, BlockHeader, BlockchainTest, BlockchainTestCase, ForkSpec, SealEngine, State,
+            },
+            ExecuteConfig, NoopHook, execute_str,
+        };
+        use crate::filter::NameFilter;
+        use alloy_primitives::{B256, U256};
+        use std::{collections::BTreeMap, path::Path};
+
+        let genesis_hash = B256::with_last_byte(1);
+        let block_hash = B256::with_last_byte(2);
+        let suite = BlockchainTest(BTreeMap::from([(
+            "wrong-parent-hash".to_string(),
+            BlockchainTestCase {
+                genesis_block_header: BlockHeader {
+                    hash: genesis_hash,
+                    gas_limit: U256::from(30_000_000),
+                    ..Default::default()
+                },
+                blocks: vec![Block {
+                    block_header: Some(BlockHeader {
+                        parent_hash: B256::with_last_byte(3),
+                        hash: block_hash,
+                        number: U256::ONE,
+                        gas_limit: U256::from(30_000_000),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                }],
+                post_state: None,
+                pre: State(BTreeMap::new()),
+                block_hashes: Vec::new(),
+                lastblockhash: block_hash,
+                network: ForkSpec::Cancun,
+                seal_engine: SealEngine::NoProof,
+                genesis_rlp: None,
+            },
+        )]));
+        let input = serde_json::to_string(&suite).unwrap();
+        let error = execute_str(
+            Path::new("wrong-parent-hash.json"),
+            &input,
+            ExecuteConfig::default(),
+            &NameFilter::default(),
+            &mut NoopHook,
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            error.kind,
+            super::TestErrorKind::ParentBlockHashMismatch { got, expected }
+                if got == B256::with_last_byte(3) && expected == genesis_hash
+        ));
+    }
+
+    #[test]
+    fn discards_expected_block_with_wrong_parent_hash() {
+        use super::{
+            super::types::{
+                Block, BlockHeader, BlockchainTest, BlockchainTestCase, ForkSpec, SealEngine, State,
+            },
+            ExecuteConfig, NoopHook, execute_str,
+        };
+        use crate::filter::NameFilter;
+        use alloy_primitives::{B256, U256};
+        use std::{collections::BTreeMap, path::Path};
+
+        let genesis_hash = B256::with_last_byte(1);
+        let suite = BlockchainTest(BTreeMap::from([(
+            "expected-wrong-parent-hash".to_string(),
+            BlockchainTestCase {
+                genesis_block_header: BlockHeader {
+                    hash: genesis_hash,
+                    gas_limit: U256::from(30_000_000),
+                    ..Default::default()
+                },
+                blocks: vec![Block {
+                    block_header: Some(BlockHeader {
+                        parent_hash: B256::with_last_byte(3),
+                        hash: B256::with_last_byte(2),
+                        number: U256::ONE,
+                        gas_limit: U256::from(30_000_000),
+                        ..Default::default()
+                    }),
+                    expect_exception: Some("invalid parent hash".to_string()),
+                    ..Default::default()
+                }],
+                post_state: None,
+                pre: State(BTreeMap::new()),
+                block_hashes: Vec::new(),
+                lastblockhash: genesis_hash,
+                network: ForkSpec::Cancun,
+                seal_engine: SealEngine::NoProof,
+                genesis_rlp: None,
+            },
+        )]));
+        let input = serde_json::to_string(&suite).unwrap();
+
+        execute_str(
+            Path::new("expected-wrong-parent-hash.json"),
+            &input,
+            ExecuteConfig::default(),
+            &NameFilter::default(),
+            &mut NoopHook,
+        )
+        .unwrap();
     }
 
     #[cfg(feature = "jit")]


### PR DESCRIPTION
## Summary
- reject blockchain-test headers whose parent hash does not match the accepted chain tip
- treat the mismatch as a discarded block when the fixture expects an exception
- add regression coverage for both paths

## Testing
- `cargo +nightly fmt --all -- --check`
- `cargo test -p evm2-eest parent_hash` *(blocked: sandbox Git credentials return 401 for the pinned `DaniPopes/algebra` dependency)*

Prompted by: @rakita