### PR TITLE
fix(jit): allow deprecated index macro expansion

### DIFF
--- a/crates/jit/codegen/src/bytecode/interner.rs
+++ b/crates/jit/codegen/src/bytecode/interner.rs
@@ -67,6 +67,8 @@ impl<I: Idx, T: std::fmt::Debug, S> std::fmt::Debug for Interner<I, T, S> {
 
 #[cfg(test)]
 mod tests {
+    #![allow(deprecated)]
+
     use super::*;
 
     oxc_index::define_index_type! {


### PR DESCRIPTION
## Summary

- allow the test-only `oxc_index` macro expansion to use its deprecated `u32::max_value` implementation
- restore nightly clippy under `-D warnings`

## Validation

- `cargo +nightly fmt --all -- --check`
- `cargo +nightly clippy -p evm2-jit-codegen --all-targets --all-features -- -D warnings`

Prompted by: @DaniPopes