### PR TITLE
chore(evm): remove journal-dirtying Evm::account_code

### DIFF
--- a/crates/eest/src/blockchaintest/execute.rs
+++ b/crates/eest/src/blockchaintest/execute.rs
@@ -885,8 +885,8 @@ fn run_system_call(
     let executed = evm.system_call(SystemTx::new(address, data))?;
     if !executed.result().status {
         let _ = executed.discard();
-        let has_code = match evm.account_code(&address) {
-            Ok(code) => !code.is_empty(),
+        let has_code = match evm.read_account_info(&address) {
+            Ok(info) => info.is_some_and(|info| info.code_hash != KECCAK256_EMPTY),
             Err(code) => return Err(database_error(evm, code)),
         };
         if has_code {

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -628,12 +628,6 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
         self.state.account_info_untracked(address)
     }
 
-    /// Returns account bytecode visible through the accepted state overlay.
-    #[inline]
-    pub fn account_code(&mut self, address: &Address) -> DbResult<Bytecode> {
-        self.state.account(address, false)?.load_code()
-    }
-
     /// Applies borrowed changes to the accepted state overlay.
     #[inline]
     pub fn commit_source<S: StateChangeSource>(&mut self, source: &S) {


### PR DESCRIPTION
## Summary

`Evm::account_code` went through `state.account(address, false)` and therefore loaded the account into the transaction overlay/journal as a side effect. This removes the function.

Its only caller — the EEST `run_system_call` failure check — only needs to know whether the system contract has code, so it now peeks via `Evm::read_account_info` (backed by `account_info_untracked`, a non-loading read) and compares `code_hash` against `KECCAK256_EMPTY`, avoiding both the journal contamination and materializing the bytecode.

Part of CYCLOPS-621.

## Testing

- `cargo cl` clean, all 2838 default `cargo nextest run` tests pass.
- Full EEST fixture suite (`--no-fail-fast`) run with and without the change: failing-test sets are byte-for-byte identical (all pre-existing on the clean tree), so no regressions.