### PR TITLE
fix(amsterdam): BPO2 blob base fee update fraction

### DIFF
--- a/crates/eest/src/execute.rs
+++ b/crates/eest/src/execute.rs
@@ -562,8 +562,14 @@ fn parse_block(env: &Env, spec: SpecId) -> BlockEnv {
 fn blob_basefee(excess_blob_gas: U256, spec: SpecId) -> u128 {
     let excess_blob_gas = excess_blob_gas.saturating_to::<u64>();
     // EIP-4844 defines blob base fee with fake exponential; EIP-7691 changes the
-    // update fraction from Prague.
-    if spec.enables(SpecId::PRAGUE) {
+    // update fraction from Prague, and the Amsterdam (BPO2) blob schedule changes it again.
+    if spec.enables(SpecId::AMSTERDAM) {
+        eip4844::fake_exponential(
+            eip4844::BLOB_TX_MIN_BLOB_GASPRICE,
+            excess_blob_gas as u128,
+            evm2::constants::BLOB_BASE_FEE_UPDATE_FRACTION_AMSTERDAM as u128,
+        )
+    } else if spec.enables(SpecId::PRAGUE) {
         eip7691::calc_blob_gasprice(excess_blob_gas)
     } else {
         eip4844::fake_exponential(

--- a/crates/evm2/src/constants.rs
+++ b/crates/evm2/src/constants.rs
@@ -27,6 +27,9 @@ pub const BLOB_BASE_FEE_UPDATE_FRACTION_CANCUN: u64 = 3_338_477;
 /// Prague blob base fee update fraction.
 pub const BLOB_BASE_FEE_UPDATE_FRACTION_PRAGUE: u64 = 5_007_716;
 
+/// Amsterdam blob base fee update fraction (BPO2 blob schedule).
+pub const BLOB_BASE_FEE_UPDATE_FRACTION_AMSTERDAM: u64 = 11_684_671;
+
 /// Maximum message call depth.
 pub const CALL_DEPTH_LIMIT: u16 = 1024;
 

--- a/crates/evm2/src/version/mod.rs
+++ b/crates/evm2/src/version/mod.rs
@@ -3,7 +3,8 @@
 use crate::{
     EvmConfig, EvmTypesHost, SpecId,
     constants::{
-        BLOB_BASE_FEE_UPDATE_FRACTION_CANCUN, BLOB_BASE_FEE_UPDATE_FRACTION_PRAGUE, MAX_CODE_SIZE,
+        BLOB_BASE_FEE_UPDATE_FRACTION_AMSTERDAM, BLOB_BASE_FEE_UPDATE_FRACTION_CANCUN,
+        BLOB_BASE_FEE_UPDATE_FRACTION_PRAGUE, MAX_CODE_SIZE,
         MAX_CODE_SIZE_AMSTERDAM, MAX_INITCODE_SIZE, MAX_INITCODE_SIZE_AMSTERDAM,
     },
     interpreter::{instructions as instr, op},
@@ -95,7 +96,9 @@ const fn base_max_blobs_per_tx(spec_id: SpecId) -> usize {
 }
 
 const fn base_blob_base_fee_update_fraction(spec_id: SpecId) -> u64 {
-    if spec_id.enables(SpecId::PRAGUE) {
+    if spec_id.enables(SpecId::AMSTERDAM) {
+        BLOB_BASE_FEE_UPDATE_FRACTION_AMSTERDAM
+    } else if spec_id.enables(SpecId::PRAGUE) {
         BLOB_BASE_FEE_UPDATE_FRACTION_PRAGUE
     } else {
         BLOB_BASE_FEE_UPDATE_FRACTION_CANCUN
@@ -291,7 +294,7 @@ mod tests {
         assert_eq!(amsterdam.max_code_size, MAX_CODE_SIZE_AMSTERDAM);
         assert_eq!(amsterdam.max_initcode_size, MAX_INITCODE_SIZE_AMSTERDAM);
         assert_eq!(amsterdam.max_blobs_per_tx, MAX_BLOBS_PER_BLOCK_DENCUN);
-        assert_eq!(amsterdam.blob_base_fee_update_fraction, BLOB_BASE_FEE_UPDATE_FRACTION_PRAGUE);
+        assert_eq!(amsterdam.blob_base_fee_update_fraction, BLOB_BASE_FEE_UPDATE_FRACTION_AMSTERDAM);
 
         let cancun = Version::base(SpecId::CANCUN);
         assert_eq!(cancun.max_blobs_per_tx, MAX_BLOBS_PER_BLOCK_DENCUN);

--- a/crates/evm2/src/version/mod.rs
+++ b/crates/evm2/src/version/mod.rs
@@ -4,8 +4,8 @@ use crate::{
     EvmConfig, EvmTypesHost, SpecId,
     constants::{
         BLOB_BASE_FEE_UPDATE_FRACTION_AMSTERDAM, BLOB_BASE_FEE_UPDATE_FRACTION_CANCUN,
-        BLOB_BASE_FEE_UPDATE_FRACTION_PRAGUE, MAX_CODE_SIZE,
-        MAX_CODE_SIZE_AMSTERDAM, MAX_INITCODE_SIZE, MAX_INITCODE_SIZE_AMSTERDAM,
+        BLOB_BASE_FEE_UPDATE_FRACTION_PRAGUE, MAX_CODE_SIZE, MAX_CODE_SIZE_AMSTERDAM,
+        MAX_INITCODE_SIZE, MAX_INITCODE_SIZE_AMSTERDAM,
     },
     interpreter::{instructions as instr, op},
 };
@@ -294,7 +294,10 @@ mod tests {
         assert_eq!(amsterdam.max_code_size, MAX_CODE_SIZE_AMSTERDAM);
         assert_eq!(amsterdam.max_initcode_size, MAX_INITCODE_SIZE_AMSTERDAM);
         assert_eq!(amsterdam.max_blobs_per_tx, MAX_BLOBS_PER_BLOCK_DENCUN);
-        assert_eq!(amsterdam.blob_base_fee_update_fraction, BLOB_BASE_FEE_UPDATE_FRACTION_AMSTERDAM);
+        assert_eq!(
+            amsterdam.blob_base_fee_update_fraction,
+            BLOB_BASE_FEE_UPDATE_FRACTION_AMSTERDAM
+        );
 
         let cancun = Version::base(SpecId::CANCUN);
         assert_eq!(cancun.max_blobs_per_tx, MAX_BLOBS_PER_BLOCK_DENCUN);


### PR DESCRIPTION
Ref: CYCLOPS-633

## Summary
- Add `BLOB_BASE_FEE_UPDATE_FRACTION_AMSTERDAM = 11_684_671` — Amsterdam inherits the BPO2 blob schedule's update fraction per execution-specs (BPO2 through Amsterdam use 11684671; Osaka stays on the Prague value 5007716).
- `base_blob_base_fee_update_fraction` now returns the Amsterdam value for `SpecId::AMSTERDAM`, falling through to Prague/Cancun as before.
- EEST harness `blob_basefee` computes the Amsterdam blob base fee with the new fraction (alloy-eips has no Amsterdam helper, so it calls `eip4844::fake_exponential` directly).

## Testing
- `cargo cl` clean; `evm2` version tests pass (Amsterdam assertion updated).
- Devnet v7.2.0 EEST blob suite: all 268 tests pass with this change.