### PR TITLE
feat: glamsterdam devnet-8 gas repricing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
         shell: bash
         run: |
           if [[ "${{ matrix.fixture }}" == "devnet" ]]; then
-            export DEVNET_VERSION="tests-glamsterdam-devnet%40v7.2.0"
+            export DEVNET_VERSION="tests-glamsterdam-devnet%40v8.1.0"
             export DEVNET_TAR="fixtures_glamsterdam-devnet.tar.gz"
             export EVM2_STATETEST_DEVNET_ONLY=1
           fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ If fixtures are already available in another worktree, symlink `test-fixtures`
 to that directory instead of re-downloading them.
 By default it downloads the glamsterdam (Amsterdam) devnet fixtures plus legacy
 Cancun/Constantinople state tests. The devnet release defaults to
-`tests-glamsterdam-devnet@v7.2.0` / `fixtures_glamsterdam-devnet.tar.gz`
+`tests-glamsterdam-devnet@v8.1.0` / `fixtures_glamsterdam-devnet.tar.gz`
 (from the `ethereum/execution-specs` repo, base overridable via `DEVNET_BASE_URL`);
 override `DEVNET_VERSION` and `DEVNET_TAR` to select a different devnet release, or
 clear either to disable devnet. The glamsterdam devnet fixtures cover

--- a/crates/evm2/src/ethereum/mod.rs
+++ b/crates/evm2/src/ethereum/mod.rs
@@ -890,15 +890,12 @@ fn eip2780_base_to_value_gas(
     let params = &version.gas_params;
     let mut gas = u64::from(EIP2780_TX_BASE_COST);
     if is_create {
+        // Since glamsterdam devnet-8, creates pay no value-based charge.
         gas += u64::from(params.get(GasId::TxCreateAccessCost));
-        if !value.is_zero() {
-            gas += u64::from(params.get(GasId::TxTransferLogCost));
-        }
     } else if !is_self_transfer {
         gas += u64::from(EIP8038_COLD_ACCOUNT_ACCESS);
         if !value.is_zero() {
-            gas += u64::from(params.get(GasId::TxTransferLogCost))
-                + u64::from(params.get(GasId::TxValueCost));
+            gas += u64::from(params.get(GasId::TxValueCost));
         }
     }
     gas
@@ -978,9 +975,9 @@ mod tests {
             ),
             // EIP-2780 replaces the 21,000 base with TX_BASE (12,000) +
             // COLD_ACCOUNT_ACCESS (3,000) for the zero-value call recipient.
-            // EIP-8038 sets the per-item access-list base to COLD_ACCOUNT_ACCESS /
-            // COLD_STORAGE_ACCESS (both 3,000).
-            (12_000 + 3000) + (3000 + 20 * 64) + (3000 + 32 * 64)
+            // EIP-8038 sets the per-item access-list base to the cold-minus-warm
+            // premium: 2,900 per address and 2,000 per storage key.
+            (12_000 + 3000) + (2900 + 20 * 64) + (2000 + 32 * 64)
         );
     }
 

--- a/crates/evm2/src/interpreter/gas.rs
+++ b/crates/evm2/src/interpreter/gas.rs
@@ -53,42 +53,48 @@ pub const EIP7702_PER_AUTH_BASE_COST: u32 = 12500;
 pub const EIP7702_PER_EMPTY_ACCOUNT_COST: u32 = 25000;
 
 // EIP-8038: State-access gas cost update. Increases the gas cost of state-access
-// operations to reflect Ethereum's larger state. Values are the parameters
-// proposed in ethereum/EIPs#11802 (still an open draft — preliminary). Active
-// alongside EIP-8037 starting at the Amsterdam hardfork. Touching an already-warm
-// account or storage slot is unchanged by EIP-8038, so the existing
+// operations to reflect Ethereum's larger state. Values match the glamsterdam
+// devnet-8 numbers in execution-specs `forks/amsterdam` (`vm/gas.py::GasCosts`).
+// Active alongside EIP-8037 starting at the Amsterdam hardfork. Touching an
+// already-warm account or storage slot is unchanged by EIP-8038, so the existing
 // `WARM_STORAGE_READ_COST` (100) is reused throughout.
 /// Cold touch of an account (was 2,600 pre-EIP-8038).
 pub(crate) const EIP8038_COLD_ACCOUNT_ACCESS: u32 = 3000;
