### PR TITLE
chore: fix Clippy range loop lints

### DIFF
--- a/crates/jit/codegen/src/bytecode/mod.rs
+++ b/crates/jit/codegen/src/bytecode/mod.rs
@@ -753,12 +753,12 @@ impl<'a> Bytecode<'a> {
             });
             entry.total += 1;
             let mut all = true;
-            for depth in 0..inputs as usize {
-                entry.per_input[depth][0] += 1;
+            for (depth, counts) in entry.per_input.iter_mut().enumerate() {
+                counts[0] += 1;
                 if let Some(val) = self.const_operand(inst, depth) {
-                    entry.per_input[depth][1] += 1;
+                    counts[1] += 1;
                     if val <= usize::MAX {
-                        entry.per_input[depth][2] += 1;
+                        counts[2] += 1;
                     }
                 } else {
                     all = false;

--- a/crates/jit/codegen/src/compiler/translate/vstack.rs
+++ b/crates/jit/codegen/src/compiler/translate/vstack.rs
@@ -55,8 +55,8 @@ impl<T: Copy> VStack<T> {
         self.slots.resize(capacity, None);
 
         // Section inputs are already in memory.
-        for i in 0..inputs {
-            self.slots[i] = Some(VSlot::Materialized);
+        for slot in self.slots.iter_mut().take(inputs) {
+            *slot = Some(VSlot::Materialized);
         }
     }
 


### PR DESCRIPTION
Use mutable iterators for JIT constant-input counters and virtual stack initialization. This fixes the new `needless_range_loop` errors raised by the current nightly Clippy without changing behavior.