### PR TITLE
fix: check mcl curve state

### DIFF
--- a/crates/evm2/src/precompiles/bn254/mcl.rs
+++ b/crates/evm2/src/precompiles/bn254/mcl.rs
@@ -5,6 +5,10 @@ use crate::precompiles::PrecompileHalt;
 use mcl_rust::{CurveType, Fp, Fp2, Fr, G1, G2, GT};
 use std::sync::Once;
 
+unsafe extern "C" {
+    fn mclBn_getCurveType() -> i32;
+}
+
 #[inline]
 fn ensure_init() {
     static INIT: Once = Once::new();
@@ -13,6 +17,9 @@ fn ensure_init() {
         // CurveType::BN254 is a different, older BN254 parameterization.
         assert!(mcl_rust::init(CurveType::SNARK), "mcl BN254 initialization failed");
     });
+
+    let curve = unsafe { mclBn_getCurveType() };
+    assert_eq!(curve, CurveType::SNARK as i32, "mcl curve changed after initialization");
 }
 
 pub(crate) struct MclOps;
@@ -23,8 +30,12 @@ impl Bn254Ops for MclOps {
     type Scalar = Fr;
 
     #[inline]
-    fn read_g1(input: &[u8]) -> Result<Self::G1, PrecompileHalt> {
+    fn init() {
         ensure_init();
+    }
+
+    #[inline]
+    fn read_g1(input: &[u8]) -> Result<Self::G1, PrecompileHalt> {
         let px = read_fp(&input[..FQ_LEN])?;
         let py = read_fp(&input[FQ_LEN..G1_LEN])?;
 
@@ -62,7 +73,6 @@ impl Bn254Ops for MclOps {
 
     #[inline]
     fn read_g2(input: &[u8]) -> Result<Self::G2, PrecompileHalt> {
-        ensure_init();
         let x = read_fp2(&input[..FQ2_LEN])?;
         let y = read_fp2(&input[FQ2_LEN..2 * FQ2_LEN])?;
 
@@ -90,7 +100,6 @@ impl Bn254Ops for MclOps {
             "unexpected scalar length. got {}, expected {SCALAR_LEN}",
             input.len()
         );
-        ensure_init();
 
         let mut le_bytes = [0u8; SCALAR_LEN];
         le_bytes.copy_from_slice(input);

--- a/crates/evm2/src/precompiles/bn254/mcl.rs
+++ b/crates/evm2/src/precompiles/bn254/mcl.rs
@@ -9,19 +9,6 @@ unsafe extern "C" {
     fn mclBn_getCurveType() -> i32;
 }
 
-#[inline]
-fn ensure_init() {
-    static INIT: Once = Once::new();
-    INIT.call_once(|| {
-        // CurveType::SNARK (MCL_BN_SNARK1) is the Ethereum-compatible BN254 (alt_bn128).
-        // CurveType::BN254 is a different, older BN254 parameterization.
-        assert!(mcl_rust::init(CurveType::SNARK), "mcl BN254 initialization failed");
-    });
-
-    let curve = unsafe { mclBn_getCurveType() };
-    assert_eq!(curve, CurveType::SNARK as i32, "mcl curve changed after initialization");
-}
-
 pub(crate) struct MclOps;
 
 impl Bn254Ops for MclOps {
@@ -31,7 +18,15 @@ impl Bn254Ops for MclOps {
 
     #[inline]
     fn init() {
-        ensure_init();
+        static INIT: Once = Once::new();
+        INIT.call_once(|| {
+            // CurveType::SNARK (MCL_BN_SNARK1) is the Ethereum-compatible BN254 (alt_bn128).
+            // CurveType::BN254 is a different, older BN254 parameterization.
+            assert!(mcl_rust::init(CurveType::SNARK), "mcl BN254 initialization failed");
+        });
+
+        let curve = unsafe { mclBn_getCurveType() };
+        assert_eq!(curve, CurveType::SNARK as i32, "mcl curve changed after initialization");
     }
 
     #[inline]

--- a/crates/evm2/src/precompiles/bn254/mod.rs
+++ b/crates/evm2/src/precompiles/bn254/mod.rs
@@ -30,6 +30,9 @@ pub(crate) trait Bn254Ops {
     type G2;
     type Scalar;
 
+    #[inline]
+    fn init() {}
+
     fn read_g1(input: &[u8]) -> Result<Self::G1, PrecompileHalt>;
     fn encode_g1(point: Self::G1) -> [u8; G1_LEN];
     fn read_g2(input: &[u8]) -> Result<Self::G2, PrecompileHalt>;
@@ -44,6 +47,7 @@ pub(crate) trait Bn254Ops {
 /// Performs point addition on two G1 points using the selected backend.
 #[inline]
 pub(crate) fn g1_point_add(p1_bytes: &[u8], p2_bytes: &[u8]) -> Result<[u8; 64], PrecompileHalt> {
+    ArithmeticOps::init();
     let p1 = ArithmeticOps::read_g1(p1_bytes)?;
     let p2 = ArithmeticOps::read_g1(p2_bytes)?;
     Ok(ArithmeticOps::encode_g1(ArithmeticOps::g1_add(p1, p2)))
@@ -55,6 +59,7 @@ pub(crate) fn g1_point_mul(
     point_bytes: &[u8],
     fr_bytes: &[u8],
 ) -> Result<[u8; 64], PrecompileHalt> {
+    ArithmeticOps::init();
     let p = ArithmeticOps::read_g1(point_bytes)?;
     let fr = ArithmeticOps::read_scalar(fr_bytes);
     Ok(ArithmeticOps::encode_g1(ArithmeticOps::g1_mul(p, fr)))
@@ -63,6 +68,7 @@ pub(crate) fn g1_point_mul(
 /// Performs a pairing check on a list of G1 and G2 point pairs using the selected backend.
 #[inline]
 pub(crate) fn pairing_check(pairs: &[(&[u8], &[u8])]) -> Result<bool, PrecompileHalt> {
+    PairingOps::init();
     let mut g1_points = Vec::with_capacity(pairs.len());
     let mut g2_points = Vec::with_capacity(pairs.len());
 


### PR DESCRIPTION
Initialize the selected BN254 backend before each precompile operation. The MCL backend now initializes once and verifies that its process-global curve remains Ethereum BN254, so a conflicting MCL reinitialization fails fast instead of silently producing incorrect results.

MCL exposes this state query through its C API, but mcl-rust does not bind it. The integration therefore declares the already-linked C symbol locally.