-/// Cold touch of a storage slot (was 2,100 pre-EIP-8038).
-pub(crate) const EIP8038_COLD_STORAGE_ACCESS: u32 = 3000;
+/// Cold touch of a storage slot. Unchanged from the pre-EIP-8038 cost, but
+/// under EIP-8038 it is the *total* cold charge (the warm base is folded in).
+pub(crate) const EIP8038_COLD_STORAGE_ACCESS: u32 = 2100;
 /// First-time account-write surcharge (was 6,700 pre-EIP-8038).
-pub(crate) const EIP8038_ACCOUNT_WRITE: u32 = 8000;
+pub(crate) const EIP8038_ACCOUNT_WRITE: u32 = 9000;
 /// First-time storage-write surcharge (was 2,800 pre-EIP-8038).
 pub(crate) const EIP8038_STORAGE_WRITE: u32 = 10000;
 /// Refund for clearing a storage slot (was 4,800 pre-EIP-8038).
 ///
 /// Derived per the spec as `(STORAGE_WRITE + COLD_STORAGE_ACCESS) * 4800 / 5000`
-/// = 12,480.
+/// = 11,616.
 pub(crate) const EIP8038_STORAGE_CLEAR_REFUND: u32 =
     (EIP8038_STORAGE_WRITE + EIP8038_COLD_STORAGE_ACCESS) * 4800 / 5000;
 /// State-access cost for contract deployment (was 7,000 pre-EIP-8038).
 ///
-/// Per the spec, `CREATE_ACCESS = ACCOUNT_WRITE + COLD_STORAGE_ACCESS` = 11,000.
+/// Per the spec, `CREATE_ACCESS = ACCOUNT_WRITE + COLD_ACCOUNT_ACCESS` = 12,000.
 /// This does not match the legacy decomposition (`GAS_CREATE - GAS_NEW_ACCOUNT`);
 /// the EIP keeps that discrepancy rather than reconciling it.
-pub(crate) const EIP8038_CREATE_ACCESS: u32 = EIP8038_ACCOUNT_WRITE + EIP8038_COLD_STORAGE_ACCESS;
-/// Access-list per-address base cost, `COLD_ACCOUNT_ACCESS` (was 2,400 pre-EIP-8038).
-pub(crate) const EIP8038_ACCESS_LIST_ADDRESS_COST: u32 = EIP8038_COLD_ACCOUNT_ACCESS;
-/// Access-list per-storage-key base cost, `COLD_STORAGE_ACCESS` (was 1,900 pre-EIP-8038).
-pub(crate) const EIP8038_ACCESS_LIST_STORAGE_KEY_COST: u32 = EIP8038_COLD_STORAGE_ACCESS;
+pub(crate) const EIP8038_CREATE_ACCESS: u32 = EIP8038_ACCOUNT_WRITE + EIP8038_COLD_ACCOUNT_ACCESS;
+/// Access-list per-address base cost (was 2,400 pre-EIP-8038). Derived per the
+/// spec as `COLD_ACCOUNT_ACCESS - WARM_ACCESS`: the access list pre-pays only
+/// the cold premium, the warm base is still charged at first use.
+pub(crate) const EIP8038_ACCESS_LIST_ADDRESS_COST: u32 =
+    EIP8038_COLD_ACCOUNT_ACCESS - WARM_STORAGE_READ_COST;
+/// Access-list per-storage-key base cost (was 1,900 pre-EIP-8038). Derived per
+/// the spec as `COLD_STORAGE_ACCESS - WARM_ACCESS`.
+pub(crate) const EIP8038_ACCESS_LIST_STORAGE_KEY_COST: u32 =
+    EIP8038_COLD_STORAGE_ACCESS - WARM_STORAGE_READ_COST;
 /// Cold premium on top of `WARM_STORAGE_READ_COST` for account access.
 pub(crate) const EIP8038_COLD_ACCOUNT_ACCESS_ADDITIONAL: u32 =
     EIP8038_COLD_ACCOUNT_ACCESS - WARM_STORAGE_READ_COST;
 /// Cold premium on top of `WARM_STORAGE_READ_COST` for storage access.
 pub(crate) const EIP8038_COLD_STORAGE_ACCESS_ADDITIONAL: u32 =
     EIP8038_COLD_STORAGE_ACCESS - WARM_STORAGE_READ_COST;
-/// CALL value-transfer cost: `ACCOUNT_WRITE + CALL_STIPEND` per the EIP = 10,300.
+/// CALL value-transfer cost: `ACCOUNT_WRITE + CALL_STIPEND` per the EIP = 11,300.
 pub(crate) const EIP8038_CALL_VALUE: u32 = EIP8038_ACCOUNT_WRITE + CALL_STIPEND;
 /// Calldata bytes charged for one EIP-7702 authorization tuple (execution-specs
 /// `AUTH_TUPLE_BYTES`): chain id, authority address, nonce, signature parity, and
