### PR TITLE
fix(inspectors): normalize generated access lists

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ evm2-jit-runtime = { path = "crates/jit/runtime", version = "0.1.0", default-fea
 
 alloy-consensus = { version = "2.0.4", default-features = false }
 alloy-chains = { version = "0.2.34", default-features = false }
+alloy-eip2930 = { version = "0.2.4", default-features = false }
 alloy-eip7928 = { version = "0.4.0", default-features = false }
 alloy-eips = { version = "2.0.4", default-features = false }
 alloy-hardforks = { version = "0.4", default-features = false }

--- a/crates/inspectors/Cargo.toml
+++ b/crates/inspectors/Cargo.toml
@@ -16,6 +16,7 @@ workspace = true
 [dependencies]
 # eth
 alloy-consensus.workspace = true
+alloy-eip2930.workspace = true
 alloy-rpc-types-eth.workspace = true
 alloy-rpc-types-trace.workspace = true
 alloy-sol-types.workspace = true
@@ -43,6 +44,7 @@ default = ["std"]
 std = [
     "alloy-primitives/std",
     "alloy-consensus/std",
+    "alloy-eip2930/std",
     "alloy-rpc-types-eth/std",
     "alloy-sol-types/std",
     "anstyle/std",
@@ -55,6 +57,7 @@ serde = [
     "dep:serde",
     "alloy-primitives/serde",
     "alloy-consensus/serde",
+    "alloy-eip2930/serde",
     "alloy-rpc-types-eth/serde",
     "evm2/serde",
 ]

--- a/crates/inspectors/src/access_list.rs
+++ b/crates/inspectors/src/access_list.rs
@@ -1,9 +1,9 @@
 use alloc::collections::BTreeSet;
+use alloy_eip2930::{AccessList, AccessListItem};
 use alloy_primitives::{
     Address, B256,
     map::{HashMap, HashSet},
 };
-use alloy_rpc_types_eth::{AccessList, AccessListItem};
 use evm2::{
     Evm, EvmTypes, Inspector,
     ethereum::RecoveredTxEnvelope,
@@ -31,7 +31,8 @@ impl AccessListInspector {
     /// Creates a new inspector instance
     ///
     /// The `access_list` is the provided access list from the call request
-    pub fn new(access_list: AccessList) -> Self {
+    pub fn new(mut access_list: AccessList) -> Self {
+        access_list.dedup();
         Self {
             excluded: Default::default(),
             touched_slots: access_list
@@ -86,7 +87,9 @@ impl AccessListInspector {
             address,
             storage_keys: slots.into_iter().collect(),
         });
-        AccessList(items.collect())
+        let mut access_list = AccessList(items.collect());
+        access_list.sort();
+        access_list
     }
 
     /// Returns list of addresses and storage keys used by the transaction. It gives you the list of
@@ -96,7 +99,9 @@ impl AccessListInspector {
             address: *address,
             storage_keys: slots.iter().copied().collect(),
         });
-        AccessList(items.collect())
+        let mut access_list = AccessList(items.collect());
+        access_list.sort();
+        access_list
     }
 
     /// Collects addresses which should be excluded from the access list. Must be called before the
@@ -107,6 +112,8 @@ impl AccessListInspector {
         self.excluded.extend(
             [message.caller, message.destination].into_iter().chain(host.precompiles().addresses()),
         );
+        // Remove seeded excluded entries; SLOAD/SSTORE can re-add slots accessed during execution.
+        self.touched_slots.retain(|address, _| !self.excluded.contains(address));
     }
 }
 

--- a/crates/inspectors/tests/it/accesslist.rs
+++ b/crates/inspectors/tests/it/accesslist.rs
@@ -1,8 +1,55 @@
 //! Accesslist tests
 
 use crate::utils::{AccountInfo, Bytecode, CacheDB, Context, EmptyDB, TransactTo, TxEnv};
-use alloy_primitives::{address, hex};
+use alloy_eip2930::{AccessList, AccessListItem};
+use alloy_primitives::{Address, B256, address, hex};
 use evm2_inspectors::access_list::AccessListInspector;
+
+#[test]
+fn initial_access_list_is_normalized_and_pruned() {
+    let [caller, callee, lower, higher] = [0x10, 0x20, 0x30, 0x40].map(Address::with_last_byte);
+    let [accessed_slot, stale_slot] = [1, 2].map(B256::with_last_byte);
+    let item = |address, storage_keys| AccessListItem { address, storage_keys };
+    let initial = AccessList(vec![
+        item(caller, vec![]),
+        item(higher, vec![stale_slot]),
+        item(callee, vec![stale_slot]),
+        item(higher, vec![accessed_slot, accessed_slot]),
+        item(Address::with_last_byte(1), vec![]),
+        item(lower, vec![]),
+    ]);
+
+    let context =
+        Context::mainnet().with_db(CacheDB::<EmptyDB>::default()).modify_db_chained(|db| {
+            db.insert_account_info(
+                &callee,
+                AccountInfo {
+                    // Read slot 1 so it is re-added after pruning the callee's stale seeded slot.
+                    code: Some(Bytecode::new_raw(hex!("60015400").into())),
+                    ..Default::default()
+                },
+            );
+        });
+    let mut inspector = AccessListInspector::new(initial);
+    let mut evm = context.build_mainnet().with_inspector(&mut inspector);
+    let result = evm
+        .inspect_tx(TxEnv {
+            caller,
+            gas_limit: 100_000,
+            kind: TransactTo::Call(callee),
+            ..Default::default()
+        })
+        .unwrap();
+    assert!(result.result.is_success(), "{result:#?}");
+
+    let expected = AccessList(vec![
+        item(callee, vec![accessed_slot]),
+        item(lower, vec![]),
+        item(higher, vec![accessed_slot, stale_slot]),
+    ]);
+    assert_eq!(inspector.access_list(), expected);
+    assert_eq!(inspector.into_access_list(), expected);
+}
 
 #[test]
 fn test_access_list_precompile() {


### PR DESCRIPTION
Depends on #380; merge #380 first.

Normalize seeded access lists with alloy-eip2930 before collecting accesses, sort generated output, and prune transaction-excluded seed entries before execution.

This preserves only storage slots actually re-accessed for excluded accounts while producing stable, deduplicated results.