### PR TITLE
fix(jit): propagate fatal child stops

### DIFF
--- a/crates/jit/builtins/src/lib.rs
+++ b/crates/jit/builtins/src/lib.rs
@@ -724,6 +724,9 @@ pub unsafe extern "C" fn __revmc_builtin_create(
     let bytecode = Bytecode::new_legacy(message.input.clone());
     let tx_env = ecx.tx_env();
     let mut result = ecx.host().execute_message(tx_env, bytecode, &mut message);
+    if result.stop.is_fatal() {
+        return Err(result.stop.into());
+    }
     ecx.gas.merge_child_gas(result.gas, result.stop);
     // EIP-8037 (ethereum/EIPs#11858): refund the conditional create state gas when the create fails
     // to deploy (no new account leaf is created).
@@ -829,6 +832,9 @@ pub unsafe extern "C" fn __revmc_builtin_call(
 
     let tx_env = ecx.tx_env();
     let mut result = ecx.host().execute_message(tx_env, loaded_code, &mut message);
+    if result.stop.is_fatal() {
+        return Err(result.stop.into());
+    }
     ecx.gas.merge_child_gas(result.gas, result.stop);
     if new_account_state_gas != 0 && !result.stop.is_success() {
         ecx.gas.refill_reservoir(new_account_state_gas);


### PR DESCRIPTION
## Summary

Propagate fatal child stops from the JIT `CALL` and `CREATE` builtins instead of converting them into recoverable EVM failures. This mirrors the interpreter path and prevents JIT/interpreter execution divergence.

Fixes [CYCLOPS-652](https://linear.app/tempoxyz/issue/CYCLOPS-652/cyclops-cyclops-ripple-effect-audit-evm2-8347f63-iteration-27).

## Testing

- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `cargo test -p evm2-jit-builtins` *(blocked before compilation: Cargo could not fetch the pinned `DaniPopes/algebra` revision; GitHub returned HTTP 401 through the sandbox proxy)*

Prompted by: @rakita