@@ -117,14 +123,13 @@ pub(crate) const EIP8038_EIP7702_PER_AUTH_BASE_REGULAR: u32 = EIP7702_AUTH_TUPLE
 // Active alongside EIP-8037 / EIP-8038 starting at the Amsterdam hardfork.
 /// Reduced intrinsic base charged to `tx.sender` (execution-specs `TX_BASE`).
 pub(crate) const EIP2780_TX_BASE_COST: u32 = 12_000;
-/// Execution gas cost of the EIP-7708 transfer log emitted for every nonzero-value
-/// transfer to a different account: `GAS_LOG + 3 * GAS_LOG_TOPIC + 32 *
-/// GAS_LOG_DATA_PER_BYTE = 375 + 1_125 + 256 = 1_756`.
-pub(crate) const EIP2780_TRANSFER_LOG_COST: u32 = 1_756;
 /// Additional intrinsic execution-gas charge for a value-bearing (non-create,
-/// non-self) transaction (execution-specs `TX_VALUE_COST`), on top of
-/// [`EIP2780_TRANSFER_LOG_COST`].
-pub(crate) const EIP2780_TX_VALUE_COST: u32 = 4_244;
+/// non-self) transaction (execution-specs `TX_VALUE_COST`).
+///
+/// Since glamsterdam devnet-8 the former separate `TRANSFER_LOG_COST` (1,756)
+/// is folded into this constant (`4,244 + 1,756 = 6,000`); contract-creation
+/// transactions no longer pay any value-based charge.
+pub(crate) const EIP2780_TX_VALUE_COST: u32 = 6_000;
 
 /// Tracks execution, state, and refunded gas.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]

