### PR TITLE
feat(inspectors): support EIP-8037 tracing

### DIFF
--- a/crates/inspectors/src/tracing/builder/geth.rs
+++ b/crates/inspectors/src/tracing/builder/geth.rs
@@ -1,5 +1,6 @@
 //! Geth trace builder
 use crate::tracing::{
+    final_refunded,
     tx_state::TxState,
     types::{CallKind, CallTraceNode, CallTraceStepStackItem},
     utils::load_account_code,
@@ -20,7 +21,7 @@ use alloy_rpc_types_trace::geth::{
     erc7562::{AccessedSlots, CallFrameType, ContractSize, Erc7562Config, Erc7562Frame},
 };
 use evm2::{
-    EvmTypesHost, TxResultWithState,
+    EvmFeatures, EvmTypesHost, TxResultExt, TxResultWithState,
     evm::{DbResult, DynDatabase},
     interpreter::op,
 };
@@ -30,19 +31,27 @@ use evm2::{
 pub struct GethTraceBuilder<'a> {
     /// Recorded trace nodes.
     nodes: Cow<'a, [CallTraceNode]>,
+    /// EVM features used to produce the trace.
+    features: EvmFeatures,
 }
 
 impl GethTraceBuilder<'static> {
     /// Returns a new instance of the builder from [`Cow::Owned`]
     pub const fn new(nodes: Vec<CallTraceNode>) -> Self {
-        Self { nodes: Cow::Owned(nodes) }
+        Self { nodes: Cow::Owned(nodes), features: EvmFeatures::empty() }
     }
 }
 
 impl<'a> GethTraceBuilder<'a> {
     /// Returns a new instance of the builder from [`Cow::Borrowed`]
     pub const fn new_borrowed(nodes: &'a [CallTraceNode]) -> Self {
-        Self { nodes: Cow::Borrowed(nodes) }
+        Self { nodes: Cow::Borrowed(nodes), features: EvmFeatures::empty() }
+    }
+
+    /// Sets the EVM features used to produce the trace.
+    pub const fn with_features(mut self, features: EvmFeatures) -> Self {
+        self.features = features;
+        self
     }
 
     /// Consumes the builder and returns the recorded trace nodes.
@@ -53,6 +62,11 @@ impl<'a> GethTraceBuilder<'a> {
     /// Returns the sum of all steps in the recorded node traces.
     fn trace_step_count(&self) -> usize {
         self.nodes.iter().map(|node| node.trace.steps.len()).sum()
+    }
+
+    #[inline]
+    const fn is_eip8037_enabled(&self) -> bool {
+        self.features.contains(EvmFeatures::EIP8037)
     }
 
     /// Fill in the geth trace with all steps of the trace and its children traces in the order they
@@ -120,6 +134,31 @@ impl<'a> GethTraceBuilder<'a> {
         return_value: Bytes,
         opts: GethDefaultTracingOptions,
     ) -> DefaultFrame {
+        self.geth_traces_inner(receipt_gas_used, None, return_value, opts)
+    }
+
+    /// Generate a geth-style trace with EIP-8037 transaction gas accounting.
+    pub fn geth_traces_with_result_gas<E>(
+        &self,
+        gas: &TxResultExt<E>,
+        return_value: Bytes,
+        opts: GethDefaultTracingOptions,
+    ) -> DefaultFrame {
+        self.geth_traces_inner(
+            gas.tx_gas_used(),
+            Some((gas.execution_gas_spent(), gas.state_gas_spent(), final_refunded(gas))),
+            return_value,
+            opts,
+        )
+    }
+
+    fn geth_traces_inner(
+        &self,
+        receipt_gas_used: u64,
+        gas: Option<(u64, u64, u64)>,
+        return_value: Bytes,
+        opts: GethDefaultTracingOptions,
+    ) -> DefaultFrame {
         if self.nodes.is_empty() {
             return Default::default();
         }
@@ -131,10 +170,15 @@ impl<'a> GethTraceBuilder<'a> {
         let mut storage = HashMap::default();
         self.fill_geth_trace(main_trace_node, &opts, &mut storage, &mut struct_logs);
 
+        let gas = gas.filter(|_| self.is_eip8037_enabled());
+
         DefaultFrame {
             // If the top-level trace succeeded, then it was a success
             failed: !main_trace.success,
             gas: receipt_gas_used,
+            execution_gas_used: gas.map(|gas| gas.0),
+            state_gas_used: gas.map(|gas| gas.1),
+            gas_refund: gas.map(|gas| gas.2),
             return_value,
             struct_logs,
         }
@@ -146,6 +190,28 @@ impl<'a> GethTraceBuilder<'a> {
     ///
     /// This expects the gas used and return value for the executed transaction.
     pub fn geth_call_traces(&self, opts: CallConfig, gas_used: u64) -> CallFrame {
+        self.geth_call_traces_inner(opts, gas_used, None)
+    }
+
+    /// Generate a geth-style call trace with EIP-8037 transaction gas accounting.
+    pub fn geth_call_traces_with_result_gas<E>(
+        &self,
+        opts: CallConfig,
+        gas: &TxResultExt<E>,
+    ) -> CallFrame {
+        self.geth_call_traces_inner(
+            opts,
+            gas.tx_gas_used(),
+            Some((gas.execution_gas_spent(), gas.state_gas_spent(), final_refunded(gas))),
+        )
+    }
+
+    fn geth_call_traces_inner(
+        &self,
+        opts: CallConfig,
+        gas_used: u64,
+        gas: Option<(u64, u64, u64)>,
+    ) -> CallFrame {
         if self.nodes.is_empty() {
             return Default::default();
         }
@@ -155,6 +221,11 @@ impl<'a> GethTraceBuilder<'a> {
         let main_trace_node = &self.nodes[0];
         let mut root_call_frame = main_trace_node.geth_empty_call_frame(include_logs);
         root_call_frame.gas_used = U256::from(gas_used);
+        if let Some(gas) = gas.filter(|_| self.is_eip8037_enabled()) {
+            root_call_frame.execution_gas_used = Some(U256::from(gas.0));
+            root_call_frame.state_gas_used = Some(U256::from(gas.1));
+            root_call_frame.gas_refund = Some(U256::from(gas.2));
+        }
 
         // selfdestructs are not recorded as individual call traces but are derived from
         // the call trace and are added as additional `CallFrame` objects to the parent call

--- a/crates/inspectors/src/tracing/debug.rs
+++ b/crates/inspectors/src/tracing/debug.rs
@@ -1,5 +1,6 @@
 use crate::tracing::{
     FourByteInspector, MuxInspector, TracingInspector, TracingInspectorConfig, TransactionContext,
+    final_refunded,
 };
 #[cfg(feature = "js-tracer")]
 use alloc::boxed::Box;
@@ -9,7 +10,7 @@ use alloy_rpc_types_eth::TransactionInfo;
 use alloy_rpc_types_trace::geth::{
     CallConfig, FourByteFrame, GethDebugBuiltInTracerType, GethDebugTracerType,
     GethDebugTracingOptions, GethDefaultTracingOptions, GethTrace, NoopFrame, PreStateConfig,
-    erc7562::Erc7562Config, mux::MuxConfig,
+    StateGasTrace, erc7562::Erc7562Config, mux::MuxConfig,
 };
 use evm2::{
     ErrorCode, EvmTypes, EvmTypesHost, Inspector, NoopInspector, TxResultWithState,
@@ -37,6 +38,8 @@ pub enum DebugInspector {
     PreStateTracer(TracingInspector, PreStateConfig),
     /// Noop tracer
     Noop(NoopInspector),
+    /// EIP-8037 state-gas tracer
+    StateGasTracer(NoopInspector),
     /// Mux tracer
     Mux(MuxInspector, MuxConfig),
     /// FlatCallTracer
@@ -60,6 +63,7 @@ impl DebugInspector {
                 Self::PreStateTracer(inspector.clone(), *config)
             }
             Self::Noop(inspector) => Self::Noop(inspector.clone()),
+            Self::StateGasTracer(inspector) => Self::StateGasTracer(inspector.clone()),
             Self::Mux(inspector, config) => Self::Mux(inspector.clone(), config.clone()),
             Self::FlatCallTracer(inspector) => Self::FlatCallTracer(inspector.clone()),
             Self::Erc7562Tracer(inspector, config) => {
@@ -107,6 +111,9 @@ impl DebugInspector {
                         )
                     }
                     GethDebugBuiltInTracerType::NoopTracer => Self::Noop(NoopInspector::default()),
+                    GethDebugBuiltInTracerType::StateGasTracer => {
+                        Self::StateGasTracer(NoopInspector::default())
+                    }
                     GethDebugBuiltInTracerType::MuxTracer => {
                         let config = tracer_config
                             .into_mux_config()
@@ -182,7 +189,7 @@ impl DebugInspector {
             | Self::FlatCallTracer(inspector)
             | Self::Erc7562Tracer(inspector, _)
             | Self::Default(inspector, _) => inspector.fuse(),
-            Self::Noop(_) => {}
+            Self::Noop(_) | Self::StateGasTracer(_) => {}
             Self::Mux(inspector, config) => {
                 *inspector = MuxInspector::try_from_config(config.clone())?;
             }
@@ -219,7 +226,10 @@ impl DebugInspector {
             Self::CallTracer(inspector, config) => {
                 inspector.set_transaction_gas_limit(tx.gas_limit());
                 inspector.set_transaction_caller(tx.signer());
-                inspector.geth_builder().geth_call_traces(*config, res.result.tx_gas_used()).into()
+                inspector
+                    .geth_builder()
+                    .geth_call_traces_with_result_gas(*config, &res.result)
+                    .into()
             }
             Self::PreStateTracer(inspector, config) => {
                 inspector.set_transaction_gas_limit(tx.gas_limit());
@@ -230,6 +240,13 @@ impl DebugInspector {
                     .into()
             }
             Self::Noop(_) => NoopFrame::default().into(),
+            Self::StateGasTracer(_) => StateGasTrace {
+                gas_used: res.result.tx_gas_used(),
+                execution_gas_used: res.result.execution_gas_spent(),
+                state_gas_used: res.result.state_gas_spent(),
+                gas_refund: final_refunded(&res.result),
+            }
+            .into(),
             Self::Mux(inspector, _) => inspector
                 .try_into_mux_frame(res, db, tx_info)
                 .map_err(DebugInspectorError::Database)?
@@ -257,7 +274,7 @@ impl DebugInspector {
                 inspector.set_transaction_caller(tx.signer());
                 inspector
                     .geth_builder()
-                    .geth_traces(res.result.tx_gas_used(), res.result.output.clone(), *config)
+                    .geth_traces_with_result_gas(&res.result, res.result.output.clone(), *config)
                     .into()
             }
             #[cfg(feature = "js-tracer")]
@@ -281,6 +298,7 @@ macro_rules! delegate {
             Self::Erc7562Tracer($insp, _) => Inspector::<T>::$method($insp, $($arg),*),
             Self::Default($insp, _) => Inspector::<T>::$method($insp, $($arg),*),
             Self::Noop($insp) => Inspector::<T>::$method($insp, $($arg),*),
+            Self::StateGasTracer($insp) => Inspector::<T>::$method($insp, $($arg),*),
             Self::Mux($insp, _) => Inspector::<T>::$method($insp, $($arg),*),
             #[cfg(feature = "js-tracer")]
             Self::Js($insp) => Inspector::<T>::$method(&mut **$insp, $($arg),*),

--- a/crates/inspectors/src/tracing/mod.rs
+++ b/crates/inspectors/src/tracing/mod.rs
@@ -15,7 +15,7 @@ use alloc::{boxed::Box, vec::Vec};
 use alloy_primitives::{Address, B256, Bytes, Log, U256};
 use core::mem;
 use evm2::{
-    Evm, EvmTypes, Inspector, SpecId,
+    Evm, EvmFeatures, EvmTypes, Inspector, SpecId, TxResultExt,
     evm::JournalEntry,
     interpreter::{
         Interpreter, Message, MessageKind, MessageResult, MessageResultExt,
@@ -64,6 +64,12 @@ pub use mux::{Error as MuxError, MuxInspector};
 mod debug;
 pub use debug::{DebugInspector, DebugInspectorError};
 
+/// Returns the effective gas refund after the calldata floor adjustment.
+#[inline]
+pub(crate) const fn final_refunded<E>(gas: &TxResultExt<E>) -> u64 {
+    if gas.total_gas_spent.saturating_sub(gas.refunded) < gas.floor_gas { 0 } else { gas.refunded }
+}
+
 /// An inspector that collects call traces.
 ///
 /// This [Inspector] can be hooked into evm2's EVM which then calls the inspector functions, such
@@ -91,6 +97,10 @@ pub struct TracingInspector {
     ///
     /// This is filled during execution.
     spec_id: Option<SpecId>,
+    /// The active EVM features.
+    ///
+    /// This is filled during execution.
+    features: EvmFeatures,
     /// Pool of reusable _empty_ step vectors to reduce allocations.
     ///
     /// All `Vec<CallTraceStep>` are always empty but may have capacity.
@@ -115,6 +125,7 @@ impl TracingInspector {
             step_stack,
             last_journal_len,
             spec_id,
+            features,
             // kept
             config,
             reusable_step_vecs,
@@ -135,6 +146,7 @@ impl TracingInspector {
         trace_stack.clear();
         step_stack.clear();
         spec_id.take();
+        *features = EvmFeatures::empty();
         *last_journal_len = 0;
     }
 
@@ -239,7 +251,7 @@ impl TracingInspector {
     /// Consumes the Inspector and returns a [GethTraceBuilder].
     #[inline]
     pub fn into_geth_builder(self) -> GethTraceBuilder<'static> {
-        GethTraceBuilder::new(self.traces.arena)
+        GethTraceBuilder::new(self.traces.arena).with_features(self.features)
     }
 
     /// Returns the  [GethTraceBuilder] for the recorded traces without consuming the type.
@@ -249,7 +261,7 @@ impl TracingInspector {
     /// starting a new transaction: [`Self::fuse`]
     #[inline]
     pub fn geth_builder(&self) -> GethTraceBuilder<'_> {
-        GethTraceBuilder::new_borrowed(&self.traces.arena)
+        GethTraceBuilder::new_borrowed(&self.traces.arena).with_features(self.features)
     }
 
     /// Returns true if we're no longer in the context of the root call.
@@ -472,6 +484,12 @@ impl TracingInspector {
             // These fields will be populated in `step_end`.
             push_stack: None,
             gas_cost: 0,
+            state_gas_cost: None,
+            state_gas_reservoir: interp
+                .version()
+                .feature(EvmFeatures::EIP8037)
+                .then_some(interp.gas().reservoir()),
+            state_gas_spent: interp.gas().state_gas_spent(),
             storage_change: None,
             status: None,
 
@@ -560,6 +578,10 @@ impl TracingInspector {
         // step the remaining gas here, at the end of the step.
         // TODO: Figure out why this can overflow. https://github.com/paradigmxyz/revm-inspectors/pull/38
         step.gas_cost = step.gas_remaining.saturating_sub(interp.gas().remaining());
+        let state_gas_delta = interp.gas().state_gas_spent().saturating_sub(step.state_gas_spent);
+        if step.state_gas_reservoir.is_some() && state_gas_delta != 0 {
+            step.state_gas_cost = Some(state_gas_delta);
+        }
 
         // set the status
         step.status = interp.result().err();
@@ -567,6 +589,12 @@ impl TracingInspector {
 }
 
 impl<T: EvmTypes> Inspector<T> for TracingInspector {
+    #[inline]
+    fn initialize_interp(&mut self, interp: &mut Interpreter<'_, '_, T>) {
+        self.spec_id = Some(interp.spec());
+        self.features = interp.version().features;
+    }
+
     #[inline]
     fn step(&mut self, interp: &mut Interpreter<'_, '_, T>) {
         if self.config.record_steps {
@@ -600,6 +628,9 @@ impl<T: EvmTypes> Inspector<T> for TracingInspector {
         interp: &mut Interpreter<'_, '_, T>,
         message: &mut Message<T>,
     ) -> Option<MessageResult<T>> {
+        self.spec_id = Some(interp.spec());
+        self.features = interp.version().features;
+
         // determine correct `from` and `to` based on the call scheme
         let (from, to) = match message.kind {
             MessageKind::DelegateCall | MessageKind::CallCode => {
@@ -645,9 +676,12 @@ impl<T: EvmTypes> Inspector<T> for TracingInspector {
 
     fn create(
         &mut self,
-        _interp: &mut Interpreter<'_, '_, T>,
+        interp: &mut Interpreter<'_, '_, T>,
         message: &mut Message<T>,
     ) -> Option<MessageResult<T>> {
+        self.spec_id = Some(interp.spec());
+        self.features = interp.version().features;
+
         self.start_trace_on_call(
             usize::from(message.depth),
             message.destination,

--- a/crates/inspectors/src/tracing/mux.rs
+++ b/crates/inspectors/src/tracing/mux.rs
@@ -1,10 +1,10 @@
-use crate::tracing::{FourByteInspector, TracingInspector, TracingInspectorConfig};
+use crate::tracing::{FourByteInspector, TracingInspector, TracingInspectorConfig, final_refunded};
 use alloc::vec::Vec;
 use alloy_primitives::{Address, Log, U256, map::HashMap};
 use alloy_rpc_types_eth::TransactionInfo;
 use alloy_rpc_types_trace::geth::{
     CallConfig, FlatCallConfig, FourByteFrame, GethDebugBuiltInTracerType, GethDebugTracerType,
-    NoopFrame, PreStateConfig,
+    NoopFrame, PreStateConfig, StateGasTrace,
     mux::{MuxConfig, MuxFrame},
 };
 use evm2::{
@@ -31,6 +31,7 @@ enum TraceConfig {
     Call(CallConfig),
     PreState(PreStateConfig),
     FlatCall(FlatCallConfig),
+    StateGas,
     Noop,
 }
 
@@ -78,6 +79,12 @@ impl MuxInspector {
                     }
                     configs.push((builtin, TraceConfig::Noop));
                 }
+                GethDebugBuiltInTracerType::StateGasTracer => {
+                    if tracer_config.is_some() {
+                        return Err(Error::UnexpectedConfig(builtin));
+                    }
+                    configs.push((builtin, TraceConfig::StateGas));
+                }
                 GethDebugBuiltInTracerType::FlatCallTracer => {
                     let flatcall_config = tracer_config
                         .ok_or(Error::MissingConfig(builtin))?
@@ -117,7 +124,7 @@ impl MuxInspector {
                     if let Some(inspector) = &self.tracing {
                         inspector
                             .geth_builder()
-                            .geth_call_traces(*call_config, result.result.tx_gas_used())
+                            .geth_call_traces_with_result_gas(*call_config, &result.result)
                             .into()
                     } else {
                         continue;
@@ -145,6 +152,13 @@ impl MuxInspector {
                     }
                 }
                 TraceConfig::Noop => NoopFrame::default().into(),
+                TraceConfig::StateGas => StateGasTrace {
+                    gas_used: result.result.tx_gas_used(),
+                    execution_gas_used: result.result.execution_gas_spent(),
+                    state_gas_used: result.result.state_gas_spent(),
+                    gas_refund: final_refunded(&result.result),
+                }
+                .into(),
             };
 
             frame.insert(GethDebugTracerType::BuiltInTracer(*tracer_type), trace);

--- a/crates/inspectors/src/tracing/types.rs
+++ b/crates/inspectors/src/tracing/types.rs
@@ -439,6 +439,7 @@ impl CallTraceNode {
             revert_reason: None,
             calls: Default::default(),
             logs: Default::default(),
+            ..Default::default()
         };
 
         if self.trace.kind.is_static_call() {
@@ -673,6 +674,13 @@ pub struct CallTraceStep {
     // Fields filled in `step_end`
     /// Gas cost of step execution
     pub gas_cost: u64,
+    /// Net state-gas change caused by this step.
+    pub state_gas_cost: Option<i64>,
+    /// State-gas reservoir before this step.
+    pub state_gas_reservoir: Option<u64>,
+    /// State-gas spent before this step, used to calculate `state_gas_cost`.
+    #[cfg_attr(feature = "serde", serde(skip))]
+    pub state_gas_spent: i64,
     /// Change of the contract state after step execution (effect of the SLOAD/SSTORE instructions)
     pub storage_change: Option<Box<StorageChange>>,
     /// Final status of the step
@@ -699,6 +707,8 @@ impl CallTraceStep {
             error: self.as_error(),
             gas: self.gas_remaining,
             gas_cost: self.gas_cost,
+            state_gas_cost: self.state_gas_cost,
+            state_gas_reservoir: self.state_gas_reservoir,
             op: if self.op.is_valid() { self.op.as_str().into() } else { "Unknown".into() },
             pc: self.pc as u64,
             refund_counter: Some(self.gas_refund_counter),

--- a/crates/inspectors/tests/it/geth.rs
+++ b/crates/inspectors/tests/it/geth.rs
@@ -3,12 +3,16 @@ use crate::utils::{
     AccountInfo, Bytecode, CacheDB, Context, ETH_TRANSFER_LOG_ADDRESS, EmptyDB, SpecId, TransactTo,
     TxEnv, deploy_contract, op,
 };
-use alloy_primitives::{Address, B256, Bytes, TxKind, address, hex, map::HashMap};
+use alloy_primitives::{Address, B256, Bytes, TxKind, U256, address, hex, map::HashMap};
 use alloy_rpc_types_eth::TransactionInfo;
 use alloy_rpc_types_trace::geth::{
     CallConfig, FlatCallConfig, GethDebugBuiltInTracerType, GethDebugTracerConfig,
     GethDebugTracerType, GethDebugTracingOptions, GethDefaultTracingOptions, GethTrace,
     PreStateConfig, PreStateFrame, erc7562::Erc7562Config, mux::MuxConfig,
+};
+use evm2::{
+    BaseEvmTypes, Evm, EvmFeatures, ExecutionConfig, Precompiles, Version,
+    ethereum::ethereum_tx_registry,
 };
 use evm2_inspectors::tracing::{
     DebugInspector, MuxInspector, TracingInspector, TracingInspectorConfig,
@@ -148,6 +152,210 @@ fn test_geth_erc7562_tracer() {
     }
 }
 
+fn trace_contract(
+    spec: SpecId,
+    opts: GethDebugTracingOptions,
+    code: Bytes,
+) -> (GethTrace, evm2::TxResult) {
+    let contract = address!("1000000000000000000000000000000000000001");
+    let caller = address!("1000000000000000000000000000000000000002");
+    let context = Context::mainnet()
+        .with_db(CacheDB::<EmptyDB>::default())
+        .modify_cfg_chained(|cfg| cfg.spec = spec)
+        .modify_db_chained(|db| {
+            db.insert_account_info(
+                &contract,
+                AccountInfo { code: Some(Bytecode::new_raw(code)), ..Default::default() },
+            );
+        });
+    let mut inspector = DebugInspector::new(opts).unwrap();
+    let mut evm = context.build_mainnet().with_inspector(&mut inspector);
+
+    let res = evm
+        .inspect_tx(TxEnv {
+            caller,
+            gas_limit: 1_000_000,
+            gas_price: 0,
+            kind: TransactTo::Call(contract),
+            data: Bytes::default(),
+            nonce: 0,
+            ..Default::default()
+        })
+        .unwrap();
+    assert!(res.result.is_success(), "{res:#?}");
+
+    let (ctx, inspector) = evm.ctx_inspector();
+    let tx = ctx.tx().envelope();
+    let block = *ctx.block();
+    let trace = inspector.get_result(None, &tx, &block, &res.tx_result, ctx.db_mut()).unwrap();
+    (trace, res.tx_result.result.clone())
+}
+
+fn trace_contract_with_version(
+    spec: SpecId,
+    version: Version,
+    opts: GethDebugTracingOptions,
+    code: Bytes,
+) -> (GethTrace, evm2::TxResult) {
+    let contract = address!("1000000000000000000000000000000000000001");
+    let caller = address!("1000000000000000000000000000000000000002");
+    let mut context =
+        Context::mainnet().with_db(CacheDB::<EmptyDB>::default()).modify_db_chained(|db| {
+            db.insert_account_info(
+                &contract,
+                AccountInfo { code: Some(Bytecode::new_raw(code)), ..Default::default() },
+            );
+        });
+    let block = *context.block();
+    let mut inspector = DebugInspector::new(opts).unwrap();
+    let mut evm = Evm::<BaseEvmTypes>::new_with_execution_config(
+        ExecutionConfig::for_spec_and_version(spec, version),
+        spec,
+        block,
+        ethereum_tx_registry(spec),
+        context.db.clone(),
+        Precompiles::base(spec),
+    );
+    evm.set_inspector(&mut inspector);
+
+    let tx = TxEnv {
+        caller,
+        gas_limit: 1_000_000,
+        gas_price: 0,
+        kind: TransactTo::Call(contract),
+        data: Bytes::default(),
+        nonce: 0,
+        ..Default::default()
+    };
+    let envelope = tx.envelope();
+    let res = evm.transact(&envelope).unwrap().detach();
+    drop(evm);
+
+    let trace = inspector.get_result(None, &envelope, &block, &res, context.db_mut()).unwrap();
+    (trace, res.result.clone())
+}
+
+#[test]
+fn test_geth_state_gas_tracer() {
+    // SSTORE slot 0 from zero to one, then STOP.
+    let (trace, gas) = trace_contract(
+        SpecId::AMSTERDAM,
+        GethDebugTracingOptions::state_gas_tracer(),
+        hex!("600160005500").into(),
+    );
+    assert!(gas.state_gas_spent() > 0);
+
+    match trace {
+        GethTrace::StateGasTracer(frame) => {
+            assert_eq!(frame.gas_used, gas.tx_gas_used());
+            assert_eq!(frame.execution_gas_used, gas.execution_gas_spent());
+            assert_eq!(frame.state_gas_used, gas.state_gas_spent());
+            assert_eq!(frame.gas_refund, gas.refunded);
+        }
+        _ => panic!("Expected StateGasTracer"),
+    }
+}
+
+#[test]
+fn test_geth_eip8037_fields_follow_fork() {
+    // SSTORE slot 0 from zero to one and restore it to zero. This exercises both positive and
+    // negative per-opcode state-gas changes while leaving the transaction's final state gas at
+    // zero.
+    let code = hex!("6001600055600060005500");
+
+    for (spec, enabled) in [(SpecId::OSAKA, false), (SpecId::AMSTERDAM, true)] {
+        let (trace, gas) = trace_contract(spec, GethDebugTracingOptions::default(), code.into());
+        assert_eq!(gas.state_gas_spent(), 0);
+
+        let GethTrace::Default(frame) = trace else {
+            panic!("Expected default tracer");
+        };
+        assert_eq!(frame.execution_gas_used, enabled.then_some(gas.execution_gas_spent()));
+        assert_eq!(frame.state_gas_used, enabled.then_some(0));
+        assert_eq!(frame.gas_refund, enabled.then_some(gas.refunded));
+
+        let sstores =
+            frame.struct_logs.iter().filter(|log| log.opcode() == "SSTORE").collect::<Vec<_>>();
+        assert_eq!(sstores.len(), 2);
+        if enabled {
+            assert!(sstores[0].state_gas_cost.is_some_and(|cost| cost > 0), "{sstores:#?}");
+            assert!(sstores[1].state_gas_cost.is_some_and(|cost| cost < 0), "{sstores:#?}");
+            assert!(frame.struct_logs.iter().all(|log| log.state_gas_reservoir.is_some()));
+        } else {
+            assert!(
+                frame
+                    .struct_logs
+                    .iter()
+                    .all(|log| log.state_gas_cost.is_none() && log.state_gas_reservoir.is_none())
+            );
+        }
+
+        let value = serde_json::to_value(&frame).unwrap();
+        assert_eq!(value.get("executionGasUsed").is_some(), enabled);
+        assert_eq!(value.get("stateGasUsed").is_some(), enabled);
+        assert_eq!(value.get("gasRefund").is_some(), enabled);
+        if enabled {
+            let sstore_logs = value["structLogs"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .filter(|log| log["op"] == "SSTORE")
+                .collect::<Vec<_>>();
+            assert!(sstore_logs[0]["stateGasCost"].as_i64().is_some_and(|cost| cost > 0));
+            assert!(sstore_logs[1]["stateGasCost"].as_i64().is_some_and(|cost| cost < 0));
+        }
+
+        let (trace, call_gas) = trace_contract(
+            spec,
+            GethDebugTracingOptions::call_tracer(CallConfig::default()),
+            code.into(),
+        );
+        let GethTrace::CallTracer(frame) = trace else {
+            panic!("Expected call tracer");
+        };
+        assert_eq!(
+            frame.execution_gas_used,
+            enabled.then(|| U256::from(call_gas.execution_gas_spent()))
+        );
+        assert_eq!(frame.state_gas_used, enabled.then_some(U256::ZERO));
+        assert_eq!(frame.gas_refund, enabled.then(|| U256::from(call_gas.refunded)));
+
+        // Empty-code calls do not initialize an interpreter, so the fork must also be captured at
+        // frame entry.
+        let (trace, empty_gas) =
+            trace_contract(spec, GethDebugTracingOptions::default(), Bytes::new());
+        let GethTrace::Default(frame) = trace else {
+            panic!("Expected default tracer");
+        };
+        assert_eq!(frame.execution_gas_used, enabled.then_some(empty_gas.execution_gas_spent()));
+        assert_eq!(frame.state_gas_used, enabled.then_some(0));
+        assert_eq!(frame.gas_refund, enabled.then_some(empty_gas.refunded));
+    }
+
+    let mut version = Version::new(SpecId::AMSTERDAM);
+    version.features.remove(EvmFeatures::EIP8037);
+    let (trace, gas) = trace_contract_with_version(
+        SpecId::AMSTERDAM,
+        version,
+        GethDebugTracingOptions::default(),
+        code.into(),
+    );
+    assert_eq!(gas.state_gas_spent(), 0);
+
+    let GethTrace::Default(frame) = trace else {
+        panic!("Expected default tracer");
+    };
+    assert!(frame.execution_gas_used.is_none());
+    assert!(frame.state_gas_used.is_none());
+    assert!(frame.gas_refund.is_none());
+    assert!(
+        frame
+            .struct_logs
+            .iter()
+            .all(|log| log.state_gas_cost.is_none() && log.state_gas_reservoir.is_none())
+    );
+}
+
 #[test]
 fn test_geth_mux_tracer() {
     /*
@@ -215,6 +423,7 @@ fn test_geth_mux_tracer() {
             GethDebugTracerType::BuiltInTracer(GethDebugBuiltInTracerType::FlatCallTracer),
             Some(GethDebugTracerConfig(serde_json::to_value(flatcall_config).unwrap())),
         ),
+        (GethDebugTracerType::BuiltInTracer(GethDebugBuiltInTracerType::StateGasTracer), None),
     ]));
 
     let mut insp = MuxInspector::try_from_config(config).unwrap();
@@ -238,7 +447,7 @@ fn test_geth_mux_tracer() {
         .try_into_mux_frame(&res.tx_result, ctx.db_mut(), TransactionInfo::default())
         .unwrap();
 
-    assert_eq!(frame.0.len(), 4);
+    assert_eq!(frame.0.len(), 5);
     assert!(frame.0.contains_key(&GethDebugTracerType::BuiltInTracer(
         GethDebugBuiltInTracerType::FourByteTracer
     )));
@@ -252,6 +461,9 @@ fn test_geth_mux_tracer() {
     )));
     assert!(frame.0.contains_key(&GethDebugTracerType::BuiltInTracer(
         GethDebugBuiltInTracerType::FlatCallTracer
+    )));
+    assert!(frame.0.contains_key(&GethDebugTracerType::BuiltInTracer(
+        GethDebugBuiltInTracerType::StateGasTracer
     )));
 
     let four_byte_frame = frame.0
@@ -307,6 +519,19 @@ fn test_geth_mux_tracer() {
             assert!(traces[5].trace.error.is_none());
         }
         _ => panic!("Expected FlatCallTracer"),
+    }
+
+    let state_gas_frame = frame.0
+        [&GethDebugTracerType::BuiltInTracer(GethDebugBuiltInTracerType::StateGasTracer)]
+        .clone();
+    match state_gas_frame {
+        GethTrace::StateGasTracer(state_gas) => {
+            assert_eq!(state_gas.gas_used, res.tx_result.result.tx_gas_used());
+            assert_eq!(state_gas.execution_gas_used, res.tx_result.result.execution_gas_spent());
+            assert_eq!(state_gas.state_gas_used, res.tx_result.result.state_gas_spent());
+            assert_eq!(state_gas.gas_refund, res.tx_result.result.refunded);
+        }
+        _ => panic!("Expected StateGasTracer"),
     }
 }
 


### PR DESCRIPTION
Ports the EIP-8037 tracing support from paradigmxyz/revm-inspectors#476 into evm2.

Adds Amsterdam-gated execution/state gas fields to Geth default and call traces, signed per-opcode state-gas fields, the `stateGasTracer`, and mux support. The implementation uses evm2's transaction gas result semantics while preserving pre-Amsterdam and legacy builder behavior.

Also removes the temporary Alloy git override now that the RPC trace types are released.
