### PR TITLE
fix(jit): decouple JUMPDEST analysis from instruction decoding

### DIFF
--- a/crates/jit/codegen/src/bytecode/mod.rs
+++ b/crates/jit/codegen/src/bytecode/mod.rs
@@ -230,7 +230,12 @@ impl<'a> Bytecode<'a> {
         let gas_params = gas_params.unwrap_or(evm2::Version::base(spec_id).gas_params);
         let mut insts = IndexVec::with_capacity(code.len() + 8);
         let mut inst_to_pc = IndexVec::with_capacity(code.len() + 8);
-        let mut jumpdests = BitVec::repeat(false, code.len());
+        // EIP-8024: JUMPDEST analysis is unchanged by DUPN/SWAPN/EXCHANGE: only PUSH
+        // data is skipped, their immediates are not. Compute the valid-jump-target
+        // bitmap with the legacy scan over the raw bytes, independent of instruction
+        // decoding below (which does consume DUPN/SWAPN/EXCHANGE immediates and can
+        // therefore desynchronize from the analysis).
+        let jumpdests = legacy_jumpdests(&code);
         let mut pc_to_inst = FxHashMap::with_capacity_and_hasher(code.len(), Default::default());
         let mut u256_interner = U256Interner::new();
         let op_infos = op_info_map(spec_id);
@@ -239,10 +244,6 @@ impl<'a> Bytecode<'a> {
             let inst: Inst = insts.next_idx();
             pc_to_inst.insert(pc as u32, inst);
             inst_to_pc.push(pc as u32);
-
-            if opcode == op::JUMPDEST {
-                jumpdests.set(pc, true)
-            }
 
             let mut flags = InstFlags::empty();
             let info = op_infos[opcode as usize];
@@ -298,17 +299,21 @@ impl<'a> Bytecode<'a> {
                 stack_section,
             });
 
-            // EIP-8024: JUMPDEST analysis is unchanged by DUPN/SWAPN/EXCHANGE. Their
-            // immediate byte is NOT masked, so 0x5b in that position is a valid jump
-            // target. When the immediate is 0x5b, rewind the iterator so it is re-yielded
-            // and processed as a normal JUMPDEST by the loop.
-            if matches!(opcode, op::DUPN | op::SWAPN | op::EXCHANGE)
-                && !info.is_unknown()
-                && !info.is_disabled()
-                && immediate == Some(&[op::JUMPDEST])
-            {
-                // SAFETY: we just consumed the 1-byte immediate.
-                unsafe { iter.rewind(1) };
+            // A valid jump target (per the legacy analysis above) can sit inside a
+            // consumed immediate: directly as a DUPN/SWAPN/EXCHANGE immediate byte, or
+            // inside a PUSH immediate once the decoded stream has diverged from the
+            // analysis past such an opcode. Rewind the iterator to the first such
+            // target so it is re-yielded and jumps have an instruction to land on.
+            // Analysis-aligned PUSH data never contains valid targets, so pre-EIP-8024
+            // bytecode never rewinds. Execution cannot fall through into the rewound
+            // bytes: every desynchronizing immediate is an invalid DUPN/SWAPN/EXCHANGE
+            // encoding, so the opcode preceding them halts at runtime.
+            if let Some(imm) = immediate {
+                let imm_end = pc + 1 + imm.len();
+                if let Some(target) = (pc + 1..imm_end).find(|&p| jumpdests[p]) {
+                    // SAFETY: we just consumed the immediate bytes at `pc + 1..imm_end`.
+                    unsafe { iter.rewind(imm_end - target) };
+                }
             }
         }
 
@@ -615,7 +620,7 @@ impl<'a> Bytecode<'a> {
     }
 
     /// Returns `true` if the given program counter is a valid jump destination.
-    fn is_valid_jump(&self, pc: usize) -> bool {
+    pub(crate) fn is_valid_jump(&self, pc: usize) -> bool {
         self.jumpdests.get(pc).as_deref().copied() == Some(true)
     }
 
@@ -1170,6 +1175,27 @@ bitflags::bitflags! {
         /// Don't generate any code.
         const DEAD_CODE = 1 << 8;
     }
+}
+
+/// Computes the legacy `JUMPDEST` analysis bitmap: a `0x5b` byte is a valid jump
+/// target unless it is part of the data of a `PUSH1..=PUSH32` instruction.
+///
+/// This is the analysis of every fork: EIP-8024 explicitly leaves it unchanged, so
+/// DUPN/SWAPN/EXCHANGE immediates are scanned as if they were opcodes.
+fn legacy_jumpdests(code: &[u8]) -> BitVec {
+    let mut jumpdests = BitVec::repeat(false, code.len());
+    let mut pc = 0;
+    while pc < code.len() {
+        let opcode = code[pc];
+        if opcode == op::JUMPDEST {
+            jumpdests.set(pc, true);
+        }
+        pc += 1;
+        if let op::PUSH1..=op::PUSH32 = opcode {
+            pc += (opcode - op::PUSH1 + 1) as usize;
+        }
+    }
+    jumpdests
 }
 
 fn bitvec_as_bytes<T: bitvec::store::BitStore, O: bitvec::order::BitOrder>(

--- a/crates/jit/codegen/src/compiler/translate/mod.rs
+++ b/crates/jit/codegen/src/compiler/translate/mod.rs
@@ -291,7 +291,13 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
         fx.bcx.unreachable();
         if bytecode.has_dynamic_jumps() {
             fx.bcx.switch_to_block(fx.dynamic_jump_table);
-            let jumpdests = bytecode.iter_insts().filter(|(_, data)| data.opcode == op::JUMPDEST);
+            // A decoded JUMPDEST is not necessarily a valid jump target: EIP-8024
+            // immediates can desynchronize decoding from the legacy JUMPDEST analysis,
+            // so a `0x5b` masked by the analysis still decodes as an instruction. Only
+            // analysis-valid targets belong in the dispatch table.
+            let jumpdests = bytecode.iter_insts().filter(|(_, data)| {
+                data.opcode == op::JUMPDEST && bytecode.is_valid_jump(data.jumpdest_pc() as usize)
+            });
             let targets = jumpdests
                 .map(|(inst, data)| (data.jumpdest_pc() as u64, fx.effective_entry(inst)))
                 .collect::<Vec<_>>();

--- a/crates/jit/codegen/src/tests/mod.rs
+++ b/crates/jit/codegen/src/tests/mod.rs
@@ -491,6 +491,51 @@ tests! {
             expected_memory: MEMORY_WHAT_INTERPRETER_SAYS,
             expected_gas: GAS_WHAT_INTERPRETER_SAYS,
         }),
+        // The reverse of the above: the byte after DUPN is analyzed as PUSH1 by the
+        // unchanged JUMPDEST analysis, so its data byte masks the 0x5b even though
+        // instruction decoding (which consumes DUPN's immediate) yields it as a
+        // JUMPDEST instruction. The jump must fail.
+        jump_to_push_masked_jumpdest_after_dupn(@raw {
+            bytecode: &[
+                op::PUSH1, 5, op::JUMP,
+                op::DUPN, op::PUSH1, op::JUMPDEST, // JUMPDEST is PUSH1 data in the analysis
+                op::PUSH1, 0x42, op::PUSH0, op::MSTORE,
+                op::PUSH1, 0x20, op::PUSH0, op::RETURN,
+            ],
+            spec_id: SpecId::AMSTERDAM,
+            expected_return: InstrStop::InvalidJump,
+            expected_stack: STACK_WHAT_INTERPRETER_SAYS,
+            expected_gas: GAS_WHAT_INTERPRETER_SAYS,
+        }),
+        // Same masked target, but reached through an unresolved dynamic jump
+        // (CALLDATASIZE is unknown at compile time): the dynamic dispatch table must
+        // not contain the analysis-masked JUMPDEST either.
+        dynamic_jump_to_push_masked_jumpdest_after_dupn(@raw {
+            bytecode: &[
+                op::PUSH1, 57, op::CALLDATASIZE, op::SUB, op::JUMP, // 64 - 57 = pc 7
+                op::DUPN, op::PUSH1, op::JUMPDEST,
+                op::PUSH1, 0x42, op::PUSH0, op::MSTORE,
+                op::PUSH1, 0x20, op::PUSH0, op::RETURN,
+            ],
+            spec_id: SpecId::AMSTERDAM,
+            expected_return: InstrStop::InvalidJump,
+            expected_stack: STACK_WHAT_INTERPRETER_SAYS,
+            expected_gas: GAS_WHAT_INTERPRETER_SAYS,
+        }),
+        // A valid target inside a PUSH immediate: DUPN desynchronizes decoding, so the
+        // 0x5b sits in the data of a decoded PUSH1 while the analysis (which does not
+        // skip DUPN immediates) sees it at an instruction boundary. The jump must land.
+        jump_into_desynced_push_immediate(@raw {
+            bytecode: &[
+                op::PUSH1, 6, op::JUMP,
+                op::DUPN, op::PUSH1, op::PUSH1, op::JUMPDEST, // decoded: DUPN(PUSH1), PUSH1(0x5b)
+                op::STOP,
+            ],
+            spec_id: SpecId::AMSTERDAM,
+            expected_return: InstrStop::Stop,
+            expected_stack: STACK_WHAT_INTERPRETER_SAYS,
+            expected_gas: GAS_WHAT_INTERPRETER_SAYS,
+        }),
 
         // Truncated PUSH2 at EOF: only 1 of 2 immediate bytes present.
         // EVM spec right-pads with zeros: PUSH2 0x42 → 0x4200.


### PR DESCRIPTION
## Summary

Fixes the JIT failure surfaced by the devnet-8 `tests-glamsterdam-devnet@v8.1.0` fixtures on #357 (`eip8024_dupn_swapn_exchange/eip_vectors/vector_push_in_immediate_masks_jumpdest`). The bug predates the fixture bump; the v8.1.0 `eip_vectors` are just the first fixtures to exercise it.

EIP-8024 leaves JUMPDEST analysis unchanged: only PUSH data is skipped, DUPN/SWAPN/EXCHANGE immediates are analyzed as if they were opcodes. The bytecode parser instead marked every decoded JUMPDEST instruction as a valid jump target, and the decoder *does* consume EIP-8024 immediates, so the two disagreed once such an immediate entered the stream. In `e6605b` (`[DUPN, PUSH1 0x5b]`) the analysis masks the `0x5b` behind the PUSH1, but decoding yielded it as a JUMPDEST instruction and the JIT accepted the jump the interpreter rejects.

## Fix

- Compute the valid-jump-target bitmap with the legacy scan over the raw bytes, decoupled from instruction decoding.
- Generalize the existing DUPN-immediate rewind: any analysis-valid target swallowed by a consumed immediate (a DUPN-family immediate byte, or a `0x5b` inside desynchronized PUSH data) is re-yielded so jumps have an instruction to land on. Analysis-aligned PUSH data never contains valid targets, so pre-EIP-8024 bytecode never rewinds.
- Exclude analysis-masked decoded JUMPDESTs from the dynamic jump dispatch table.

Execution cannot fall through into rewound bytes: every immediate that desynchronizes decoding from the analysis is an invalid DUPN/SWAPN/EXCHANGE encoding (`decode_single`/`decode_pair` reject 91..=127, which covers `0x5b` and all PUSH opcodes), so the opcode preceding them halts at runtime.

## Validation

- New codegen matrix tests: static + dynamic jump to a PUSH-masked `0x5b` after DUPN (must be invalid), and a jump to an analysis-valid `0x5b` inside desynchronized PUSH data (must land).
- All 2,226 `evm2-jit-codegen` tests and the 30 `.evm` snapshot tests pass; workspace suite passes.
- With this fix cherry-picked onto #357 (so the fixtures match the gas schedule): the full `for_amsterdam` devnet state-test corpus (2,737 files, `EVM2_COMPILED_EEST_SUBSET=all`) passes through the JIT — the configuration the `jit ubuntu jit` CI job runs.

Note: #357's JIT job needs this fix to go green (rebase or merge-order either way).