### PR TITLE
refactor(message): carry bytecode in Message

### DIFF
--- a/crates/evm2/examples/custom_evm/tx.rs
+++ b/crates/evm2/examples/custom_evm/tx.rs
@@ -55,13 +55,13 @@ pub fn execute_code(
     let mut message = MessageExt {
         gas_limit: req.tx.gas_limit,
         destination: req.tx.target,
+        code: Bytecode::new_legacy(req.tx.code.clone()),
         code_address: req.tx.target,
         ext: CustomMessageExt { is_system: false },
         ..MessageExt::default()
     };
     let tx_env = TxEnvExt { ext: CustomTxEnvExt { label: "execute-code" }, ..TxEnvExt::default() };
-    let mut result =
-        req.host.execute_message(&tx_env, Bytecode::new_legacy(req.tx.code.clone()), &mut message);
+    let mut result = req.host.execute_message(&tx_env, &mut message);
     result.ext = CustomMessageResultExt { handled_custom_message: true };
     Ok(evm2::TxResult::<CustomTypes> {
         status: result.stop.is_success(),

--- a/crates/evm2/examples/precompile_subcall.rs
+++ b/crates/evm2/examples/precompile_subcall.rs
@@ -17,16 +17,16 @@ const SUBCALL_TARGET: Address = Address::with_last_byte(0xca);
 
 fn main() {
     let mut evm = evm_with_custom_precompile();
-    let parent_code = Bytecode::new_legacy(parent_code());
     let mut message = MessageExt {
         kind: MessageKind::Call,
         gas_limit: 200_000,
         destination: PARENT,
+        code: Bytecode::new_legacy(parent_code()),
         code_address: PARENT,
         ..MessageExt::default()
     };
 
-    let result = Host::execute_message(&mut evm, &TxEnvExt::default(), parent_code, &mut message);
+    let result = Host::execute_message(&mut evm, &TxEnvExt::default(), &mut message);
     assert_eq!(result.stop, InstrStop::Return);
     assert_eq!(result.output.len(), 32);
 
@@ -77,13 +77,14 @@ fn staticcall_precompile(
         caller: message.destination,
         input: message.input.clone(),
         value: U256::ZERO,
+        code: loaded.code,
         code_address: SUBCALL_TARGET,
         caller_is_static: message.caller_is_static
             || matches!(message.kind, MessageKind::StaticCall),
         ..MessageExt::default()
     };
 
-    let result = Host::execute_message(evm, &TxEnvExt::default(), loaded.code, &mut child);
+    let result = Host::execute_message(evm, &TxEnvExt::default(), &mut child);
     gas.merge_child_gas(result.gas, result.stop);
 
     match result.stop {

--- a/crates/evm2/src/ethereum/eip1559.rs
+++ b/crates/evm2/src/ethereum/eip1559.rs
@@ -1,10 +1,9 @@
 use super::{
-    access_list_counts, effective_gas_price, execute_initial_frame, floor_gas,
-    initial_gas_and_reservoir, intrinsic_gas, prepare_initial_frame, validate_block_gas_limit,
-    validate_chain_id, validate_create_initcode, validate_floor_gas, validate_gas_price,
-    validate_intrinsic_gas, validate_nonce_not_overflow, validate_priority_fee,
-    validate_regular_gas_limit_cap, validate_sender, validate_tx_gas_limit_cap, warm_access_list,
-    warm_base_accounts,
+    access_list_counts, effective_gas_price, floor_gas, initial_gas_and_reservoir, initial_message,
+    intrinsic_gas, validate_block_gas_limit, validate_chain_id, validate_create_initcode,
+    validate_floor_gas, validate_gas_price, validate_intrinsic_gas, validate_nonce_not_overflow,
+    validate_priority_fee, validate_regular_gas_limit_cap, validate_sender,
+    validate_tx_gas_limit_cap, warm_access_list, warm_base_accounts,
 };
 use crate::{
     EvmTypes, TxResult,
@@ -13,7 +12,7 @@ use crate::{
         error_handler,
         handler::{DefaultTxHandlerHooks, GasSettlement, TxHandlerHooks},
     },
-    interpreter::GasTracker,
+    interpreter::Host,
     registry::{HandlerResult, TxRequest},
 };
 use alloy_consensus::TxEip1559;
@@ -86,10 +85,12 @@ pub fn handle_with_hooks<T: EvmTypes, H: TxHandlerHooks<T>>(
         chain_id: U256::from(req.host.version().chain_id),
         ..TxEnvExt::default()
     };
-    let mut tx_gas = GasTracker::new_with_regular_gas_and_reservoir(gas_limit, reservoir);
-    let frame =
-        prepare_initial_frame(req.host, caller, tx.nonce, tx.to, &tx.input, tx.value, &mut tx_gas)?;
-    let result = execute_initial_frame(req.host, &tx_env, frame, &mut tx_gas, gas_limit, reservoir);
+    let mut message = initial_message(
+        req.host, caller, tx.nonce, tx.to, &tx.input, tx.value, gas_limit, reservoir,
+    )?;
+    // Failed execution has already been rolled back to the message's own checkpoint (and halt gas
+    // zeroed) inside `execute_message`, so the result settles directly.
+    let result = req.host.execute_message(&tx_env, &mut message);
     H::settle_transaction(
         req.host,
         req.envelope,

--- a/crates/evm2/src/ethereum/eip1559.rs
+++ b/crates/evm2/src/ethereum/eip1559.rs
@@ -1,9 +1,10 @@
 use super::{
-    access_list_counts, effective_gas_price, floor_gas, initial_gas_and_reservoir, initial_message,
-    intrinsic_gas, validate_block_gas_limit, validate_chain_id, validate_create_initcode,
-    validate_floor_gas, validate_gas_price, validate_intrinsic_gas, validate_nonce_not_overflow,
-    validate_priority_fee, validate_regular_gas_limit_cap, validate_sender,
-    validate_tx_gas_limit_cap, warm_access_list, warm_base_accounts,
+    access_list_counts, effective_gas_price, execute_initial_frame, floor_gas,
+    initial_gas_and_reservoir, intrinsic_gas, prepare_initial_frame, validate_block_gas_limit,
+    validate_chain_id, validate_create_initcode, validate_floor_gas, validate_gas_price,
+    validate_intrinsic_gas, validate_nonce_not_overflow, validate_priority_fee,
+    validate_regular_gas_limit_cap, validate_sender, validate_tx_gas_limit_cap, warm_access_list,
+    warm_base_accounts,
 };
 use crate::{
     EvmTypes, TxResult,
@@ -12,7 +13,7 @@ use crate::{
         error_handler,
         handler::{DefaultTxHandlerHooks, GasSettlement, TxHandlerHooks},
     },
-    interpreter::Host,
+    interpreter::GasTracker,
     registry::{HandlerResult, TxRequest},
 };
 use alloy_consensus::TxEip1559;
@@ -85,12 +86,10 @@ pub fn handle_with_hooks<T: EvmTypes, H: TxHandlerHooks<T>>(
         chain_id: U256::from(req.host.version().chain_id),
         ..TxEnvExt::default()
     };
-    let (bytecode, mut message) = initial_message(
-        req.host, caller, tx.nonce, tx.to, &tx.input, tx.value, gas_limit, reservoir,
-    )?;
-    // Failed execution has already been rolled back to the message's own checkpoint (and halt gas
-    // zeroed) inside `execute_message`, so the result settles directly.
-    let result = req.host.execute_message(&tx_env, bytecode, &mut message);
+    let mut tx_gas = GasTracker::new_with_regular_gas_and_reservoir(gas_limit, reservoir);
+    let frame =
+        prepare_initial_frame(req.host, caller, tx.nonce, tx.to, &tx.input, tx.value, &mut tx_gas)?;
+    let result = execute_initial_frame(req.host, &tx_env, frame, &mut tx_gas, gas_limit, reservoir);
     H::settle_transaction(
         req.host,
         req.envelope,

--- a/crates/evm2/src/ethereum/eip2930.rs
+++ b/crates/evm2/src/ethereum/eip2930.rs
@@ -1,7 +1,7 @@
 use super::{
-    access_list_counts, floor_gas, initial_gas_and_reservoir, initial_message, intrinsic_gas,
-    validate_block_gas_limit, validate_chain_id, validate_create_initcode, validate_floor_gas,
-    validate_gas_price, validate_intrinsic_gas, validate_nonce_not_overflow,
+    access_list_counts, execute_initial_frame, floor_gas, initial_gas_and_reservoir, intrinsic_gas,
+    prepare_initial_frame, validate_block_gas_limit, validate_chain_id, validate_create_initcode,
+    validate_floor_gas, validate_gas_price, validate_intrinsic_gas, validate_nonce_not_overflow,
     validate_regular_gas_limit_cap, validate_sender, validate_tx_gas_limit_cap, warm_access_list,
     warm_base_accounts,
 };
@@ -12,7 +12,7 @@ use crate::{
         error_handler,
         handler::{DefaultTxHandlerHooks, GasSettlement, TxHandlerHooks},
     },
-    interpreter::Host,
+    interpreter::GasTracker,
     registry::{HandlerResult, TxRequest},
 };
 use alloy_consensus::TxEip2930;
@@ -80,12 +80,10 @@ pub fn handle_with_hooks<T: EvmTypes, H: TxHandlerHooks<T>>(
         chain_id: U256::from(req.host.version().chain_id),
         ..TxEnvExt::default()
     };
-    let (bytecode, mut message) = initial_message(
-        req.host, caller, tx.nonce, tx.to, &tx.input, tx.value, gas_limit, reservoir,
-    )?;
-    // Failed execution has already been rolled back to the message's own checkpoint (and halt gas
-    // zeroed) inside `execute_message`, so the result settles directly.
-    let result = req.host.execute_message(&tx_env, bytecode, &mut message);
+    let mut tx_gas = GasTracker::new_with_regular_gas_and_reservoir(gas_limit, reservoir);
+    let frame =
+        prepare_initial_frame(req.host, caller, tx.nonce, tx.to, &tx.input, tx.value, &mut tx_gas)?;
+    let result = execute_initial_frame(req.host, &tx_env, frame, &mut tx_gas, gas_limit, reservoir);
     H::settle_transaction(
         req.host,
         req.envelope,

--- a/crates/evm2/src/ethereum/eip2930.rs
+++ b/crates/evm2/src/ethereum/eip2930.rs
@@ -1,7 +1,7 @@
 use super::{
-    access_list_counts, execute_initial_frame, floor_gas, initial_gas_and_reservoir, intrinsic_gas,
-    prepare_initial_frame, validate_block_gas_limit, validate_chain_id, validate_create_initcode,
-    validate_floor_gas, validate_gas_price, validate_intrinsic_gas, validate_nonce_not_overflow,
+    access_list_counts, floor_gas, initial_gas_and_reservoir, initial_message, intrinsic_gas,
+    validate_block_gas_limit, validate_chain_id, validate_create_initcode, validate_floor_gas,
+    validate_gas_price, validate_intrinsic_gas, validate_nonce_not_overflow,
     validate_regular_gas_limit_cap, validate_sender, validate_tx_gas_limit_cap, warm_access_list,
     warm_base_accounts,
 };
@@ -12,7 +12,7 @@ use crate::{
         error_handler,
         handler::{DefaultTxHandlerHooks, GasSettlement, TxHandlerHooks},
     },
-    interpreter::GasTracker,
+    interpreter::Host,
     registry::{HandlerResult, TxRequest},
 };
 use alloy_consensus::TxEip2930;
@@ -80,10 +80,12 @@ pub fn handle_with_hooks<T: EvmTypes, H: TxHandlerHooks<T>>(
         chain_id: U256::from(req.host.version().chain_id),
         ..TxEnvExt::default()
     };
-    let mut tx_gas = GasTracker::new_with_regular_gas_and_reservoir(gas_limit, reservoir);
-    let frame =
-        prepare_initial_frame(req.host, caller, tx.nonce, tx.to, &tx.input, tx.value, &mut tx_gas)?;
-    let result = execute_initial_frame(req.host, &tx_env, frame, &mut tx_gas, gas_limit, reservoir);
+    let mut message = initial_message(
+        req.host, caller, tx.nonce, tx.to, &tx.input, tx.value, gas_limit, reservoir,
+    )?;
+    // Failed execution has already been rolled back to the message's own checkpoint (and halt gas
+    // zeroed) inside `execute_message`, so the result settles directly.
+    let result = req.host.execute_message(&tx_env, &mut message);
     H::settle_transaction(
         req.host,
         req.envelope,

--- a/crates/evm2/src/ethereum/eip4844.rs
+++ b/crates/evm2/src/ethereum/eip4844.rs
@@ -1,10 +1,9 @@
 use super::{
-    access_list_counts, effective_gas_price, execute_initial_frame, floor_gas,
-    initial_gas_and_reservoir, intrinsic_gas, prepare_initial_frame, validate_block_gas_limit,
-    validate_chain_id, validate_create_initcode, validate_floor_gas, validate_gas_price,
-    validate_intrinsic_gas, validate_nonce_not_overflow, validate_priority_fee,
-    validate_regular_gas_limit_cap, validate_sender, validate_tx_gas_limit_cap, warm_access_list,
-    warm_base_accounts,
+    access_list_counts, effective_gas_price, floor_gas, initial_gas_and_reservoir, initial_message,
+    intrinsic_gas, validate_block_gas_limit, validate_chain_id, validate_create_initcode,
+    validate_floor_gas, validate_gas_price, validate_intrinsic_gas, validate_nonce_not_overflow,
+    validate_priority_fee, validate_regular_gas_limit_cap, validate_sender,
+    validate_tx_gas_limit_cap, warm_access_list, warm_base_accounts,
 };
 use crate::{
     EvmTypes, TxResult,
@@ -13,7 +12,7 @@ use crate::{
         error_handler,
         handler::{DefaultTxHandlerHooks, GasSettlement, TxHandlerHooks},
     },
-    interpreter::GasTracker,
+    interpreter::Host,
     registry::{HandlerError, HandlerResult, TxRequest},
     utils::b256_to_word,
 };
@@ -104,17 +103,19 @@ pub fn handle_with_hooks<T: EvmTypes, H: TxHandlerHooks<T>>(
         ext: T::TxEnvExt::default(),
         _non_exhaustive: (),
     };
-    let mut tx_gas = GasTracker::new_with_regular_gas_and_reservoir(gas_limit, reservoir);
-    let frame = prepare_initial_frame(
+    let mut message = initial_message(
         req.host,
         caller,
         tx.nonce,
         tx.to.into(),
         &tx.input,
         tx.value,
-        &mut tx_gas,
+        gas_limit,
+        reservoir,
     )?;
-    let result = execute_initial_frame(req.host, &tx_env, frame, &mut tx_gas, gas_limit, reservoir);
+    // Failed execution has already been rolled back to the message's own checkpoint (and halt gas
+    // zeroed) inside `execute_message`, so the result settles directly.
+    let result = req.host.execute_message(&tx_env, &mut message);
     H::settle_transaction(
         req.host,
         req.envelope,

--- a/crates/evm2/src/ethereum/eip4844.rs
+++ b/crates/evm2/src/ethereum/eip4844.rs
@@ -1,9 +1,10 @@
 use super::{
-    access_list_counts, effective_gas_price, floor_gas, initial_gas_and_reservoir, initial_message,
-    intrinsic_gas, validate_block_gas_limit, validate_chain_id, validate_create_initcode,
-    validate_floor_gas, validate_gas_price, validate_intrinsic_gas, validate_nonce_not_overflow,
-    validate_priority_fee, validate_regular_gas_limit_cap, validate_sender,
-    validate_tx_gas_limit_cap, warm_access_list, warm_base_accounts,
+    access_list_counts, effective_gas_price, execute_initial_frame, floor_gas,
+    initial_gas_and_reservoir, intrinsic_gas, prepare_initial_frame, validate_block_gas_limit,
+    validate_chain_id, validate_create_initcode, validate_floor_gas, validate_gas_price,
+    validate_intrinsic_gas, validate_nonce_not_overflow, validate_priority_fee,
+    validate_regular_gas_limit_cap, validate_sender, validate_tx_gas_limit_cap, warm_access_list,
+    warm_base_accounts,
 };
 use crate::{
     EvmTypes, TxResult,
@@ -12,7 +13,7 @@ use crate::{
         error_handler,
         handler::{DefaultTxHandlerHooks, GasSettlement, TxHandlerHooks},
     },
-    interpreter::Host,
+    interpreter::GasTracker,
     registry::{HandlerError, HandlerResult, TxRequest},
     utils::b256_to_word,
 };
@@ -103,19 +104,17 @@ pub fn handle_with_hooks<T: EvmTypes, H: TxHandlerHooks<T>>(
         ext: T::TxEnvExt::default(),
         _non_exhaustive: (),
     };
-    let (bytecode, mut message) = initial_message(
+    let mut tx_gas = GasTracker::new_with_regular_gas_and_reservoir(gas_limit, reservoir);
+    let frame = prepare_initial_frame(
         req.host,
         caller,
         tx.nonce,
         tx.to.into(),
         &tx.input,
         tx.value,
-        gas_limit,
-        reservoir,
+        &mut tx_gas,
     )?;
-    // Failed execution has already been rolled back to the message's own checkpoint (and halt gas
-    // zeroed) inside `execute_message`, so the result settles directly.
-    let result = req.host.execute_message(&tx_env, bytecode, &mut message);
+    let result = execute_initial_frame(req.host, &tx_env, frame, &mut tx_gas, gas_limit, reservoir);
     H::settle_transaction(
         req.host,
         req.envelope,

--- a/crates/evm2/src/ethereum/eip7702.rs
+++ b/crates/evm2/src/ethereum/eip7702.rs
@@ -1,10 +1,10 @@
 use super::{
-    LazyAuthorization, access_list_counts, effective_gas_price, floor_gas,
-    initial_gas_and_reservoir, initial_message, intrinsic_gas, validate_block_gas_limit,
-    validate_chain_id, validate_create_initcode, validate_floor_gas, validate_gas_price,
-    validate_intrinsic_gas, validate_nonce_not_overflow, validate_priority_fee,
-    validate_regular_gas_limit_cap, validate_sender, validate_tx_gas_limit_cap, warm_access_list,
-    warm_base_accounts,
+    InitialFrame, LazyAuthorization, access_list_counts, effective_gas_price, floor_gas,
+    initial_gas_and_reservoir, intrinsic_gas, prepare_initial_frame, runtime_oog_result,
+    settle_initial_frame_gas, validate_block_gas_limit, validate_chain_id,
+    validate_create_initcode, validate_floor_gas, validate_gas_price, validate_intrinsic_gas,
+    validate_nonce_not_overflow, validate_priority_fee, validate_regular_gas_limit_cap,
+    validate_sender, validate_tx_gas_limit_cap, warm_access_list, warm_base_accounts,
 };
 use crate::{
     Evm, EvmFeatures, EvmTypes, TxResult, Version,
@@ -13,9 +13,7 @@ use crate::{
         error_handler,
         handler::{DefaultTxHandlerHooks, GasSettlement, TxHandlerHooks},
     },
-    interpreter::{
-        GasTracker, Host, InstrStop, MessageResult, MessageResultExt, gas::EIP8038_ACCOUNT_WRITE,
-    },
+    interpreter::{GasTracker, Host, InstrStop, MessageResult, gas::EIP8038_ACCOUNT_WRITE},
     registry::{HandlerError, HandlerResult, TxRequest},
     version::GasId,
 };
@@ -128,10 +126,9 @@ pub fn handle_with_hooks<T: EvmTypes, H: TxHandlerHooks<T>>(
     };
 
     // Applies the pre-Amsterdam authorization regular refund (zero under EIP-2780) and settles
-    // the transaction with the given authorization state gas on top of the hook-provided
-    // intrinsic state gas (charged upfront, before `runtime_checkpoint`, so it persists on every
-    // exit). Every exit below funnels through here.
-    let settle = |host: &mut Evm<'_, T>, mut result: MessageResult<T>, auth_state_gas: u64| {
+    // the transaction with the hook-provided intrinsic state gas (charged upfront, before
+    // `runtime_checkpoint`, so it persists on every exit). Every exit below funnels through here.
+    let settle = |host: &mut Evm<'_, T>, mut result: MessageResult<T>| {
         result.gas.set_refunded(
             result.gas.refunded().saturating_add(i64::try_from(regular_refund).unwrap_or(i64::MAX)),
         );
@@ -143,54 +140,47 @@ pub fn handle_with_hooks<T: EvmTypes, H: TxHandlerHooks<T>>(
                 gas_price,
                 gas_limit: tx.gas_limit,
                 floor_gas,
-                initial_state_gas: initial_state_gas.saturating_add(auth_state_gas),
+                initial_state_gas,
                 state_refund,
                 result,
             },
         )
     };
     // Settles the transaction as an out-of-gas halt when the runtime gas phase (the authorization
-    // charges or the first-frame recipient charge) runs out of gas: reverts the runtime
+    // charges or the first-frame recipient charge) runs out of gas: reverts the authorization
     // checkpoint to drop the applied delegations, then consumes all regular gas and returns the
     // reservoir. Unreachable pre-Amsterdam, where no runtime charge is attempted.
     let settle_oog = |host: &mut Evm<'_, T>| {
         let features = host.version().features;
         host.state.rollback(runtime_checkpoint, features);
-        settle(
-            host,
-            MessageResultExt {
-                stop: InstrStop::OutOfGas,
-                gas: GasTracker::new_spent_with_reservoir(regular_gas_limit, reservoir),
-                ..MessageResultExt::default()
-            },
-            0,
-        )
+        settle(host, runtime_oog_result(regular_gas_limit, reservoir))
     };
 
     if auth_oog {
         return settle_oog(req.host);
     }
-    // State gas charged for the authorizations, carried into the block state-gas accounting.
-    let auth_state_gas = tx_gas.state_gas_spent().max(0) as u64;
-    let (bytecode, mut message) = initial_message(
+    let Some(InitialFrame { mut message, charged_state_gas }) = prepare_initial_frame(
         req.host,
         caller,
         tx.nonce,
         tx.to.into(),
         &tx.input,
         tx.value,
-        tx_gas.remaining(),
-        tx_gas.reservoir(),
-    )?;
-    // Failed execution has already been rolled back to the message's own checkpoint (past the
-    // applied delegations, which stay) inside `execute_message`.
-    let result = req.host.execute_message(&tx_env, bytecode, &mut message);
-    // A depth-0 recipient charge that ran out of gas is part of the runtime gas phase, so it
-    // drops the delegations too.
-    if result.runtime_gas_oog {
+        &mut tx_gas,
+    )?
+    else {
+        // A depth-0 recipient charge that ran out of gas is part of the runtime gas phase, so it
+        // drops the delegations too.
         return settle_oog(req.host);
-    }
-    settle(req.host, result, auth_state_gas)
+    };
+
+    // Failed execution has already been rolled back to the message's own checkpoint (past the
+    // applied delegations, which stay) inside `execute_message`. The settle merges the frame gas
+    // into `tx_gas`, which carries the authorization state gas into the block state-gas
+    // accounting.
+    let mut result = req.host.execute_message(&tx_env, &mut message);
+    settle_initial_frame_gas(&mut tx_gas, &mut result, charged_state_gas);
+    settle(req.host, result)
 }
 
 fn eip7702_authorization_gas<'a, T: EvmTypes>(host: &Evm<'a, T>, authorizations: usize) -> u64 {

--- a/crates/evm2/src/ethereum/eip7702.rs
+++ b/crates/evm2/src/ethereum/eip7702.rs
@@ -1,10 +1,10 @@
 use super::{
-    InitialFrame, LazyAuthorization, access_list_counts, effective_gas_price, floor_gas,
-    initial_gas_and_reservoir, intrinsic_gas, prepare_initial_frame, runtime_oog_result,
-    settle_initial_frame_gas, validate_block_gas_limit, validate_chain_id,
-    validate_create_initcode, validate_floor_gas, validate_gas_price, validate_intrinsic_gas,
-    validate_nonce_not_overflow, validate_priority_fee, validate_regular_gas_limit_cap,
-    validate_sender, validate_tx_gas_limit_cap, warm_access_list, warm_base_accounts,
+    LazyAuthorization, access_list_counts, effective_gas_price, floor_gas,
+    initial_gas_and_reservoir, initial_message, intrinsic_gas, validate_block_gas_limit,
+    validate_chain_id, validate_create_initcode, validate_floor_gas, validate_gas_price,
+    validate_intrinsic_gas, validate_nonce_not_overflow, validate_priority_fee,
+    validate_regular_gas_limit_cap, validate_sender, validate_tx_gas_limit_cap, warm_access_list,
+    warm_base_accounts,
 };
 use crate::{
     Evm, EvmFeatures, EvmTypes, TxResult, Version,
@@ -13,7 +13,9 @@ use crate::{
         error_handler,
         handler::{DefaultTxHandlerHooks, GasSettlement, TxHandlerHooks},
     },
-    interpreter::{GasTracker, Host, InstrStop, MessageResult, gas::EIP8038_ACCOUNT_WRITE},
+    interpreter::{
+        GasTracker, Host, InstrStop, MessageResult, MessageResultExt, gas::EIP8038_ACCOUNT_WRITE,
+    },
     registry::{HandlerError, HandlerResult, TxRequest},
     version::GasId,
 };
@@ -126,9 +128,10 @@ pub fn handle_with_hooks<T: EvmTypes, H: TxHandlerHooks<T>>(
     };
 
     // Applies the pre-Amsterdam authorization regular refund (zero under EIP-2780) and settles
-    // the transaction with the hook-provided intrinsic state gas (charged upfront, before
-    // `runtime_checkpoint`, so it persists on every exit). Every exit below funnels through here.
-    let settle = |host: &mut Evm<'_, T>, mut result: MessageResult<T>| {
+    // the transaction with the given authorization state gas on top of the hook-provided
+    // intrinsic state gas (charged upfront, before `runtime_checkpoint`, so it persists on every
+    // exit). Every exit below funnels through here.
+    let settle = |host: &mut Evm<'_, T>, mut result: MessageResult<T>, auth_state_gas: u64| {
         result.gas.set_refunded(
             result.gas.refunded().saturating_add(i64::try_from(regular_refund).unwrap_or(i64::MAX)),
         );
@@ -140,47 +143,54 @@ pub fn handle_with_hooks<T: EvmTypes, H: TxHandlerHooks<T>>(
                 gas_price,
                 gas_limit: tx.gas_limit,
                 floor_gas,
-                initial_state_gas,
+                initial_state_gas: initial_state_gas.saturating_add(auth_state_gas),
                 state_refund,
                 result,
             },
         )
     };
     // Settles the transaction as an out-of-gas halt when the runtime gas phase (the authorization
-    // charges or the first-frame recipient charge) runs out of gas: reverts the authorization
+    // charges or the first-frame recipient charge) runs out of gas: reverts the runtime
     // checkpoint to drop the applied delegations, then consumes all regular gas and returns the
     // reservoir. Unreachable pre-Amsterdam, where no runtime charge is attempted.
     let settle_oog = |host: &mut Evm<'_, T>| {
         let features = host.version().features;
         host.state.rollback(runtime_checkpoint, features);
-        settle(host, runtime_oog_result(regular_gas_limit, reservoir))
+        settle(
+            host,
+            MessageResultExt {
+                stop: InstrStop::OutOfGas,
+                gas: GasTracker::new_spent_with_reservoir(regular_gas_limit, reservoir),
+                ..MessageResultExt::default()
+            },
+            0,
+        )
     };
 
     if auth_oog {
         return settle_oog(req.host);
     }
-    let Some(InitialFrame { mut message, charged_state_gas }) = prepare_initial_frame(
+    // State gas charged for the authorizations, carried into the block state-gas accounting.
+    let auth_state_gas = tx_gas.state_gas_spent().max(0) as u64;
+    let mut message = initial_message(
         req.host,
         caller,
         tx.nonce,
         tx.to.into(),
         &tx.input,
         tx.value,
-        &mut tx_gas,
-    )?
-    else {
-        // A depth-0 recipient charge that ran out of gas is part of the runtime gas phase, so it
-        // drops the delegations too.
-        return settle_oog(req.host);
-    };
-
+        tx_gas.remaining(),
+        tx_gas.reservoir(),
+    )?;
     // Failed execution has already been rolled back to the message's own checkpoint (past the
-    // applied delegations, which stay) inside `execute_message`. The settle merges the frame gas
-    // into `tx_gas`, which carries the authorization state gas into the block state-gas
-    // accounting.
-    let mut result = req.host.execute_message(&tx_env, &mut message);
-    settle_initial_frame_gas(&mut tx_gas, &mut result, charged_state_gas);
-    settle(req.host, result)
+    // applied delegations, which stay) inside `execute_message`.
+    let result = req.host.execute_message(&tx_env, &mut message);
+    // A depth-0 recipient charge that ran out of gas is part of the runtime gas phase, so it
+    // drops the delegations too.
+    if result.runtime_gas_oog {
+        return settle_oog(req.host);
+    }
+    settle(req.host, result, auth_state_gas)
 }
 
 fn eip7702_authorization_gas<'a, T: EvmTypes>(host: &Evm<'a, T>, authorizations: usize) -> u64 {

--- a/crates/evm2/src/ethereum/legacy.rs
+++ b/crates/evm2/src/ethereum/legacy.rs
@@ -1,8 +1,8 @@
 use super::{
-    floor_gas, initial_gas_and_reservoir, initial_message, intrinsic_gas, validate_block_gas_limit,
-    validate_chain_id, validate_create_initcode, validate_floor_gas, validate_gas_price,
-    validate_intrinsic_gas, validate_nonce_not_overflow, validate_regular_gas_limit_cap,
-    validate_sender, validate_tx_gas_limit_cap, warm_base_accounts,
+    execute_initial_frame, floor_gas, initial_gas_and_reservoir, intrinsic_gas,
+    prepare_initial_frame, validate_block_gas_limit, validate_chain_id, validate_create_initcode,
+    validate_floor_gas, validate_gas_price, validate_intrinsic_gas, validate_nonce_not_overflow,
+    validate_regular_gas_limit_cap, validate_sender, validate_tx_gas_limit_cap, warm_base_accounts,
 };
 use crate::{
     EvmTypes, TxResult,
@@ -11,7 +11,7 @@ use crate::{
         error_handler,
         handler::{DefaultTxHandlerHooks, GasSettlement, TxHandlerHooks},
     },
-    interpreter::Host,
+    interpreter::GasTracker,
     registry::{HandlerResult, TxRequest},
 };
 use alloy_consensus::TxLegacy;
@@ -62,12 +62,10 @@ pub fn handle_with_hooks<T: EvmTypes, H: TxHandlerHooks<T>>(
         chain_id: U256::from(req.host.version().chain_id),
         ..TxEnvExt::default()
     };
-    let (bytecode, mut message) = initial_message(
-        req.host, caller, tx.nonce, tx.to, &tx.input, tx.value, gas_limit, reservoir,
-    )?;
-    // Failed execution has already been rolled back to the message's own checkpoint (and halt gas
-    // zeroed) inside `execute_message`, so the result settles directly.
-    let result = req.host.execute_message(&tx_env, bytecode, &mut message);
+    let mut tx_gas = GasTracker::new_with_regular_gas_and_reservoir(gas_limit, reservoir);
+    let frame =
+        prepare_initial_frame(req.host, caller, tx.nonce, tx.to, &tx.input, tx.value, &mut tx_gas)?;
+    let result = execute_initial_frame(req.host, &tx_env, frame, &mut tx_gas, gas_limit, reservoir);
     H::settle_transaction(
         req.host,
         req.envelope,

--- a/crates/evm2/src/ethereum/legacy.rs
+++ b/crates/evm2/src/ethereum/legacy.rs
@@ -1,8 +1,8 @@
 use super::{
-    execute_initial_frame, floor_gas, initial_gas_and_reservoir, intrinsic_gas,
-    prepare_initial_frame, validate_block_gas_limit, validate_chain_id, validate_create_initcode,
-    validate_floor_gas, validate_gas_price, validate_intrinsic_gas, validate_nonce_not_overflow,
-    validate_regular_gas_limit_cap, validate_sender, validate_tx_gas_limit_cap, warm_base_accounts,
+    floor_gas, initial_gas_and_reservoir, initial_message, intrinsic_gas, validate_block_gas_limit,
+    validate_chain_id, validate_create_initcode, validate_floor_gas, validate_gas_price,
+    validate_intrinsic_gas, validate_nonce_not_overflow, validate_regular_gas_limit_cap,
+    validate_sender, validate_tx_gas_limit_cap, warm_base_accounts,
 };
 use crate::{
     EvmTypes, TxResult,
@@ -11,7 +11,7 @@ use crate::{
         error_handler,
         handler::{DefaultTxHandlerHooks, GasSettlement, TxHandlerHooks},
     },
-    interpreter::GasTracker,
+    interpreter::Host,
     registry::{HandlerResult, TxRequest},
 };
 use alloy_consensus::TxLegacy;
@@ -62,10 +62,12 @@ pub fn handle_with_hooks<T: EvmTypes, H: TxHandlerHooks<T>>(
         chain_id: U256::from(req.host.version().chain_id),
         ..TxEnvExt::default()
     };
-    let mut tx_gas = GasTracker::new_with_regular_gas_and_reservoir(gas_limit, reservoir);
-    let frame =
-        prepare_initial_frame(req.host, caller, tx.nonce, tx.to, &tx.input, tx.value, &mut tx_gas)?;
-    let result = execute_initial_frame(req.host, &tx_env, frame, &mut tx_gas, gas_limit, reservoir);
+    let mut message = initial_message(
+        req.host, caller, tx.nonce, tx.to, &tx.input, tx.value, gas_limit, reservoir,
+    )?;
+    // Failed execution has already been rolled back to the message's own checkpoint (and halt gas
+    // zeroed) inside `execute_message`, so the result settles directly.
+    let result = req.host.execute_message(&tx_env, &mut message);
     H::settle_transaction(
         req.host,
         req.envelope,

--- a/crates/evm2/src/ethereum/mod.rs
+++ b/crates/evm2/src/ethereum/mod.rs
@@ -17,12 +17,10 @@ pub use lazy_eip7702::{LazyAuthorization, LazyTxEip7702};
 use crate::{
     Evm, EvmFeatures, EvmTypes, SpecId, TxResult, TxResultExt, Version,
     bytecode::Bytecode,
-    env::TxEnv,
     evm::{AccountInfo, error_handler, handler::GasSettlement},
     interpreter::{
-        GasTracker, Host, InstrStop, Message, MessageExt, MessageKind, MessageResult,
-        MessageResultExt, Word,
-        gas::{EIP2780_TX_BASE_COST, EIP8038_COLD_ACCOUNT_ACCESS, WARM_STORAGE_READ_COST},
+        Message, MessageExt, MessageKind, Word,
+        gas::{EIP2780_TX_BASE_COST, EIP8038_COLD_ACCOUNT_ACCESS},
     },
     registry::{HandlerError, HandlerResult, TxRegistry},
     utils::num_words,
@@ -452,9 +450,9 @@ pub fn charge_upfront<'a, T: EvmTypes>(
 /// pessimistic EIP-7702 authorization state gas, or hook-added charges). It is deducted from the
 /// reservoir, spilling into the regular budget when the reservoir is insufficient. It is zero
 /// without EIP-8037; under EIP-2780 the state-dependent charges are metered at the runtime gas
-/// phase instead ([`prepare_initial_frame`]). The pre-EIP-2780 EIP-7702 state-gas refund is not an
-/// input here: per execution-specs it is credited directly back to the reservoir after the
-/// authorizations are applied, not applied to regular gas first.
+/// phase instead. The pre-EIP-2780 EIP-7702 state-gas refund is not an input here: per
+/// execution-specs it is credited directly back to the reservoir after the authorizations are
+/// applied, not applied to regular gas first.
 pub fn initial_gas_and_reservoir(
     version: &Version,
     tx_gas_limit: u64,
@@ -480,111 +478,33 @@ pub fn initial_gas_and_reservoir(
     (regular_gas_limit, reservoir)
 }
 
-/// The first frame of a transaction, prepared by [`prepare_initial_frame`].
-#[derive(Clone, Debug)]
-pub struct InitialFrame<T: EvmTypes> {
-    /// Top-level call or create message, carrying the resolved bytecode to run.
-    pub message: Message<T>,
-    /// EIP-8037 state gas charged on the transaction-level tracker for the account leaf this
-    /// frame creates (the call recipient's new-account charge or the create target's
-    /// account-creation charge), zero when nothing was charged. Refunded by
-    /// [`settle_initial_frame_gas`] when the frame fails and the leaf is not created.
-    pub charged_state_gas: u64,
-}
-
-/// Completes the EIP-2780 runtime gas phase on the transaction-level `tx_gas` and builds the
-/// first frame — the depth-0 analog of the CALL/CREATE opcodes' account-load-and-charge step.
-///
-/// For a call, the recipient pays the new-account state gas when the call transfers value to an
-/// empty recipient (charged before the delegation resolution, matching the spec's
-/// `prepare_dispatch` order), and a delegated recipient pays the delegation-target access
-/// following the EIP-2929 warm/cold model: the warm cost lands before the target load and the
-/// cold premium after it, with the load gated on `skip_cold_load` (as nested calls do) so a
-/// cold, unafforded target stays out of the EIP-7928 block access list. For a create, the
-/// account-creation state gas is charged when the destination is not already alive (existing,
-/// non-empty), so a create at a pre-existing balance-only account pays nothing for the leaf
-/// (execution-specs `created_target_alive`); nested creates are charged on the parent frame by
-/// the CREATE opcode instead. A delegated recipient is still resolved (for free) so the frame
-/// runs the delegate's code.
-///
-/// The frame's `gas_limit`/`reservoir` snapshot `tx_gas` after the charges. Returns `None` when
-/// a charge runs out of gas: the transaction stays valid but is included as an out-of-gas halt
-/// without entering execution ([`runtime_oog_result`]).
-pub fn prepare_initial_frame<'a, T: EvmTypes>(
+#[allow(clippy::too_many_arguments)]
+/// Creates the top-level message and its bytecode for a transaction call or create.
+pub fn initial_message<'a, T: EvmTypes>(
     host: &mut Evm<'a, T>,
     caller: Address,
     nonce: u64,
     to: TxKind,
     input: &Bytes,
     value: U256,
-    tx_gas: &mut GasTracker,
-) -> HandlerResult<Option<InitialFrame<T>>> {
-    let mut charged_state_gas = 0;
+    gas_limit: u64,
+    reservoir: u64,
+) -> HandlerResult<Message<T>> {
     let message = match to {
         TxKind::Call(to) => {
-            let (recipient_is_empty, mut code) = {
-                let mut account = host.state.account(&to, false).map_err(error_handler!(host))?;
-                // A nonexistent recipient reads as an empty account (EIP-161).
-                let recipient_is_empty = account.get().is_none_or(AccountInfo::is_empty);
-                (recipient_is_empty, account.load_code().map_err(error_handler!(host))?)
-            };
-            let mut code_address = to;
-            let mut disable_precompiles = false;
-            if host.feature(EvmFeatures::EIP2780) && !value.is_zero() && recipient_is_empty {
-                let new_account_state_gas = host.version().gas_params.new_account_state_gas();
-                if tx_gas.spend_state(new_account_state_gas).is_err() {
-                    return Ok(None);
-                }
-                charged_state_gas = new_account_state_gas;
-            }
-            // An empty recipient is never delegated, so the charge above and the resolution below
-            // are mutually exclusive.
-            if host.feature(EvmFeatures::EIP7702)
-                && let Some(delegated_address) = code.eip7702_address()
-            {
-                if host.feature(EvmFeatures::EIP2780) {
-                    // Delegation-target access, EIP-2929 warm/cold: charge the warm access first
-                    // (covered → the target is loaded and enters the block access list), then the
-                    // cold premium after the load. The load is skipped when the cold premium is
-                    // unaffordable, keeping a cold, unafforded target out of the block access
-                    // list.
-                    let cold_additional = host.version().gas_params.cold_account_additional_cost();
-                    if tx_gas.spend(u64::from(WARM_STORAGE_READ_COST)).is_err() {
-                        return Ok(None);
-                    }
-                    let skip_cold_load = tx_gas.remaining() < cold_additional;
-                    let Ok(load) =
-                        Host::load_account(host, &delegated_address, true, skip_cold_load)
-                    else {
-                        return Ok(None);
-                    };
-                    if load.is_cold && tx_gas.spend(cold_additional).is_err() {
-                        return Ok(None);
-                    }
-                    code = load.code;
-                } else {
-                    let mut account = host
-                        .state
-                        .account(&delegated_address, false)
-                        .map_err(error_handler!(host))?;
-                    account.warm();
-                    code = account.load_code().map_err(error_handler!(host))?;
-                }
-                code_address = delegated_address;
-                disable_precompiles = true;
-            }
+            let initial_code = initial_call_code(host, to)?;
             MessageExt {
                 kind: MessageKind::Call,
                 depth: 0,
-                gas_limit: tx_gas.remaining(),
-                reservoir: tx_gas.reservoir(),
+                gas_limit,
+                reservoir,
                 destination: to,
                 caller,
                 input: input.clone(),
                 value,
-                code,
-                code_address,
-                disable_precompiles,
+                code: initial_code.code,
+                code_address: initial_code.code_address,
+                disable_precompiles: initial_code.disable_precompiles,
                 caller_is_static: false,
                 salt: B256::ZERO,
                 ext: T::MessageExt::default(),
@@ -592,33 +512,18 @@ pub fn prepare_initial_frame<'a, T: EvmTypes>(
             }
         }
         TxKind::Create => {
-            let destination = caller.create(nonce);
-            if host.feature(EvmFeatures::EIP8037) {
-                let target_alive = host
-                    .state
-                    .account(&destination, false)
-                    .map_err(error_handler!(host))?
-                    .get()
-                    .is_some_and(|info| !info.is_empty());
-                if !target_alive {
-                    let create_state_gas = host.version().gas_params.create_state_gas();
-                    if tx_gas.spend_state(create_state_gas).is_err() {
-                        return Ok(None);
-                    }
-                    charged_state_gas = create_state_gas;
-                }
-            }
+            let address = caller.create(nonce);
             MessageExt {
                 kind: MessageKind::Create,
                 depth: 0,
-                gas_limit: tx_gas.remaining(),
-                reservoir: tx_gas.reservoir(),
-                destination,
+                gas_limit,
+                reservoir,
+                destination: address,
                 caller,
                 input: input.clone(),
                 value,
                 code: Bytecode::new_legacy(input.clone()),
-                code_address: destination,
+                code_address: address,
                 disable_precompiles: false,
                 caller_is_static: false,
                 salt: B256::ZERO,
@@ -628,72 +533,47 @@ pub fn prepare_initial_frame<'a, T: EvmTypes>(
         }
     };
     debug_assert_eq!(message.depth, 0);
-    Ok(Some(InitialFrame { message, charged_state_gas }))
+    Ok(message)
 }
 
-/// Settles the first frame's result into the transaction-level `tx_gas` and writes the settled
-/// tracker back to the result for gas finalization.
-///
-/// All regular gas was forwarded to the frame, so it is first consumed on `tx_gas` and the
-/// frame's settled gas merged back like any parent frame would
-/// ([`GasTracker::merge_child_gas`]). When the frame did not create the account leaf whose state
-/// gas the runtime gas phase charged upfront ([`InitialFrame::charged_state_gas`]), the charge
-/// is refunded in LIFO order ([`GasTracker::refill_reservoir`]), exactly as the CALL/CREATE
-/// opcodes refund their upfront state charges for failed children. Unlike an inner frame's
-/// caller, the transaction ends here: an exceptional halt consumes all regular gas, including
-/// the spilled portion the refill just credited back to `remaining`.
-pub const fn settle_initial_frame_gas<E>(
-    tx_gas: &mut GasTracker,
-    result: &mut MessageResultExt<E>,
-    charged_state_gas: u64,
-) {
-    tx_gas.spend_all();
-    tx_gas.merge_child_gas(result.gas, result.stop);
-    if charged_state_gas != 0 && !result.stop.is_success() {
-        tx_gas.refill_reservoir(charged_state_gas);
-        if result.stop.is_halt() {
-            tx_gas.spend_all();
+struct InitialCallCode {
+    code: Bytecode,
+    code_address: Address,
+    disable_precompiles: bool,
+}
+
+fn initial_call_code<'a, T: EvmTypes>(
+    host: &mut Evm<'a, T>,
+    to: Address,
+) -> HandlerResult<InitialCallCode> {
+    let code = host
+        .state
+        .account(&to, false)
+        .map_err(error_handler!(host))?
+        .load_code()
+        .map_err(error_handler!(host))?;
+    if host.feature(EvmFeatures::EIP7702)
+        && let Some(delegated_address) = code.eip7702_address()
+    {
+        // Under EIP-2780 the delegation resolution is deferred to the frame
+        // (`apply_eip2780_call_charges`), which meters the delegation-target access and gates its
+        // load on gas so a cold, unafforded target stays out of the EIP-7928 block access list. The
+        // frame swaps in the delegate's code and code_address after the charge; loading the target
+        // here would leak it into the block access list on a runtime out-of-gas.
+        if host.feature(EvmFeatures::EIP2780) {
+            return Ok(InitialCallCode { code, code_address: to, disable_precompiles: true });
         }
+        let mut account =
+            host.state.account(&delegated_address, false).map_err(error_handler!(host))?;
+        account.warm();
+        let delegated_code = account.load_code().map_err(error_handler!(host))?;
+        return Ok(InitialCallCode {
+            code: delegated_code,
+            code_address: delegated_address,
+            disable_precompiles: true,
+        });
     }
-    result.gas = *tx_gas;
-}
-
-/// Executes the prepared first frame and settles its gas into the transaction-level tracker.
-pub fn execute_initial_frame<T: EvmTypes>(
-    host: &mut Evm<'_, T>,
-    tx_env: &TxEnv<T>,
-    frame: Option<InitialFrame<T>>,
-    tx_gas: &mut GasTracker,
-    regular_gas_limit: u64,
-    reservoir: u64,
-) -> MessageResult<T> {
-    let Some(InitialFrame { mut message, charged_state_gas }) = frame else {
-        return runtime_oog_result(regular_gas_limit, reservoir);
-    };
-
-    // Failed execution has already been rolled back to the message's own checkpoint inside
-    // `execute_message`; the settle merges the frame gas into the transaction-level gas.
-    let mut result = host.execute_message(tx_env, &mut message);
-    settle_initial_frame_gas(tx_gas, &mut result, charged_state_gas);
-    result
-}
-
-/// Builds the result for a transaction whose EIP-2780 runtime gas phase ran out of gas
-/// ([`prepare_initial_frame`] returned `None`, or the EIP-7702 authorization charges bailed).
-///
-/// The transaction is valid but cannot afford the state-dependent runtime charges: it is
-/// included as an out-of-gas halt that consumes all regular gas and returns the reservoir,
-/// without entering execution. The phase's partial charges are dropped by rebuilding the
-/// pristine transaction-level gas from `regular_gas_limit` and `reservoir`.
-pub fn runtime_oog_result<E: Default>(
-    regular_gas_limit: u64,
-    reservoir: u64,
-) -> MessageResultExt<E> {
-    MessageResultExt {
-        stop: InstrStop::OutOfGas,
-        gas: GasTracker::new_spent_with_reservoir(regular_gas_limit, reservoir),
-        ..MessageResultExt::default()
-    }
+    Ok(InitialCallCode { code, code_address: to, disable_precompiles: false })
 }
 
 /// Applies the default Ethereum gas refund, sender reimbursement, and beneficiary reward rules.
@@ -758,13 +638,12 @@ pub fn finalize_gas<'a, T: EvmTypes>(
     // regular gas (EIP-7778/EIP-8037) accumulates `tx_gas_used_before_refund` per
     // execution-specs, without the floor clamp.
     //
-    // The settled tracker's state gas is self-consistent: a failed frame's state charges were
-    // rolled back before it was merged, while unconditional pre-execution charges (the EIP-7702
-    // authorizations, whose delegations survive an execution failure) remain. The upfront
-    // `initial_state_gas` is likewise added unconditionally.
-    let state_gas_spent =
-        (result.gas.state_gas_spent().saturating_add_unsigned(initial_state_gas).max(0) as u64)
-            .saturating_sub(state_refund);
+    // Execution state gas contributes only on success: a revert/halt rolls back its state changes.
+    // The upfront `initial_state_gas` is added unconditionally — an EIP-7702 execution failure
+    // still leaves the applied delegations (and their state gas) in place.
+    let exec_state_gas = if result.stop.is_success() { result.gas.state_gas_spent() } else { 0 };
+    let state_gas_spent = (exec_state_gas.saturating_add_unsigned(initial_state_gas).max(0) as u64)
+        .saturating_sub(state_refund);
     Ok(TxResultExt {
         status: result.stop.is_success(),
         total_gas_spent,
@@ -1187,22 +1066,20 @@ mod tests {
             Precompiles::base(SpecId::PRAGUE),
         );
 
-        let mut tx_gas = GasTracker::new_with_regular_gas_and_reservoir(100_000, 0);
-        let InitialFrame { mut message, charged_state_gas } = prepare_initial_frame(
+        let mut message = initial_message(
             &mut evm,
             caller,
             0,
             TxKind::Call(target),
             &Bytes::new(),
             U256::ZERO,
-            &mut tx_gas,
+            100_000,
+            0,
         )
-        .unwrap()
         .unwrap();
         assert_eq!(message.destination, target);
         assert_eq!(message.code_address, delegated);
         assert!(message.disable_precompiles);
-        assert_eq!(charged_state_gas, 0);
 
         let result = Host::execute_message(&mut evm, &TxEnvExt::default(), &mut message);
 

--- a/crates/evm2/src/ethereum/mod.rs
+++ b/crates/evm2/src/ethereum/mod.rs
@@ -17,10 +17,12 @@ pub use lazy_eip7702::{LazyAuthorization, LazyTxEip7702};
 use crate::{
     Evm, EvmFeatures, EvmTypes, SpecId, TxResult, TxResultExt, Version,
     bytecode::Bytecode,
+    env::TxEnv,
     evm::{AccountInfo, error_handler, handler::GasSettlement},
     interpreter::{
-        Message, MessageExt, MessageKind, Word,
-        gas::{EIP2780_TX_BASE_COST, EIP8038_COLD_ACCOUNT_ACCESS},
+        GasTracker, Host, InstrStop, Message, MessageExt, MessageKind, MessageResult,
+        MessageResultExt, Word,
+        gas::{EIP2780_TX_BASE_COST, EIP8038_COLD_ACCOUNT_ACCESS, WARM_STORAGE_READ_COST},
     },
     registry::{HandlerError, HandlerResult, TxRegistry},
     utils::num_words,
@@ -450,9 +452,9 @@ pub fn charge_upfront<'a, T: EvmTypes>(
 /// pessimistic EIP-7702 authorization state gas, or hook-added charges). It is deducted from the
 /// reservoir, spilling into the regular budget when the reservoir is insufficient. It is zero
 /// without EIP-8037; under EIP-2780 the state-dependent charges are metered at the runtime gas
-/// phase instead. The pre-EIP-2780 EIP-7702 state-gas refund is not an input here: per
-/// execution-specs it is credited directly back to the reservoir after the authorizations are
-/// applied, not applied to regular gas first.
+/// phase instead ([`prepare_initial_frame`]). The pre-EIP-2780 EIP-7702 state-gas refund is not an
+/// input here: per execution-specs it is credited directly back to the reservoir after the
+/// authorizations are applied, not applied to regular gas first.
 pub fn initial_gas_and_reservoir(
     version: &Version,
     tx_gas_limit: u64,
@@ -478,102 +480,220 @@ pub fn initial_gas_and_reservoir(
     (regular_gas_limit, reservoir)
 }
 
-#[allow(clippy::too_many_arguments)]
-/// Creates the bytecode and top-level message for a transaction call or create.
-pub fn initial_message<'a, T: EvmTypes>(
+/// The first frame of a transaction, prepared by [`prepare_initial_frame`].
+#[derive(Clone, Debug)]
+pub struct InitialFrame<T: EvmTypes> {
+    /// Top-level call or create message, carrying the resolved bytecode to run.
+    pub message: Message<T>,
+    /// EIP-8037 state gas charged on the transaction-level tracker for the account leaf this
+    /// frame creates (the call recipient's new-account charge or the create target's
+    /// account-creation charge), zero when nothing was charged. Refunded by
+    /// [`settle_initial_frame_gas`] when the frame fails and the leaf is not created.
+    pub charged_state_gas: u64,
+}
+
+/// Completes the EIP-2780 runtime gas phase on the transaction-level `tx_gas` and builds the
+/// first frame — the depth-0 analog of the CALL/CREATE opcodes' account-load-and-charge step.
+///
+/// For a call, the recipient pays the new-account state gas when the call transfers value to an
+/// empty recipient (charged before the delegation resolution, matching the spec's
+/// `prepare_dispatch` order), and a delegated recipient pays the delegation-target access
+/// following the EIP-2929 warm/cold model: the warm cost lands before the target load and the
+/// cold premium after it, with the load gated on `skip_cold_load` (as nested calls do) so a
+/// cold, unafforded target stays out of the EIP-7928 block access list. For a create, the
+/// account-creation state gas is charged when the destination is not already alive (existing,
+/// non-empty), so a create at a pre-existing balance-only account pays nothing for the leaf
+/// (execution-specs `created_target_alive`); nested creates are charged on the parent frame by
+/// the CREATE opcode instead. A delegated recipient is still resolved (for free) so the frame
+/// runs the delegate's code.
+///
+/// The frame's `gas_limit`/`reservoir` snapshot `tx_gas` after the charges. Returns `None` when
+/// a charge runs out of gas: the transaction stays valid but is included as an out-of-gas halt
+/// without entering execution ([`runtime_oog_result`]).
+pub fn prepare_initial_frame<'a, T: EvmTypes>(
     host: &mut Evm<'a, T>,
     caller: Address,
     nonce: u64,
     to: TxKind,
     input: &Bytes,
     value: U256,
-    gas_limit: u64,
-    reservoir: u64,
-) -> HandlerResult<(Bytecode, Message<T>)> {
-    let r = match to {
+    tx_gas: &mut GasTracker,
+) -> HandlerResult<Option<InitialFrame<T>>> {
+    let mut charged_state_gas = 0;
+    let message = match to {
         TxKind::Call(to) => {
-            let initial_code = initial_call_code(host, to)?;
-            let message = MessageExt {
+            let (recipient_is_empty, mut code) = {
+                let mut account = host.state.account(&to, false).map_err(error_handler!(host))?;
+                // A nonexistent recipient reads as an empty account (EIP-161).
+                let recipient_is_empty = account.get().is_none_or(AccountInfo::is_empty);
+                (recipient_is_empty, account.load_code().map_err(error_handler!(host))?)
+            };
+            let mut code_address = to;
+            let mut disable_precompiles = false;
+            if host.feature(EvmFeatures::EIP2780) && !value.is_zero() && recipient_is_empty {
+                let new_account_state_gas = host.version().gas_params.new_account_state_gas();
+                if tx_gas.spend_state(new_account_state_gas).is_err() {
+                    return Ok(None);
+                }
+                charged_state_gas = new_account_state_gas;
+            }
+            // An empty recipient is never delegated, so the charge above and the resolution below
+            // are mutually exclusive.
+            if host.feature(EvmFeatures::EIP7702)
+                && let Some(delegated_address) = code.eip7702_address()
+            {
+                if host.feature(EvmFeatures::EIP2780) {
+                    // Delegation-target access, EIP-2929 warm/cold: charge the warm access first
+                    // (covered → the target is loaded and enters the block access list), then the
+                    // cold premium after the load. The load is skipped when the cold premium is
+                    // unaffordable, keeping a cold, unafforded target out of the block access
+                    // list.
+                    let cold_additional = host.version().gas_params.cold_account_additional_cost();
+                    if tx_gas.spend(u64::from(WARM_STORAGE_READ_COST)).is_err() {
+                        return Ok(None);
+                    }
+                    let skip_cold_load = tx_gas.remaining() < cold_additional;
+                    let Ok(load) =
+                        Host::load_account(host, &delegated_address, true, skip_cold_load)
+                    else {
+                        return Ok(None);
+                    };
+                    if load.is_cold && tx_gas.spend(cold_additional).is_err() {
+                        return Ok(None);
+                    }
+                    code = load.code;
+                } else {
+                    let mut account = host
+                        .state
+                        .account(&delegated_address, false)
+                        .map_err(error_handler!(host))?;
+                    account.warm();
+                    code = account.load_code().map_err(error_handler!(host))?;
+                }
+                code_address = delegated_address;
+                disable_precompiles = true;
+            }
+            MessageExt {
                 kind: MessageKind::Call,
                 depth: 0,
-                gas_limit,
-                reservoir,
+                gas_limit: tx_gas.remaining(),
+                reservoir: tx_gas.reservoir(),
                 destination: to,
                 caller,
                 input: input.clone(),
                 value,
-                code_address: initial_code.code_address,
-                disable_precompiles: initial_code.disable_precompiles,
+                code,
+                code_address,
+                disable_precompiles,
                 caller_is_static: false,
                 salt: B256::ZERO,
                 ext: T::MessageExt::default(),
                 _non_exhaustive: (),
-            };
-            (initial_code.code, message)
+            }
         }
         TxKind::Create => {
-            let address = caller.create(nonce);
-            let message = MessageExt {
+            let destination = caller.create(nonce);
+            if host.feature(EvmFeatures::EIP8037) {
+                let target_alive = host
+                    .state
+                    .account(&destination, false)
+                    .map_err(error_handler!(host))?
+                    .get()
+                    .is_some_and(|info| !info.is_empty());
+                if !target_alive {
+                    let create_state_gas = host.version().gas_params.create_state_gas();
+                    if tx_gas.spend_state(create_state_gas).is_err() {
+                        return Ok(None);
+                    }
+                    charged_state_gas = create_state_gas;
+                }
+            }
+            MessageExt {
                 kind: MessageKind::Create,
                 depth: 0,
-                gas_limit,
-                reservoir,
-                destination: address,
+                gas_limit: tx_gas.remaining(),
+                reservoir: tx_gas.reservoir(),
+                destination,
                 caller,
                 input: input.clone(),
                 value,
-                code_address: address,
+                code: Bytecode::new_legacy(input.clone()),
+                code_address: destination,
                 disable_precompiles: false,
                 caller_is_static: false,
                 salt: B256::ZERO,
                 ext: T::MessageExt::default(),
                 _non_exhaustive: (),
-            };
-            (Bytecode::new_legacy(input.clone()), message)
+            }
         }
     };
-    debug_assert_eq!(r.1.depth, 0);
-    Ok(r)
+    debug_assert_eq!(message.depth, 0);
+    Ok(Some(InitialFrame { message, charged_state_gas }))
 }
 
-struct InitialCallCode {
-    code: Bytecode,
-    code_address: Address,
-    disable_precompiles: bool,
-}
-
-fn initial_call_code<'a, T: EvmTypes>(
-    host: &mut Evm<'a, T>,
-    to: Address,
-) -> HandlerResult<InitialCallCode> {
-    let code = host
-        .state
-        .account(&to, false)
-        .map_err(error_handler!(host))?
-        .load_code()
-        .map_err(error_handler!(host))?;
-    if host.feature(EvmFeatures::EIP7702)
-        && let Some(delegated_address) = code.eip7702_address()
-    {
-        // Under EIP-2780 the delegation resolution is deferred to the frame
-        // (`apply_eip2780_call_charges`), which meters the delegation-target access and gates its
-        // load on gas so a cold, unafforded target stays out of the EIP-7928 block access list. The
-        // frame swaps in the delegate's code and code_address after the charge; loading the target
-        // here would leak it into the block access list on a runtime out-of-gas.
-        if host.feature(EvmFeatures::EIP2780) {
-            return Ok(InitialCallCode { code, code_address: to, disable_precompiles: true });
+/// Settles the first frame's result into the transaction-level `tx_gas` and writes the settled
+/// tracker back to the result for gas finalization.
+///
+/// All regular gas was forwarded to the frame, so it is first consumed on `tx_gas` and the
+/// frame's settled gas merged back like any parent frame would
+/// ([`GasTracker::merge_child_gas`]). When the frame did not create the account leaf whose state
+/// gas the runtime gas phase charged upfront ([`InitialFrame::charged_state_gas`]), the charge
+/// is refunded in LIFO order ([`GasTracker::refill_reservoir`]), exactly as the CALL/CREATE
+/// opcodes refund their upfront state charges for failed children. Unlike an inner frame's
+/// caller, the transaction ends here: an exceptional halt consumes all regular gas, including
+/// the spilled portion the refill just credited back to `remaining`.
+pub const fn settle_initial_frame_gas<E>(
+    tx_gas: &mut GasTracker,
+    result: &mut MessageResultExt<E>,
+    charged_state_gas: u64,
+) {
+    tx_gas.spend_all();
+    tx_gas.merge_child_gas(result.gas, result.stop);
+    if charged_state_gas != 0 && !result.stop.is_success() {
+        tx_gas.refill_reservoir(charged_state_gas);
+        if result.stop.is_halt() {
+            tx_gas.spend_all();
         }
-        let mut account =
-            host.state.account(&delegated_address, false).map_err(error_handler!(host))?;
-        account.warm();
-        let delegated_code = account.load_code().map_err(error_handler!(host))?;
-        return Ok(InitialCallCode {
-            code: delegated_code,
-            code_address: delegated_address,
-            disable_precompiles: true,
-        });
     }
-    Ok(InitialCallCode { code, code_address: to, disable_precompiles: false })
+    result.gas = *tx_gas;
+}
+
+/// Executes the prepared first frame and settles its gas into the transaction-level tracker.
+pub fn execute_initial_frame<T: EvmTypes>(
+    host: &mut Evm<'_, T>,
+    tx_env: &TxEnv<T>,
+    frame: Option<InitialFrame<T>>,
+    tx_gas: &mut GasTracker,
+    regular_gas_limit: u64,
+    reservoir: u64,
+) -> MessageResult<T> {
+    let Some(InitialFrame { mut message, charged_state_gas }) = frame else {
+        return runtime_oog_result(regular_gas_limit, reservoir);
+    };
+
+    // Failed execution has already been rolled back to the message's own checkpoint inside
+    // `execute_message`; the settle merges the frame gas into the transaction-level gas.
+    let mut result = host.execute_message(tx_env, &mut message);
+    settle_initial_frame_gas(tx_gas, &mut result, charged_state_gas);
+    result
+}
+
+/// Builds the result for a transaction whose EIP-2780 runtime gas phase ran out of gas
+/// ([`prepare_initial_frame`] returned `None`, or the EIP-7702 authorization charges bailed).
+///
+/// The transaction is valid but cannot afford the state-dependent runtime charges: it is
+/// included as an out-of-gas halt that consumes all regular gas and returns the reservoir,
+/// without entering execution. The phase's partial charges are dropped by rebuilding the
+/// pristine transaction-level gas from `regular_gas_limit` and `reservoir`.
+pub fn runtime_oog_result<E: Default>(
+    regular_gas_limit: u64,
+    reservoir: u64,
+) -> MessageResultExt<E> {
+    MessageResultExt {
+        stop: InstrStop::OutOfGas,
+        gas: GasTracker::new_spent_with_reservoir(regular_gas_limit, reservoir),
+        ..MessageResultExt::default()
+    }
 }
 
 /// Applies the default Ethereum gas refund, sender reimbursement, and beneficiary reward rules.
@@ -638,12 +758,13 @@ pub fn finalize_gas<'a, T: EvmTypes>(
     // regular gas (EIP-7778/EIP-8037) accumulates `tx_gas_used_before_refund` per
     // execution-specs, without the floor clamp.
     //
-    // Execution state gas contributes only on success: a revert/halt rolls back its state changes.
-    // The upfront `initial_state_gas` is added unconditionally — an EIP-7702 execution failure
-    // still leaves the applied delegations (and their state gas) in place.
-    let exec_state_gas = if result.stop.is_success() { result.gas.state_gas_spent() } else { 0 };
-    let state_gas_spent = (exec_state_gas.saturating_add_unsigned(initial_state_gas).max(0) as u64)
-        .saturating_sub(state_refund);
+    // The settled tracker's state gas is self-consistent: a failed frame's state charges were
+    // rolled back before it was merged, while unconditional pre-execution charges (the EIP-7702
+    // authorizations, whose delegations survive an execution failure) remain. The upfront
+    // `initial_state_gas` is likewise added unconditionally.
+    let state_gas_spent =
+        (result.gas.state_gas_spent().saturating_add_unsigned(initial_state_gas).max(0) as u64)
+            .saturating_sub(state_refund);
     Ok(TxResultExt {
         status: result.stop.is_success(),
         total_gas_spent,
@@ -1066,22 +1187,24 @@ mod tests {
             Precompiles::base(SpecId::PRAGUE),
         );
 
-        let (bytecode, mut message) = initial_message(
+        let mut tx_gas = GasTracker::new_with_regular_gas_and_reservoir(100_000, 0);
+        let InitialFrame { mut message, charged_state_gas } = prepare_initial_frame(
             &mut evm,
             caller,
             0,
             TxKind::Call(target),
             &Bytes::new(),
             U256::ZERO,
-            100_000,
-            0,
+            &mut tx_gas,
         )
+        .unwrap()
         .unwrap();
         assert_eq!(message.destination, target);
         assert_eq!(message.code_address, delegated);
         assert!(message.disable_precompiles);
+        assert_eq!(charged_state_gas, 0);
 
-        let result = Host::execute_message(&mut evm, &TxEnvExt::default(), bytecode, &mut message);
+        let result = Host::execute_message(&mut evm, &TxEnvExt::default(), &mut message);
 
         assert_eq!(result.stop, InstrStop::Return);
         assert_eq!(result.output.len(), 32);

--- a/crates/evm2/src/evm/handler.rs
+++ b/crates/evm2/src/evm/handler.rs
@@ -19,8 +19,7 @@ pub struct GasSettlement<T: EvmTypes> {
     pub initial_state_gas: u64,
     /// State gas refunded by pre-execution processing.
     pub state_refund: u64,
-    /// Result of executing the top-level message, carrying the settled transaction-level gas
-    /// ([`settle_initial_frame_gas`](crate::ethereum::settle_initial_frame_gas)).
+    /// Result of executing the top-level message.
     pub result: MessageResult<T>,
 }
 

--- a/crates/evm2/src/evm/handler.rs
+++ b/crates/evm2/src/evm/handler.rs
@@ -19,7 +19,8 @@ pub struct GasSettlement<T: EvmTypes> {
     pub initial_state_gas: u64,
     /// State gas refunded by pre-execution processing.
     pub state_refund: u64,
-    /// Result of executing the top-level message.
+    /// Result of executing the top-level message, carrying the settled transaction-level gas
+    /// ([`settle_initial_frame_gas`](crate::ethereum::settle_initial_frame_gas)).
     pub result: MessageResult<T>,
 }
 

--- a/crates/evm2/src/evm/inspector.rs
+++ b/crates/evm2/src/evm/inspector.rs
@@ -380,8 +380,8 @@ mod tests {
         );
         evm.set_inspector(inspector);
         let tx_env = TxEnvExt::default();
-        let bytecode = legacy_bytecode(code);
-        let mut message = MessageExt { gas_limit, code: bytecode, ..message.clone() };
+        let mut message =
+            Message::<BaseEvmTypes> { gas_limit, code: legacy_bytecode(code), ..message.clone() };
         let result = Host::execute_message(&mut evm, &tx_env, &mut message);
         let inspector = evm.clear_inspector_as::<I>().unwrap();
         (result, inspector, evm)
@@ -644,8 +644,8 @@ mod tests {
         );
         evm.set_inspector(MutateCallInspector { destination: replacement });
         let tx_env = TxEnvExt::default();
-        let bytecode = legacy_bytecode(code);
-        let mut message = MessageExt { gas_limit: 100_000, code: bytecode, ..Default::default() };
+        let mut message =
+            MessageExt { gas_limit: 100_000, code: legacy_bytecode(code), ..Default::default() };
         let result = Host::execute_message(&mut evm, &tx_env, &mut message);
 
         assert_matches!(result.stop, InstrStop::Stop);

--- a/crates/evm2/src/evm/inspector.rs
+++ b/crates/evm2/src/evm/inspector.rs
@@ -381,9 +381,8 @@ mod tests {
         evm.set_inspector(inspector);
         let tx_env = TxEnvExt::default();
         let bytecode = legacy_bytecode(code);
-        let mut message = message.clone();
-        message.gas_limit = gas_limit;
-        let result = Host::execute_message(&mut evm, &tx_env, bytecode, &mut message);
+        let mut message = MessageExt { gas_limit, code: bytecode, ..message.clone() };
+        let result = Host::execute_message(&mut evm, &tx_env, &mut message);
         let inspector = evm.clear_inspector_as::<I>().unwrap();
         (result, inspector, evm)
     }
@@ -646,8 +645,8 @@ mod tests {
         evm.set_inspector(MutateCallInspector { destination: replacement });
         let tx_env = TxEnvExt::default();
         let bytecode = legacy_bytecode(code);
-        let mut message = MessageExt { gas_limit: 100_000, ..Default::default() };
-        let result = Host::execute_message(&mut evm, &tx_env, bytecode, &mut message);
+        let mut message = MessageExt { gas_limit: 100_000, code: bytecode, ..Default::default() };
+        let result = Host::execute_message(&mut evm, &tx_env, &mut message);
 
         assert_matches!(result.stop, InstrStop::Stop);
         // The redirected call transferred the value to the replacement, not the target.
@@ -948,9 +947,12 @@ mod tests {
         code.push(op::SELFDESTRUCT);
 
         let tx_env = TxEnvExt::default();
-        let bytecode = legacy_bytecode(code);
-        let message = Message::<TestTypes> { gas_limit: 10_000, ..Default::default() };
-        let mut interp = Interpreter::<TestTypes>::new(bytecode, &tx_env, &message);
+        let message = Message::<TestTypes> {
+            gas_limit: 10_000,
+            code: legacy_bytecode(code),
+            ..Default::default()
+        };
+        let mut interp = Interpreter::<TestTypes>::new(&tx_env, &message);
         let config = ExecutionConfig::for_base_spec::<BaseEvmConfigSelector>(SpecId::OSAKA);
         let stop = interp.run_inspect(&config, &mut host, &mut inspector);
 

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -123,7 +123,7 @@ use crate::{
     error::error_unavailable,
     interpreter::{
         Gas, GasTracker, Host, InstrStop, Interpreter, InterpreterPool, Message, MessageKind,
-        MessageResult, MessageResultExt, Word, gas::WARM_STORAGE_READ_COST,
+        MessageResult, MessageResultExt, Word,
     },
     registry::{HandlerError, HandlerResult, TxRegistry},
     trustme,
@@ -1114,17 +1114,16 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
     fn execute_message_impl(
         &mut self,
         tx_env: &TxEnv<T>,
-        bytecode: Bytecode,
         message: &mut Message<T>,
     ) -> MessageResult<T> {
         let mut result = match message.kind {
             MessageKind::Create | MessageKind::Create2 => {
-                self.execute_create_message(tx_env, bytecode, message)
+                self.execute_create_message(tx_env, message)
             }
             MessageKind::Call
             | MessageKind::CallCode
             | MessageKind::DelegateCall
-            | MessageKind::StaticCall => self.execute_call_message(tx_env, bytecode, message),
+            | MessageKind::StaticCall => self.execute_call_message(tx_env, message),
         };
         // Settle the returning frame's gas for its stop reason at this single exit,
         // rather than in each result builder, so every consumer (parent
@@ -1141,12 +1140,11 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
     fn execute_message_inspected<'frame>(
         &mut self,
         tx_env: &'frame TxEnv<T>,
-        bytecode: Bytecode,
         message: &'frame mut Message<T>,
     ) -> MessageResult<T> {
         let _guard = self.enter_execution();
         let Some(inspector) = self.inspector.as_deref_mut() else {
-            return self.execute_message_impl(tx_env, bytecode, message);
+            return self.execute_message_impl(tx_env, message);
         };
         // SAFETY: The inspector is stored in `self`; the execution guard prevents inspector
         // replacement while the hooks are running.
@@ -1170,7 +1168,7 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
                 let frame = top_frame.insert(self.interpreter_pool.pop());
                 // SAFETY: The message outlives the frame, which is returned to the pool below.
                 let frame_message = unsafe { trustme::decouple_lt(&*message) };
-                frame.init(bytecode.clone(), tx_env, frame_message);
+                frame.init(tx_env, frame_message);
                 // SAFETY: `execution_config` points to a private field that host execution does
                 // not replace or mutate, so the pointee remains valid for the lifetime of the
                 // frame.
@@ -1188,8 +1186,7 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
             inspector.call(frame, message)
         };
 
-        let mut result =
-            inspected.unwrap_or_else(|| self.execute_message_impl(tx_env, bytecode, message));
+        let mut result = inspected.unwrap_or_else(|| self.execute_message_impl(tx_env, message));
 
         if is_create {
             inspector.create_end(frame, message, &mut result);
@@ -1208,7 +1205,6 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
     fn execute_create_message(
         &mut self,
         tx_env: &TxEnv<T>,
-        bytecode: Bytecode,
         message: &mut Message<T>,
     ) -> MessageResult<T> {
         if message.depth > CALL_DEPTH_LIMIT {
@@ -1222,20 +1218,6 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
             return Self::error_message_result(stop, message.gas_limit, message.reservoir);
         }
         let checkpoint = self.state.checkpoint();
-        // EIP-2780: capture whether the target leaf is already alive
-        // (existing, non-empty) before creation, so a top-level create at a pre-existing
-        // balance-only account is not charged the account-creation state gas below (no new leaf is
-        // created — execution-specs `created_target_alive`).
-        let target_alive = if self.feature(EvmFeatures::EIP8037) {
-            match self.account_is_alive(&message.destination) {
-                Ok(alive) => alive,
-                Err(stop) => {
-                    return Self::error_message_result(stop, message.gas_limit, message.reservoir);
-                }
-            }
-        } else {
-            false
-        };
         if let Err(stop) = self.create_message_account(message) {
             self.state.rollback(checkpoint, self.features);
             return Self::error_message_result(stop, message.gas_limit, message.reservoir);
@@ -1244,27 +1226,7 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
         message.disable_precompiles = false;
         let input = core::mem::take(&mut message.input);
 
-        // EIP-2780: a top-level create (depth 0) charges the
-        // account-creation state gas at frame entry, conditional on the destination not already
-        // existing (`!target_alive`). Nested creates are charged on the parent frame by the CREATE
-        // opcode instead. The charge is state gas on this frame's tracker, refilled by the frame's
-        // own settle on failure; an unaffordable charge halts the create out-of-gas without running
-        // the initcode, returning the reservoir.
-        let mut frame_gas =
-            GasTracker::new_with_regular_gas_and_reservoir(message.gas_limit, message.reservoir);
-        if message.depth == 0
-            && !target_alive
-            && self.feature(EvmFeatures::EIP8037)
-            && frame_gas.spend_state(self.version().gas_params.create_state_gas()).is_err()
-        {
-            self.state.rollback(checkpoint, self.features);
-            return Self::error_message_result(
-                InstrStop::OutOfGas,
-                message.gas_limit,
-                message.reservoir,
-            );
-        }
-        let stop = self.run_interpreter(bytecode, tx_env, message, frame_gas);
+        let stop = self.run_interpreter(tx_env, message);
         message.input = input;
 
         self.finish_create_message_run(checkpoint, &message.destination, message.gas_limit, stop)
@@ -1304,15 +1266,6 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
         Ok(())
     }
 
-    /// Returns whether the account is alive (exists and is non-empty), matching execution-specs
-    /// `is_account_alive`. Used by EIP-8037 to detect a create at a pre-existing leaf.
-    fn account_is_alive(&mut self, address: &Address) -> Result<bool, InstrStop> {
-        match self.state.account(address, false) {
-            Ok(account) => Ok(account.get().is_some_and(|info| !info.is_empty())),
-            Err(code) => Err(store_error!(self, code)),
-        }
-    }
-
     #[inline(never)]
     fn create_message_account(&mut self, message: &Message<T>) -> Result<(), InstrStop> {
         self.state
@@ -1342,7 +1295,6 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
                     gas: *gas.tracker(),
                     output: Bytes::new(),
                     created_address: None,
-                    runtime_gas_oog: false,
                     ext: T::MessageResultExt::default(),
                     _non_exhaustive: (),
                 };
@@ -1369,7 +1321,6 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
             gas: *gas.tracker(),
             output,
             created_address: stop.is_success().then_some(*address),
-            runtime_gas_oog: false,
             ext: T::MessageResultExt::default(),
             _non_exhaustive: (),
         }
@@ -1418,7 +1369,6 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
     fn execute_call_message(
         &mut self,
         tx_env: &TxEnv<T>,
-        bytecode: Bytecode,
         message: &mut Message<T>,
     ) -> MessageResult<T> {
         if message.depth > CALL_DEPTH_LIMIT {
@@ -1429,35 +1379,6 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
             );
         }
         let checkpoint = self.state.checkpoint();
-        // EIP-2780 top-level (depth-0) execution charges, metered on the frame gas before the
-        // precompile/interpreter split. Read from the recipient's pre-call state (before the value
-        // transfer below) and applied inside the checkpoint, so the delegated-target load it
-        // performs is unwound if the frame later rolls back. For a delegated recipient this also
-        // resolves the delegation (gating the target load on gas), returning the delegate's code
-        // and address so the frame runs the delegate's code.
-        let mut frame_gas =
-            GasTracker::new_with_regular_gas_and_reservoir(message.gas_limit, message.reservoir);
-        let mut bytecode = bytecode;
-        match self.apply_eip2780_call_charges(message, &mut frame_gas) {
-            Ok(Some((delegate_code, delegate_address))) => {
-                message.code_address = delegate_address;
-                message.disable_precompiles = true;
-                bytecode = delegate_code;
-            }
-            Ok(None) => {}
-            Err(()) => {
-                self.state.rollback(checkpoint, self.features);
-                let mut result = Self::error_message_result(
-                    InstrStop::OutOfGas,
-                    message.gas_limit,
-                    message.reservoir,
-                );
-                // Signal a runtime gas-phase out-of-gas so the EIP-7702 handler can revert the
-                // delegations applied before the frame (ethereum/EIPs#11844).
-                result.runtime_gas_oog = true;
-                return result;
-            }
-        }
         // EIP-161 state clearing depends on zero-value direct call targets being touched.
         let transfers_balance = matches!(
             message.kind,
@@ -1483,77 +1404,12 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
         }
 
         if self.contains_precompile(message) {
-            return self.execute_call_precompile(checkpoint, message, frame_gas);
+            return self.execute_call_precompile(checkpoint, message);
         }
 
-        let stop = self.run_interpreter(bytecode, tx_env, message, frame_gas);
+        let stop = self.run_interpreter(tx_env, message);
 
         self.finish_call_message_run(checkpoint, stop)
-    }
-
-    /// Applies the EIP-2780 top-level (depth-0) execution charges for a call to
-    /// `message.destination`, metered on the frame `gas`:
-    /// - `new_account_state_gas` of state gas when the recipient is empty (EIP-161) and the call
-    ///   transfers value (charged before delegation resolution, per execution-specs
-    ///   `prepare_dispatch`), and
-    /// - the delegation-target access following the EIP-2929 warm/cold model when the recipient
-    ///   carries an EIP-7702 delegation.
-    ///
-    /// The delegation-target access is charged as a warm access first and the cold premium after
-    /// the target is loaded, and the load is gated on `skip_cold_load` (as nested calls do): a
-    /// frame that cannot afford the cold access never loads the target, so it stays out of the
-    /// EIP-7928 block access list. On success the delegated recipient's resolved code and
-    /// address are returned so the caller runs the delegate's code; `Err(())` signals a runtime
-    /// out-of-gas. A no-op returning `Ok(None)` off the depth-0 EIP-2780 path.
-    fn apply_eip2780_call_charges(
-        &mut self,
-        message: &Message<T>,
-        gas: &mut GasTracker,
-    ) -> Result<Option<(Bytecode, Address)>, ()> {
-        if message.depth != 0 || !self.feature(EvmFeatures::EIP2780) {
-            return Ok(None);
-        }
-        let dest = message.destination;
-        // A nonexistent recipient reads as an empty account (EIP-161).
-        let recipient_is_empty = match self.state.account_info_untracked(&dest) {
-            Ok(info) => info.as_ref().is_none_or(AccountInfo::is_empty),
-            Err(_) => return Ok(None),
-        };
-        // Empty recipient + value transfer: pay the new account leaf's state gas. Checked before
-        // the delegation resolution, matching the spec's `prepare_dispatch` order.
-        if !message.value.is_zero() && recipient_is_empty {
-            if gas.spend_state(self.version().gas_params.new_account_state_gas()).is_err() {
-                return Err(());
-            }
-            // An empty recipient is never delegated.
-            return Ok(None);
-        }
-        if recipient_is_empty {
-            return Ok(None);
-        }
-        // Resolve the recipient's delegation designator (the recipient is the warm tx target; its
-        // stored code must be loaded to read the designator).
-        let delegated = match self.state.account(&dest, false) {
-            Ok(mut acc) => acc.load_code().ok().and_then(|code| code.eip7702_address()),
-            Err(_) => None,
-        };
-        let Some(delegated) = delegated else {
-            return Ok(None);
-        };
-        // Delegation-target access, EIP-2929 warm/cold: charge the warm access first (covered → the
-        // target is loaded and enters the block access list), then the cold premium after the load.
-        // The load is skipped when the cold premium is unaffordable, keeping a cold, unafforded
-        // target out of the block access list.
-        let cold_additional = self.version().gas_params.cold_account_additional_cost();
-        if gas.spend(u64::from(WARM_STORAGE_READ_COST)).is_err() {
-            return Err(());
-        }
-        let skip_cold_load = gas.remaining() < cold_additional;
-        let load = self.load_account(&delegated, true, skip_cold_load).map_err(|_| ())?;
-        if load.is_cold && gas.spend(cold_additional).is_err() {
-            return Err(());
-        }
-        Ok(Some((load.code, delegated)))
     }
 
     #[inline(never)]
@@ -1561,10 +1417,9 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
         &mut self,
         checkpoint: StateCheckpoint,
         message: &Message<T>,
-        mut gas: GasTracker,
     ) -> MessageResult<T> {
-        // `gas` is the frame tracker built by the caller with the inherited reservoir and
-        // any EIP-2780 depth-0 charge already applied; the precompile only adds regular gas.
+        let mut gas =
+            GasTracker::new_with_regular_gas_and_reservoir(message.gas_limit, message.reservoir);
         let logs_len = self.state.logs().len();
         let execution = self.execute_precompile(message, &mut gas);
         let logs = self.state.logs()[logs_len..].to_vec();
@@ -1592,7 +1447,6 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
             gas,
             output,
             created_address: None,
-            runtime_gas_oog: false,
             ext: T::MessageResultExt::default(),
             _non_exhaustive: (),
         }
@@ -1616,7 +1470,6 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
             gas: *child_gas.tracker(),
             output,
             created_address: None,
-            runtime_gas_oog: false,
             ext: T::MessageResultExt::default(),
             _non_exhaustive: (),
         }
@@ -1638,21 +1491,13 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
     #[inline(never)]
     fn run_interpreter<'frame>(
         &mut self,
-        bytecode: Bytecode,
         tx_env: &'frame TxEnv<T>,
         message: &'frame Message<T>,
-        frame_gas: GasTracker,
     ) -> InstrStop {
         let mut interp: Box<Interpreter<'frame, 'a, T>> = self.interpreter_pool.pop();
         let _guard = self.enter_execution();
         let interp_ref = interp.as_mut();
-        interp_ref.init(bytecode, tx_env, message);
-        // Adopt the caller's frame tracker, which carries the EIP-2780 depth-0 charges
-        // already applied; it is otherwise identical to the one `init` derived (same
-        // regular limit and inherited reservoir). A later revert/halt unwinds the state
-        // charge via the existing `rollback_state_gas` reconciliation, like any in-frame
-        // state gas.
-        *interp_ref.gas_mut().tracker_mut() = frame_gas;
+        interp_ref.init(tx_env, message);
         // SAFETY: `execution_config` points to a private field that host execution does not
         // replace or mutate, so the pointee remains valid here.
         let execution_config = unsafe { trustme::decouple_lt(&self.execution_config) };
@@ -1816,16 +1661,11 @@ impl<'a, T: EvmTypes> Host<T> for Evm<'a, T> {
     }
 
     #[inline]
-    fn execute_message(
-        &mut self,
-        tx_env: &TxEnv<T>,
-        bytecode: Bytecode,
-        message: &mut Message<T>,
-    ) -> MessageResult<T> {
+    fn execute_message(&mut self, tx_env: &TxEnv<T>, message: &mut Message<T>) -> MessageResult<T> {
         if self.inspector.is_some() {
-            return self.execute_message_inspected(tx_env, bytecode, message);
+            return self.execute_message_inspected(tx_env, message);
         }
-        self.execute_message_impl(tx_env, bytecode, message)
+        self.execute_message_impl(tx_env, message)
     }
 
     fn selfdestruct(
@@ -2128,16 +1968,13 @@ mod tests {
         );
         evm.set_interpreter_runner(TestInterpreterRunner { stop, calls: Arc::clone(&calls) });
         let tx_env = TxEnvExt::default();
-        let message = MessageExt { gas_limit: 30_000, ..Default::default() };
+        let message = MessageExt {
+            gas_limit: 30_000,
+            code: Bytecode::new_legacy(Bytes::copy_from_slice(bytecode)),
+            ..Default::default()
+        };
 
-        let frame_gas =
-            GasTracker::new_with_regular_gas_and_reservoir(message.gas_limit, message.reservoir);
-        let stop = evm.run_interpreter(
-            Bytecode::new_legacy(Bytes::copy_from_slice(bytecode)),
-            &tx_env,
-            &message,
-            frame_gas,
-        );
+        let stop = evm.run_interpreter(&tx_env, &message);
 
         assert_eq!(calls.load(Ordering::Relaxed), 1);
         stop
@@ -2194,6 +2031,7 @@ mod tests {
             caller: Address::ZERO,
             input: Bytes::new(),
             value: U256::ZERO,
+            code: Bytecode::default(),
             code_address: address,
             disable_precompiles: false,
             caller_is_static: false,
@@ -2231,12 +2069,7 @@ mod tests {
         evm.set_inspector(LogInspector::default());
         let mut message = precompile_message(TEST_PRECOMPILE);
 
-        let result = Host::execute_message(
-            &mut evm,
-            &TxEnvExt::default(),
-            Bytecode::new_legacy(Bytes::new()),
-            &mut message,
-        );
+        let result = Host::execute_message(&mut evm, &TxEnvExt::default(), &mut message);
 
         assert_eq!(result.stop, InstrStop::Return);
         let inspector = evm.clear_inspector_as::<LogInspector>().unwrap();
@@ -2314,10 +2147,11 @@ mod tests {
             destination: contract,
             code_address: contract,
             gas_limit: 200_000,
+            code: bytecode,
             ..MessageExt::default()
         };
 
-        let result = Host::execute_message(&mut evm, &TxEnvExt::default(), bytecode, &mut message);
+        let result = Host::execute_message(&mut evm, &TxEnvExt::default(), &mut message);
 
         assert_eq!(result.stop, InstrStop::FatalPrecompileError);
         assert_eq!(evm.error_code(), Some(ErrorCode::FATAL_PRECOMPILE));
@@ -2369,10 +2203,11 @@ mod tests {
             destination: contract,
             code_address: contract,
             gas_limit: 200_000,
+            code: bytecode,
             ..MessageExt::default()
         };
 
-        let result = Host::execute_message(&mut evm, &TxEnvExt::default(), bytecode, &mut message);
+        let result = Host::execute_message(&mut evm, &TxEnvExt::default(), &mut message);
 
         assert_eq!(result.stop, InstrStop::Stop);
         assert!(evm.error_code().is_none());
@@ -2629,12 +2464,12 @@ mod tests {
             Precompiles::base(SpecId::OSAKA),
         );
         evm.set_inspector(AccessingInspector { access });
-        let message = MessageExt::default();
+        let message = MessageExt {
+            code: Bytecode::new_legacy(Bytes::from_static(&[op::STOP])),
+            ..MessageExt::default()
+        };
         let tx_env = TxEnvExt::default();
-        let bytecode = Bytecode::new_legacy(Bytes::from_static(&[op::STOP]));
-        let frame_gas =
-            GasTracker::new_with_regular_gas_and_reservoir(message.gas_limit, message.reservoir);
-        let _ = evm.run_interpreter(bytecode, &tx_env, &message, frame_gas);
+        let _ = evm.run_interpreter(&tx_env, &message);
     }
 
     #[test]
@@ -2655,13 +2490,13 @@ mod tests {
             Precompiles::base(SpecId::OSAKA),
         );
         evm.set_inspector(ReadingInspector {});
-        let message = MessageExt::default();
+        let message = MessageExt {
+            code: Bytecode::new_legacy(Bytes::from_static(&[op::STOP])),
+            ..MessageExt::default()
+        };
         let tx_env = TxEnvExt::default();
-        let bytecode = Bytecode::new_legacy(Bytes::from_static(&[op::STOP]));
 
-        let frame_gas =
-            GasTracker::new_with_regular_gas_and_reservoir(message.gas_limit, message.reservoir);
-        let _ = evm.run_interpreter(bytecode, &tx_env, &message, frame_gas);
+        let _ = evm.run_interpreter(&tx_env, &message);
     }
 
     #[test]
@@ -2713,12 +2548,12 @@ mod tests {
             Precompiles::base(SpecId::OSAKA),
         );
         evm.set_inspector(BlockReplacingInspector);
-        let message = MessageExt::default();
+        let message = MessageExt {
+            code: Bytecode::new_legacy(Bytes::from_static(&[op::STOP])),
+            ..MessageExt::default()
+        };
         let tx_env = TxEnvExt::default();
-        let bytecode = Bytecode::new_legacy(Bytes::from_static(&[op::STOP]));
-        let frame_gas =
-            GasTracker::new_with_regular_gas_and_reservoir(message.gas_limit, message.reservoir);
-        let _ = evm.run_interpreter(bytecode, &tx_env, &message, frame_gas);
+        let _ = evm.run_interpreter(&tx_env, &message);
         assert_eq!(evm.block().number, Word::from(123));
         assert_eq!(evm.block().timestamp, Word::from(124));
     }
@@ -2748,12 +2583,12 @@ mod tests {
             Precompiles::base(SpecId::OSAKA),
         );
         evm.set_inspector(ConfigReplacingInspector);
-        let message = MessageExt::default();
+        let message = MessageExt {
+            code: Bytecode::new_legacy(Bytes::from_static(&[op::STOP])),
+            ..MessageExt::default()
+        };
         let tx_env = TxEnvExt::default();
-        let bytecode = Bytecode::new_legacy(Bytes::from_static(&[op::STOP]));
-        let frame_gas =
-            GasTracker::new_with_regular_gas_and_reservoir(message.gas_limit, message.reservoir);
-        let _ = evm.run_interpreter(bytecode, &tx_env, &message, frame_gas);
+        let _ = evm.run_interpreter(&tx_env, &message);
     }
 
     #[derive(Clone, Copy)]
@@ -2806,21 +2641,11 @@ mod tests {
             ),
             TopLevelInspectorHook::Call => {
                 let mut message = MessageExt { kind: MessageKind::Call, ..Default::default() };
-                let _ = Host::execute_message(
-                    &mut evm,
-                    &TxEnvExt::default(),
-                    Bytecode::default(),
-                    &mut message,
-                );
+                let _ = Host::execute_message(&mut evm, &TxEnvExt::default(), &mut message);
             }
             TopLevelInspectorHook::Create => {
                 let mut message = MessageExt { kind: MessageKind::Create, ..Default::default() };
-                let _ = Host::execute_message(
-                    &mut evm,
-                    &TxEnvExt::default(),
-                    Bytecode::default(),
-                    &mut message,
-                );
+                let _ = Host::execute_message(&mut evm, &TxEnvExt::default(), &mut message);
             }
         }
     }
@@ -2874,6 +2699,7 @@ mod tests {
             caller: Address::with_last_byte(0x7a),
             input: Bytes::from_static(b"message input"),
             value: U256::from(99),
+            code: Bytecode::default(),
             code_address: address,
             disable_precompiles: false,
             caller_is_static: false,
@@ -3229,10 +3055,11 @@ mod tests {
             destination: contract,
             code_address: contract,
             gas_limit: 50_000,
+            code: bytecode,
             ..MessageExt::default()
         };
 
-        let result = Host::execute_message(&mut evm, &TxEnvExt::default(), bytecode, &mut message);
+        let result = Host::execute_message(&mut evm, &TxEnvExt::default(), &mut message);
         assert!(result.stop.is_success());
     }
 
@@ -3293,10 +3120,11 @@ mod tests {
             destination: contract,
             code_address: contract,
             gas_limit: 50_000,
+            code: bytecode,
             ..MessageExt::default()
         };
 
-        let result = Host::execute_message(&mut evm, &TxEnvExt::default(), bytecode, &mut message);
+        let result = Host::execute_message(&mut evm, &TxEnvExt::default(), &mut message);
 
         assert_eq!(result.stop, InstrStop::FatalExternalError);
         let error_code = evm.error_code().unwrap();
@@ -3322,10 +3150,11 @@ mod tests {
             destination: contract,
             code_address: contract,
             gas_limit: 500,
+            code: bytecode,
             ..MessageExt::default()
         };
 
-        let result = Host::execute_message(&mut evm, &TxEnvExt::default(), bytecode, &mut message);
+        let result = Host::execute_message(&mut evm, &TxEnvExt::default(), &mut message);
 
         assert_eq!(result.stop, InstrStop::OutOfGas);
         assert!(!evm.state.storage(&contract).is_warm(&key));
@@ -3404,15 +3233,10 @@ mod tests {
             destination: contract,
             code_address: contract,
             gas_limit: 6_000,
+            code: selfdestruct_to_code(&target),
             ..MessageExt::default()
         };
-
-        let result = Host::execute_message(
-            &mut evm,
-            &TxEnvExt::default(),
-            selfdestruct_to_code(&target),
-            &mut message,
-        );
+        let result = Host::execute_message(&mut evm, &TxEnvExt::default(), &mut message);
 
         assert_eq!(result.stop, InstrStop::OutOfGas);
         assert_eq!(target_reads.load(Ordering::SeqCst), 0);
@@ -3431,17 +3255,18 @@ mod tests {
             database,
             Precompiles::base(SpecId::FRONTIER),
         );
+        let code =
+            Bytecode::new_legacy(Bytes::from_static(&[op::PUSH1, 1, op::PUSH1, 0, op::RETURN]));
         let mut message = MessageExt {
             kind: MessageKind::Create,
             destination: created,
             caller,
             gas_limit: 50,
+            code,
             ..MessageExt::default()
         };
-        let code =
-            Bytecode::new_legacy(Bytes::from_static(&[op::PUSH1, 1, op::PUSH1, 0, op::RETURN]));
 
-        let result = Host::execute_message(&mut evm, &TxEnvExt::default(), code, &mut message);
+        let result = Host::execute_message(&mut evm, &TxEnvExt::default(), &mut message);
         assert!(result.stop.is_success());
 
         evm.state.finalize_transaction_(Version::base(SpecId::FRONTIER));
@@ -3464,17 +3289,18 @@ mod tests {
             database,
             Precompiles::base(SpecId::HOMESTEAD),
         );
+        let code =
+            Bytecode::new_legacy(Bytes::from_static(&[op::PUSH1, 1, op::PUSH1, 0, op::RETURN]));
         let mut message = MessageExt {
             kind: MessageKind::Create,
             destination: created,
             caller,
             gas_limit: 50,
+            code,
             ..MessageExt::default()
         };
-        let code =
-            Bytecode::new_legacy(Bytes::from_static(&[op::PUSH1, 1, op::PUSH1, 0, op::RETURN]));
 
-        let result = Host::execute_message(&mut evm, &TxEnvExt::default(), code, &mut message);
+        let result = Host::execute_message(&mut evm, &TxEnvExt::default(), &mut message);
         assert_eq!(result.stop, InstrStop::OutOfGas);
         assert!(result.output.is_empty());
 
@@ -3496,13 +3322,6 @@ mod tests {
             database,
             Precompiles::base(SpecId::LONDON),
         );
-        let mut message = MessageExt {
-            kind: MessageKind::Create,
-            destination: created,
-            caller,
-            gas_limit: 50_000,
-            ..MessageExt::default()
-        };
         let code = Bytecode::new_legacy(Bytes::from_static(&[
             op::PUSH1,
             0xef,
@@ -3515,8 +3334,16 @@ mod tests {
             0,
             op::RETURN,
         ]));
+        let mut message = MessageExt {
+            kind: MessageKind::Create,
+            destination: created,
+            caller,
+            gas_limit: 50_000,
+            code,
+            ..MessageExt::default()
+        };
 
-        let result = Host::execute_message(&mut evm, &TxEnvExt::default(), code, &mut message);
+        let result = Host::execute_message(&mut evm, &TxEnvExt::default(), &mut message);
 
         assert_eq!(result.stop, InstrStop::CreateContractStartingWithEF);
         assert!(result.output.is_empty());
@@ -3535,13 +3362,6 @@ mod tests {
             database,
             Precompiles::base(SpecId::SPURIOUS_DRAGON),
         );
-        let mut message = MessageExt {
-            kind: MessageKind::Create,
-            destination: created,
-            caller,
-            gas_limit: 100_000,
-            ..MessageExt::default()
-        };
         let code = Bytecode::new_legacy(Bytes::from_static(&[
             op::PUSH2,
             0x60,
@@ -3550,8 +3370,16 @@ mod tests {
             0,
             op::RETURN,
         ]));
+        let mut message = MessageExt {
+            kind: MessageKind::Create,
+            destination: created,
+            caller,
+            gas_limit: 100_000,
+            code,
+            ..MessageExt::default()
+        };
 
-        let result = Host::execute_message(&mut evm, &TxEnvExt::default(), code, &mut message);
+        let result = Host::execute_message(&mut evm, &TxEnvExt::default(), &mut message);
 
         assert_eq!(result.stop, InstrStop::CreateContractSizeLimit);
         assert!(result.output.is_empty());
@@ -3578,12 +3406,7 @@ mod tests {
             ..MessageExt::default()
         };
 
-        let result = Host::execute_message(
-            &mut evm,
-            &TxEnvExt::default(),
-            Bytecode::default(),
-            &mut message,
-        );
+        let result = Host::execute_message(&mut evm, &TxEnvExt::default(), &mut message);
         assert!(result.stop.is_success());
 
         evm.state.finalize_transaction_(Version::base(SpecId::SPURIOUS_DRAGON));
@@ -3618,12 +3441,7 @@ mod tests {
             ..MessageExt::default()
         };
 
-        let result = Host::execute_message(
-            &mut evm,
-            &TxEnvExt::default(),
-            Bytecode::default(),
-            &mut message,
-        );
+        let result = Host::execute_message(&mut evm, &TxEnvExt::default(), &mut message);
         assert!(result.stop.is_success());
 
         evm.state.finalize_transaction_(Version::base(SpecId::SPURIOUS_DRAGON));
@@ -3689,12 +3507,7 @@ mod tests {
             ..MessageExt::default()
         };
 
-        let result = Host::execute_message(
-            &mut evm,
-            &TxEnvExt::default(),
-            Bytecode::default(),
-            &mut message,
-        );
+        let result = Host::execute_message(&mut evm, &TxEnvExt::default(), &mut message);
         assert!(result.stop.is_success());
 
         let version = *evm.version();

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -123,7 +123,7 @@ use crate::{
     error::error_unavailable,
     interpreter::{
         Gas, GasTracker, Host, InstrStop, Interpreter, InterpreterPool, Message, MessageKind,
-        MessageResult, MessageResultExt, Word,
+        MessageResult, MessageResultExt, Word, gas::WARM_STORAGE_READ_COST,
     },
     registry::{HandlerError, HandlerResult, TxRegistry},
     trustme,
@@ -1218,6 +1218,20 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
             return Self::error_message_result(stop, message.gas_limit, message.reservoir);
         }
         let checkpoint = self.state.checkpoint();
+        // EIP-2780: capture whether the target leaf is already alive
+        // (existing, non-empty) before creation, so a top-level create at a pre-existing
+        // balance-only account is not charged the account-creation state gas below (no new leaf is
+        // created — execution-specs `created_target_alive`).
+        let target_alive = if self.feature(EvmFeatures::EIP8037) {
+            match self.account_is_alive(&message.destination) {
+                Ok(alive) => alive,
+                Err(stop) => {
+                    return Self::error_message_result(stop, message.gas_limit, message.reservoir);
+                }
+            }
+        } else {
+            false
+        };
         if let Err(stop) = self.create_message_account(message) {
             self.state.rollback(checkpoint, self.features);
             return Self::error_message_result(stop, message.gas_limit, message.reservoir);
@@ -1226,7 +1240,27 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
         message.disable_precompiles = false;
         let input = core::mem::take(&mut message.input);
 
-        let stop = self.run_interpreter(tx_env, message);
+        // EIP-2780: a top-level create (depth 0) charges the
+        // account-creation state gas at frame entry, conditional on the destination not already
+        // existing (`!target_alive`). Nested creates are charged on the parent frame by the CREATE
+        // opcode instead. The charge is state gas on this frame's tracker, refilled by the frame's
+        // own settle on failure; an unaffordable charge halts the create out-of-gas without running
+        // the initcode, returning the reservoir.
+        let mut frame_gas =
+            GasTracker::new_with_regular_gas_and_reservoir(message.gas_limit, message.reservoir);
+        if message.depth == 0
+            && !target_alive
+            && self.feature(EvmFeatures::EIP8037)
+            && frame_gas.spend_state(self.version().gas_params.create_state_gas()).is_err()
+        {
+            self.state.rollback(checkpoint, self.features);
+            return Self::error_message_result(
+                InstrStop::OutOfGas,
+                message.gas_limit,
+                message.reservoir,
+            );
+        }
+        let stop = self.run_interpreter(tx_env, message, frame_gas);
         message.input = input;
 
         self.finish_create_message_run(checkpoint, &message.destination, message.gas_limit, stop)
@@ -1266,6 +1300,15 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
         Ok(())
     }
 
+    /// Returns whether the account is alive (exists and is non-empty), matching execution-specs
+    /// `is_account_alive`. Used by EIP-8037 to detect a create at a pre-existing leaf.
+    fn account_is_alive(&mut self, address: &Address) -> Result<bool, InstrStop> {
+        match self.state.account(address, false) {
+            Ok(account) => Ok(account.get().is_some_and(|info| !info.is_empty())),
+            Err(code) => Err(store_error!(self, code)),
+        }
+    }
+
     #[inline(never)]
     fn create_message_account(&mut self, message: &Message<T>) -> Result<(), InstrStop> {
         self.state
@@ -1295,6 +1338,7 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
                     gas: *gas.tracker(),
                     output: Bytes::new(),
                     created_address: None,
+                    runtime_gas_oog: false,
                     ext: T::MessageResultExt::default(),
                     _non_exhaustive: (),
                 };
@@ -1321,6 +1365,7 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
             gas: *gas.tracker(),
             output,
             created_address: stop.is_success().then_some(*address),
+            runtime_gas_oog: false,
             ext: T::MessageResultExt::default(),
             _non_exhaustive: (),
         }
@@ -1379,6 +1424,34 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
             );
         }
         let checkpoint = self.state.checkpoint();
+        // EIP-2780 top-level (depth-0) execution charges, metered on the frame gas before the
+        // precompile/interpreter split. Read from the recipient's pre-call state (before the value
+        // transfer below) and applied inside the checkpoint, so the delegated-target load it
+        // performs is unwound if the frame later rolls back. For a delegated recipient this also
+        // resolves the delegation (gating the target load on gas), returning the delegate's code
+        // and address so the frame runs the delegate's code.
+        let mut frame_gas =
+            GasTracker::new_with_regular_gas_and_reservoir(message.gas_limit, message.reservoir);
+        match self.apply_eip2780_call_charges(message, &mut frame_gas) {
+            Ok(Some((delegate_code, delegate_address))) => {
+                message.code_address = delegate_address;
+                message.disable_precompiles = true;
+                message.code = delegate_code;
+            }
+            Ok(None) => {}
+            Err(()) => {
+                self.state.rollback(checkpoint, self.features);
+                let mut result = Self::error_message_result(
+                    InstrStop::OutOfGas,
+                    message.gas_limit,
+                    message.reservoir,
+                );
+                // Signal a runtime gas-phase out-of-gas so the EIP-7702 handler can revert the
+                // delegations applied before the frame (ethereum/EIPs#11844).
+                result.runtime_gas_oog = true;
+                return result;
+            }
+        }
         // EIP-161 state clearing depends on zero-value direct call targets being touched.
         let transfers_balance = matches!(
             message.kind,
@@ -1404,12 +1477,77 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
         }
 
         if self.contains_precompile(message) {
-            return self.execute_call_precompile(checkpoint, message);
+            return self.execute_call_precompile(checkpoint, message, frame_gas);
         }
 
-        let stop = self.run_interpreter(tx_env, message);
+        let stop = self.run_interpreter(tx_env, message, frame_gas);
 
         self.finish_call_message_run(checkpoint, stop)
+    }
+
+    /// Applies the EIP-2780 top-level (depth-0) execution charges for a call to
+    /// `message.destination`, metered on the frame `gas`:
+    /// - `new_account_state_gas` of state gas when the recipient is empty (EIP-161) and the call
+    ///   transfers value (charged before delegation resolution, per execution-specs
+    ///   `prepare_dispatch`), and
+    /// - the delegation-target access following the EIP-2929 warm/cold model when the recipient
+    ///   carries an EIP-7702 delegation.
+    ///
+    /// The delegation-target access is charged as a warm access first and the cold premium after
+    /// the target is loaded, and the load is gated on `skip_cold_load` (as nested calls do): a
+    /// frame that cannot afford the cold access never loads the target, so it stays out of the
+    /// EIP-7928 block access list. On success the delegated recipient's resolved code and
+    /// address are returned so the caller runs the delegate's code; `Err(())` signals a runtime
+    /// out-of-gas. A no-op returning `Ok(None)` off the depth-0 EIP-2780 path.
+    fn apply_eip2780_call_charges(
+        &mut self,
+        message: &Message<T>,
+        gas: &mut GasTracker,
+    ) -> Result<Option<(Bytecode, Address)>, ()> {
+        if message.depth != 0 || !self.feature(EvmFeatures::EIP2780) {
+            return Ok(None);
+        }
+        let dest = message.destination;
+        // A nonexistent recipient reads as an empty account (EIP-161).
+        let recipient_is_empty = match self.state.account_info_untracked(&dest) {
+            Ok(info) => info.as_ref().is_none_or(AccountInfo::is_empty),
+            Err(_) => return Ok(None),
+        };
+        // Empty recipient + value transfer: pay the new account leaf's state gas. Checked before
+        // the delegation resolution, matching the spec's `prepare_dispatch` order.
+        if !message.value.is_zero() && recipient_is_empty {
+            if gas.spend_state(self.version().gas_params.new_account_state_gas()).is_err() {
+                return Err(());
+            }
+            // An empty recipient is never delegated.
+            return Ok(None);
+        }
+        if recipient_is_empty {
+            return Ok(None);
+        }
+        // Resolve the recipient's delegation designator (the recipient is the warm tx target; its
+        // stored code must be loaded to read the designator).
+        let delegated = match self.state.account(&dest, false) {
+            Ok(mut acc) => acc.load_code().ok().and_then(|code| code.eip7702_address()),
+            Err(_) => None,
+        };
+        let Some(delegated) = delegated else {
+            return Ok(None);
+        };
+        // Delegation-target access, EIP-2929 warm/cold: charge the warm access first (covered → the
+        // target is loaded and enters the block access list), then the cold premium after the load.
+        // The load is skipped when the cold premium is unaffordable, keeping a cold, unafforded
+        // target out of the block access list.
+        let cold_additional = self.version().gas_params.cold_account_additional_cost();
+        if gas.spend(u64::from(WARM_STORAGE_READ_COST)).is_err() {
+            return Err(());
+        }
+        let skip_cold_load = gas.remaining() < cold_additional;
+        let load = self.load_account(&delegated, true, skip_cold_load).map_err(|_| ())?;
+        if load.is_cold && gas.spend(cold_additional).is_err() {
+            return Err(());
+        }
+        Ok(Some((load.code, delegated)))
     }
 
     #[inline(never)]
@@ -1417,9 +1555,10 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
         &mut self,
         checkpoint: StateCheckpoint,
         message: &Message<T>,
+        mut gas: GasTracker,
     ) -> MessageResult<T> {
-        let mut gas =
-            GasTracker::new_with_regular_gas_and_reservoir(message.gas_limit, message.reservoir);
+        // `gas` is the frame tracker built by the caller with the inherited reservoir and
+        // any EIP-2780 depth-0 charge already applied; the precompile only adds regular gas.
         let logs_len = self.state.logs().len();
         let execution = self.execute_precompile(message, &mut gas);
         let logs = self.state.logs()[logs_len..].to_vec();
@@ -1447,6 +1586,7 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
             gas,
             output,
             created_address: None,
+            runtime_gas_oog: false,
             ext: T::MessageResultExt::default(),
             _non_exhaustive: (),
         }
@@ -1470,6 +1610,7 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
             gas: *child_gas.tracker(),
             output,
             created_address: None,
+            runtime_gas_oog: false,
             ext: T::MessageResultExt::default(),
             _non_exhaustive: (),
         }
@@ -1493,11 +1634,18 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
         &mut self,
         tx_env: &'frame TxEnv<T>,
         message: &'frame Message<T>,
+        frame_gas: GasTracker,
     ) -> InstrStop {
         let mut interp: Box<Interpreter<'frame, 'a, T>> = self.interpreter_pool.pop();
         let _guard = self.enter_execution();
         let interp_ref = interp.as_mut();
         interp_ref.init(tx_env, message);
+        // Adopt the caller's frame tracker, which carries the EIP-2780 depth-0 charges
+        // already applied; it is otherwise identical to the one `init` derived (same
+        // regular limit and inherited reservoir). A later revert/halt unwinds the state
+        // charge via the existing `rollback_state_gas` reconciliation, like any in-frame
+        // state gas.
+        *interp_ref.gas_mut().tracker_mut() = frame_gas;
         // SAFETY: `execution_config` points to a private field that host execution does not
         // replace or mutate, so the pointee remains valid here.
         let execution_config = unsafe { trustme::decouple_lt(&self.execution_config) };
@@ -1973,8 +2121,10 @@ mod tests {
             code: Bytecode::new_legacy(Bytes::copy_from_slice(bytecode)),
             ..Default::default()
         };
+        let frame_gas =
+            GasTracker::new_with_regular_gas_and_reservoir(message.gas_limit, message.reservoir);
 
-        let stop = evm.run_interpreter(&tx_env, &message);
+        let stop = evm.run_interpreter(&tx_env, &message, frame_gas);
 
         assert_eq!(calls.load(Ordering::Relaxed), 1);
         stop
@@ -2469,7 +2619,9 @@ mod tests {
             ..MessageExt::default()
         };
         let tx_env = TxEnvExt::default();
-        let _ = evm.run_interpreter(&tx_env, &message);
+        let frame_gas =
+            GasTracker::new_with_regular_gas_and_reservoir(message.gas_limit, message.reservoir);
+        let _ = evm.run_interpreter(&tx_env, &message, frame_gas);
     }
 
     #[test]
@@ -2496,7 +2648,9 @@ mod tests {
         };
         let tx_env = TxEnvExt::default();
 
-        let _ = evm.run_interpreter(&tx_env, &message);
+        let frame_gas =
+            GasTracker::new_with_regular_gas_and_reservoir(message.gas_limit, message.reservoir);
+        let _ = evm.run_interpreter(&tx_env, &message, frame_gas);
     }
 
     #[test]
@@ -2553,7 +2707,9 @@ mod tests {
             ..MessageExt::default()
         };
         let tx_env = TxEnvExt::default();
-        let _ = evm.run_interpreter(&tx_env, &message);
+        let frame_gas =
+            GasTracker::new_with_regular_gas_and_reservoir(message.gas_limit, message.reservoir);
+        let _ = evm.run_interpreter(&tx_env, &message, frame_gas);
         assert_eq!(evm.block().number, Word::from(123));
         assert_eq!(evm.block().timestamp, Word::from(124));
     }
@@ -2588,7 +2744,9 @@ mod tests {
             ..MessageExt::default()
         };
         let tx_env = TxEnvExt::default();
-        let _ = evm.run_interpreter(&tx_env, &message);
+        let frame_gas =
+            GasTracker::new_with_regular_gas_and_reservoir(message.gas_limit, message.reservoir);
+        let _ = evm.run_interpreter(&tx_env, &message, frame_gas);
     }
 
     #[derive(Clone, Copy)]

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -2123,7 +2123,6 @@ mod tests {
         };
         let frame_gas =
             GasTracker::new_with_regular_gas_and_reservoir(message.gas_limit, message.reservoir);
-
         let stop = evm.run_interpreter(&tx_env, &message, frame_gas);
 
         assert_eq!(calls.load(Ordering::Relaxed), 1);

--- a/crates/evm2/src/evm/registry.rs
+++ b/crates/evm2/src/evm/registry.rs
@@ -326,7 +326,6 @@ mod tests {
     use super::*;
     use crate::{
         BaseEvmConfigSelector, EvmFeatures, EvmTypesHost, SpecId,
-        bytecode::Bytecode,
         env::{BlockEnv, BlockEnvExt, TxEnv},
         evm::{AccountLoad, SLoad, SStore, SelfDestructResult},
         interpreter::{Host, InstrStop, Message, MessageResult, Word},
@@ -443,7 +442,6 @@ mod tests {
         fn execute_message(
             &mut self,
             _tx_env: &TxEnv<TestTypes>,
-            _bytecode: Bytecode,
             _message: &mut Message<TestTypes>,
         ) -> MessageResult<TestTypes> {
             unimplemented!()

--- a/crates/evm2/src/evm/system.rs
+++ b/crates/evm2/src/evm/system.rs
@@ -12,8 +12,8 @@ use super::{SendEvmRef, r#async};
 use crate::{
     EvmTypes,
     env::TxEnvExt,
-    ethereum::initial_message,
-    interpreter::Host,
+    ethereum::{execute_initial_frame, prepare_initial_frame},
+    interpreter::GasTracker,
     registry::{HandlerError, HandlerResult},
     version::{EvmFeatures, GasId},
 };
@@ -145,17 +145,25 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
         } else {
             0
         };
-        let (bytecode, mut message) = initial_message(
+        let mut tx_gas =
+            GasTracker::new_with_regular_gas_and_reservoir(SYSTEM_CALL_GAS_LIMIT, reservoir);
+        let frame = prepare_initial_frame(
             self,
             caller,
             0,
             TxKind::Call(system_contract_address),
             &data,
             U256::ZERO,
+            &mut tx_gas,
+        )?;
+        let result = execute_initial_frame(
+            self,
+            &tx_env,
+            frame,
+            &mut tx_gas,
             SYSTEM_CALL_GAS_LIMIT,
             reservoir,
-        )?;
-        let result = Host::execute_message(self, &tx_env, bytecode, &mut message);
+        );
         if let Some(code) = self.error_code {
             return Err(HandlerError::Fatal(code));
         }

--- a/crates/evm2/src/evm/system.rs
+++ b/crates/evm2/src/evm/system.rs
@@ -12,8 +12,8 @@ use super::{SendEvmRef, r#async};
 use crate::{
     EvmTypes,
     env::TxEnvExt,
-    ethereum::{execute_initial_frame, prepare_initial_frame},
-    interpreter::GasTracker,
+    ethereum::initial_message,
+    interpreter::Host,
     registry::{HandlerError, HandlerResult},
     version::{EvmFeatures, GasId},
 };
@@ -145,25 +145,17 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
         } else {
             0
         };
-        let mut tx_gas =
-            GasTracker::new_with_regular_gas_and_reservoir(SYSTEM_CALL_GAS_LIMIT, reservoir);
-        let frame = prepare_initial_frame(
+        let mut message = initial_message(
             self,
             caller,
             0,
             TxKind::Call(system_contract_address),
             &data,
             U256::ZERO,
-            &mut tx_gas,
-        )?;
-        let result = execute_initial_frame(
-            self,
-            &tx_env,
-            frame,
-            &mut tx_gas,
             SYSTEM_CALL_GAS_LIMIT,
             reservoir,
-        );
+        )?;
+        let result = Host::execute_message(self, &tx_env, &mut message);
         if let Some(code) = self.error_code {
             return Err(HandlerError::Fatal(code));
         }

--- a/crates/evm2/src/interpreter/host.rs
+++ b/crates/evm2/src/interpreter/host.rs
@@ -152,8 +152,7 @@ pub trait Host<T: EvmTypesHost> {
     /// Records an emitted log.
     fn log(&mut self, log: Log);
 
-    /// Executes a message inside this host. The message carries the bytecode to run
-    /// ([`MessageExt::code`](super::MessageExt::code)).
+    /// Executes a message inside this host.
     fn execute_message(&mut self, tx_env: &TxEnv<T>, message: &mut Message<T>) -> MessageResult<T>;
 
     /// Registers the current contract for self-destruction.

--- a/crates/evm2/src/interpreter/host.rs
+++ b/crates/evm2/src/interpreter/host.rs
@@ -1,7 +1,6 @@
 use super::{GasTracker, InstrStop, Message, Result, Word};
 use crate::{
     BaseEvmTypes, EvmFeatures, EvmTypesHost, SpecId,
-    bytecode::Bytecode,
     env::{BlockEnv, TxEnv},
     evm::{AccountLoad, SLoad, SStore, SelfDestructResult},
 };
@@ -26,11 +25,6 @@ pub struct MessageResultExt<E = ()> {
     pub output: Bytes,
     /// Created address for successful create messages.
     pub created_address: Option<Address>,
-    /// EIP-2780: whether a depth-0 runtime gas-phase charge (the recipient's new-account state gas
-    /// or delegation-target access) ran out of gas before the frame executed. The EIP-7702 handler
-    /// treats this as a runtime out-of-gas: it reverts the applied delegations and includes the
-    /// transaction as an out-of-gas halt. Always `false` off the depth-0 path.
-    pub runtime_gas_oog: bool,
     /// EVM type-specific extension data.
     pub ext: E,
     #[doc(hidden)] // Not public API. Please use an existing constructor.
@@ -153,13 +147,9 @@ pub trait Host<T: EvmTypesHost> {
     /// Records an emitted log.
     fn log(&mut self, log: Log);
 
-    /// Executes a message inside this host.
-    fn execute_message(
-        &mut self,
-        tx_env: &TxEnv<T>,
-        bytecode: Bytecode,
-        message: &mut Message<T>,
-    ) -> MessageResult<T>;
+    /// Executes a message inside this host. The message carries the bytecode to run
+    /// ([`MessageExt::code`](super::MessageExt::code)).
+    fn execute_message(&mut self, tx_env: &TxEnv<T>, message: &mut Message<T>) -> MessageResult<T>;
 
     /// Registers the current contract for self-destruction.
     fn selfdestruct(

--- a/crates/evm2/src/interpreter/host.rs
+++ b/crates/evm2/src/interpreter/host.rs
@@ -25,6 +25,11 @@ pub struct MessageResultExt<E = ()> {
     pub output: Bytes,
     /// Created address for successful create messages.
     pub created_address: Option<Address>,
+    /// EIP-2780: whether a depth-0 runtime gas-phase charge (the recipient's new-account state gas
+    /// or delegation-target access) ran out of gas before the frame executed. The EIP-7702 handler
+    /// treats this as a runtime out-of-gas: it reverts the applied delegations and includes the
+    /// transaction as an out-of-gas halt. Always `false` off the depth-0 path.
+    pub runtime_gas_oog: bool,
     /// EVM type-specific extension data.
     pub ext: E,
     #[doc(hidden)] // Not public API. Please use an existing constructor.

--- a/crates/evm2/src/interpreter/instructions/macro_tests.rs
+++ b/crates/evm2/src/interpreter/instructions/macro_tests.rs
@@ -1,7 +1,7 @@
 use crate::{
     BaseEvmConfig, EvmConfig, ExecutionConfig, SpecId,
     env::BlockEnvExt,
-    interpreter::{Host, InstrStop, Interpreter, Word, op},
+    interpreter::{Host, InstrStop, Interpreter, Message, Word, op},
     test_utils::{RunConfig, TestHost, TestInterpreter, TestTypes, legacy_bytecode, push},
     version::OpcodeConfig,
 };
@@ -78,10 +78,9 @@ const fn macro_opcode_config() -> OpcodeConfig<TestTypes> {
 
 fn run(config: RunConfig<'_>) -> TestInterpreter {
     let execution_config = ExecutionConfig::<TestTypes>::for_config::<MacroConfig>();
-    let RunConfig { code, host, spec_id, tx_env, mut message, gas_limit, return_data } = config;
-    let bytecode = legacy_bytecode(code);
-    message.gas_limit = gas_limit;
-    let mut inner = Interpreter::<TestTypes>::new(bytecode, &tx_env, &message);
+    let RunConfig { code, host, spec_id, tx_env, message, gas_limit, return_data } = config;
+    let message = Message::<TestTypes> { code: legacy_bytecode(code), gas_limit, ..message };
+    let mut inner = Interpreter::<TestTypes>::new(&tx_env, &message);
     *inner.return_data_mut() = return_data;
     let mut default_host = TestHost::default();
     let host = host.unwrap_or(&mut default_host);

--- a/crates/evm2/src/interpreter/instructions/memory.rs
+++ b/crates/evm2/src/interpreter/instructions/memory.rs
@@ -102,9 +102,9 @@ mod tests {
         code.push(op::STOP);
 
         let tx_env = TxEnvExt::default();
-        let message = MessageExt { gas_limit: 10_000, ..MessageExt::default() };
-        let bytecode = legacy_bytecode(code);
-        let mut interp = Interpreter::<TestTypes>::new(bytecode, &tx_env, &message);
+        let message =
+            MessageExt { gas_limit: 10_000, code: legacy_bytecode(code), ..MessageExt::default() };
+        let mut interp = Interpreter::<TestTypes>::new(&tx_env, &message);
         let mut host = TestHost::default();
         let err = interp.run(&config, &mut host);
 
@@ -124,9 +124,9 @@ mod tests {
         code.push(op::STOP);
 
         let tx_env = TxEnvExt::default();
-        let message = MessageExt { gas_limit: 17, ..MessageExt::default() };
-        let bytecode = legacy_bytecode(code);
-        let mut interp = Interpreter::<TestTypes>::new(bytecode, &tx_env, &message);
+        let message =
+            MessageExt { gas_limit: 17, code: legacy_bytecode(code), ..MessageExt::default() };
+        let mut interp = Interpreter::<TestTypes>::new(&tx_env, &message);
         let mut host = TestHost::default();
         let err = interp.run(&config, &mut host);
 

--- a/crates/evm2/src/interpreter/instructions/system.rs
+++ b/crates/evm2/src/interpreter/instructions/system.rs
@@ -3,9 +3,10 @@
 use crate::{
     EvmFeatures, EvmTypesHost,
     bytecode::Bytecode,
+    constants::CALL_DEPTH_LIMIT,
     interpreter::{
         Gas, Host, InstrStop, InterpreterState, Message, MessageExt, MessageKind, Result, StackMut,
-        Word,
+        Word, derive_create_destination,
     },
     utils::{word_to_address, word_to_usize},
     version::GasId,
@@ -151,7 +152,6 @@ fn prepare_call<T: EvmTypesHost>(
     state: &mut InterpreterState<'_, '_, T>,
     kind: MessageKind,
     message: &mut Message<T>,
-    code: &mut Bytecode,
     return_memory_range: &mut Range<usize>,
 ) -> Result<u64> {
     let has_value = match kind {
@@ -209,6 +209,7 @@ fn prepare_call<T: EvmTypesHost>(
         caller,
         input,
         value: call_value,
+        code: loaded_code,
         code_address,
         disable_precompiles,
         caller_is_static: state.is_static(),
@@ -216,7 +217,6 @@ fn prepare_call<T: EvmTypesHost>(
         ext: T::MessageExt::default(),
         _non_exhaustive: (),
     };
-    *code = loaded_code;
     *return_memory_range = prepared_return_memory_range;
 
     Ok(new_account_state_gas)
@@ -230,20 +230,12 @@ fn call_inner<T: EvmTypesHost>(
     kind: MessageKind,
 ) -> Result {
     let mut message = Message::<T>::default();
-    let mut code = Bytecode::default();
     let mut return_memory_range = 0..0;
-    let new_account_state_gas = prepare_call(
-        stack.reborrow(),
-        gas,
-        state,
-        kind,
-        &mut message,
-        &mut code,
-        &mut return_memory_range,
-    )?;
+    let new_account_state_gas =
+        prepare_call(stack.reborrow(), gas, state, kind, &mut message, &mut return_memory_range)?;
 
     let tx_env = state.tx();
-    let mut result = state.host().execute_message(tx_env, code, &mut message);
+    let mut result = state.host().execute_message(tx_env, &mut message);
     if result.stop.is_fatal() {
         return Err(result.stop);
     }
@@ -317,39 +309,30 @@ fn create_inner<T: EvmTypesHost>(
     };
     gas.spend(create_cost)?;
 
-    // Build the message up front (minus the child gas split, filled in below).
+    let kind = if is_create2 { MessageKind::Create2 } else { MessageKind::Create };
     let current = state.message();
-    let mut message = MessageExt {
-        kind: if is_create2 { MessageKind::Create2 } else { MessageKind::Create },
-        depth: current.depth.saturating_add(1),
-        gas_limit: 0,
-        reservoir: 0,
-        // Derived below into the yet-to-be-created contract address.
-        destination: Address::ZERO,
-        caller: current.destination,
-        input,
-        value,
-        code_address: current.destination,
-        disable_precompiles: false,
-        // CREATE is rejected in a static context (see `require_non_staticcall`).
-        caller_is_static: false,
-        salt: salt.map(|salt| B256::from(salt.to_be_bytes())).unwrap_or_default(),
-        ext: T::MessageExt::default(),
-        _non_exhaustive: (),
-    };
+    let caller = current.destination;
+    let depth = current.depth.saturating_add(1);
+    let salt = salt.map(|salt| B256::from(salt.to_be_bytes())).unwrap_or_default();
 
-    // Derive the created contract address once and record it in `destination`. CREATE needs the
-    // creator's (pre-bump) nonce; the caller is the currently-executing contract, already warm and
-    // in the access list, so this read is neutral. CREATE2 needs no nonce. The same load feeds the
-    // EIP-8037 balance/nonce checks below, so it is only performed when one of the two needs it.
+    // Derive the created contract address once. CREATE needs the creator's (pre-bump) nonce; the
+    // caller is the currently-executing contract, already warm and in the access list, so this read
+    // is neutral. CREATE2 needs no nonce. The same load feeds the EIP-8037 balance/nonce checks
+    // below, so it is only performed when one of the two needs it.
     let caller_info = if is_create2 && !state.feature(EvmFeatures::EIP8037) {
         None
     } else {
-        Some(state.host().load_account(&message.caller, false, false)?)
+        Some(state.host().load_account(&caller, false, false)?)
     };
-    message.derive_destination(caller_info.as_ref().map_or(0, |info| info.nonce));
+    let destination = derive_create_destination(
+        kind,
+        &caller,
+        &salt,
+        &input,
+        caller_info.as_ref().map_or(0, |info| info.nonce),
+    );
 
-    // EIP-8037 (ethereum/EIPs#11858): charge the CREATE account-creation state gas on this frame
+    // EIP-8037: charge the CREATE account-creation state gas on this frame
     // before the child gas/reservoir split, conditional on the destination not already existing.
     // The single destination read decides the charge (and warms the address); a create at a
     // pre-existing leaf pays nothing, so its child is not shortchanged by an unneeded spill. The
@@ -357,13 +340,16 @@ fn create_inner<T: EvmTypesHost>(
     // create-failure path after `execute_message`).
     let mut charged_create_state_gas = false;
     if let Some(caller_info) = caller_info.filter(|_| state.feature(EvmFeatures::EIP8037)) {
-        // Only decide the account-creation charge once the endowment and nonce pre-checks pass: a
-        // create that early-fails on those never accesses the destination, so reading it here would
-        // leak it into the EIP-7928 block access list. The early-fail itself (pushing 0) is handled
-        // by the child frame below.
-        if caller_info.balance >= message.value && caller_info.nonce != u64::MAX {
+        // Only decide the account-creation charge once the depth, endowment, and nonce pre-checks
+        // pass: a create that early-fails on those never accesses the destination, so reading it
+        // here would leak it into the EIP-7928 block access list (and warm the address). The
+        // early-fail itself (pushing 0) is handled by the child frame below.
+        if depth <= CALL_DEPTH_LIMIT
+            && caller_info.balance >= value
+            && caller_info.nonce != u64::MAX
+        {
             let features = state.version().features;
-            if state.host().target_is_empty_for_new_account_gas(&message.destination, features)? {
+            if state.host().target_is_empty_for_new_account_gas(&destination, features)? {
                 gas.spend_state(state.gas_params().create_state_gas())?;
                 charged_create_state_gas = true;
             }
@@ -375,18 +361,33 @@ fn create_inner<T: EvmTypesHost>(
         gas.remaining()
     };
     gas.spend(gas_limit)?;
-    message.gas_limit = gas_limit;
-    message.reservoir = gas.reservoir();
 
-    let bytecode = crate::bytecode::Bytecode::new_legacy(message.input.clone());
     let tx_env = state.tx();
-    let mut result = state.host().execute_message(tx_env, bytecode, &mut message);
+    let mut message = MessageExt {
+        kind,
+        depth,
+        gas_limit,
+        reservoir: gas.reservoir(),
+        destination,
+        caller,
+        code: Bytecode::new_legacy(input.clone()),
+        input,
+        value,
+        code_address: caller,
+        disable_precompiles: false,
+        // CREATE is rejected in a static context (see `require_non_staticcall`).
+        caller_is_static: false,
+        salt,
+        ext: T::MessageExt::default(),
+        _non_exhaustive: (),
+    };
+    let mut result = state.host().execute_message(tx_env, &mut message);
     if result.stop.is_fatal() {
         return Err(result.stop);
     }
     gas.merge_child_gas(result.gas, result.stop);
 
-    // EIP-8037 (ethereum/EIPs#11858): when the opcode charged the conditional `create_state_gas`
+    // EIP-8037: when the opcode charged the conditional `create_state_gas`
     // and the create then fails to deploy (revert, halt, or an early-fail leaving
     // `created_address == None` — depth, out-of-funds, nonce overflow), no new account leaf is
     // created, so refund the charge to the reservoir via `refill_reservoir` (matching 0→x→0 storage
@@ -907,6 +908,25 @@ mod tests {
         assert_eq!(interp.stack(), [Word::ZERO]);
         assert_eq!(interp.gas_remaining(), 17_991);
         assert!(host.calls.is_empty());
+    }
+
+    #[test]
+    fn create_too_deep_skips_destination_read_eip8037() {
+        // EIP-8037: a create failing the depth pre-check must not access the destination —
+        // the read would leak the address into the EIP-7928 block access list.
+        let mut host = TestHost { exists: false, ..Default::default() };
+        let mut code = Vec::new();
+        push_all(&mut code, [Word::ZERO, Word::ZERO, Word::ZERO]);
+        code.extend([op::CREATE, op::STOP]);
+
+        let interp = run(RunConfig::new(code)
+            .host(&mut host)
+            .spec(SpecId::AMSTERDAM)
+            .message(MessageExt { depth: CALL_DEPTH_LIMIT, ..Default::default() })
+            .gas_limit(50_000));
+        assert_matches!(interp.err, InstrStop::Stop);
+        assert_eq!(interp.stack(), [Word::ZERO]);
+        assert!(host.new_account_checks.is_empty());
     }
 
     #[test]

--- a/crates/evm2/src/interpreter/instructions/system.rs
+++ b/crates/evm2/src/interpreter/instructions/system.rs
@@ -3,10 +3,9 @@
 use crate::{
     EvmFeatures, EvmTypesHost,
     bytecode::Bytecode,
-    constants::CALL_DEPTH_LIMIT,
     interpreter::{
         Gas, Host, InstrStop, InterpreterState, Message, MessageExt, MessageKind, Result, StackMut,
-        Word, derive_create_destination,
+        Word,
     },
     utils::{word_to_address, word_to_usize},
     version::GasId,
@@ -309,30 +308,41 @@ fn create_inner<T: EvmTypesHost>(
     };
     gas.spend(create_cost)?;
 
-    let kind = if is_create2 { MessageKind::Create2 } else { MessageKind::Create };
+    // Build the message up front (minus the child gas split, filled in below).
     let current = state.message();
-    let caller = current.destination;
-    let depth = current.depth.saturating_add(1);
-    let salt = salt.map(|salt| B256::from(salt.to_be_bytes())).unwrap_or_default();
+    let code = Bytecode::new_legacy(input.clone());
+    let mut message = MessageExt {
+        kind: if is_create2 { MessageKind::Create2 } else { MessageKind::Create },
+        depth: current.depth.saturating_add(1),
+        gas_limit: 0,
+        reservoir: 0,
+        // Derived below into the yet-to-be-created contract address.
+        destination: Address::ZERO,
+        caller: current.destination,
+        input,
+        value,
+        code,
+        code_address: current.destination,
+        disable_precompiles: false,
+        // CREATE is rejected in a static context (see `require_non_staticcall`).
+        caller_is_static: false,
+        salt: salt.map(|salt| B256::from(salt.to_be_bytes())).unwrap_or_default(),
+        ext: T::MessageExt::default(),
+        _non_exhaustive: (),
+    };
 
-    // Derive the created contract address once. CREATE needs the creator's (pre-bump) nonce; the
-    // caller is the currently-executing contract, already warm and in the access list, so this read
-    // is neutral. CREATE2 needs no nonce. The same load feeds the EIP-8037 balance/nonce checks
-    // below, so it is only performed when one of the two needs it.
+    // Derive the created contract address once and record it in `destination`. CREATE needs the
+    // creator's (pre-bump) nonce; the caller is the currently-executing contract, already warm and
+    // in the access list, so this read is neutral. CREATE2 needs no nonce. The same load feeds the
+    // EIP-8037 balance/nonce checks below, so it is only performed when one of the two needs it.
     let caller_info = if is_create2 && !state.feature(EvmFeatures::EIP8037) {
         None
     } else {
-        Some(state.host().load_account(&caller, false, false)?)
+        Some(state.host().load_account(&message.caller, false, false)?)
     };
-    let destination = derive_create_destination(
-        kind,
-        &caller,
-        &salt,
-        &input,
-        caller_info.as_ref().map_or(0, |info| info.nonce),
-    );
+    message.derive_destination(caller_info.as_ref().map_or(0, |info| info.nonce));
 
-    // EIP-8037: charge the CREATE account-creation state gas on this frame
+    // EIP-8037 (ethereum/EIPs#11858): charge the CREATE account-creation state gas on this frame
     // before the child gas/reservoir split, conditional on the destination not already existing.
     // The single destination read decides the charge (and warms the address); a create at a
     // pre-existing leaf pays nothing, so its child is not shortchanged by an unneeded spill. The
@@ -340,16 +350,13 @@ fn create_inner<T: EvmTypesHost>(
     // create-failure path after `execute_message`).
     let mut charged_create_state_gas = false;
     if let Some(caller_info) = caller_info.filter(|_| state.feature(EvmFeatures::EIP8037)) {
-        // Only decide the account-creation charge once the depth, endowment, and nonce pre-checks
-        // pass: a create that early-fails on those never accesses the destination, so reading it
-        // here would leak it into the EIP-7928 block access list (and warm the address). The
-        // early-fail itself (pushing 0) is handled by the child frame below.
-        if depth <= CALL_DEPTH_LIMIT
-            && caller_info.balance >= value
-            && caller_info.nonce != u64::MAX
-        {
+        // Only decide the account-creation charge once the endowment and nonce pre-checks pass: a
+        // create that early-fails on those never accesses the destination, so reading it here would
+        // leak it into the EIP-7928 block access list. The early-fail itself (pushing 0) is handled
+        // by the child frame below.
+        if caller_info.balance >= message.value && caller_info.nonce != u64::MAX {
             let features = state.version().features;
-            if state.host().target_is_empty_for_new_account_gas(&destination, features)? {
+            if state.host().target_is_empty_for_new_account_gas(&message.destination, features)? {
                 gas.spend_state(state.gas_params().create_state_gas())?;
                 charged_create_state_gas = true;
             }
@@ -361,33 +368,17 @@ fn create_inner<T: EvmTypesHost>(
         gas.remaining()
     };
     gas.spend(gas_limit)?;
+    message.gas_limit = gas_limit;
+    message.reservoir = gas.reservoir();
 
     let tx_env = state.tx();
-    let mut message = MessageExt {
-        kind,
-        depth,
-        gas_limit,
-        reservoir: gas.reservoir(),
-        destination,
-        caller,
-        code: Bytecode::new_legacy(input.clone()),
-        input,
-        value,
-        code_address: caller,
-        disable_precompiles: false,
-        // CREATE is rejected in a static context (see `require_non_staticcall`).
-        caller_is_static: false,
-        salt,
-        ext: T::MessageExt::default(),
-        _non_exhaustive: (),
-    };
     let mut result = state.host().execute_message(tx_env, &mut message);
     if result.stop.is_fatal() {
         return Err(result.stop);
     }
     gas.merge_child_gas(result.gas, result.stop);
 
-    // EIP-8037: when the opcode charged the conditional `create_state_gas`
+    // EIP-8037 (ethereum/EIPs#11858): when the opcode charged the conditional `create_state_gas`
     // and the create then fails to deploy (revert, halt, or an early-fail leaving
     // `created_address == None` — depth, out-of-funds, nonce overflow), no new account leaf is
     // created, so refund the charge to the reservoir via `refill_reservoir` (matching 0→x→0 storage
@@ -908,25 +899,6 @@ mod tests {
         assert_eq!(interp.stack(), [Word::ZERO]);
         assert_eq!(interp.gas_remaining(), 17_991);
         assert!(host.calls.is_empty());
-    }
-
-    #[test]
-    fn create_too_deep_skips_destination_read_eip8037() {
-        // EIP-8037: a create failing the depth pre-check must not access the destination —
-        // the read would leak the address into the EIP-7928 block access list.
-        let mut host = TestHost { exists: false, ..Default::default() };
-        let mut code = Vec::new();
-        push_all(&mut code, [Word::ZERO, Word::ZERO, Word::ZERO]);
-        code.extend([op::CREATE, op::STOP]);
-
-        let interp = run(RunConfig::new(code)
-            .host(&mut host)
-            .spec(SpecId::AMSTERDAM)
-            .message(MessageExt { depth: CALL_DEPTH_LIMIT, ..Default::default() })
-            .gas_limit(50_000));
-        assert_matches!(interp.err, InstrStop::Stop);
-        assert_eq!(interp.stack(), [Word::ZERO]);
-        assert!(host.new_account_checks.is_empty());
     }
 
     #[test]

--- a/crates/evm2/src/interpreter/message.rs
+++ b/crates/evm2/src/interpreter/message.rs
@@ -1,4 +1,4 @@
-use crate::{BaseEvmTypes, EvmTypesHost};
+use crate::{BaseEvmTypes, EvmTypesHost, bytecode::Bytecode};
 use alloy_primitives::{Address, B256, Bytes, U256, keccak256};
 
 /// EVM message kind.
@@ -60,6 +60,12 @@ pub struct MessageExt<E = ()> {
     pub input: Bytes,
     /// Value transferred with the message.
     pub value: U256,
+    /// Bytecode this frame executes: the code at [`MessageExt::code_address`] (the resolved
+    /// delegate's code for an EIP-7702 delegated call), or the initcode for create messages.
+    ///
+    /// Resolved by the message's producer when it is constructed, so frames never load accounts
+    /// for code.
+    pub code: Bytecode,
     /// Address whose code is being executed. This can differ from `destination` for `CALLCODE`,
     /// `DELEGATECALL`, and EIP-7702 delegated-code execution.
     pub code_address: Address,
@@ -77,25 +83,21 @@ pub struct MessageExt<E = ()> {
     pub _non_exhaustive: (),
 }
 
-impl<E> MessageExt<E> {
-    /// Returns the keccak256 hash of the init code ([`MessageExt::input`]).
-    ///
-    /// Only meaningful for create messages, where `input` holds the initcode.
-    #[inline]
-    pub fn init_code_hash_slow(&self) -> B256 {
-        keccak256(self.input.as_ref())
-    }
-
-    /// Derives this create message's contract address and stores it in [`MessageExt::destination`].
-    ///
-    /// `nonce` is the creator's nonce and is only used by the `CREATE` scheme; `CREATE2` derives
-    /// the address from the salt and [`MessageExt::init_code_hash_slow`]. Called once when the
-    /// create message is constructed.
-    #[inline]
-    pub fn derive_destination(&mut self, nonce: u64) {
-        self.destination = match self.kind {
-            MessageKind::Create2 => self.caller.create2(self.salt, self.init_code_hash_slow()),
-            _ => self.caller.create(nonce),
-        };
+/// Derives the contract address a create message deploys to, i.e. its
+/// [`destination`](MessageExt::destination).
+///
+/// `nonce` is the creator's (pre-bump) nonce and is only used by the `CREATE` scheme; `CREATE2`
+/// derives the address from `salt` and the initcode hash instead.
+#[inline]
+pub fn derive_create_destination(
+    kind: MessageKind,
+    caller: &Address,
+    salt: &B256,
+    init_code: &[u8],
+    nonce: u64,
+) -> Address {
+    match kind {
+        MessageKind::Create2 => caller.create2(salt, keccak256(init_code)),
+        _ => caller.create(nonce),
     }
 }

--- a/crates/evm2/src/interpreter/message.rs
+++ b/crates/evm2/src/interpreter/message.rs
@@ -83,21 +83,25 @@ pub struct MessageExt<E = ()> {
     pub _non_exhaustive: (),
 }
 
-/// Derives the contract address a create message deploys to, i.e. its
-/// [`destination`](MessageExt::destination).
-///
-/// `nonce` is the creator's (pre-bump) nonce and is only used by the `CREATE` scheme; `CREATE2`
-/// derives the address from `salt` and the initcode hash instead.
-#[inline]
-pub fn derive_create_destination(
-    kind: MessageKind,
-    caller: &Address,
-    salt: &B256,
-    init_code: &[u8],
-    nonce: u64,
-) -> Address {
-    match kind {
-        MessageKind::Create2 => caller.create2(salt, keccak256(init_code)),
-        _ => caller.create(nonce),
+impl<E> MessageExt<E> {
+    /// Returns the keccak256 hash of the init code ([`MessageExt::input`]).
+    ///
+    /// Only meaningful for create messages, where `input` holds the initcode.
+    #[inline]
+    pub fn init_code_hash_slow(&self) -> B256 {
+        keccak256(self.input.as_ref())
+    }
+
+    /// Derives this create message's contract address and stores it in [`MessageExt::destination`].
+    ///
+    /// `nonce` is the creator's nonce and is only used by the `CREATE` scheme; `CREATE2` derives
+    /// the address from the salt and [`MessageExt::init_code_hash_slow`]. Called once when the
+    /// create message is constructed.
+    #[inline]
+    pub fn derive_destination(&mut self, nonce: u64) {
+        self.destination = match self.kind {
+            MessageKind::Create2 => self.caller.create2(self.salt, self.init_code_hash_slow()),
+            _ => self.caller.create(nonce),
+        };
     }
 }

--- a/crates/evm2/src/interpreter/mod.rs
+++ b/crates/evm2/src/interpreter/mod.rs
@@ -28,7 +28,7 @@ mod memory;
 pub use memory::Memory;
 
 mod message;
-pub use message::{Message, MessageExt, MessageKind};
+pub use message::{Message, MessageExt, MessageKind, derive_create_destination};
 
 mod host;
 pub use host::{Host, MessageResult, MessageResultExt};

--- a/crates/evm2/src/interpreter/mod.rs
+++ b/crates/evm2/src/interpreter/mod.rs
@@ -28,7 +28,7 @@ mod memory;
 pub use memory::Memory;
 
 mod message;
-pub use message::{Message, MessageExt, MessageKind, derive_create_destination};
+pub use message::{Message, MessageExt, MessageKind};
 
 mod host;
 pub use host::{Host, MessageResult, MessageResultExt};

--- a/crates/evm2/src/interpreter/runtime.rs
+++ b/crates/evm2/src/interpreter/runtime.rs
@@ -75,21 +75,17 @@ impl<T: EvmTypesHost> Default for Interpreter<'_, '_, T> {
 }
 
 impl<'frame, 'host, T: EvmTypesHost> Interpreter<'frame, 'host, T> {
-    /// Creates an interpreter from analyzed bytecode, a transaction-global environment, and a
-    /// frame-local message.
-    pub fn new(bytecode: Bytecode, tx_env: &'frame TxEnv<T>, message: &'frame Message<T>) -> Self {
+    /// Creates an interpreter from a transaction-global environment and a frame-local message,
+    /// which carries the bytecode to run.
+    pub fn new(tx_env: &'frame TxEnv<T>, message: &'frame Message<T>) -> Self {
         let mut interp = Self::default();
-        interp.init(bytecode, tx_env, message);
+        interp.init(tx_env, message);
         interp
     }
 
     /// Initializes this interpreter for a new frame, retaining reusable allocations.
-    pub(crate) fn init(
-        &mut self,
-        bytecode: Bytecode,
-        tx_env: &'frame TxEnv<T>,
-        message: &'frame Message<T>,
-    ) {
+    pub(crate) fn init(&mut self, tx_env: &'frame TxEnv<T>, message: &'frame Message<T>) {
+        let bytecode = message.code.clone();
         let gas_limit = message.gas_limit;
         let is_static = message.caller_is_static || matches!(message.kind, MessageKind::StaticCall);
         self.pc = bytecode.original_byte_slice().as_ptr();

--- a/crates/evm2/src/test_utils.rs
+++ b/crates/evm2/src/test_utils.rs
@@ -51,6 +51,7 @@ pub(crate) struct TestHost {
     pub(crate) calls: Vec<Message<TestTypes>>,
     pub(crate) call_static_flags: Vec<bool>,
     pub(crate) selfdestructs: Vec<(Address, Address, bool)>,
+    pub(crate) new_account_checks: Vec<Address>,
 }
 
 impl Default for TestHost {
@@ -78,6 +79,7 @@ impl Default for TestHost {
             calls: Vec::new(),
             call_static_flags: Vec::new(),
             selfdestructs: Vec::new(),
+            new_account_checks: Vec::new(),
         }
     }
 }
@@ -118,9 +120,10 @@ impl Host<TestTypes> for TestHost {
 
     fn target_is_empty_for_new_account_gas(
         &mut self,
-        _address: &Address,
+        address: &Address,
         features: EvmFeatures,
     ) -> Result<bool, InstrStop> {
+        self.new_account_checks.push(*address);
         if features.contains(EvmFeatures::EIP161) {
             return Ok(!self.exists || self.is_empty);
         }
@@ -192,7 +195,6 @@ impl Host<TestTypes> for TestHost {
     fn execute_message(
         &mut self,
         _tx_env: &TxEnv<TestTypes>,
-        _bytecode: Bytecode,
         message: &mut Message<TestTypes>,
     ) -> MessageResult<TestTypes> {
         // Mimics the depth limit enforced by the real host.
@@ -324,10 +326,9 @@ impl Default for RunConfig<'_> {
 }
 
 pub(crate) fn run(config: RunConfig<'_>) -> TestInterpreter {
-    let RunConfig { code, host, spec_id, tx_env, mut message, gas_limit, return_data } = config;
-    let bytecode = legacy_bytecode(code);
-    message.gas_limit = gas_limit;
-    let mut inner = Interpreter::<TestTypes>::new(bytecode, &tx_env, &message);
+    let RunConfig { code, host, spec_id, tx_env, message, gas_limit, return_data } = config;
+    let message = Message::<TestTypes> { code: legacy_bytecode(code), gas_limit, ..message };
+    let mut inner = Interpreter::<TestTypes>::new(&tx_env, &message);
     *inner.return_data_mut() = return_data;
     let mut default_host = TestHost::default();
     let host = host.unwrap_or(&mut default_host);

--- a/crates/evm2/src/test_utils.rs
+++ b/crates/evm2/src/test_utils.rs
@@ -51,7 +51,6 @@ pub(crate) struct TestHost {
     pub(crate) calls: Vec<Message<TestTypes>>,
     pub(crate) call_static_flags: Vec<bool>,
     pub(crate) selfdestructs: Vec<(Address, Address, bool)>,
-    pub(crate) new_account_checks: Vec<Address>,
 }
 
 impl Default for TestHost {
@@ -79,7 +78,6 @@ impl Default for TestHost {
             calls: Vec::new(),
             call_static_flags: Vec::new(),
             selfdestructs: Vec::new(),
-            new_account_checks: Vec::new(),
         }
     }
 }
@@ -120,10 +118,9 @@ impl Host<TestTypes> for TestHost {
 
     fn target_is_empty_for_new_account_gas(
         &mut self,
-        address: &Address,
+        _address: &Address,
         features: EvmFeatures,
     ) -> Result<bool, InstrStop> {
-        self.new_account_checks.push(*address);
         if features.contains(EvmFeatures::EIP161) {
             return Ok(!self.exists || self.is_empty);
         }

--- a/crates/evm2/src/tests.rs
+++ b/crates/evm2/src/tests.rs
@@ -16,10 +16,10 @@ fn run_tx(evm: &mut TestEvm, destination: Address, code: impl Into<Vec<u8>>) {
         destination,
         code_address: destination,
         gas_limit: 100_000,
+        code: legacy_bytecode(code),
         ..Default::default()
     };
-    let result =
-        Host::execute_message(evm, &TxEnvExt::default(), legacy_bytecode(code), &mut message);
+    let result = Host::execute_message(evm, &TxEnvExt::default(), &mut message);
     assert!(result.stop.is_success());
 }
 
@@ -130,14 +130,10 @@ fn evm_propagates_child_sstore_negative_refund() {
         destination: contract,
         code_address: contract,
         gas_limit: 100_000,
+        code: legacy_bytecode(parent_code),
         ..Default::default()
     };
-    let result = Host::execute_message(
-        &mut evm,
-        &TxEnvExt::default(),
-        legacy_bytecode(parent_code),
-        &mut message,
-    );
+    let result = Host::execute_message(&mut evm, &TxEnvExt::default(), &mut message);
 
     assert!(result.stop.is_success());
     assert_eq!(result.gas.refunded(), 0);
@@ -157,14 +153,10 @@ fn evm_reports_invalid_transaction_execution() {
         destination: contract,
         code_address: contract,
         gas_limit: 100_000,
+        code: legacy_bytecode([op::PUSH1, 0x01, op::SSTORE]),
         ..Default::default()
     };
-    let result = Host::execute_message(
-        &mut evm,
-        &TxEnvExt::default(),
-        legacy_bytecode([op::PUSH1, 0x01, op::SSTORE]),
-        &mut message,
-    );
+    let result = Host::execute_message(&mut evm, &TxEnvExt::default(), &mut message);
 
     assert_eq!(result.stop, InstrStop::StackUnderflow);
 }

--- a/crates/inspectors/src/opcode.rs
+++ b/crates/inspectors/src/opcode.rs
@@ -171,10 +171,12 @@ mod tests {
 
         let opcodes = [op::ADD, op::ADD, op::ADD, op::BYTE];
 
-        let bytecode = Bytecode::new_legacy(Bytes::from(opcodes));
         let tx_env = TxEnv::<BaseEvmTypes>::default();
-        let message = Message::<BaseEvmTypes>::default();
-        let mut interp = Interpreter::<BaseEvmTypes>::new(bytecode, &tx_env, &message);
+        let message = Message::<BaseEvmTypes> {
+            code: Bytecode::new_legacy(Bytes::from(opcodes)),
+            ..Message::<BaseEvmTypes>::default()
+        };
+        let mut interp = Interpreter::<BaseEvmTypes>::new(&tx_env, &message);
 
         for _ in &opcodes {
             opcode_counter.step(&mut interp);
@@ -187,10 +189,12 @@ mod tests {
 
         let opcodes = [op::PUSH1, op::PUSH1, op::ADD, op::PUSH1, op::SSTORE, op::STOP];
 
-        let bytecode = Bytecode::new_legacy(Bytes::from(opcodes));
         let tx_env = TxEnv::<BaseEvmTypes>::default();
-        let message = Message::<BaseEvmTypes>::default();
-        let mut interp = Interpreter::<BaseEvmTypes>::new(bytecode, &tx_env, &message);
+        let message = Message::<BaseEvmTypes> {
+            code: Bytecode::new_legacy(Bytes::from(opcodes)),
+            ..Message::<BaseEvmTypes>::default()
+        };
+        let mut interp = Interpreter::<BaseEvmTypes>::new(&tx_env, &message);
 
         for _ in &opcodes {
             opcode_counter.step(&mut interp);

--- a/crates/jit/builtins/src/lib.rs
+++ b/crates/jit/builtins/src/lib.rs
@@ -16,8 +16,8 @@ use alloy_primitives::{Address, B256, Bytes, KECCAK256_EMPTY, Log, LogData, U256
 use core::cmp::min;
 use evm2::{
     bytecode::Bytecode,
-    constants::{BLOCK_HASH_HISTORY, CALL_DEPTH_LIMIT},
-    interpreter::{Host, MessageExt, MessageKind, Word, derive_create_destination, i256},
+    constants::BLOCK_HASH_HISTORY,
+    interpreter::{Host, MessageExt, MessageKind, Word, i256},
     utils::{word_to_usize, word_to_usize_saturated},
     version::{EvmFeatures, GasId},
 };
@@ -668,39 +668,48 @@ pub unsafe extern "C" fn __revmc_builtin_create(
     } else {
         B256::ZERO
     };
-    let kind = if is_create2 { MessageKind::Create2 } else { MessageKind::Create };
+    // Build the message up front (minus the child gas split, filled in below).
     let current = ecx.message();
-    let caller = current.destination;
-    let depth = current.depth.saturating_add(1);
-    let value = value.to_u256();
+    let bytecode = Bytecode::new_legacy(code.clone());
+    let mut message = MessageExt {
+        kind: if is_create2 { MessageKind::Create2 } else { MessageKind::Create },
+        depth: current.depth.saturating_add(1),
+        gas_limit: 0,
+        reservoir: 0,
+        // Derived below into the yet-to-be-created contract address.
+        destination: Address::ZERO,
+        caller: current.destination,
+        input: code,
+        value: value.to_u256(),
+        code: bytecode,
+        code_address: current.destination,
+        disable_precompiles: false,
+        caller_is_static: false,
+        salt,
+        ext: (),
+        _non_exhaustive: (),
+    };
 
-    // Derive the created contract address once (mirrors the interpreter's `create` opcode). CREATE
-    // needs the creator's (pre-bump) nonce; the caller is the currently-executing contract, already
-    // warm. CREATE2 needs no nonce. The same load feeds the EIP-8037 balance/nonce checks below, so
-    // it is only performed when one of the two needs it.
+    // Derive the created contract address once and record it in `destination` (mirrors the
+    // interpreter's `create` opcode). CREATE needs the creator's (pre-bump) nonce; the caller is the
+    // currently-executing contract, already warm. CREATE2 needs no nonce. The same load feeds the
+    // EIP-8037 balance/nonce checks below, so it is only performed when one of the two needs it.
     let caller_info = if is_create2 && !ecx.enables(EvmFeatures::EIP8037) {
         None
     } else {
-        Some(ecx.host().load_account(&caller, false, false)?)
+        Some(ecx.host().load_account(&message.caller, false, false)?)
     };
-    let destination = derive_create_destination(
-        kind,
-        &caller,
-        &salt,
-        &code,
-        caller_info.as_ref().map_or(0, |info| info.nonce),
-    );
+    message.derive_destination(caller_info.as_ref().map_or(0, |info| info.nonce));
 
-    // EIP-8037: charge the CREATE account-creation state gas before the child
-    // gas split, conditional on the destination not already existing (and on the depth, endowment,
-    // and nonce pre-checks passing, so an early-failing create leaves the destination out of the
-    // block access list).
+    // EIP-8037 (ethereum/EIPs#11858): charge the CREATE account-creation state gas before the child
+    // gas split, conditional on the destination not already existing (and on the endowment/nonce
+    // pre-checks passing, so an early-failing create leaves the destination out of the block access
+    // list).
     let mut charged_create_state_gas = false;
     if let Some(caller_info) = caller_info.filter(|_| ecx.enables(EvmFeatures::EIP8037))
-        && depth <= CALL_DEPTH_LIMIT
-        && caller_info.balance >= value
+        && caller_info.balance >= message.value
         && caller_info.nonce != u64::MAX
-        && ecx.host().target_is_empty_for_new_account_gas(&destination, version.features)?
+        && ecx.host().target_is_empty_for_new_account_gas(&message.destination, version.features)?
     {
         ecx.gas.spend_state(version.gas_params.create_state_gas())?;
         charged_create_state_gas = true;
@@ -711,31 +720,16 @@ pub unsafe extern "C" fn __revmc_builtin_create(
         gas_limit = version.gas_params.call_stipend_reduction(gas_limit);
     }
     ecx.gas.spend(gas_limit)?;
+    message.gas_limit = gas_limit;
+    message.reservoir = ecx.gas.reservoir();
 
     let tx_env = ecx.tx_env();
-    let mut message = MessageExt {
-        kind,
-        depth,
-        gas_limit,
-        reservoir: ecx.gas.reservoir(),
-        destination,
-        caller,
-        code: Bytecode::new_legacy(code.clone()),
-        input: code,
-        value,
-        code_address: caller,
-        disable_precompiles: false,
-        caller_is_static: false,
-        salt,
-        ext: (),
-        _non_exhaustive: (),
-    };
     let mut result = ecx.host().execute_message(tx_env, &mut message);
     if result.stop.is_fatal() {
         return Err(result.stop.into());
     }
     ecx.gas.merge_child_gas(result.gas, result.stop);
-    // EIP-8037: refund the conditional create state gas when the create fails
+    // EIP-8037 (ethereum/EIPs#11858): refund the conditional create state gas when the create fails
     // to deploy (no new account leaf is created).
     let create_failed = result.created_address.is_none() || !result.stop.is_success();
     if charged_create_state_gas && create_failed {

--- a/crates/jit/builtins/src/lib.rs
+++ b/crates/jit/builtins/src/lib.rs
@@ -16,8 +16,8 @@ use alloy_primitives::{Address, B256, Bytes, KECCAK256_EMPTY, Log, LogData, U256
 use core::cmp::min;
 use evm2::{
     bytecode::Bytecode,
-    constants::BLOCK_HASH_HISTORY,
-    interpreter::{Host, MessageExt, MessageKind, Word, i256},
+    constants::{BLOCK_HASH_HISTORY, CALL_DEPTH_LIMIT},
+    interpreter::{Host, MessageExt, MessageKind, Word, derive_create_destination, i256},
     utils::{word_to_usize, word_to_usize_saturated},
     version::{EvmFeatures, GasId},
 };
@@ -668,46 +668,39 @@ pub unsafe extern "C" fn __revmc_builtin_create(
     } else {
         B256::ZERO
     };
-    // Build the message up front (minus the child gas split, filled in below).
+    let kind = if is_create2 { MessageKind::Create2 } else { MessageKind::Create };
     let current = ecx.message();
-    let mut message = MessageExt {
-        kind: if is_create2 { MessageKind::Create2 } else { MessageKind::Create },
-        depth: current.depth.saturating_add(1),
-        gas_limit: 0,
-        reservoir: 0,
-        // Derived below into the yet-to-be-created contract address.
-        destination: Address::ZERO,
-        caller: current.destination,
-        input: code,
-        value: value.to_u256(),
-        code_address: current.destination,
-        disable_precompiles: false,
-        caller_is_static: false,
-        salt,
-        ext: (),
-        _non_exhaustive: (),
-    };
+    let caller = current.destination;
+    let depth = current.depth.saturating_add(1);
+    let value = value.to_u256();
 
-    // Derive the created contract address once and record it in `destination` (mirrors the
-    // interpreter's `create` opcode). CREATE needs the creator's (pre-bump) nonce; the caller is the
-    // currently-executing contract, already warm. CREATE2 needs no nonce. The same load feeds the
-    // EIP-8037 balance/nonce checks below, so it is only performed when one of the two needs it.
+    // Derive the created contract address once (mirrors the interpreter's `create` opcode). CREATE
+    // needs the creator's (pre-bump) nonce; the caller is the currently-executing contract, already
+    // warm. CREATE2 needs no nonce. The same load feeds the EIP-8037 balance/nonce checks below, so
+    // it is only performed when one of the two needs it.
     let caller_info = if is_create2 && !ecx.enables(EvmFeatures::EIP8037) {
         None
     } else {
-        Some(ecx.host().load_account(&message.caller, false, false)?)
+        Some(ecx.host().load_account(&caller, false, false)?)
     };
-    message.derive_destination(caller_info.as_ref().map_or(0, |info| info.nonce));
+    let destination = derive_create_destination(
+        kind,
+        &caller,
+        &salt,
+        &code,
+        caller_info.as_ref().map_or(0, |info| info.nonce),
+    );
 
-    // EIP-8037 (ethereum/EIPs#11858): charge the CREATE account-creation state gas before the child
-    // gas split, conditional on the destination not already existing (and on the endowment/nonce
-    // pre-checks passing, so an early-failing create leaves the destination out of the block access
-    // list).
+    // EIP-8037: charge the CREATE account-creation state gas before the child
+    // gas split, conditional on the destination not already existing (and on the depth, endowment,
+    // and nonce pre-checks passing, so an early-failing create leaves the destination out of the
+    // block access list).
     let mut charged_create_state_gas = false;
     if let Some(caller_info) = caller_info.filter(|_| ecx.enables(EvmFeatures::EIP8037))
-        && caller_info.balance >= message.value
+        && depth <= CALL_DEPTH_LIMIT
+        && caller_info.balance >= value
         && caller_info.nonce != u64::MAX
-        && ecx.host().target_is_empty_for_new_account_gas(&message.destination, version.features)?
+        && ecx.host().target_is_empty_for_new_account_gas(&destination, version.features)?
     {
         ecx.gas.spend_state(version.gas_params.create_state_gas())?;
         charged_create_state_gas = true;
@@ -718,17 +711,31 @@ pub unsafe extern "C" fn __revmc_builtin_create(
         gas_limit = version.gas_params.call_stipend_reduction(gas_limit);
     }
     ecx.gas.spend(gas_limit)?;
-    message.gas_limit = gas_limit;
-    message.reservoir = ecx.gas.reservoir();
 
-    let bytecode = Bytecode::new_legacy(message.input.clone());
     let tx_env = ecx.tx_env();
-    let mut result = ecx.host().execute_message(tx_env, bytecode, &mut message);
+    let mut message = MessageExt {
+        kind,
+        depth,
+        gas_limit,
+        reservoir: ecx.gas.reservoir(),
+        destination,
+        caller,
+        code: Bytecode::new_legacy(code.clone()),
+        input: code,
+        value,
+        code_address: caller,
+        disable_precompiles: false,
+        caller_is_static: false,
+        salt,
+        ext: (),
+        _non_exhaustive: (),
+    };
+    let mut result = ecx.host().execute_message(tx_env, &mut message);
     if result.stop.is_fatal() {
         return Err(result.stop.into());
     }
     ecx.gas.merge_child_gas(result.gas, result.stop);
-    // EIP-8037 (ethereum/EIPs#11858): refund the conditional create state gas when the create fails
+    // EIP-8037: refund the conditional create state gas when the create fails
     // to deploy (no new account leaf is created).
     let create_failed = result.created_address.is_none() || !result.stop.is_success();
     if charged_create_state_gas && create_failed {
@@ -822,6 +829,7 @@ pub unsafe extern "C" fn __revmc_builtin_call(
         caller,
         input,
         value: call_value,
+        code: loaded_code,
         code_address,
         disable_precompiles,
         caller_is_static: ecx.is_static(),
@@ -831,7 +839,7 @@ pub unsafe extern "C" fn __revmc_builtin_call(
     };
 
     let tx_env = ecx.tx_env();
-    let mut result = ecx.host().execute_message(tx_env, loaded_code, &mut message);
+    let mut result = ecx.host().execute_message(tx_env, &mut message);
     if result.stop.is_fatal() {
         return Err(result.stop.into());
     }
@@ -1148,13 +1156,14 @@ mod tests {
             ..MessageInspector::default()
         });
         let tx_env = TxEnvExt::default();
-        let message =
-            MessageExt { gas_limit: 1_000_000, destination: caller, ..MessageExt::default() };
-        let mut interpreter = evm2::interpreter::Interpreter::<BaseEvmTypes>::new(
-            Bytecode::new_legacy(Bytes::from_static(&[op::STOP])),
-            &tx_env,
-            &message,
-        );
+        let message = MessageExt {
+            gas_limit: 1_000_000,
+            destination: caller,
+            code: Bytecode::new_legacy(Bytes::from_static(&[op::STOP])),
+            ..MessageExt::default()
+        };
+        let mut interpreter =
+            evm2::interpreter::Interpreter::<BaseEvmTypes>::new(&tx_env, &message);
 
         {
             let mut frame = prepare_frame(&mut interpreter, &mut host);
@@ -1205,13 +1214,11 @@ mod tests {
             destination,
             caller,
             value: Word::from(0x99),
+            code: Bytecode::new_legacy(Bytes::from_static(&[op::STOP])),
             ..MessageExt::default()
         };
-        let mut interpreter = evm2::interpreter::Interpreter::<BaseEvmTypes>::new(
-            Bytecode::new_legacy(Bytes::from_static(&[op::STOP])),
-            &tx_env,
-            &message,
-        );
+        let mut interpreter =
+            evm2::interpreter::Interpreter::<BaseEvmTypes>::new(&tx_env, &message);
 
         {
             let mut frame = prepare_frame(&mut interpreter, &mut host);
@@ -1247,13 +1254,11 @@ mod tests {
             destination,
             caller,
             value: current_value,
+            code: Bytecode::new_legacy(Bytes::from_static(&[op::STOP])),
             ..MessageExt::default()
         };
-        let mut interpreter = evm2::interpreter::Interpreter::<BaseEvmTypes>::new(
-            Bytecode::new_legacy(Bytes::from_static(&[op::STOP])),
-            &tx_env,
-            &message,
-        );
+        let mut interpreter =
+            evm2::interpreter::Interpreter::<BaseEvmTypes>::new(&tx_env, &message);
 
         {
             let mut frame = prepare_frame(&mut interpreter, &mut host);
@@ -1288,13 +1293,11 @@ mod tests {
             destination,
             caller,
             value: Word::from(0x99),
+            code: Bytecode::new_legacy(Bytes::from_static(&[op::STOP])),
             ..MessageExt::default()
         };
-        let mut interpreter = evm2::interpreter::Interpreter::<BaseEvmTypes>::new(
-            Bytecode::new_legacy(Bytes::from_static(&[op::STOP])),
-            &tx_env,
-            &message,
-        );
+        let mut interpreter =
+            evm2::interpreter::Interpreter::<BaseEvmTypes>::new(&tx_env, &message);
 
         {
             let mut frame = prepare_frame(&mut interpreter, &mut host);
@@ -1331,12 +1334,13 @@ mod tests {
             ..MessageInspector::default()
         });
         let tx_env = TxEnvExt::default();
-        let message = MessageExt { gas_limit: 1_000_000, ..MessageExt::default() };
-        let mut interpreter = evm2::interpreter::Interpreter::<BaseEvmTypes>::new(
-            Bytecode::new_legacy(Bytes::from_static(&[op::STOP])),
-            &tx_env,
-            &message,
-        );
+        let message = MessageExt {
+            gas_limit: 1_000_000,
+            code: Bytecode::new_legacy(Bytes::from_static(&[op::STOP])),
+            ..MessageExt::default()
+        };
+        let mut interpreter =
+            evm2::interpreter::Interpreter::<BaseEvmTypes>::new(&tx_env, &message);
 
         {
             let mut frame = prepare_frame(&mut interpreter, &mut host);
@@ -1375,12 +1379,13 @@ mod tests {
             ..MessageInspector::default()
         });
         let tx_env = TxEnvExt::default();
-        let message = MessageExt { gas_limit: 1_000_000, ..MessageExt::default() };
-        let mut interpreter = evm2::interpreter::Interpreter::<BaseEvmTypes>::new(
-            Bytecode::new_legacy(Bytes::from_static(&[op::STOP])),
-            &tx_env,
-            &message,
-        );
+        let message = MessageExt {
+            gas_limit: 1_000_000,
+            code: Bytecode::new_legacy(Bytes::from_static(&[op::STOP])),
+            ..MessageExt::default()
+        };
+        let mut interpreter =
+            evm2::interpreter::Interpreter::<BaseEvmTypes>::new(&tx_env, &message);
 
         {
             let mut frame = prepare_frame(&mut interpreter, &mut host);

--- a/crates/jit/codegen/src/tests/runner.rs
+++ b/crates/jit/codegen/src/tests/runner.rs
@@ -393,11 +393,9 @@ fn with_evm_context_and_host_mut<
     if let Some(modify_message) = modify_message {
         modify_message(&mut message);
     }
-    let mut interpreter = Interpreter::<BaseEvmTypes>::new(
-        Bytecode::new_legacy(Bytes::copy_from_slice(bytecode)),
-        &tx_env,
-        &message,
-    );
+    let message =
+        Message { code: Bytecode::new_legacy(Bytes::copy_from_slice(bytecode)), ..message };
+    let mut interpreter = Interpreter::<BaseEvmTypes>::new(&tx_env, &message);
     interpreter.prepare_run(config.base_spec_id(), config.version(), host);
 
     let (mut ecx, stack, stack_len) = EvmContext::from_interpreter_with_stack(&mut interpreter);
@@ -511,11 +509,9 @@ fn run_compiled_test_case_with_context(
         modify_message(&mut message);
     }
     message.caller_is_static = is_static;
-    let mut interpreter = Interpreter::<BaseEvmTypes>::new(
-        Bytecode::new_legacy(Bytes::copy_from_slice(bytecode)),
-        &tx_env,
-        &message,
-    );
+    let message =
+        Message { code: Bytecode::new_legacy(Bytes::copy_from_slice(bytecode)), ..message };
+    let mut interpreter = Interpreter::<BaseEvmTypes>::new(&tx_env, &message);
     let mut int_host = prepare_host(spec_id);
     let int_stop = interpreter.run(&config, &mut int_host);
     let int_result = int_stop;

--- a/crates/jit/codegen/src/tests/runner.rs
+++ b/crates/jit/codegen/src/tests/runner.rs
@@ -393,8 +393,10 @@ fn with_evm_context_and_host_mut<
     if let Some(modify_message) = modify_message {
         modify_message(&mut message);
     }
-    let message =
-        Message { code: Bytecode::new_legacy(Bytes::copy_from_slice(bytecode)), ..message };
+    let message = Message::<BaseEvmTypes> {
+        code: Bytecode::new_legacy(Bytes::copy_from_slice(bytecode)),
+        ..message
+    };
     let mut interpreter = Interpreter::<BaseEvmTypes>::new(&tx_env, &message);
     interpreter.prepare_run(config.base_spec_id(), config.version(), host);
 
@@ -509,8 +511,10 @@ fn run_compiled_test_case_with_context(
         modify_message(&mut message);
     }
     message.caller_is_static = is_static;
-    let message =
-        Message { code: Bytecode::new_legacy(Bytes::copy_from_slice(bytecode)), ..message };
+    let message = Message::<BaseEvmTypes> {
+        code: Bytecode::new_legacy(Bytes::copy_from_slice(bytecode)),
+        ..message
+    };
     let mut interpreter = Interpreter::<BaseEvmTypes>::new(&tx_env, &message);
     let mut int_host = prepare_host(spec_id);
     let int_stop = interpreter.run(&config, &mut int_host);

--- a/crates/jit/runtime/src/evm2_evm.rs
+++ b/crates/jit/runtime/src/evm2_evm.rs
@@ -207,12 +207,12 @@ mod tests {
             SpecId::CANCUN,
         );
         let tx_env = TxEnvExt::default();
-        let message = MessageExt { gas_limit: 1_000_000, ..Default::default() };
-        let mut interpreter = Interpreter::<BaseEvmTypes>::new(
-            Bytecode::new_legacy(Bytes::from_static(&[op::STOP])),
-            &tx_env,
-            &message,
-        );
+        let message = MessageExt {
+            gas_limit: 1_000_000,
+            code: Bytecode::new_legacy(Bytes::from_static(&[op::STOP])),
+            ..Default::default()
+        };
+        let mut interpreter = Interpreter::<BaseEvmTypes>::new(&tx_env, &message);
         let mut host = Evm::<BaseEvmTypes>::new(
             SpecId::CANCUN,
             BlockEnvExt::default(),
@@ -252,8 +252,6 @@ mod tests {
         );
         host.set_interpreter_runner(JitInterpreterRunner::new(backend.clone()));
         let tx_env = TxEnvExt::default();
-        let message =
-            MessageExt { gas_limit: 1_000_000, destination: caller, ..MessageExt::default() };
         let mut code = vec![op::PUSH1, 0x20, op::PUSH0, op::PUSH0, op::PUSH0, op::PUSH0];
         push20(&mut code, target);
         code.extend([
@@ -270,8 +268,13 @@ mod tests {
             op::PUSH0,
             op::RETURN,
         ]);
-        let mut interpreter =
-            Interpreter::<BaseEvmTypes>::new(Bytecode::new_legacy(code.into()), &tx_env, &message);
+        let message = MessageExt {
+            gas_limit: 1_000_000,
+            destination: caller,
+            code: Bytecode::new_legacy(code.into()),
+            ..MessageExt::default()
+        };
+        let mut interpreter = Interpreter::<BaseEvmTypes>::new(&tx_env, &message);
 
         assert_eq!(
             run_interpreter(&backend, &config, &mut interpreter, &mut host),
@@ -300,8 +303,6 @@ mod tests {
         );
         host.set_interpreter_runner(JitInterpreterRunner::new(backend.clone()));
         let tx_env = TxEnvExt::default();
-        let message =
-            MessageExt { gas_limit: 1_000_000, destination: creator, ..MessageExt::default() };
         let code = [
             op::PUSH10,
             0x60,
@@ -331,11 +332,13 @@ mod tests {
             op::PUSH0,
             op::RETURN,
         ];
-        let mut interpreter = Interpreter::<BaseEvmTypes>::new(
-            Bytecode::new_legacy(Bytes::copy_from_slice(&code)),
-            &tx_env,
-            &message,
-        );
+        let message = MessageExt {
+            gas_limit: 1_000_000,
+            destination: creator,
+            code: Bytecode::new_legacy(Bytes::copy_from_slice(&code)),
+            ..MessageExt::default()
+        };
+        let mut interpreter = Interpreter::<BaseEvmTypes>::new(&tx_env, &message);
 
         assert_eq!(
             run_interpreter(&backend, &config, &mut interpreter, &mut host),
@@ -377,12 +380,6 @@ mod tests {
         );
         host.set_interpreter_runner(JitInterpreterRunner::new(backend.clone()));
         let tx_env = TxEnvExt::default();
-        let message = MessageExt {
-            gas_limit: 1_000_000,
-            destination: caller,
-            value: Word::from(30),
-            ..MessageExt::default()
-        };
         let code = vec![
             op::PUSH1,
             0x20,
@@ -401,11 +398,14 @@ mod tests {
             op::PUSH0,
             op::RETURN,
         ];
-        let mut interpreter = Interpreter::<BaseEvmTypes>::new(
-            Bytecode::new_legacy(Bytes::copy_from_slice(&code)),
-            &tx_env,
-            &message,
-        );
+        let message = MessageExt {
+            gas_limit: 1_000_000,
+            destination: caller,
+            value: Word::from(30),
+            code: Bytecode::new_legacy(Bytes::copy_from_slice(&code)),
+            ..MessageExt::default()
+        };
+        let mut interpreter = Interpreter::<BaseEvmTypes>::new(&tx_env, &message);
 
         assert_eq!(
             run_interpreter(&backend, &config, &mut interpreter, &mut host),
@@ -456,12 +456,6 @@ mod tests {
         );
         host.set_interpreter_runner(JitInterpreterRunner::new(backend.clone()));
         let tx_env = TxEnvExt::default();
-        let message = MessageExt {
-            gas_limit: 1_000_000,
-            destination: caller,
-            value: Word::from(30),
-            ..MessageExt::default()
-        };
         let code = vec![
             op::PUSH1,
             0x69,
@@ -480,11 +474,14 @@ mod tests {
             op::STATICCALL,
             op::STOP,
         ];
-        let mut interpreter = Interpreter::<BaseEvmTypes>::new(
-            Bytecode::new_legacy(Bytes::copy_from_slice(&code)),
-            &tx_env,
-            &message,
-        );
+        let message = MessageExt {
+            gas_limit: 1_000_000,
+            destination: caller,
+            value: Word::from(30),
+            code: Bytecode::new_legacy(Bytes::copy_from_slice(&code)),
+            ..MessageExt::default()
+        };
+        let mut interpreter = Interpreter::<BaseEvmTypes>::new(&tx_env, &message);
 
         assert_eq!(
             run_interpreter(&backend, &config, &mut interpreter, &mut host),
@@ -513,6 +510,7 @@ mod tests {
             caller,
             input: Bytes::copy_from_slice(&input),
             value: Word::from(10),
+            code: Bytecode::new_legacy(Bytes::copy_from_slice(&outer_code)),
             code_address: outer,
             ..MessageExt::default()
         };
@@ -548,11 +546,7 @@ mod tests {
             if with_jit {
                 host.set_interpreter_runner(JitInterpreterRunner::new(backend.clone()));
             }
-            let mut interpreter = Interpreter::<BaseEvmTypes>::new(
-                Bytecode::new_legacy(Bytes::copy_from_slice(&outer_code)),
-                &tx_env,
-                &message,
-            );
+            let mut interpreter = Interpreter::<BaseEvmTypes>::new(&tx_env, &message);
             let stop = if with_jit {
                 run_interpreter(&backend, &config, &mut interpreter, &mut host).unwrap()
             } else {


### PR DESCRIPTION
This is the bytecode-carrying portion of #329, split out for review. Each `Message` now carries the bytecode it executes, including top-level and test messages.

The test cleanup standardizes `Message { ..., code: ... }` construction. Credit to @rakita for the original implementation in #329.
