### PR TITLE
fix(jit): split gas sections at cold loads

### DIFF
--- a/crates/jit/codegen/src/bytecode/mod.rs
+++ b/crates/jit/codegen/src/bytecode/mod.rs
@@ -1094,26 +1094,27 @@ impl InstData {
     /// Returns `true` if this instruction requires to know `gasleft()`.
     #[inline]
     pub(crate) const fn requires_gasleft(&self, spec_id: SpecId) -> bool {
-        matches!(
-            self.opcode,
-            op::GAS
-                | op::CREATE
-                | op::CALL
-                | op::CALLCODE
-                | op::DELEGATECALL
-                | op::CREATE2
-                | op::STATICCALL
-        ) || (spec_id.enables(SpecId::ISTANBUL) && self.opcode == op::SSTORE)
-            || (spec_id.enables(SpecId::BERLIN)
-                && matches!(
-                    self.opcode,
-                    op::BALANCE
-                        | op::EXTCODESIZE
-                        | op::EXTCODECOPY
-                        | op::EXTCODEHASH
-                        | op::SLOAD
-                        | op::SELFDESTRUCT
-                ))
+        match self.opcode {
+            // GAS pushes the remaining gas after paying its own base cost.
+            op::GAS => true,
+            // Calls and contract creation cap the gas forwarded based on the remaining gas.
+            op::CREATE
+            | op::CALL
+            | op::CALLCODE
+            | op::DELEGATECALL
+            | op::CREATE2
+            | op::STATICCALL => true,
+            // EIP-2200 rejects SSTORE when the remaining gas is at most the call stipend.
+            op::SSTORE => spec_id.enables(SpecId::ISTANBUL),
+            // EIP-2929 skips cold host loads when the remaining gas cannot cover their cost.
+            op::BALANCE
+            | op::EXTCODESIZE
+            | op::EXTCODECOPY
+            | op::EXTCODEHASH
+            | op::SLOAD
+            | op::SELFDESTRUCT => spec_id.enables(SpecId::BERLIN),
+            _ => false,
+        }
     }
 
     /// Returns `true` if execution can fall through to the next sequential instruction.

--- a/crates/jit/codegen/src/bytecode/mod.rs
+++ b/crates/jit/codegen/src/bytecode/mod.rs
@@ -1103,7 +1103,17 @@ impl InstData {
                 | op::DELEGATECALL
                 | op::CREATE2
                 | op::STATICCALL
-        ) || (self.opcode == op::SSTORE && spec_id.enables(SpecId::ISTANBUL))
+        ) || (spec_id.enables(SpecId::ISTANBUL) && self.opcode == op::SSTORE)
+            || (spec_id.enables(SpecId::BERLIN)
+                && matches!(
+                    self.opcode,
+                    op::BALANCE
+                        | op::EXTCODESIZE
+                        | op::EXTCODECOPY
+                        | op::EXTCODEHASH
+                        | op::SLOAD
+                        | op::SELFDESTRUCT
+                ))
     }
 
     /// Returns `true` if execution can fall through to the next sequential instruction.

--- a/crates/jit/codegen/src/bytecode/passes/sections.rs
+++ b/crates/jit/codegen/src/bytecode/passes/sections.rs
@@ -348,6 +348,28 @@ mod tests {
         assert!(after_call.is_stack_section_head());
     }
 
+    #[test]
+    fn cold_load_requires_gasleft_ends_section() {
+        let cases = [
+            ("PUSH0 BALANCE PUSH0 STOP", op::BALANCE),
+            ("PUSH0 EXTCODESIZE PUSH0 STOP", op::EXTCODESIZE),
+            ("PUSH0 PUSH0 PUSH0 PUSH0 EXTCODECOPY PUSH0 STOP", op::EXTCODECOPY),
+            ("PUSH0 EXTCODEHASH PUSH0 STOP", op::EXTCODEHASH),
+            ("PUSH0 SLOAD PUSH0 STOP", op::SLOAD),
+        ];
+
+        for (src, opcode) in cases {
+            let bytecode = analyze_asm_spec(src, SpecId::AMSTERDAM);
+            let (inst, data) =
+                bytecode.iter_insts().find(|(_, data)| data.opcode == opcode).unwrap();
+            assert!(data.requires_gasleft(SpecId::AMSTERDAM));
+
+            let after = bytecode.inst(inst + 1);
+            assert!(after.is_stack_section_head());
+            assert_eq!(after.gas_section.gas_cost, 2);
+        }
+    }
+
     /// Disabled opcodes must not contribute stack I/O or gas to the preceding section.
     /// Otherwise the section-head underflow check fires before the disabled opcode's
     /// `NotActivated` guard, producing a divergent `StackUnderflow`.


### PR DESCRIPTION
The JIT precharges the static gas for each section, but Berlin cold-access builtins inspect the remaining gas to decide whether to skip a host read. Static gas from later instructions could therefore make the JIT skip a read that the interpreter performs, which caused EIP-7928 block access list and database-error visibility differences.

End gas and stack sections after each cold account or storage access. This keeps the opcode's own base charge before the host call while deferring later instructions until after it. Add regression coverage for `SLOAD`, `BALANCE`, and the `EXTCODE*` opcodes.

Addresses CYCLOPS-620.
