### PR TITLE
refactor(state): borrow account info directly

### DIFF
--- a/crates/eest/src/blockchaintest/execute.rs
+++ b/crates/eest/src/blockchaintest/execute.rs
@@ -33,7 +33,7 @@ use evm2::{
     env::{BlockEnv, BlockEnvExt},
     ethereum::{RecoveredTxEnvelope, ethereum_tx_registry},
     evm::{
-        AccountChangeRef, AccountInfo as EvmAccountInfo, AccountInfoRef, BEACON_ROOTS_ADDRESS, Bal,
+        AccountChangeRef, AccountInfo as EvmAccountInfo, BEACON_ROOTS_ADDRESS, Bal,
         BlockStateAccumulator, DbStats, DbStatsCounts, HISTORY_STORAGE_ADDRESS, InMemoryDB,
         StateChangeSink, StateChangeSource, SystemTx, Tee, WITHDRAWAL_REQUEST_ADDRESS,
     },
@@ -938,20 +938,11 @@ impl StateChangeSource for AccountStateChange {
     fn visit<S: StateChangeSink>(&self, sink: &mut S) -> Result<(), S::Error> {
         sink.account(AccountChangeRef {
             address: self.address,
-            original: self.original.as_ref().map(account_info_ref),
-            current: self.current.as_ref().map(account_info_ref),
+            original: self.original.as_ref(),
+            current: self.current.as_ref(),
             created: false,
             selfdestructed: false,
         })
-    }
-}
-
-const fn account_info_ref(info: &EvmAccountInfo) -> AccountInfoRef<'_> {
-    AccountInfoRef {
-        balance: info.balance,
-        nonce: info.nonce,
-        code_hash: info.code_hash,
-        code: info.code.as_ref(),
     }
 }
 

--- a/crates/evm2/src/evm/bal/bal_context.rs
+++ b/crates/evm2/src/evm/bal/bal_context.rs
@@ -4,8 +4,8 @@ use super::{AccountBal, Bal, BalError, BlockAccessIndex};
 use crate::{
     AnyError, ErrorCode,
     evm::state::{
-        Account, AccountChangeRef, AccountInfo, AccountInfoRef, PendingState, StateChangeSink,
-        StorageChange, StorageOverlay,
+        Account, AccountChangeRef, AccountInfo, PendingState, StateChangeSink, StorageChange,
+        StorageOverlay,
     },
     interpreter::Word,
 };
