### PR TITLE
fix: support Cranelift TCO builds

### DIFF
--- a/crates/evm2/build.rs
+++ b/crates/evm2/build.rs
@@ -100,6 +100,7 @@ fn rustc() -> OsString {
     env("RUSTC").unwrap_or_else(|| OsString::from("rustc"))
 }
 
+// taken from https://github.com/rust-lang/rustc_codegen_cranelift/blob/9cac33b3d15c9eaf38525ee191ab470b1e26453c/src/abi/mod.rs#L60-L85
 fn is_cranelift_backend() -> bool {
     env("CARGO_ENCODED_RUSTFLAGS").is_some_and(|rustflags| {
         rustflags

--- a/crates/evm2/build.rs
+++ b/crates/evm2/build.rs
@@ -3,7 +3,9 @@
 use std::{ffi::OsString, process::Command};
 
 fn main() {
-    for cfg in ["dispatch_packed", "dispatch_single_return", "dispatch_unpacked", "tco"] {
+    for cfg in
+        ["dispatch_packed", "dispatch_single_return", "dispatch_unpacked", "tco", "tco_cranelift"]
+    {
         println!("cargo:rustc-check-cfg=cfg({cfg})");
     }
     println!("cargo:rerun-if-changed=build.rs");
@@ -12,7 +14,11 @@ fn main() {
     let is_wasm = target_is_wasm();
     let target_pointer_width = target_pointer_width();
     let no_tco = env("CARGO_FEATURE_NO_TCO");
-    match DispatchBackend::load().resolve(is_wasm, target_pointer_width, no_tco.is_some()) {
+    let backend = DispatchBackend::load().resolve(is_wasm, target_pointer_width, no_tco.is_some());
+    if is_cranelift_backend() && matches!(&backend, DispatchBackend::Tco) {
+        println!("cargo:rustc-cfg=tco_cranelift");
+    }
+    match backend {
         DispatchBackend::Auto => unreachable!("auto backend must resolve to a concrete backend"),
         DispatchBackend::Tco => println!("cargo:rustc-cfg=tco"),
         DispatchBackend::Packed => println!("cargo:rustc-cfg=dispatch_packed"),
@@ -90,6 +96,15 @@ fn rustc_is_nightly() -> bool {
 
 fn rustc() -> OsString {
     env("RUSTC").unwrap_or_else(|| OsString::from("rustc"))
+}
+
+fn is_cranelift_backend() -> bool {
+    env("CARGO_ENCODED_RUSTFLAGS").is_some_and(|rustflags| {
+        rustflags
+            .to_string_lossy()
+            .split('\x1f')
+            .any(|flag| flag.contains("codegen-backend") && flag.contains("cranelift"))
+    })
 }
 
 fn env(key: &str) -> Option<OsString> {

--- a/crates/evm2/build.rs
+++ b/crates/evm2/build.rs
@@ -4,11 +4,15 @@ use std::{ffi::OsString, process::Command};
 
 fn main() {
     for cfg in
-        ["dispatch_packed", "dispatch_single_return", "dispatch_unpacked", "tco", "tco_cranelift"]
+        ["cranelift", "dispatch_packed", "dispatch_single_return", "dispatch_unpacked", "tco"]
     {
         println!("cargo:rustc-check-cfg=cfg({cfg})");
     }
     println!("cargo:rerun-if-changed=build.rs");
+
+    if is_cranelift_backend() {
+        println!("cargo:rustc-cfg=cranelift");
+    }
 
     // Select interpreter backend.
     let is_wasm = target_is_wasm();
@@ -17,12 +21,7 @@ fn main() {
     let backend = DispatchBackend::load().resolve(is_wasm, target_pointer_width, no_tco.is_some());
     match backend {
         DispatchBackend::Auto => unreachable!("auto backend must resolve to a concrete backend"),
-        DispatchBackend::Tco => {
-            if is_cranelift_backend() {
-                println!("cargo:rustc-cfg=tco_cranelift");
-            }
-            println!("cargo:rustc-cfg=tco");
-        }
+        DispatchBackend::Tco => println!("cargo:rustc-cfg=tco"),
         DispatchBackend::Packed => println!("cargo:rustc-cfg=dispatch_packed"),
         DispatchBackend::SingleReturn => println!("cargo:rustc-cfg=dispatch_single_return"),
         DispatchBackend::Unpacked => println!("cargo:rustc-cfg=dispatch_unpacked"),
@@ -100,7 +99,8 @@ fn rustc() -> OsString {
     env("RUSTC").unwrap_or_else(|| OsString::from("rustc"))
 }
 
-// taken from https://github.com/rust-lang/rustc_codegen_cranelift/blob/9cac33b3d15c9eaf38525ee191ab470b1e26453c/src/abi/mod.rs#L60-L85
+// Cranelift does not implement `rust-preserve-none`.
+// Taken from https://github.com/rust-lang/rustc_codegen_cranelift/blob/9cac33b3d15c9eaf38525ee191ab470b1e26453c/src/abi/mod.rs#L60-L85.
 fn is_cranelift_backend() -> bool {
     env("CARGO_ENCODED_RUSTFLAGS").is_some_and(|rustflags| {
         rustflags

--- a/crates/evm2/build.rs
+++ b/crates/evm2/build.rs
@@ -18,8 +18,7 @@ fn main() {
     let is_wasm = target_is_wasm();
     let target_pointer_width = target_pointer_width();
     let no_tco = env("CARGO_FEATURE_NO_TCO");
-    let backend = DispatchBackend::load().resolve(is_wasm, target_pointer_width, no_tco.is_some());
-    match backend {
+    match DispatchBackend::load().resolve(is_wasm, target_pointer_width, no_tco.is_some()) {
         DispatchBackend::Auto => unreachable!("auto backend must resolve to a concrete backend"),
         DispatchBackend::Tco => println!("cargo:rustc-cfg=tco"),
         DispatchBackend::Packed => println!("cargo:rustc-cfg=dispatch_packed"),

--- a/crates/evm2/build.rs
+++ b/crates/evm2/build.rs
@@ -15,12 +15,14 @@ fn main() {
     let target_pointer_width = target_pointer_width();
     let no_tco = env("CARGO_FEATURE_NO_TCO");
     let backend = DispatchBackend::load().resolve(is_wasm, target_pointer_width, no_tco.is_some());
-    if is_cranelift_backend() && matches!(&backend, DispatchBackend::Tco) {
-        println!("cargo:rustc-cfg=tco_cranelift");
-    }
     match backend {
         DispatchBackend::Auto => unreachable!("auto backend must resolve to a concrete backend"),
-        DispatchBackend::Tco => println!("cargo:rustc-cfg=tco"),
+        DispatchBackend::Tco => {
+            if is_cranelift_backend() {
+                println!("cargo:rustc-cfg=tco_cranelift");
+            }
+            println!("cargo:rustc-cfg=tco");
+        }
         DispatchBackend::Packed => println!("cargo:rustc-cfg=dispatch_packed"),
         DispatchBackend::SingleReturn => println!("cargo:rustc-cfg=dispatch_single_return"),
         DispatchBackend::Unpacked => println!("cargo:rustc-cfg=dispatch_unpacked"),

--- a/crates/evm2/src/interpreter/utils.rs
+++ b/crates/evm2/src/interpreter/utils.rs
@@ -46,19 +46,11 @@ macro_rules! asm_comment {
     };
 }
 
-#[cfg(all(tco, not(cranelift)))]
+#[cfg(tco)]
 #[collapse_debuginfo(yes)]
 macro_rules! tail_return {
     ($e:expr) => {
         become $e;
-    };
-}
-
-#[cfg(all(tco, cranelift))]
-#[collapse_debuginfo(yes)]
-macro_rules! tail_return {
-    ($e:expr) => {
-        return $e;
     };
 }
 

--- a/crates/evm2/src/interpreter/utils.rs
+++ b/crates/evm2/src/interpreter/utils.rs
@@ -46,7 +46,7 @@ macro_rules! asm_comment {
     };
 }
 
-#[cfg(all(tco, not(tco_cranelift)))]
+#[cfg(all(tco, not(cranelift)))]
 #[collapse_debuginfo(yes)]
 macro_rules! tail_return {
     ($e:expr) => {
@@ -54,7 +54,7 @@ macro_rules! tail_return {
     };
 }
 
-#[cfg(tco_cranelift)]
+#[cfg(all(tco, cranelift))]
 #[collapse_debuginfo(yes)]
 macro_rules! tail_return {
     ($e:expr) => {
@@ -62,7 +62,7 @@ macro_rules! tail_return {
     };
 }
 
-#[cfg(all(tco, not(tco_cranelift)))]
+#[cfg(all(tco, not(cranelift)))]
 #[collapse_debuginfo(yes)]
 macro_rules! extern_table {
     ($(#[$attr:meta])* fn $($f:tt)*) => {
@@ -73,7 +73,7 @@ macro_rules! extern_table {
     };
 }
 
-#[cfg(any(not(tco), tco_cranelift))]
+#[cfg(any(not(tco), cranelift))]
 #[collapse_debuginfo(yes)]
 macro_rules! extern_table {
     ($(#[$attr:meta])* fn $($f:tt)*) => {

--- a/crates/evm2/src/interpreter/utils.rs
+++ b/crates/evm2/src/interpreter/utils.rs
@@ -46,7 +46,7 @@ macro_rules! asm_comment {
     };
 }
 
-#[cfg(tco)]
+#[cfg(all(tco, not(tco_cranelift)))]
 #[collapse_debuginfo(yes)]
 macro_rules! tail_return {
     ($e:expr) => {
@@ -54,7 +54,15 @@ macro_rules! tail_return {
     };
 }
 
-#[cfg(tco)]
+#[cfg(tco_cranelift)]
+#[collapse_debuginfo(yes)]
+macro_rules! tail_return {
+    ($e:expr) => {
+        return $e;
+    };
+}
+
+#[cfg(all(tco, not(tco_cranelift)))]
 #[collapse_debuginfo(yes)]
 macro_rules! extern_table {
     ($(#[$attr:meta])* fn $($f:tt)*) => {
@@ -65,7 +73,7 @@ macro_rules! extern_table {
     };
 }
 
-#[cfg(not(tco))]
+#[cfg(any(not(tco), tco_cranelift))]
 #[collapse_debuginfo(yes)]
 macro_rules! extern_table {
     ($(#[$attr:meta])* fn $($f:tt)*) => {

--- a/crates/evm2/src/lib.rs
+++ b/crates/evm2/src/lib.rs
@@ -1,9 +1,6 @@
 #![doc = include_str!("../README.md")]
-#![cfg_attr(
-    all(tco, not(cranelift)),
-    feature(explicit_tail_calls, rust_preserve_none_cc),
-    allow(incomplete_features)
-)]
+#![cfg_attr(tco, feature(explicit_tail_calls), allow(incomplete_features))]
+#![cfg_attr(all(tco, not(cranelift)), feature(rust_preserve_none_cc))]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 

--- a/crates/evm2/src/lib.rs
+++ b/crates/evm2/src/lib.rs
@@ -1,5 +1,9 @@
 #![doc = include_str!("../README.md")]
-#![cfg_attr(tco, feature(explicit_tail_calls, rust_preserve_none_cc), allow(incomplete_features))]
+#![cfg_attr(
+    all(tco, not(tco_cranelift)),
+    feature(explicit_tail_calls, rust_preserve_none_cc),
+    allow(incomplete_features)
+)]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 

--- a/crates/evm2/src/lib.rs
+++ b/crates/evm2/src/lib.rs
@@ -1,6 +1,6 @@
 #![doc = include_str!("../README.md")]
 #![cfg_attr(
-    all(tco, not(tco_cranelift)),
+    all(tco, not(cranelift)),
     feature(explicit_tail_calls, rust_preserve_none_cc),
     allow(incomplete_features)
 )]


### PR DESCRIPTION
Detect Cranelift through Cargo's encoded rustflags and select a compatible TCO variant. The variant avoids LLVM-only ABI and explicit tail-call lowering while keeping the TCO dispatcher.