### PR TITLE
chore(evm): destructure Self in clear_transaction_state

### DIFF
--- a/crates/evm2/src/evm/state/mod.rs
+++ b/crates/evm2/src/evm/state/mod.rs
@@ -329,13 +329,19 @@ impl<'a> State<'a> {
 
     /// Clears transaction-scoped substate.
     pub fn clear_transaction_state(&mut self) {
-        self.accounts.clear();
-        self.prewarm_set.clear();
-        self.storage.clear();
-        self.journal.clear();
-        self.selfdestructs.clear();
-        self.transient_storage.clear();
-        self.logs.clear();
+        let Self {
+            accounts,
+            storage,
+            transient_storage,
+            inner: StateInner { prewarm_set, journal, selfdestructs, logs, database: _ },
+        } = self;
+        accounts.clear();
+        storage.clear();
+        transient_storage.clear();
+        prewarm_set.clear();
+        journal.clear();
+        selfdestructs.clear();
+        logs.clear();
     }
 
     /// Ensures the account is present in the transaction overlay, loading it from the backing


### PR DESCRIPTION
Destructures `Self` (including `StateInner`) in `clear_transaction_state` so adding a new field becomes a compile error at this site, preventing transaction-scoped substate from being silently left uncleared.

This is just a more direct cleanup — no behavior change.