--- a/crates/evm2/src/version/gas_params.rs
+++ b/crates/evm2/src/version/gas_params.rs
@@ -167,8 +167,6 @@ gas_ids! {
     /// EIP-7702 transaction state gas per authorization.
     TxEip7702PerAuthState;
 
-    /// EIP-2780 execution gas cost of the EIP-7708 transfer log on a nonzero-value transfer.
-    TxTransferLogCost;
     /// EIP-2780 additional intrinsic charge for a value-bearing non-create, non-self transaction.
     TxValueCost;
     /// EIP-2780/EIP-8038 execution gas cost of a top-level CREATE access.
@@ -523,17 +521,17 @@ mod tests {
         assert_eq!(prague.get(GasId::TxFloorZeroByteMultiplier), 1);
 
         let amsterdam = gas_params(SpecId::AMSTERDAM);
-        // EIP-8038 (ethereum/EIPs#11802) state-access cost values.
-        assert_eq!(amsterdam.get(GasId::Create), 11_000);
+        // EIP-8038 state-access cost values (glamsterdam devnet-8).
+        assert_eq!(amsterdam.get(GasId::Create), 12_000);
         assert_eq!(amsterdam.get(GasId::WarmStorageReadCost), 100); // unchanged
-        assert_eq!(amsterdam.get(GasId::ColdStorageCost), 2900);
+        assert_eq!(amsterdam.get(GasId::ColdStorageCost), 2000);
         assert_eq!(amsterdam.get(GasId::ColdAccountAdditionalCost), 2900);
-        assert_eq!(amsterdam.get(GasId::TransferValueCost), 10_300);
+        assert_eq!(amsterdam.get(GasId::TransferValueCost), 11_300);
         // CALL folds the account-write surcharge into CALL_VALUE, so a new target
         // adds no extra execution gas (only NEW_ACCOUNT state gas).
         assert_eq!(amsterdam.get(GasId::NewAccountCost), 0);
         assert_eq!(amsterdam.get(GasId::SstoreSetWithoutLoadCost), 10_000);
-        assert_eq!(amsterdam.get(GasId::SstoreClearingSlotRefund), 12_480);
+        assert_eq!(amsterdam.get(GasId::SstoreClearingSlotRefund), 11_616);
         // EIP-2780/Amsterdam intrinsic per-auth execution gas: the state-independent
         // REGULAR_PER_AUTH_BASE_COST = 101*16 + 3000 + 3000 + 2*100 = 7_816 (the ACCOUNT_WRITE
         // and state-gas remainder is charged at the runtime gas phase).
@@ -541,8 +539,8 @@ mod tests {
         assert_eq!(amsterdam.get(GasId::TxEip7702AuthRefund), 0);
         assert_eq!(amsterdam.get(GasId::SstoreSetState), 64 * 1530);
         assert_eq!(amsterdam.get(GasId::TxEip7702PerAuthState), 23 * 1530);
-        assert_eq!(amsterdam.get(GasId::TxAccessListAddressCost), 3000 + 20 * 64);
-        assert_eq!(amsterdam.get(GasId::TxAccessListStorageKeyCost), 3000 + 32 * 64);
+        assert_eq!(amsterdam.get(GasId::TxAccessListAddressCost), 2900 + 20 * 64);
+        assert_eq!(amsterdam.get(GasId::TxAccessListStorageKeyCost), 2000 + 32 * 64);
         assert_eq!(amsterdam.get(GasId::TxAccessListFloorByteMultiplier), 4);
         // EIP-7976: zero bytes weigh the same as non-zero bytes in the floor.
         assert_eq!(amsterdam.get(GasId::TxFloorZeroByteMultiplier), 4);

--- a/crates/evm2/src/version/mod.rs
+++ b/crates/evm2/src/version/mod.rs
@@ -790,17 +790,17 @@ evm_versions! {
             TxEip7702AuthRefund: 0,
             TxEip7702PerAuthState: 23 * AMSTERDAM_CPSB,
 
-            // EIP-8038: State-access gas cost update (ethereum/EIPs#11802;
-            // preliminary draft values). Constants in `interpreter::gas`.
+            // EIP-8038: State-access gas cost update (glamsterdam devnet-8
+            // values). Constants in `interpreter::gas`.
             //   WARM_ACCESS                    100 ->    100  (unchanged)
             //   COLD_ACCOUNT_ACCESS          2,600 ->  3,000
-            //   ACCOUNT_WRITE                6,700 ->  8,000
-            //   COLD_STORAGE_ACCESS          2,100 ->  3,000
+            //   ACCOUNT_WRITE                6,700 ->  9,000
+            //   COLD_STORAGE_ACCESS          2,100 ->  2,100  (unchanged)
             //   STORAGE_WRITE                2,800 -> 10,000
-            //   STORAGE_CLEAR_REFUND         4,800 -> 12,480
-            //   CREATE_ACCESS                7,000 -> 11,000  (ACCOUNT_WRITE + COLD_STORAGE_ACCESS)
-            //   ACCESS_LIST_ADDRESS_COST     2,400 ->  3,000  (COLD_ACCOUNT_ACCESS)
-            //   ACCESS_LIST_STORAGE_KEY_COST 1,900 ->  3,000  (COLD_STORAGE_ACCESS)
+            //   STORAGE_CLEAR_REFUND         4,800 -> 11,616
+            //   CREATE_ACCESS                7,000 -> 12,000  (ACCOUNT_WRITE + COLD_ACCOUNT_ACCESS)
+            //   ACCESS_LIST_ADDRESS_COST     2,400 ->  2,900  (COLD_ACCOUNT_ACCESS - WARM_ACCESS)
+            //   ACCESS_LIST_STORAGE_KEY_COST 1,900 ->  2,000  (COLD_STORAGE_ACCESS - WARM_ACCESS)
             //
             // WARM_ACCESS and the SSTORE warm base (`SstoreStatic`) are unchanged
             // (100), so they keep their inherited Berlin values.
@@ -809,9 +809,9 @@ evm_versions! {
             ColdAccountAdditionalCost: EIP8038_COLD_ACCOUNT_ACCESS_ADDITIONAL,
             ColdStorageAdditionalCost: EIP8038_COLD_STORAGE_ACCESS_ADDITIONAL,
             // EIP-8038 folds the warm base into the cold cost: a cold SSTORE pays
-            // `COLD_STORAGE_ACCESS` (3000) total, not warm(100)+cold. Since
+            // `COLD_STORAGE_ACCESS` (2100) total, not warm(100)+cold. Since
             // `SstoreStatic` (warm, 100) is always charged, the cold add-on here
-            // is the premium above warm (2900), unlike pre-8038 forks which add
+            // is the premium above warm (2000), unlike pre-8038 forks which add
             // the full `COLD_SLOAD_COST` on top of the warm base.
             ColdStorageCost: EIP8038_COLD_STORAGE_ACCESS_ADDITIONAL,
             // CALL_VALUE = ACCOUNT_WRITE + CALL_STIPEND. A value-bearing CALL already
@@ -836,7 +836,8 @@ evm_versions! {
             TxCreateCost: EIP8038_CREATE_ACCESS,
             // EIP-7981: charge access-list data at 64 gas per byte (20 bytes per
             // address, 32 per storage key), baked into the per-item cost; EIP-8038
-            // sets each per-item base to COLD_*_ACCESS (3,000).
+            // sets each per-item base to the cold-minus-warm premium (2,900 per
+            // address, 2,000 per storage key).
             TxAccessListAddressCost: EIP8038_ACCESS_LIST_ADDRESS_COST + 20 * EIP7981_ACCESS_LIST_DATA_COST_PER_BYTE,
             TxAccessListStorageKeyCost: EIP8038_ACCESS_LIST_STORAGE_KEY_COST + 32 * EIP7981_ACCESS_LIST_DATA_COST_PER_BYTE,
             // EIP-2780 (ethereum/EIPs#11844): the intrinsic per-auth charge is
@@ -848,7 +849,6 @@ evm_versions! {
             // EIP-2780: Reduce intrinsic transaction gas. The `to`- and
             // `value`-based intrinsic charges. ACCOUNT_WRITE / CREATE_ACCESS
             // source from EIP-8038 so a single change propagates everywhere.
-            TxTransferLogCost: EIP2780_TRANSFER_LOG_COST,
             TxValueCost: EIP2780_TX_VALUE_COST,
             TxCreateAccessCost: EIP8038_CREATE_ACCESS,
         ],

--- a/scripts/setup_test_fixtures.py
+++ b/scripts/setup_test_fixtures.py
@@ -41,10 +41,10 @@ DEVNET_BASE_URL = os.environ.get(
     "DEVNET_BASE_URL",
     "https://github.com/ethereum/execution-specs/releases/download",
 )
-# Default fork-specific devnet fixtures: glamsterdam (Amsterdam) devnet-7. Downloaded by default so
+# Default fork-specific devnet fixtures: glamsterdam (Amsterdam) devnet-8. Downloaded by default so
 # the Amsterdam tests run without extra configuration; override DEVNET_VERSION/DEVNET_TAR to select a
 # different devnet release. The version is a URL path component, so the `@` is percent-encoded.
-DEFAULT_DEVNET_VERSION = "tests-glamsterdam-devnet%40v7.2.0"
+DEFAULT_DEVNET_VERSION = "tests-glamsterdam-devnet%40v8.1.0"
 DEFAULT_DEVNET_TAR = "fixtures_glamsterdam-devnet.tar.gz"
 LEGACY_URL = (
     f"https://github.com/ethereum/tests/archive/refs/tags/{LEGACY_VERSION}.tar.gz"


### PR DESCRIPTION
## Summary

Backport of [bluealloy/revm#3850](https://github.com/bluealloy/revm/pull/3850), aligning Amsterdam with execution-specs `forks/amsterdam` at glamsterdam devnet-8 (fixtures `tests-glamsterdam-devnet@v8.1.0`).

### EIP-8038 repricing (`interpreter::gas`)

| Constant | devnet-7 | devnet-8 |
|---|---:|---:|
| `ACCOUNT_WRITE` | 8,000 | 9,000 |
| `COLD_STORAGE_ACCESS` | 3,000 | 2,100 |
| `CREATE_ACCESS` | 11,000 (`AW + COLD_STORAGE`) | 12,000 (`AW + COLD_ACCOUNT`) |
| `ACCESS_LIST_ADDRESS_COST` | 3,000 (full cold) | 2,900 (cold − warm) |
| `ACCESS_LIST_STORAGE_KEY_COST` | 3,000 (full cold) | 2,000 (cold − warm) |
| `STORAGE_CLEAR_REFUND` (derived) | 12,480 | 11,616 |
| `CALL_VALUE` (derived) | 10,300 | 11,300 |

### EIP-2780 value-charge fold

- `TX_VALUE_COST` 4,244 → 6,000; `TRANSFER_LOG_COST` (1,756) deleted (folded per spec).
- Calls with value are unchanged at 21,000 intrinsic total; **create transactions no longer pay any value-based charge** (24,000 flat = `TX_BASE + CREATE_ACCESS`).
- The `TxTransferLogCost` GasId is removed. The EIP-7708 transfer-log emission itself is unchanged.

### Misc

- Devnet fixtures bumped to `tests-glamsterdam-devnet@v8.1.0` in `setup_test_fixtures.py`, `ci.yml`, and AGENTS.md.

## Validation

- `tests-glamsterdam-devnet@v8.1.0`: all 33,079 interpreter EEST tests pass (480 usual skips).
- Compiled suites over the Amsterdam devnet roots: `statetests::aot`, `blockchain_tests::aot`, and the JIT smoke sets all pass.
- Workspace tests, clippy, fmt, docs clean.

Note: v8.1.0 fixtures were cut pre-freeze; a follow-up release carrying the frozen repricing (ethereum/EIPs PR-12083) is expected. Since `CREATE_ACCESS`, `CALL_VALUE`, and the refunds are derived, a renumber should only touch the base constants.
