### PR TITLE
refactor: don't expose unsafe interpreter initializer

### DIFF
--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -1161,10 +1161,9 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
                 >(frame.as_mut())
             },
             None => {
-                let frame = top_frame.insert(guard.evm.interpreter_pool.pop());
                 // SAFETY: The message outlives the frame, which is returned to the pool below.
                 let frame_message = unsafe { trustme::decouple_lt(&*message) };
-                frame.init(tx_env, frame_message);
+                let frame = top_frame.insert(guard.evm.interpreter_pool.pop(tx_env, frame_message));
                 // SAFETY: `execution_config` points to a private field that host execution does
                 // not replace or mutate, so the pointee remains valid for the lifetime of the
                 // frame.
@@ -1491,10 +1490,10 @@ impl<'a, T: EvmTypes> Evm<'a, T> {
         tx_env: &'frame TxEnv<T>,
         message: &'frame Message<T>,
     ) -> InstrStop {
-        let mut interp: Box<Interpreter<'frame, 'a, T>> = self.interpreter_pool.pop();
         let guard = self.enter_execution();
+        let mut interp: Box<Interpreter<'frame, 'a, T>> =
+            guard.evm.interpreter_pool.pop(tx_env, message);
         let interp_ref = interp.as_mut();
-        interp_ref.init(tx_env, message);
         // SAFETY: `execution_config` points to a private field that host execution does not
         // replace or mutate, so the pointee remains valid here.
         let execution_config = unsafe { trustme::decouple_lt(&guard.evm.execution_config) };

--- a/crates/evm2/src/interpreter/runtime.rs
+++ b/crates/evm2/src/interpreter/runtime.rs
@@ -48,8 +48,20 @@ pub struct Interpreter<'frame, 'host, T: EvmTypesHost> {
 // execution and not used after the owning execution context is gone.
 unsafe impl<T: EvmTypesHost> Send for Interpreter<'_, '_, T> {}
 
-impl<T: EvmTypesHost> Default for Interpreter<'_, '_, T> {
-    fn default() -> Self {
+impl<'frame, 'host, T: EvmTypesHost> Interpreter<'frame, 'host, T> {
+    /// Creates an interpreter from a transaction-global environment and a frame-local message,
+    /// which carries the bytecode to run.
+    pub fn new(tx_env: &'frame TxEnv<T>, message: &'frame Message<T>) -> Self {
+        // SAFETY: Calling init right after.
+        let mut interp = unsafe { Self::uninit() };
+        interp.init(tx_env, message);
+        interp
+    }
+
+    /// # Safety
+    ///
+    /// Must call `init` before use.
+    unsafe fn uninit() -> Self {
         let bytecode = Bytecode::new();
         Self {
             pc: bytecode.original_byte_slice().as_ptr(),
@@ -72,19 +84,9 @@ impl<T: EvmTypesHost> Default for Interpreter<'_, '_, T> {
             stack: unsafe { Box::new_uninit().assume_init() },
         }
     }
-}
-
-impl<'frame, 'host, T: EvmTypesHost> Interpreter<'frame, 'host, T> {
-    /// Creates an interpreter from a transaction-global environment and a frame-local message,
-    /// which carries the bytecode to run.
-    pub fn new(tx_env: &'frame TxEnv<T>, message: &'frame Message<T>) -> Self {
-        let mut interp = Self::default();
-        interp.init(tx_env, message);
-        interp
-    }
 
     /// Initializes this interpreter for a new frame, retaining reusable allocations.
-    pub(crate) fn init(&mut self, tx_env: &'frame TxEnv<T>, message: &'frame Message<T>) {
+    fn init(&mut self, tx_env: &'frame TxEnv<T>, message: &'frame Message<T>) {
         let bytecode = message.code.clone();
         let gas_limit = message.gas_limit;
         let is_static = message.caller_is_static || matches!(message.kind, MessageKind::StaticCall);
@@ -564,8 +566,18 @@ impl<T: EvmTypesHost> InterpreterPool<T> {
         Self { frames: Vec::new() }
     }
 
-    pub(crate) fn pop<'frame, 'host>(&mut self) -> Box<Interpreter<'frame, 'host, T>> {
-        let frame = self.frames.pop().unwrap_or_default();
+    pub(crate) fn pop<'frame, 'host>(
+        &mut self,
+        tx_env: &'frame TxEnv<T>,
+        message: &'frame Message<T>,
+    ) -> Box<Interpreter<'frame, 'host, T>> {
+        let frame = match self.frames.pop() {
+            Some(mut frame) => {
+                frame.init(tx_env, message);
+                frame
+            }
+            None => Box::new(Interpreter::new(tx_env, message)),
+        };
         // SAFETY: Frames stored in the pool have their frame-local references cleared before they
         // are erased to `'static`. Rebinding the lifetime is only used to initialize the next
         // frame.


### PR DESCRIPTION
Move default impl to unsafe private `fn uninit`, such that `fn new` is the only valid exposed initializer.