@@ -327,8 +327,8 @@ impl StateChangeSink for BalContext {
     fn account(&mut self, change: AccountChangeRef<'_>) -> Result<(), Self::Error> {
         let index = self.bal_index;
         if let Some(bal) = self.bal_builder.as_mut() {
-            let original = change.original.map(AccountInfoRef::to_account_info).unwrap_or_default();
-            let current = change.current.map(AccountInfoRef::to_account_info).unwrap_or_default();
+            let original = change.original.cloned().unwrap_or_default();
+            let current = change.current.cloned().unwrap_or_default();
             bal.accounts
                 .entry(change.address)
                 .or_default()
@@ -358,7 +358,7 @@ impl StateChangeSink for BalContext {
     fn account_read(
         &mut self,
         address: Address,
-        _info: Option<AccountInfoRef<'_>>,
+        _info: Option<&AccountInfo>,
     ) -> Result<(), Self::Error> {
         if let Some(bal) = self.bal_builder.as_mut() {
             bal.accounts.entry(address).or_default();

--- a/crates/evm2/src/evm/db/cache.rs
+++ b/crates/evm2/src/evm/db/cache.rs
@@ -7,7 +7,7 @@ use crate::{
     evm::{
         bal::BalContext,
         state::{
-            Account, AccountChangeRef, AccountInfo, AccountInfoRef, PendingState, StateChangeSink,
+            Account, AccountChangeRef, AccountInfo, PendingState, StateChangeSink,
             StateChangeSource, StorageChange, StorageOverlay,
         },
     },
@@ -161,10 +161,7 @@ impl<ExtDB> CacheDB<ExtDB> {
                 continue;
             }
             match entry.present.as_ref() {
-                Some(account) => self.insert_account_info(
-                    &address,
-                    AccountInfoRef::from_info(account).to_account_info_without_code(),
-                ),
+                Some(account) => self.insert_account_info(&address, account.clone_no_code()),
                 None => {
                     self.cache.accounts.insert(address, None);
                     self.cache.storage.entry(address).or_default().wipe();
@@ -257,7 +254,7 @@ impl<ExtDB> StateChangeSink for CacheDB<ExtDB> {
     fn account(&mut self, change: AccountChangeRef<'_>) -> Result<(), Self::Error> {
         self.bal_context.account(change)?;
         match change.current {
-            Some(info) => self.insert_account_info(&change.address, info.to_account_info()),
+            Some(info) => self.insert_account_info(&change.address, info.clone()),
             None => {
                 self.cache.accounts.insert(change.address, None);
                 self.cache.storage.entry(change.address).or_default().wipe();
@@ -270,7 +267,7 @@ impl<ExtDB> StateChangeSink for CacheDB<ExtDB> {
     fn account_read(
         &mut self,
         address: Address,
-        info: Option<AccountInfoRef<'_>>,
+        info: Option<&AccountInfo>,
     ) -> Result<(), Self::Error> {
         self.bal_context.account_read(address, info)
     }

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -174,10 +174,10 @@ pub use tx::{ExecutedTx, TxResult, TxResultExt, TxResultWithState};
 
 mod state;
 pub use state::{
-    AccountChangeRef, AccountHandle, AccountInfo, AccountInfoRef, BlockStateAccumulator,
-    JournalEntry, NoopChangeSink, PendingState, State, StateChangeSink, StateChangeSource,
-    StateCheckpoint, StateInner, StorageChange, StorageHandle, StorageOverlay, StorageSlot,
-    StorageSlotHandle, Tee, Tracked,
+    AccountChangeRef, AccountHandle, AccountInfo, BlockStateAccumulator, JournalEntry,
+    NoopChangeSink, PendingState, State, StateChangeSink, StateChangeSource, StateCheckpoint,
+    StateInner, StorageChange, StorageHandle, StorageOverlay, StorageSlot, StorageSlotHandle, Tee,
+    Tracked,
 };
 
 mod prewarm_set;

--- a/crates/evm2/src/evm/state/account.rs
+++ b/crates/evm2/src/evm/state/account.rs
@@ -72,6 +72,18 @@ impl AccountInfo {
         Self { balance, nonce, code_hash, code: Some(code), _non_exhaustive: () }
     }
 
+    /// Clones this account without bytecode.
+    #[inline]
+    pub(crate) const fn clone_no_code(&self) -> Self {
+        Self {
+            balance: self.balance,
+            nonce: self.nonce,
+            code_hash: self.code_hash,
+            code: None,
+            _non_exhaustive: (),
+        }
+    }
+
     /// Creates a new [`AccountInfo`] with the given code.
     #[inline]
     pub fn with_code(self, code: Bytecode) -> Self {

--- a/crates/evm2/src/evm/state/block.rs
+++ b/crates/evm2/src/evm/state/block.rs
@@ -1,8 +1,7 @@
 //! Block-level state accumulation.
 
 use super::{
-    AccountChangeRef, AccountInfo, AccountInfoRef, StateChangeSink, StateChangeSource,
-    StorageChange, Tracked,
+    AccountChangeRef, AccountInfo, StateChangeSink, StateChangeSource, StorageChange, Tracked,
 };
 use crate::{
     bytecode::Bytecode,
@@ -113,8 +112,8 @@ impl StateChangeSink for BlockStateAccumulator {
     }
 
     fn account(&mut self, change: AccountChangeRef<'_>) -> Result<(), Self::Error> {
-        let original = change.original.map(AccountInfoRef::to_account_info_without_code);
-        let current = change.current.map(AccountInfoRef::to_account_info_without_code);
+        let original = change.original.map(AccountInfo::clone_no_code);
+        let current = change.current.map(AccountInfo::clone_no_code);
         let deletes_account = current.is_none();
 
         match self.accounts.entry(change.address) {
@@ -225,8 +224,8 @@ fn visit_block_changes<S: StateChangeSink>(
     for (address, delta) in account_deltas {
         sink.account(AccountChangeRef {
             address: *address,
-            original: delta.original.as_ref().map(AccountInfoRef::from_info),
-            current: delta.current.as_ref().map(AccountInfoRef::from_info),
+            original: delta.original.as_ref(),
+            current: delta.current.as_ref(),
             // Block-level aggregation loses per-transaction lifecycle flags.
             created: false,
             selfdestructed: false,

--- a/crates/evm2/src/evm/state/mod.rs
+++ b/crates/evm2/src/evm/state/mod.rs
@@ -15,8 +15,7 @@ pub use journal::{JournalEntry, StateCheckpoint};
 pub use pending::PendingState;
 pub use storage::{StorageHandle, StorageOverlay, StorageSlot, StorageSlotHandle};
 pub use stream::{
-    AccountChangeRef, AccountInfoRef, NoopChangeSink, StateChangeSink, StateChangeSource,
-    StorageChange, Tee,
+    AccountChangeRef, NoopChangeSink, StateChangeSink, StateChangeSource, StorageChange, Tee,
 };
 pub use tracked::Tracked;
 
@@ -808,8 +807,8 @@ impl<'a> State<'a> {
             if entry.is_changed() {
                 sink.account(AccountChangeRef {
                     address,
-                    original: entry.original.as_ref().map(AccountInfoRef::from_info),
-                    current: entry.present.as_ref().map(AccountInfoRef::from_info),
+                    original: entry.original.as_ref(),
+                    current: entry.present.as_ref(),
                     created: entry.is_created(),
                     selfdestructed: self.selfdestructs.contains(&address),
                 })?;

--- a/crates/evm2/src/evm/state/pending.rs
+++ b/crates/evm2/src/evm/state/pending.rs
@@ -1,8 +1,8 @@
 //! Owned pending transaction state detached from the EVM.
 
 use super::{
-    Account, AccountChangeRef, AccountInfo, AccountInfoRef, StateChangeSink, StateChangeSource,
-    StorageChange, StorageOverlay, StorageSlot, Tracked,
+    Account, AccountChangeRef, AccountInfo, StateChangeSink, StateChangeSource, StorageChange,
+    StorageOverlay, StorageSlot, Tracked,
 };
 use crate::interpreter::Word;
 use alloy_primitives::{
@@ -133,13 +133,13 @@ impl StateChangeSource for PendingState {
             if entry.is_changed() || entry.is_created() || selfdestructed {
                 sink.account(AccountChangeRef {
                     address,
-                    original: entry.original.as_ref().map(AccountInfoRef::from_info),
-                    current: entry.present.as_ref().map(AccountInfoRef::from_info),
+                    original: entry.original.as_ref(),
+                    current: entry.present.as_ref(),
                     created: entry.is_created(),
                     selfdestructed,
                 })?;
             } else {
-                sink.account_read(address, entry.present.as_ref().map(AccountInfoRef::from_info))?;
+                sink.account_read(address, entry.present.as_ref())?;
             }
         }
         Ok(())

--- a/crates/evm2/src/evm/state/stream.rs
+++ b/crates/evm2/src/evm/state/stream.rs
@@ -6,63 +6,15 @@ use alloy_primitives::{Address, B256};
 use auto_impl::auto_impl;
 use core::convert::Infallible;
 
-/// Borrowed account information exposed to change sinks.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct AccountInfoRef<'a> {
-    /// Account balance.
-    pub balance: Word,
-    /// Account nonce.
-    pub nonce: u64,
-    /// Account code hash.
-    pub code_hash: B256,
-    /// Borrowed bytecode when the source has it available.
-    pub code: Option<&'a Bytecode>,
-}
-
-impl<'a> AccountInfoRef<'a> {
-    #[inline]
-    pub(crate) const fn from_info(info: &'a AccountInfo) -> Self {
-        Self {
-            balance: info.balance,
-            nonce: info.nonce,
-            code_hash: info.code_hash,
-            code: info.code.as_ref(),
-        }
-    }
-
-    /// Materializes this borrowed account into owned account info.
-    #[inline]
-    pub fn to_account_info(self) -> AccountInfo {
-        AccountInfo {
-            balance: self.balance,
-            nonce: self.nonce,
-            code_hash: self.code_hash,
-            code: self.code.cloned(),
-            _non_exhaustive: (),
-        }
-    }
-
-    #[inline]
-    pub(crate) const fn to_account_info_without_code(self) -> AccountInfo {
-        AccountInfo {
-            balance: self.balance,
-            nonce: self.nonce,
-            code_hash: self.code_hash,
-            code: None,
-            _non_exhaustive: (),
-        }
-    }
-}
-
 /// Borrowed account change passed to [`StateChangeSink`].
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct AccountChangeRef<'a> {
     /// Account address.
     pub address: Address,
     /// Account at the start of the source's aggregation boundary.
-    pub original: Option<AccountInfoRef<'a>>,
+    pub original: Option<&'a AccountInfo>,
     /// Account after the change. `None` is an explicit deletion.
-    pub current: Option<AccountInfoRef<'a>>,
+    pub current: Option<&'a AccountInfo>,
     /// Whether the account was created during the transaction.
     ///
     /// Only transaction-level sources report this; block-level aggregation loses per-transaction
@@ -129,7 +81,7 @@ pub trait StateChangeSink {
     fn account_read(
         &mut self,
         _address: Address,
-        _info: Option<AccountInfoRef<'_>>,
+        _info: Option<&AccountInfo>,
     ) -> Result<(), Self::Error> {
         Ok(())
     }
@@ -216,7 +168,7 @@ where
     fn account_read(
         &mut self,
         address: Address,
-        info: Option<AccountInfoRef<'_>>,
+        info: Option<&AccountInfo>,
     ) -> Result<(), Self::Error> {
         self.a.account_read(address, info)?;
         self.b.account_read(address, info)

--- a/crates/inspectors/src/tracing/tx_state.rs
+++ b/crates/inspectors/src/tracing/tx_state.rs
@@ -7,8 +7,8 @@ use alloy_primitives::{
 use core::convert::Infallible;
 use evm2::{
     evm::{
-        AccountChangeRef, AccountInfo, AccountInfoRef, PendingState, StateChangeSink,
-        StateChangeSource, StorageChange, Tracked,
+        AccountChangeRef, AccountInfo, PendingState, StateChangeSink, StateChangeSource,
+        StorageChange, Tracked,
     },
     interpreter::Word,
 };
@@ -55,13 +55,21 @@ impl TxAccount {
     }
 }
 
+fn clone_account_info(target: &mut Option<AccountInfo>, source: Option<&AccountInfo>) {
+    match (target, source) {
+        (Some(target), Some(source)) => target.clone_from(source),
+        (target, Some(source)) => *target = Some(source.clone()),
+        (target, None) => *target = None,
+    }
+}
+
 impl StateChangeSink for TxState {
     type Error = Infallible;
 
     fn account(&mut self, change: AccountChangeRef<'_>) -> Result<(), Self::Error> {
         let entry = self.accounts.entry(change.address).or_default();
-        entry.original = change.original.map(AccountInfoRef::to_account_info);
-        entry.current = change.current.map(AccountInfoRef::to_account_info);
+        clone_account_info(&mut entry.original, change.original);
+        clone_account_info(&mut entry.current, change.current);
         entry.created = change.created;
         entry.selfdestructed = change.selfdestructed;
         Ok(())
@@ -79,11 +87,11 @@ impl StateChangeSink for TxState {
     fn account_read(
         &mut self,
         address: Address,
-        info: Option<AccountInfoRef<'_>>,
+        info: Option<&AccountInfo>,
     ) -> Result<(), Self::Error> {
         let entry = self.accounts.entry(address).or_default();
-        entry.original = info.map(AccountInfoRef::to_account_info);
-        entry.current = entry.original.clone();
+        clone_account_info(&mut entry.original, info);
+        entry.current.clone_from(&entry.original);
         Ok(())
     }
 


### PR DESCRIPTION
Replace `AccountInfoRef` with `&AccountInfo`, which lets state-change consumers use standard reference and clone APIs. Add `clone_no_code` to preserve code-free block and cache state without cloning bytecode.