### PR TITLE
fix(state): clear selfdestructs on transaction commit

### DIFF
--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -3745,6 +3745,24 @@ mod tests {
     }
 
     #[test]
+    fn commit_transaction_clears_detached_selfdestructs() {
+        let contract = Address::from([0x44; 20]);
+        let code = Bytecode::new_legacy(Bytes::from_static(&[op::STOP]));
+        let mut database = InMemoryDB::default();
+        database.insert_account_info(&contract, AccountInfo::default().with_code(code));
+        let mut state = State::new(database);
+
+        state.account(&contract, false).unwrap().mark_destructed();
+        state.finalize_transaction_(Version::base(SpecId::AMSTERDAM));
+        let pending = state.take_pending_state();
+
+        state.set_pending_state(pending);
+        state.commit_transaction();
+
+        assert!(!state.account(&contract, false).unwrap().is_destructed());
+    }
+
+    #[test]
     fn eip8246_selfdestruct_zero_balance_is_deleted() {
         let contract = Address::from([0x22; 20]);
         let code = Bytecode::new_legacy(Bytes::from_static(&[op::STOP]));

--- a/crates/evm2/src/evm/state/mod.rs
+++ b/crates/evm2/src/evm/state/mod.rs
@@ -826,13 +826,14 @@ impl<'a> State<'a> {
     /// Accepts the current transaction's state transition into the accepted overlay.
     ///
     /// This advances the in-memory accepted overlay by the transaction's write-set and clears the
-    /// transaction account/storage layers. It does not take logs or write to the wrapped backing
-    /// database.
+    /// transaction account/storage layers and selfdestruct markers. It does not take logs or write
+    /// to the wrapped backing database.
     pub fn commit_transaction(&mut self) {
         // The transaction overlay is folded into the accepted-overlay database directly, without
         // detaching it.
         self.inner.database.commit(&self.accounts, &self.storage);
         self.accounts.clear();
         self.storage.clear();
+        self.inner.selfdestructs.clear();
     }
 }


### PR DESCRIPTION
Clears the transaction-scoped SELFDESTRUCT set when accepting a reattached pending state through `State::commit_transaction`. Without this, the documented `detach` -> `set_pending_state` -> `commit_transaction` flow leaves stale markers installed and later transactions can repeat account deletion and storage wipes.

Adds a regression test covering the detached-state acceptance path.

Tests: `cargo +nightly fmt --all -- --check`; focused `cargo test` could not start because the environment could not fetch the pinned `DaniPopes/algebra` git revision (HTTP 401).

Prompted by: @rakita