### PR TITLE
fix(evm,jit): reject Amsterdam CREATE pre-access failures before child frames

### DIFF
--- a/crates/evm2/src/evm/inspector.rs
+++ b/crates/evm2/src/evm/inspector.rs
@@ -371,12 +371,23 @@ mod tests {
         gas_limit: u64,
         inspector: I,
     ) -> (MessageResult<BaseEvmTypes>, Box<I>, Evm<'static, BaseEvmTypes>) {
+        run_evm_with_inspector_db_spec(SpecId::OSAKA, db, code, message, gas_limit, inspector)
+    }
+
+    fn run_evm_with_inspector_db_spec<I: Inspector<BaseEvmTypes> + 'static>(
+        spec_id: SpecId,
+        db: InMemoryDB,
+        code: Vec<u8>,
+        message: &Message<BaseEvmTypes>,
+        gas_limit: u64,
+        inspector: I,
+    ) -> (MessageResult<BaseEvmTypes>, Box<I>, Evm<'static, BaseEvmTypes>) {
         let mut evm = Evm::<BaseEvmTypes>::new(
-            SpecId::OSAKA,
+            spec_id,
             BlockEnvExt::default(),
             TxRegistry::new(),
             db,
-            Precompiles::base(SpecId::OSAKA),
+            Precompiles::base(spec_id),
         );
         evm.set_inspector(inspector);
         let tx_env = TxEnvExt::default();
@@ -757,6 +768,44 @@ mod tests {
 
         assert_matches!(result.stop, InstrStop::Stop);
         assert_eq!(inspector.create_destinations, [expected]);
+    }
+
+    #[test]
+    fn amsterdam_create_preaccess_failure_does_not_fire_create_hook() {
+        let contract = Address::from([0x11; 20]);
+        for is_create2 in [false, true] {
+            for (balance, nonce, value) in
+                [(Word::from(1), 0, Word::from(2)), (Word::MAX, u64::MAX, Word::ZERO)]
+            {
+                let mut code = Vec::new();
+                if is_create2 {
+                    push_all(&mut code, [Word::ZERO, Word::ZERO, Word::ZERO, value]);
+                } else {
+                    push_all(&mut code, [Word::ZERO, Word::ZERO, value]);
+                }
+                code.push(if is_create2 { op::CREATE2 } else { op::CREATE });
+                return_top_word(&mut code);
+
+                let mut db = InMemoryDB::default();
+                db.insert_account_info(
+                    &contract,
+                    AccountInfo { balance, nonce, ..Default::default() },
+                );
+                let (result, inspector, _) = run_evm_with_inspector_db_spec(
+                    SpecId::AMSTERDAM,
+                    db,
+                    code,
+                    &MessageExt { destination: contract, ..Default::default() },
+                    100_000,
+                    HookInspector::default(),
+                );
+
+                assert_matches!(result.stop, InstrStop::Return);
+                assert_eq!(Word::from_be_slice(&result.output), Word::ZERO);
+                assert!(inspector.create_depths.is_empty());
+                assert!(inspector.create_end_stops.is_empty());
+            }
+        }
     }
 
     #[test]

--- a/crates/evm2/src/evm/inspector.rs
+++ b/crates/evm2/src/evm/inspector.rs
@@ -774,9 +774,11 @@ mod tests {
     fn amsterdam_create_preaccess_failure_does_not_fire_create_hook() {
         let contract = Address::from([0x11; 20]);
         for is_create2 in [false, true] {
-            for (balance, nonce, value) in
-                [(Word::from(1), 0, Word::from(2)), (Word::MAX, u64::MAX, Word::ZERO)]
-            {
+            for (balance, nonce, value, depth) in [
+                (Word::from(1), 0, Word::from(2), 0),
+                (Word::MAX, u64::MAX, Word::ZERO, 0),
+                (Word::MAX, 0, Word::ZERO, CALL_DEPTH_LIMIT),
+            ] {
                 let mut code = Vec::new();
                 if is_create2 {
                     push_all(&mut code, [Word::ZERO, Word::ZERO, Word::ZERO, value]);
@@ -795,7 +797,7 @@ mod tests {
                     SpecId::AMSTERDAM,
                     db,
                     code,
-                    &MessageExt { destination: contract, ..Default::default() },
+                    &MessageExt { destination: contract, depth, ..Default::default() },
                     100_000,
                     HookInspector::default(),
                 );

--- a/crates/evm2/src/interpreter/instructions/system.rs
+++ b/crates/evm2/src/interpreter/instructions/system.rs
@@ -324,15 +324,6 @@ fn create_inner<T: EvmTypesHost>(
     } else {
         Some(state.host().load_account(&caller, false, false)?)
     };
-    if let Some(caller_info) = caller_info.as_ref().filter(|_| state.feature(EvmFeatures::EIP8037))
-        && (caller_info.balance < value
-            || caller_info.nonce == u64::MAX
-            || depth > CALL_DEPTH_LIMIT)
-    {
-        state.clear_return_data();
-        stack.push(Word::ZERO)?;
-        return Ok(());
-    }
     let destination = derive_create_destination(
         kind,
         &caller,
@@ -348,9 +339,20 @@ fn create_inner<T: EvmTypesHost>(
     // charge is refunded via `refill_reservoir` if the create fails to deploy (see the
     // create-failure path after `execute_message`).
     let mut charged_create_state_gas = false;
-    // Balance, nonce, and depth pre-access failures returned above, before the destination was
-    // accessed.
     if state.feature(EvmFeatures::EIP8037) {
+        // `caller_info` is always `Some` when EIP-8037 is enabled.
+        if let Some(caller_info) = caller_info.as_ref()
+            && (caller_info.balance < value
+                || caller_info.nonce == u64::MAX
+                || depth > CALL_DEPTH_LIMIT)
+        {
+            state.clear_return_data();
+            stack.push(Word::ZERO)?;
+            return Ok(());
+        }
+
+        // The destination is loaded here and made warm. Balance, nonce, and depth pre-access
+        // failures return above before the destination is accessed.
         let features = state.version().features;
         if state.host().target_is_empty_for_new_account_gas(&destination, features)? {
             gas.spend_state(state.gas_params().create_state_gas())?;

--- a/crates/evm2/src/interpreter/instructions/system.rs
+++ b/crates/evm2/src/interpreter/instructions/system.rs
@@ -324,6 +324,13 @@ fn create_inner<T: EvmTypesHost>(
     } else {
         Some(state.host().load_account(&caller, false, false)?)
     };
+    if let Some(caller_info) = caller_info.as_ref().filter(|_| state.feature(EvmFeatures::EIP8037))
+        && (caller_info.balance < value || caller_info.nonce == u64::MAX)
+    {
+        state.clear_return_data();
+        stack.push(Word::ZERO)?;
+        return Ok(());
+    }
     let destination = derive_create_destination(
         kind,
         &caller,
@@ -339,20 +346,13 @@ fn create_inner<T: EvmTypesHost>(
     // charge is refunded via `refill_reservoir` if the create fails to deploy (see the
     // create-failure path after `execute_message`).
     let mut charged_create_state_gas = false;
-    if let Some(caller_info) = caller_info.filter(|_| state.feature(EvmFeatures::EIP8037)) {
-        // Only decide the account-creation charge once the depth, endowment, and nonce pre-checks
-        // pass: a create that early-fails on those never accesses the destination, so reading it
-        // here would leak it into the EIP-7928 block access list (and warm the address). The
-        // early-fail itself (pushing 0) is handled by the child frame below.
-        if depth <= CALL_DEPTH_LIMIT
-            && caller_info.balance >= value
-            && caller_info.nonce != u64::MAX
-        {
-            let features = state.version().features;
-            if state.host().target_is_empty_for_new_account_gas(&destination, features)? {
-                gas.spend_state(state.gas_params().create_state_gas())?;
-                charged_create_state_gas = true;
-            }
+    // Only decide the account-creation charge once the depth pre-check passes. Balance and nonce
+    // pre-access failures returned above, before the destination was accessed.
+    if state.feature(EvmFeatures::EIP8037) && depth <= CALL_DEPTH_LIMIT {
+        let features = state.version().features;
+        if state.host().target_is_empty_for_new_account_gas(&destination, features)? {
+            gas.spend_state(state.gas_params().create_state_gas())?;
+            charged_create_state_gas = true;
         }
     }
     let gas_limit = if state.feature(EvmFeatures::EIP150) {

--- a/crates/evm2/src/interpreter/instructions/system.rs
+++ b/crates/evm2/src/interpreter/instructions/system.rs
@@ -325,7 +325,9 @@ fn create_inner<T: EvmTypesHost>(
         Some(state.host().load_account(&caller, false, false)?)
     };
     if let Some(caller_info) = caller_info.as_ref().filter(|_| state.feature(EvmFeatures::EIP8037))
-        && (caller_info.balance < value || caller_info.nonce == u64::MAX)
+        && (caller_info.balance < value
+            || caller_info.nonce == u64::MAX
+            || depth > CALL_DEPTH_LIMIT)
     {
         state.clear_return_data();
         stack.push(Word::ZERO)?;
@@ -346,9 +348,9 @@ fn create_inner<T: EvmTypesHost>(
     // charge is refunded via `refill_reservoir` if the create fails to deploy (see the
     // create-failure path after `execute_message`).
     let mut charged_create_state_gas = false;
-    // Only decide the account-creation charge once the depth pre-check passes. Balance and nonce
-    // pre-access failures returned above, before the destination was accessed.
-    if state.feature(EvmFeatures::EIP8037) && depth <= CALL_DEPTH_LIMIT {
+    // Balance, nonce, and depth pre-access failures returned above, before the destination was
+    // accessed.
+    if state.feature(EvmFeatures::EIP8037) {
         let features = state.version().features;
         if state.host().target_is_empty_for_new_account_gas(&destination, features)? {
             gas.spend_state(state.gas_params().create_state_gas())?;
@@ -911,21 +913,22 @@ mod tests {
     }
 
     #[test]
-    fn create_too_deep_skips_destination_read_eip8037() {
+    fn create_too_deep_clears_return_data_and_skips_destination_read_eip8037() {
         // EIP-8037: a create failing the depth pre-check must not access the destination —
         // the read would leak the address into the EIP-7928 block access list.
         let mut host = TestHost { exists: false, ..Default::default() };
         let mut code = Vec::new();
         push_all(&mut code, [Word::ZERO, Word::ZERO, Word::ZERO]);
-        code.extend([op::CREATE, op::STOP]);
+        code.extend([op::CREATE, op::RETURNDATASIZE, op::STOP]);
 
         let interp = run(RunConfig::new(code)
             .host(&mut host)
             .spec(SpecId::AMSTERDAM)
             .message(MessageExt { depth: CALL_DEPTH_LIMIT, ..Default::default() })
+            .return_data(Bytes::from_static(b"stale"))
             .gas_limit(50_000));
         assert_matches!(interp.err, InstrStop::Stop);
-        assert_eq!(interp.stack(), [Word::ZERO]);
+        assert_eq!(interp.stack(), [Word::ZERO, Word::ZERO]);
         assert!(host.new_account_checks.is_empty());
     }
 

--- a/crates/jit/builtins/src/lib.rs
+++ b/crates/jit/builtins/src/lib.rs
@@ -683,17 +683,6 @@ pub unsafe extern "C" fn __revmc_builtin_create(
     } else {
         Some(ecx.host().load_account(&caller, false, false)?)
     };
-    if let Some(caller_info) = caller_info.as_ref().filter(|_| ecx.enables(EvmFeatures::EIP8037))
-        && (caller_info.balance < value
-            || caller_info.nonce == u64::MAX
-            || depth > CALL_DEPTH_LIMIT)
-    {
-        unsafe {
-            sp.write(EvmWord::ZERO);
-        }
-        ecx.set_return_data(Bytes::new());
-        return Ok(());
-    }
     let destination = derive_create_destination(
         kind,
         &caller,
@@ -703,14 +692,28 @@ pub unsafe extern "C" fn __revmc_builtin_create(
     );
 
     // EIP-8037: charge the CREATE account-creation state gas before the child
-    // gas split, conditional on the destination not already existing. Balance, nonce, and depth
-    // pre-access failures returned above, before the destination was accessed.
+    // gas split, conditional on the destination not already existing.
     let mut charged_create_state_gas = false;
-    if ecx.enables(EvmFeatures::EIP8037)
-        && ecx.host().target_is_empty_for_new_account_gas(&destination, version.features)?
-    {
-        ecx.gas.spend_state(version.gas_params.create_state_gas())?;
-        charged_create_state_gas = true;
+    if ecx.enables(EvmFeatures::EIP8037) {
+        // `caller_info` is always `Some` when EIP-8037 is enabled.
+        if let Some(caller_info) = caller_info.as_ref()
+            && (caller_info.balance < value
+                || caller_info.nonce == u64::MAX
+                || depth > CALL_DEPTH_LIMIT)
+        {
+            unsafe {
+                sp.write(EvmWord::ZERO);
+            }
+            ecx.set_return_data(Bytes::new());
+            return Ok(());
+        }
+
+        // The destination is loaded here and made warm. Balance, nonce, and depth pre-access
+        // failures return above before the destination is accessed.
+        if ecx.host().target_is_empty_for_new_account_gas(&destination, version.features)? {
+            ecx.gas.spend_state(version.gas_params.create_state_gas())?;
+            charged_create_state_gas = true;
+        }
     }
 
     let mut gas_limit = ecx.gas.remaining();

--- a/crates/jit/builtins/src/lib.rs
+++ b/crates/jit/builtins/src/lib.rs
@@ -684,7 +684,9 @@ pub unsafe extern "C" fn __revmc_builtin_create(
         Some(ecx.host().load_account(&caller, false, false)?)
     };
     if let Some(caller_info) = caller_info.as_ref().filter(|_| ecx.enables(EvmFeatures::EIP8037))
-        && (caller_info.balance < value || caller_info.nonce == u64::MAX)
+        && (caller_info.balance < value
+            || caller_info.nonce == u64::MAX
+            || depth > CALL_DEPTH_LIMIT)
     {
         unsafe {
             sp.write(EvmWord::ZERO);
@@ -701,11 +703,10 @@ pub unsafe extern "C" fn __revmc_builtin_create(
     );
 
     // EIP-8037: charge the CREATE account-creation state gas before the child
-    // gas split, conditional on the destination not already existing. Balance and nonce
+    // gas split, conditional on the destination not already existing. Balance, nonce, and depth
     // pre-access failures returned above, before the destination was accessed.
     let mut charged_create_state_gas = false;
     if ecx.enables(EvmFeatures::EIP8037)
-        && depth <= CALL_DEPTH_LIMIT
         && ecx.host().target_is_empty_for_new_account_gas(&destination, version.features)?
     {
         ecx.gas.spend_state(version.gas_params.create_state_gas())?;
@@ -1427,9 +1428,11 @@ mod tests {
     fn create_builtin_preaccess_failure_skips_child_message() {
         let contract = Address::from([0x11; 20]);
         for create_kind in [CreateKind::Create, CreateKind::Create2] {
-            for (balance, nonce, value) in
-                [(Word::ZERO, 0, Word::from(1)), (Word::MAX, u64::MAX, Word::ZERO)]
-            {
+            for (balance, nonce, value, depth) in [
+                (Word::ZERO, 0, Word::from(1), 0),
+                (Word::MAX, u64::MAX, Word::ZERO, 0),
+                (Word::MAX, 0, Word::ZERO, CALL_DEPTH_LIMIT),
+            ] {
                 let mut db = InMemoryDB::default();
                 db.insert_account_info(
                     &contract,
@@ -1445,6 +1448,7 @@ mod tests {
                 host.set_inspector(MessageInspector::default());
                 let tx_env = TxEnvExt::default();
                 let message = MessageExt {
+                    depth,
                     gas_limit: 100_000,
                     destination: contract,
                     code: Bytecode::new_legacy(Bytes::from_static(&[op::STOP])),

--- a/crates/jit/builtins/src/lib.rs
+++ b/crates/jit/builtins/src/lib.rs
@@ -683,6 +683,15 @@ pub unsafe extern "C" fn __revmc_builtin_create(
     } else {
         Some(ecx.host().load_account(&caller, false, false)?)
     };
+    if let Some(caller_info) = caller_info.as_ref().filter(|_| ecx.enables(EvmFeatures::EIP8037))
+        && (caller_info.balance < value || caller_info.nonce == u64::MAX)
+    {
+        unsafe {
+            sp.write(EvmWord::ZERO);
+        }
+        ecx.set_return_data(Bytes::new());
+        return Ok(());
+    }
     let destination = derive_create_destination(
         kind,
         &caller,
@@ -692,14 +701,11 @@ pub unsafe extern "C" fn __revmc_builtin_create(
     );
 
     // EIP-8037: charge the CREATE account-creation state gas before the child
-    // gas split, conditional on the destination not already existing (and on the depth, endowment,
-    // and nonce pre-checks passing, so an early-failing create leaves the destination out of the
-    // block access list).
+    // gas split, conditional on the destination not already existing. Balance and nonce
+    // pre-access failures returned above, before the destination was accessed.
     let mut charged_create_state_gas = false;
-    if let Some(caller_info) = caller_info.filter(|_| ecx.enables(EvmFeatures::EIP8037))
+    if ecx.enables(EvmFeatures::EIP8037)
         && depth <= CALL_DEPTH_LIMIT
-        && caller_info.balance >= value
-        && caller_info.nonce != u64::MAX
         && ecx.host().target_is_empty_for_new_account_gas(&destination, version.features)?
     {
         ecx.gas.spend_state(version.gas_params.create_state_gas())?;
@@ -1039,7 +1045,7 @@ mod tests {
         BaseEvmConfigSelector, BaseEvmTypes, Evm, EvmConfigSelector, Precompiles, SpecId,
         env::{BlockEnvExt, TxEnvExt},
         ethereum::ethereum_tx_registry,
-        evm::{EmptyDB, inspector::Inspector},
+        evm::{AccountInfo, EmptyDB, InMemoryDB, inspector::Inspector},
         interpreter::{GasTracker, Message, MessageResult, MessageResultExt, op},
     };
     use evm2_jit_context::EvmStack;
@@ -1131,9 +1137,16 @@ mod tests {
         interpreter: &'ctx mut evm2::interpreter::Interpreter<'frame, 'host, BaseEvmTypes>,
         host: &'ctx mut Evm<'host, BaseEvmTypes>,
     ) -> PreparedJitFrame<'ctx, 'frame, 'host> {
-        let config = <BaseEvmConfigSelector as EvmConfigSelector<BaseEvmTypes>>::execution_config(
-            SpecId::CANCUN,
-        );
+        prepare_frame_for_spec(interpreter, host, SpecId::CANCUN)
+    }
+
+    fn prepare_frame_for_spec<'ctx, 'frame, 'host>(
+        interpreter: &'ctx mut evm2::interpreter::Interpreter<'frame, 'host, BaseEvmTypes>,
+        host: &'ctx mut Evm<'host, BaseEvmTypes>,
+        spec_id: SpecId,
+    ) -> PreparedJitFrame<'ctx, 'frame, 'host> {
+        let config =
+            <BaseEvmConfigSelector as EvmConfigSelector<BaseEvmTypes>>::execution_config(spec_id);
         let config = Box::leak(Box::new(config));
         interpreter.prepare_run(config.base_spec_id(), config.version(), host);
         let (ecx, stack, _stack_len) = EvmContext::from_interpreter_with_stack(interpreter);
@@ -1408,5 +1421,66 @@ mod tests {
         assert_eq!(inspector.creates[0].kind, MessageKind::Create2);
         assert_eq!(inspector.creates[0].input.as_ref(), initcode);
         assert_eq!(inspector.creates[0].salt, B256::from(salt.to_be_bytes()));
+    }
+
+    #[test]
+    fn create_builtin_preaccess_failure_skips_child_message() {
+        let contract = Address::from([0x11; 20]);
+        for create_kind in [CreateKind::Create, CreateKind::Create2] {
+            for (balance, nonce, value) in
+                [(Word::ZERO, 0, Word::from(1)), (Word::MAX, u64::MAX, Word::ZERO)]
+            {
+                let mut db = InMemoryDB::default();
+                db.insert_account_info(
+                    &contract,
+                    AccountInfo { balance, nonce, ..Default::default() },
+                );
+                let mut host = Evm::<BaseEvmTypes>::new(
+                    SpecId::AMSTERDAM,
+                    BlockEnvExt::default(),
+                    ethereum_tx_registry(SpecId::AMSTERDAM),
+                    db,
+                    Precompiles::base(SpecId::AMSTERDAM),
+                );
+                host.set_inspector(MessageInspector::default());
+                let tx_env = TxEnvExt::default();
+                let message = MessageExt {
+                    gas_limit: 100_000,
+                    destination: contract,
+                    code: Bytecode::new_legacy(Bytes::from_static(&[op::STOP])),
+                    ..MessageExt::default()
+                };
+                let mut interpreter =
+                    evm2::interpreter::Interpreter::<BaseEvmTypes>::new(&tx_env, &message);
+
+                {
+                    let mut frame =
+                        prepare_frame_for_spec(&mut interpreter, &mut host, SpecId::AMSTERDAM);
+                    frame.ecx.set_return_data(Bytes::from_static(b"stale"));
+                    match create_kind {
+                        CreateKind::Create => {
+                            frame.stack.set(0, EvmWord::ZERO);
+                            frame.stack.set(1, EvmWord::ZERO);
+                            frame.stack.set(2, EvmWord::from(value));
+                        }
+                        CreateKind::Create2 => {
+                            frame.stack.set(0, EvmWord::ZERO);
+                            frame.stack.set(1, EvmWord::ZERO);
+                            frame.stack.set(2, EvmWord::ZERO);
+                            frame.stack.set(3, EvmWord::from(value));
+                        }
+                    }
+
+                    let sp = frame.stack.as_mut_ptr();
+                    unsafe { __revmc_builtin_create(&mut frame.ecx, sp, create_kind) };
+
+                    assert_eq!(unsafe { frame.stack.get_unchecked(0) }, &EvmWord::ZERO);
+                    assert!(frame.ecx.return_data().is_empty());
+                }
+
+                let inspector = host.clear_inspector_as::<MessageInspector>().unwrap();
+                assert!(inspector.creates.is_empty());
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

- reject Amsterdam `CREATE`/`CREATE2` when the caller cannot fund the endowment or its nonce is exhausted
- return zero and clear returndata before deriving/accessing the destination or constructing a child message
- mirror the pre-access path in the interpreter and JIT builtins, with inspector regressions for both failure modes

## Divergence

Under EIP-8037, revm performs the caller balance and nonce checks in the CREATE opcode before yielding a child frame. evm2 already used those checks to suppress destination state-gas access, but still split child gas, constructed a create message, and invoked the host/inspector. That produced a spurious CREATE/CREATE2 inspector frame for an operation revm completed locally.

This keeps the opcode charge and caller load, then matches revm by clearing returndata, pushing zero, and returning immediately. The destination remains untouched and no child gas split or inspector hook occurs.

The earlier CALL runtime-OOG candidate is intentionally excluded: the frame-preparation changes from #315 already charge runtime gas before host/inspector execution, and its saved artifact passes.

## Validation

- `cargo test -p evm2 --lib` (480 passed)
- `LLVM_SYS_221_PREFIX=/usr/lib/llvm-22 cargo test -p evm2-jit-builtins --lib` (7 passed)
- `LLVM_SYS_221_PREFIX=/usr/lib/llvm-22 cargo clippy -p evm2 -p evm2-jit-builtins --all-targets -- -D warnings`
- `cargo +nightly fmt --all -- --check`
- replayed `structured_compare_amsterdam/crash-32ae6735a8cc706d748eb11f591a96e9bb24d096`
- replayed `bytecode_compare_amsterdam/crash-3fd99af48ccd1bbe3ef5a22fe6f9580add92ab9a`
- replayed `bytecode_compare_amsterdam/crash-f97ed6c8940d4ebaf809c86eeb31dd32af83455e`

Built as one commit from `a48e281c76f5fd0011b7f13f17c32d3db0ffbf11`.
