### PR TITLE
fix(state): publish code from account info

### DIFF
--- a/crates/evm2/src/evm/state/account.rs
+++ b/crates/evm2/src/evm/state/account.rs
@@ -190,7 +190,8 @@ impl Account {
         let account = self.present.as_ref()?;
         let code = account.code.as_ref()?;
         let code_hash = account.code_hash;
-        (self.code_changed
+        ((self.code_changed
+            || self.original.as_ref().map(|original| original.code_hash) != Some(code_hash))
             && !code.is_empty()
             && !code_hash.is_zero()
             && code_hash != KECCAK256_EMPTY)
@@ -623,6 +624,21 @@ mod tests {
         assert!(!state.account(&address, false).unwrap().is_warm());
         assert!(state.account_info_untracked(&address).unwrap().is_none());
         assert!(!state.take_pending_state().is_changed());
+    }
+
+    #[test]
+    fn account_info_set_code_is_published_on_commit() {
+        use alloy_primitives::Bytes;
+
+        let address = Address::from([0x8c; 20]);
+        let code = Bytecode::new_raw(Bytes::from_static(&[0x60, 0x01]));
+        let mut state = State::new(CacheDB::default());
+
+        state.account(&address, false).unwrap().get_or_insert().set_code(code.clone());
+        state.commit_transaction();
+
+        let loaded = state.account(&address, false).unwrap().load_code().unwrap();
+        assert_eq!(loaded, code);
     }
 
     #[test]


### PR DESCRIPTION
AccountHandle::get_or_insert exposes a mutable AccountInfo, so host code could call AccountInfo::set_code without raising the overlay's code_changed flag. Commit and state-change visitors would then publish the new account code hash without publishing its bytecode body.

Derive code publication from the original and present code hashes as well as the explicit flag. This also protects direct mutation through the exposed AccountInfo reference, and adds a regression test that commits and reloads code installed through that path.

This path requires direct access to the Rust host API. Ordinary EVM transactions cannot reach it, and the standard CREATE, CREATE2, and EIP-7702 paths already use the overlay-aware AccountHandle setters.

Closes ZELLIC-231.
