### PR TITLE
fix(eest): validate final blockchain test hash

### DIFF
--- a/crates/eest/src/blockchaintest/error.rs
+++ b/crates/eest/src/blockchaintest/error.rs
@@ -88,6 +88,14 @@ pub(crate) enum TestErrorKind {
         /// Hash of the previously accepted block.
         expected: alloy_primitives::B256,
     },
+    /// Final accepted block hash does not match the fixture's last block hash.
+    #[error("last block hash mismatch: got {got}, expected {expected}")]
+    LastBlockHashMismatch {
+        /// Hash of the final accepted block.
+        got: alloy_primitives::B256,
+        /// Last block hash declared by the fixture.
+        expected: alloy_primitives::B256,
+    },
     /// Recomputed post-block state root does not match the block header.
     #[error("state root mismatch: got {got}, expected {expected}")]
     StateRootMismatch {

--- a/crates/eest/src/blockchaintest/execute.rs
+++ b/crates/eest/src/blockchaintest/execute.rs
@@ -294,6 +294,18 @@ fn execute_case(
         }
     }
 
+    let final_block_hash = parent_block_hash.expect("genesis block hash should be available");
+    if final_block_hash != test_case.lastblockhash {
+        return Err(TestError::case(
+            path,
+            name,
+            TestErrorKind::LastBlockHashMismatch {
+                got: final_block_hash,
+                expected: test_case.lastblockhash,
+            },
+        ));
+    }
+
     if config.validate_post_state
         && let Some(expected) = &test_case.post_state
     {
@@ -1592,6 +1604,64 @@ mod tests {
             &mut NoopHook,
         )
         .unwrap();
+    }
+
+    #[test]
+    fn rejects_case_with_wrong_last_block_hash() {
+        use super::{
+            super::types::{
+                Block, BlockHeader, BlockchainTest, BlockchainTestCase, ForkSpec, SealEngine, State,
+            },
+            ExecuteConfig, NoopHook, execute_str,
+        };
+        use crate::filter::NameFilter;
+        use alloy_primitives::{B256, U256};
+        use std::{collections::BTreeMap, path::Path};
+
+        let genesis_hash = B256::with_last_byte(1);
+        let block_hash = B256::with_last_byte(2);
+        let suite = BlockchainTest(BTreeMap::from([(
+            "wrong-last-block-hash".to_string(),
+            BlockchainTestCase {
+                genesis_block_header: BlockHeader {
+                    hash: genesis_hash,
+                    gas_limit: U256::from(30_000_000),
+                    ..Default::default()
+                },
+                blocks: vec![Block {
+                    block_header: Some(BlockHeader {
+                        parent_hash: genesis_hash,
+                        hash: block_hash,
+                        number: U256::ONE,
+                        gas_limit: U256::from(30_000_000),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                }],
+                post_state: None,
+                pre: State(BTreeMap::new()),
+                block_hashes: Vec::new(),
+                lastblockhash: genesis_hash,
+                network: ForkSpec::Cancun,
+                seal_engine: SealEngine::NoProof,
+                genesis_rlp: None,
+            },
+        )]));
+        let input = serde_json::to_string(&suite).unwrap();
+        let error = execute_str(
+            Path::new("wrong-last-block-hash.json"),
+            &input,
+            ExecuteConfig::default(),
+            &NameFilter::default(),
+            &mut NoopHook,
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            error.kind,
+            super::TestErrorKind::LastBlockHashMismatch { got, expected }
+                if got == block_hash && expected == genesis_hash
+        ));
     }
 
     #[cfg(feature = "jit")]


### PR DESCRIPTION
Summary:

- Validate the final accepted blockchain-test block hash against the fixture lastblockhash.

- Add a regression test for mismatched final-tip commitments.

Tests: `cargo +nightly fmt --all -- --check` and `cargo metadata --no-deps --format-version 1` pass. The targeted test could not start because the pinned DaniPopes/algebra revision is unavailable locally and GitHub dependency fetch returns HTTP 401.
Prompted by: @rakita