### PR TITLE
fix(build): select the wasm dispatch backend before the toolchain

### DIFF
--- a/crates/evm2/build.rs
+++ b/crates/evm2/build.rs
@@ -52,10 +52,10 @@ impl DispatchBackend {
     fn resolve(self, is_wasm: bool, target_pointer_width: Option<u32>, no_tco: bool) -> Self {
         match self {
             Self::Auto => {
-                if !no_tco && rustc_is_nightly() {
-                    Self::Tco
-                } else if is_wasm {
+                if is_wasm {
                     Self::SingleReturn
+                } else if !no_tco && rustc_is_nightly() {
+                    Self::Tco
                 } else if target_pointer_width == Some(64) {
                     Self::Packed
                 } else {


### PR DESCRIPTION
`DispatchBackend::resolve` tested the toolchain before the target, so a wasm build on nightly selected the TCO backend instead of the `single_return` backend provided for wasm. Testing `is_wasm` first fixes it, and `EVM2_DISPATCH_BACKEND=tco` still opts in explicitly.
