### PR TITLE
chore(deps): use crates.io mcl_rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,7 +141,7 @@ bn = { package = "substrate-bn", version = "0.6", default-features = false }
 c-kzg = { version = "2.1.7", default-features = false }
 gmp-mpfr-sys = { version = "1.6", default-features = false }
 k256 = { version = "0.14", default-features = false }
-mcl_rust = { version = "1.2.0", default-features = false, git = "https://github.com/herumi/mcl-rust", rev = "v1.2.0" }
+mcl_rust = { version = "1.2.0", default-features = false }
 p256 = { version = "0.14.0", default-features = false }
 ripemd = { version = "0.2.0", default-features = false }
 secp256k1 = { version = "0.31.1", default-features = false }


### PR DESCRIPTION
## Summary

- Replace the `mcl_rust` Git revision with the crates.io `1.2.0` release.

## Testing

- `cargo +nightly fmt --all -- --check`
- `cargo check -p evm2 --no-default-features --features std,bn254-mcl`

Prompted by: @DaniPopes