### PR TITLE
fix(inspectors): filter authorization exclusions

### DIFF
--- a/crates/inspectors/Cargo.toml
+++ b/crates/inspectors/Cargo.toml
@@ -35,6 +35,7 @@ boa_engine = { workspace = true, optional = true }
 boa_gc = { workspace = true, optional = true }
 
 [dev-dependencies]
+alloy-eips.workspace = true
 alloy-hardforks.workspace = true
 snapbox = { workspace = true, features = ["term-svg"] }
 

--- a/crates/inspectors/src/access_list.rs
+++ b/crates/inspectors/src/access_list.rs
@@ -1,6 +1,6 @@
 use alloc::collections::BTreeSet;
 use alloy_primitives::{
-    Address, B256,
+    Address, B256, U256,
     map::{HashMap, HashSet},
 };
 use alloy_rpc_types_eth::{AccessList, AccessListItem};
@@ -55,11 +55,18 @@ impl AccessListInspector {
     ///
     /// 7702 authorities should be excluded because those get loaded anyway.
     pub fn with_excluded_from_tx(self, tx: &RecoveredTxEnvelope) -> Self {
-        let authorities = tx
-            .as_eip7702()
-            .into_iter()
-            .flat_map(|tx| &tx.authorization_list)
-            .filter_map(|authorization| authorization.authority());
+        let Some(tx) = tx.as_eip7702() else { return self };
+        let chain_id = U256::from(tx.chain_id);
+        let authorities = tx.authorization_list.iter().filter_map(|authorization| {
+            let auth_chain_id = authorization.chain_id();
+            if !auth_chain_id.is_zero() && auth_chain_id != &chain_id {
+                return None;
+            }
+            if authorization.nonce() == u64::MAX {
+                return None;
+            }
+            authorization.authority()
+        });
         self.with_excluded(authorities)
     }
 

--- a/crates/inspectors/src/access_list.rs
+++ b/crates/inspectors/src/access_list.rs
@@ -54,9 +54,10 @@ impl AccessListInspector {
     /// Excludes the transaction's addresses from the final access list.
     ///
     /// 7702 authorities should be excluded because those get loaded anyway.
-    pub fn with_excluded_from_tx(self, tx: &RecoveredTxEnvelope) -> Self {
+    /// `chain_id` is the configured execution chain ID used to validate those authorizations.
+    pub fn with_excluded_from_tx(self, tx: &RecoveredTxEnvelope, chain_id: u64) -> Self {
         let Some(tx) = tx.as_eip7702() else { return self };
-        let chain_id = U256::from(tx.chain_id);
+        let chain_id = U256::from(chain_id);
         let authorities = tx.authorization_list.iter().filter_map(|authorization| {
             let auth_chain_id = authorization.chain_id();
             if !auth_chain_id.is_zero() && auth_chain_id != &chain_id {

--- a/crates/inspectors/tests/it/accesslist.rs
+++ b/crates/inspectors/tests/it/accesslist.rs
@@ -54,6 +54,7 @@ fn test_access_list_precompile() {
 #[test]
 fn test_access_list_authorization_exclusions() {
     const CHAIN_ID: u64 = 1;
+    const TX_CHAIN_ID: u64 = CHAIN_ID + 1;
 
     let current_chain = address!("00000000000000000000000000000000000000c0");
     let zero_chain = address!("00000000000000000000000000000000000000d0");
@@ -75,13 +76,13 @@ fn test_access_list_authorization_exclusions() {
     ];
     let tx = Recovered::new_unchecked(
         TxEnvelope::Eip7702(LazyTxEip7702::from_cached_recovered_authorizations(
-            TxEip7702 { chain_id: CHAIN_ID, ..Default::default() },
+            TxEip7702 { chain_id: TX_CHAIN_ID, ..Default::default() },
             authorizations,
         )),
         Address::ZERO,
     );
 
-    let inspector = AccessListInspector::default().with_excluded_from_tx(&tx);
+    let inspector = AccessListInspector::default().with_excluded_from_tx(&tx, CHAIN_ID);
     let excluded = inspector.excluded();
 
     assert!(excluded.contains(&current_chain));

--- a/crates/inspectors/tests/it/accesslist.rs
+++ b/crates/inspectors/tests/it/accesslist.rs
@@ -1,7 +1,10 @@
 //! Accesslist tests
 
 use crate::utils::{AccountInfo, Bytecode, CacheDB, Context, EmptyDB, TransactTo, TxEnv};
-use alloy_primitives::{address, hex};
+use alloy_consensus::{TxEip7702, transaction::Recovered};
+use alloy_eips::eip7702::{Authorization, RecoveredAuthority, RecoveredAuthorization};
+use alloy_primitives::{Address, U256, address, hex};
+use evm2::ethereum::{LazyTxEip7702, TxEnvelope};
 use evm2_inspectors::access_list::AccessListInspector;
 
 #[test]
@@ -46,4 +49,45 @@ fn test_access_list_precompile() {
     let erecover = address!("0x0000000000000000000000000000000000000001");
     assert!(accesslist.excluded().contains(&erecover));
     assert!(accesslist.into_access_list().is_empty());
+}
+
+#[test]
+fn test_access_list_authorization_exclusions() {
+    const CHAIN_ID: u64 = 1;
+
+    let current_chain = address!("00000000000000000000000000000000000000c0");
+    let zero_chain = address!("00000000000000000000000000000000000000d0");
+    let wrong_chain = address!("00000000000000000000000000000000000000e0");
+    let max_nonce = address!("00000000000000000000000000000000000000f0");
+
+    let authorization = |chain_id, nonce, authority| {
+        RecoveredAuthorization::new_unchecked(
+            Authorization { chain_id: U256::from(chain_id), address: Address::ZERO, nonce },
+            authority,
+        )
+    };
+    let authorizations = vec![
+        authorization(CHAIN_ID, 0, RecoveredAuthority::Valid(current_chain)),
+        authorization(0, 0, RecoveredAuthority::Valid(zero_chain)),
+        authorization(CHAIN_ID + 1, 0, RecoveredAuthority::Valid(wrong_chain)),
+        authorization(CHAIN_ID, u64::MAX, RecoveredAuthority::Valid(max_nonce)),
+        authorization(CHAIN_ID, 0, RecoveredAuthority::Invalid),
+    ];
+    let tx = Recovered::new_unchecked(
+        TxEnvelope::Eip7702(LazyTxEip7702::from_cached_recovered_authorizations(
+            TxEip7702 { chain_id: CHAIN_ID, ..Default::default() },
+            authorizations,
+        )),
+        Address::ZERO,
+    );
+
+    let inspector = AccessListInspector::default().with_excluded_from_tx(&tx);
+    let excluded = inspector.excluded();
+
+    assert!(excluded.contains(&current_chain));
+    assert!(excluded.contains(&zero_chain));
+    assert!(!excluded.contains(&wrong_chain));
+    assert!(!excluded.contains(&max_nonce));
+    // The unrecoverable authorization has no authority and therefore adds nothing.
+    assert_eq!(excluded.len(), 2);
 }


### PR DESCRIPTION
Exclude only EIP-7702 authorities that apply to the configured execution chain and have a non-overflowing nonce. The inspector now takes that chain ID explicitly so unchecked or synthetic transaction envelopes cannot select the wrong exclusions.