### PR TITLE
fix: validate decoded block access lists

### DIFF
--- a/crates/eest/src/blockchaintest/execute.rs
+++ b/crates/eest/src/blockchaintest/execute.rs
@@ -625,9 +625,13 @@ fn execute_block(
 
         if let Some(expected_bal) = block_access_list(block) {
             let built = evm.state_mut().take_bal_builder().unwrap_or_default();
-            if let Err(kind) =
-                check_block_access_list(block_index, built, expected_bal, block_header(block))
-            {
+            if let Err(kind) = check_block_access_list(
+                block_index,
+                built,
+                expected_bal,
+                block_header(block),
+                transactions.len(),
+            ) {
                 if should_fail {
                     return Ok(BlockResolution::Discard);
                 }
@@ -1161,6 +1165,7 @@ fn check_block_access_list(
     built: Bal,
     expected: &BlockAccessList,
     header: Option<&BlockHeader>,
+    transaction_count: usize,
 ) -> Result<(), TestErrorKind> {
     let built = BlockAccessList::from(built);
 
@@ -1181,6 +1186,18 @@ fn check_block_access_list(
         }
     }
 
+    // Validate the fixture-provided list against this block's transaction count before
+    // canonicalizing it for comparison. Invalid expected data represents an invalid block; it
+    // must not be retained as raw input after a failed conversion.
+    let expected = BlockAccessList::from(
+        Bal::try_from_alloy_ref_with_transaction_count(expected.as_slice(), transaction_count)
+            .map_err(|err| {
+                TestErrorKind::UnexpectedFailure(format!(
+                    "invalid expected block access list: {err}"
+                ))
+            })?,
+    );
+
     // The header commits to the computed list by hash (execution-specs compares
     // `hash_block_access_list` against `header.block_access_list_hash`).
     if let Some(expected_hash) = header.and_then(|header| header.block_access_list_hash) {
@@ -1192,10 +1209,6 @@ fn check_block_access_list(
         }
     }
 
-    let expected = match Bal::try_from(expected.clone()) {
-        Ok(bal) => BlockAccessList::from(bal),
-        Err(_) => expected.clone(),
-    };
     if built == expected {
         return Ok(());
     }
@@ -1330,6 +1343,28 @@ mod tests {
 
     #[cfg(feature = "jit")]
     const BYTECODE_STORE42: &[u8] = &[op::PUSH1, 0x42, op::PUSH0, op::SSTORE, op::STOP];
+
+    #[test]
+    fn bal_check_surfaces_contextual_expected_list_errors() {
+        use super::{Bal, BlockHeader, TestErrorKind, check_block_access_list};
+        use alloy_eip7928::{AccountChanges, BalanceChange, BlockAccessIndex};
+        use alloy_primitives::{Address, U256};
+
+        let expected = vec![AccountChanges {
+            address: Address::with_last_byte(1),
+            balance_changes: vec![BalanceChange::new(BlockAccessIndex::new(3), U256::ONE)],
+            ..Default::default()
+        }];
+        let header = BlockHeader { gas_limit: U256::from(30_000_000), ..Default::default() };
+
+        let err = check_block_access_list(0, Bal::new(), &expected, Some(&header), 1).unwrap_err();
+        assert!(matches!(
+            err,
+            TestErrorKind::UnexpectedFailure(message)
+                if message.contains("invalid expected block access list")
+                    && message.contains("exceeds the block maximum 2")
+        ));
+    }
 
     #[test]
     fn blockchain_tests_apply_ommer_rewards_before_merge() {

--- a/crates/evm2/src/evm/bal/account.rs
+++ b/crates/evm2/src/evm/bal/account.rs
@@ -1,11 +1,11 @@
 //! BAL builder module
 
 use super::{
-    BalError, BlockAccessIndex,
+    BalChangeKind, BalDecodeError, BalError, BlockAccessIndex,
     changes::{BalChanges, BalCodeChange},
 };
 use crate::{
-    bytecode::{Bytecode, BytecodeDecodeError},
+    bytecode::Bytecode,
     evm::state::{AccountInfo, StorageSlot},
 };
 use alloc::vec::Vec;
@@ -39,7 +39,7 @@ impl AccountBal {
 }
 
 impl TryFrom<&AlloyAccountChanges> for AccountBal {
-    type Error = BytecodeDecodeError;
+    type Error = BalDecodeError;
 
     /// Create an account BAL from borrowed EIP-7928 [`AlloyAccountChanges`] without
     /// consuming the source.
@@ -49,32 +49,26 @@ impl TryFrom<&AlloyAccountChanges> for AccountBal {
     ///
     /// # Errors
     ///
-    /// Returns [`BytecodeDecodeError`] if any code change contains bytecode rejected by
-    /// [`Bytecode::new_raw_checked`]. This currently happens for malformed EIP-7702
-    /// bytecode, such as bytes with the EIP-7702 magic prefix but an invalid length or
-    /// unsupported version.
+    /// Returns [`BalDecodeError`] if the account entry violates EIP-7928 ordering or uniqueness,
+    /// contains an invalid block access index, or contains malformed bytecode.
     #[inline]
     fn try_from(alloy_account: &AlloyAccountChanges) -> Result<Self, Self::Error> {
+        let address = alloy_account.address;
         Ok(Self {
             account_info: AccountInfoBal {
-                nonce: alloy_account.nonce_changes.clone().into(),
-                balance: alloy_account.balance_changes.clone().into(),
-                code: alloy_account
-                    .code_changes
-                    .iter()
-                    .map(BalCodeChange::try_from)
-                    .collect::<Result<Vec<_>, _>>()?
-                    .into(),
+                nonce: checked_clone_changes(
+                    address,
+                    BalChangeKind::Nonce,
+                    &alloy_account.nonce_changes,
+                )?,
+                balance: checked_clone_changes(
+                    address,
+                    BalChangeKind::Balance,
+                    &alloy_account.balance_changes,
+                )?,
+                code: checked_code_changes_ref(address, &alloy_account.code_changes)?,
             },
-            storage: StorageBal::from_iter(
-                alloy_account
-                    .storage_changes
-                    .iter()
-                    .map(|slot| (slot.slot, slot.changes.clone().into()))
-                    .chain(
-                        alloy_account.storage_reads.iter().map(|key| (*key, BalChanges::default())),
-                    ),
-            ),
+            storage: checked_storage_ref(alloy_account)?,
         })
     }
 }
@@ -134,7 +128,7 @@ impl From<AccountBal> for AlloyAccountChanges {
 }
 
 impl TryFrom<AlloyAccountChanges> for AccountBal {
-    type Error = BytecodeDecodeError;
+    type Error = BalDecodeError;
 
     /// Create an account BAL from EIP-7928 [`AlloyAccountChanges`].
     ///
@@ -143,37 +137,191 @@ impl TryFrom<AlloyAccountChanges> for AccountBal {
     ///
     /// # Errors
     ///
-    /// Returns [`BytecodeDecodeError`] if any code change contains bytecode rejected by
-    /// [`Bytecode::new_raw_checked`]. This currently happens for malformed EIP-7702
-    /// bytecode, such as bytes with the EIP-7702 magic prefix but an invalid length or
-    /// unsupported version.
+    /// Returns [`BalDecodeError`] if the account entry violates EIP-7928 ordering or uniqueness,
+    /// contains an invalid block access index, or contains malformed bytecode.
     #[inline]
     fn try_from(alloy_account: AlloyAccountChanges) -> Result<Self, Self::Error> {
+        let address = alloy_account.address;
         Ok(Self {
             account_info: AccountInfoBal {
-                nonce: alloy_account.nonce_changes.into(),
-                balance: alloy_account.balance_changes.into(),
-                code: alloy_account
-                    .code_changes
-                    .iter()
-                    .map(BalCodeChange::try_from)
-                    .collect::<Result<Vec<_>, _>>()?
-                    .into(),
+                nonce: checked_changes(address, BalChangeKind::Nonce, alloy_account.nonce_changes)?,
+                balance: checked_changes(
+                    address,
+                    BalChangeKind::Balance,
+                    alloy_account.balance_changes,
+                )?,
+                code: checked_code_changes(address, alloy_account.code_changes)?,
             },
-            storage: StorageBal::from_iter(
-                alloy_account
-                    .storage_changes
-                    .into_iter()
-                    .chain(
-                        alloy_account
-                            .storage_reads
-                            .into_iter()
-                            .map(|key| AlloySlotChanges::new(key, Default::default())),
-                    )
-                    .map(|slot| (slot.slot, slot.changes.into())),
-            ),
+            storage: checked_storage(
+                address,
+                alloy_account.storage_changes,
+                alloy_account.storage_reads,
+            )?,
         })
     }
+}
+
+/// Clone and validate borrowed storage entries while building the storage map.
+#[inline]
+fn checked_storage_ref(account: &AlloyAccountChanges) -> Result<StorageBal, BalDecodeError> {
+    let address = account.address;
+    let mut storage = U256Map::with_capacity_and_hasher(
+        account.storage_changes.len() + account.storage_reads.len(),
+        Default::default(),
+    );
+    let mut previous = None;
+    for slot in &account.storage_changes {
+        check_storage_key_order(address, &mut previous, slot.slot)?;
+        if slot.changes.is_empty() {
+            return Err(BalDecodeError::EmptyStorageChanges { address, slot: slot.slot });
+        }
+        let changes = checked_clone_changes(address, BalChangeKind::Storage, &slot.changes)?;
+        if storage.insert(slot.slot, changes).is_some() {
+            return Err(BalDecodeError::DuplicateStorageKey { address, slot: slot.slot });
+        }
+    }
+    previous = None;
+    for &slot in &account.storage_reads {
+        check_storage_key_order(address, &mut previous, slot)?;
+        if storage.insert(slot, BalChanges::default()).is_some() {
+            return Err(BalDecodeError::DuplicateStorageKey { address, slot });
+        }
+    }
+    Ok(StorageBal { storage })
+}
+
+/// Validate owned storage entries while building the storage map.
+#[inline]
+fn checked_storage(
+    address: Address,
+    storage_changes: Vec<AlloySlotChanges>,
+    storage_reads: Vec<U256>,
+) -> Result<StorageBal, BalDecodeError> {
+    let mut storage = U256Map::with_capacity_and_hasher(
+        storage_changes.len() + storage_reads.len(),
+        Default::default(),
+    );
+    let mut previous = None;
+    for slot in storage_changes {
+        check_storage_key_order(address, &mut previous, slot.slot)?;
+        if slot.changes.is_empty() {
+            return Err(BalDecodeError::EmptyStorageChanges { address, slot: slot.slot });
+        }
+        let changes = checked_changes(address, BalChangeKind::Storage, slot.changes)?;
+        if storage.insert(slot.slot, changes).is_some() {
+            return Err(BalDecodeError::DuplicateStorageKey { address, slot: slot.slot });
+        }
+    }
+    previous = None;
+    for slot in storage_reads {
+        check_storage_key_order(address, &mut previous, slot)?;
+        if storage.insert(slot, BalChanges::default()).is_some() {
+            return Err(BalDecodeError::DuplicateStorageKey { address, slot });
+        }
+    }
+    Ok(StorageBal { storage })
+}
+
+/// Enforce strictly increasing storage keys.
+#[inline]
+fn check_storage_key_order(
+    address: Address,
+    previous: &mut Option<U256>,
+    slot: U256,
+) -> Result<(), BalDecodeError> {
+    if let Some(previous) = *previous {
+        if previous == slot {
+            return Err(BalDecodeError::DuplicateStorageKey { address, slot });
+        }
+        if previous > slot {
+            return Err(BalDecodeError::StorageKeysOutOfOrder { address, previous, slot });
+        }
+    }
+    *previous = Some(slot);
+    Ok(())
+}
+
+/// Clone a borrowed change list while validating its indices.
+#[inline]
+fn checked_clone_changes<T: super::BalChange + Clone>(
+    address: Address,
+    kind: BalChangeKind,
+    changes: &[T],
+) -> Result<BalChanges<T>, BalDecodeError> {
+    let mut converted = Vec::with_capacity(changes.len());
+    let mut previous = None;
+    for change in changes {
+        check_change_index(address, kind, &mut previous, change.block_access_index())?;
+        converted.push(change.clone());
+    }
+    Ok(converted.into())
+}
+
+/// Validate and wrap an owned change list without reallocating it.
+#[inline]
+fn checked_changes<T: super::BalChange>(
+    address: Address,
+    kind: BalChangeKind,
+    changes: Vec<T>,
+) -> Result<BalChanges<T>, BalDecodeError> {
+    let mut previous = None;
+    for change in &changes {
+        check_change_index(address, kind, &mut previous, change.block_access_index())?;
+    }
+    Ok(changes.into())
+}
+
+/// Decode and validate borrowed code changes in one pass.
+#[inline]
+fn checked_code_changes_ref(
+    address: Address,
+    changes: &[AlloyCodeChange],
+) -> Result<BalChanges<BalCodeChange>, BalDecodeError> {
+    let mut converted = Vec::with_capacity(changes.len());
+    let mut previous = None;
+    for change in changes {
+        check_change_index(address, BalChangeKind::Code, &mut previous, change.block_access_index)?;
+        converted.push(BalCodeChange::try_from(change)?);
+    }
+    Ok(converted.into())
+}
+
+/// Decode and validate owned code changes in one pass.
+#[inline]
+fn checked_code_changes(
+    address: Address,
+    changes: Vec<AlloyCodeChange>,
+) -> Result<BalChanges<BalCodeChange>, BalDecodeError> {
+    let mut converted = Vec::with_capacity(changes.len());
+    let mut previous = None;
+    for change in changes {
+        check_change_index(address, BalChangeKind::Code, &mut previous, change.block_access_index)?;
+        converted.push(BalCodeChange::try_from(change)?);
+    }
+    Ok(converted.into())
+}
+
+/// Enforce valid, strictly increasing block access indices.
+#[inline]
+fn check_change_index(
+    address: Address,
+    kind: BalChangeKind,
+    previous: &mut Option<BlockAccessIndex>,
+    index: BlockAccessIndex,
+) -> Result<(), BalDecodeError> {
+    if index.get() > u32::MAX as u64 {
+        return Err(BalDecodeError::BlockAccessIndexOutOfRange { address, kind, index });
+    }
+    if let Some(previous) = *previous {
+        if previous == index {
+            return Err(BalDecodeError::DuplicateBlockAccessIndex { address, kind, index });
+        }
+        if previous > index {
+            return Err(BalDecodeError::ChangeIndicesOutOfOrder { address, kind, previous, index });
+        }
+    }
+    *previous = Some(index);
+    Ok(())
 }
 
 /// Account info bal structure.

--- a/crates/evm2/src/evm/bal/changes.rs
+++ b/crates/evm2/src/evm/bal/changes.rs
@@ -138,6 +138,18 @@ impl TryFrom<&AlloyCodeChange> for BalCodeChange {
     }
 }
 
+impl TryFrom<AlloyCodeChange> for BalCodeChange {
+    type Error = BytecodeDecodeError;
+
+    /// Decode an owned code change without cloning its bytecode.
+    #[inline]
+    fn try_from(change: AlloyCodeChange) -> Result<Self, Self::Error> {
+        let bytecode = Bytecode::new_raw_checked(change.new_code)?;
+        let hash = bytecode.hash_slow();
+        Ok(Self { block_access_index: change.block_access_index, code: (hash, bytecode) })
+    }
+}
+
 impl From<BalCodeChange> for AlloyCodeChange {
     fn from(change: BalCodeChange) -> Self {
         Self::new(change.block_access_index, change.code.1.original_bytes())

--- a/crates/evm2/src/evm/bal/decode_error.rs
+++ b/crates/evm2/src/evm/bal/decode_error.rs
@@ -1,0 +1,133 @@
+//! Errors returned when importing a decoded EIP-7928 block access list.
+
+use super::BlockAccessIndex;
+use crate::bytecode::BytecodeDecodeError;
+use alloy_primitives::{Address, U256};
+use thiserror::Error;
+
+/// A change list within an EIP-7928 account entry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BalChangeKind {
+    /// Storage changes for one slot.
+    Storage,
+    /// Account balance changes.
+    Balance,
+    /// Account nonce changes.
+    Nonce,
+    /// Account code changes.
+    Code,
+}
+
+impl core::fmt::Display for BalChangeKind {
+    #[inline]
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str(match self {
+            Self::Storage => "storage",
+            Self::Balance => "balance",
+            Self::Nonce => "nonce",
+            Self::Code => "code",
+        })
+    }
+}
+
+/// Error returned when decoded EIP-7928 data is not canonical or cannot be imported.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
+pub enum BalDecodeError {
+    /// A code change contains malformed bytecode.
+    #[error(transparent)]
+    Bytecode(#[from] BytecodeDecodeError),
+    /// The same account occurs more than once.
+    #[error("account {address} occurs more than once in the BAL")]
+    DuplicateAccount {
+        /// Duplicated account address.
+        address: Address,
+    },
+    /// Account entries are not ordered lexicographically by address.
+    #[error("BAL account {address} appears after {previous}, violating canonical order")]
+    AccountsOutOfOrder {
+        /// Previous account address.
+        previous: Address,
+        /// Out-of-order account address.
+        address: Address,
+    },
+    /// The same storage key occurs more than once or in both storage lists.
+    #[error("storage slot {slot:#x} occurs more than once for account {address}")]
+    DuplicateStorageKey {
+        /// Account containing the duplicated key.
+        address: Address,
+        /// Duplicated storage key.
+        slot: U256,
+    },
+    /// Storage keys in one of the account's lists are not in canonical order.
+    #[error(
+        "storage slot {slot:#x} appears after {previous:#x} for account {address}, violating canonical order"
+    )]
+    StorageKeysOutOfOrder {
+        /// Account containing the out-of-order key.
+        address: Address,
+        /// Previous storage key.
+        previous: U256,
+        /// Out-of-order storage key.
+        slot: U256,
+    },
+    /// A `SlotChanges` entry has no changes.
+    #[error("storage slot {slot:#x} has an empty change list for account {address}")]
+    EmptyStorageChanges {
+        /// Account containing the empty entry.
+        address: Address,
+        /// Storage key with no changes.
+        slot: U256,
+    },
+    /// The same block access index occurs more than once in one change list.
+    #[error(
+        "block access index {index} occurs more than once in a {kind} change list for account {address}"
+    )]
+    DuplicateBlockAccessIndex {
+        /// Account containing the change list.
+        address: Address,
+        /// Kind of change list.
+        kind: BalChangeKind,
+        /// Duplicated block access index.
+        index: BlockAccessIndex,
+    },
+    /// A change list is not ordered by block access index.
+    #[error(
+        "block access index {index} appears after {previous} in a {kind} change list for account {address}"
+    )]
+    ChangeIndicesOutOfOrder {
+        /// Account containing the change list.
+        address: Address,
+        /// Kind of change list.
+        kind: BalChangeKind,
+        /// Previous block access index.
+        previous: BlockAccessIndex,
+        /// Out-of-order block access index.
+        index: BlockAccessIndex,
+    },
+    /// A block access index does not fit the EIP-7928 `uint32` representation.
+    #[error(
+        "block access index {index} in a {kind} change list for account {address} exceeds uint32"
+    )]
+    BlockAccessIndexOutOfRange {
+        /// Account containing the change list.
+        address: Address,
+        /// Kind of change list.
+        kind: BalChangeKind,
+        /// Invalid block access index.
+        index: BlockAccessIndex,
+    },
+    /// A block access index is greater than the block's post-execution index.
+    #[error(
+        "block access index {index} in a {kind} change list for account {address} exceeds the block maximum {max}"
+    )]
+    BlockAccessIndexExceedsBlock {
+        /// Account containing the change list.
+        address: Address,
+        /// Kind of change list.
+        kind: BalChangeKind,
+        /// Invalid block access index.
+        index: BlockAccessIndex,
+        /// Post-execution index for the block.
+        max: BlockAccessIndex,
+    },
+}

--- a/crates/evm2/src/evm/bal/list.rs
+++ b/crates/evm2/src/evm/bal/list.rs
@@ -1,10 +1,7 @@
 //! The top-level Block Access List structure.
 
-use super::{AccountBal, BalError, BlockAccessIndex};
-use crate::{
-    bytecode::BytecodeDecodeError,
-    evm::state::{AccountInfo, PendingState},
-};
+use super::{AccountBal, BalDecodeError, BalError, BlockAccessIndex};
+use crate::evm::state::{AccountInfo, PendingState};
 use alloc::vec::Vec;
 use alloy_eip7928::{AccountChanges as AlloyAccountChanges, BlockAccessList as AlloyBal};
 use alloy_primitives::{Address, U256, map::AddressMap};
@@ -26,6 +23,77 @@ impl Bal {
     /// Create a new BAL builder.
     pub fn new() -> Self {
         Self { accounts: AddressMap::default() }
+    }
+
+    /// Import an EIP-7928 BAL and validate indices against the block's transaction count.
+    ///
+    /// Unlike the [`TryFrom`] conversion, this can enforce that every block access index is at
+    /// most the post-execution index (`transaction_count + 1`).
+    #[inline]
+    pub fn try_from_alloy_with_transaction_count(
+        alloy_bal: AlloyBal,
+        transaction_count: usize,
+    ) -> Result<Self, BalDecodeError> {
+        let bal = Self::try_from(alloy_bal)?;
+        bal.validate_block_access_indices(transaction_count)?;
+        Ok(bal)
+    }
+
+    /// Import a borrowed EIP-7928 BAL and validate indices against the block's transaction count.
+    ///
+    /// Unlike the [`TryFrom`] conversion, this can enforce that every block access index is at
+    /// most the post-execution index (`transaction_count + 1`).
+    #[inline]
+    pub fn try_from_alloy_ref_with_transaction_count(
+        alloy_bal: &[AlloyAccountChanges],
+        transaction_count: usize,
+    ) -> Result<Self, BalDecodeError> {
+        let bal = Self::try_from(alloy_bal)?;
+        bal.validate_block_access_indices(transaction_count)?;
+        Ok(bal)
+    }
+
+    /// Validate every change index against this block's transaction count.
+    ///
+    /// EIP-7928 assigns index zero to pre-execution, indices `1..=transaction_count` to
+    /// transactions, and `transaction_count + 1` to post-execution.
+    #[inline]
+    pub fn validate_block_access_indices(
+        &self,
+        transaction_count: usize,
+    ) -> Result<(), BalDecodeError> {
+        let max = BlockAccessIndex::new(
+            u64::try_from(transaction_count).unwrap_or(u64::MAX).saturating_add(1),
+        );
+        for (address, account) in &self.accounts {
+            validate_block_change_indices(
+                *address,
+                super::BalChangeKind::Nonce,
+                &account.account_info.nonce,
+                max,
+            )?;
+            validate_block_change_indices(
+                *address,
+                super::BalChangeKind::Balance,
+                &account.account_info.balance,
+                max,
+            )?;
+            validate_block_change_indices(
+                *address,
+                super::BalChangeKind::Code,
+                &account.account_info.code,
+                max,
+            )?;
+            for changes in account.storage.storage.values() {
+                validate_block_change_indices(
+                    *address,
+                    super::BalChangeKind::Storage,
+                    changes,
+                    max,
+                )?;
+            }
+        }
+        Ok(())
     }
 
     /// Extend BAL with a transaction's detached [`PendingState`] at `bal_index`.
@@ -99,6 +167,21 @@ impl Bal {
     }
 }
 
+#[inline]
+fn validate_block_change_indices<T: super::BalChange>(
+    address: Address,
+    kind: super::BalChangeKind,
+    changes: &super::BalChanges<T>,
+    max: BlockAccessIndex,
+) -> Result<(), BalDecodeError> {
+    if let Some(index) =
+        changes.changes.iter().map(super::BalChange::block_access_index).find(|index| *index > max)
+    {
+        return Err(BalDecodeError::BlockAccessIndexExceedsBlock { address, kind, index, max });
+    }
+    Ok(())
+}
+
 impl From<Bal> for AlloyBal {
     /// Consume `Bal` and create a canonical EIP-7928 [`AlloyBal`].
     ///
@@ -121,22 +204,23 @@ impl From<Bal> for AlloyBal {
 }
 
 impl TryFrom<&[AlloyAccountChanges]> for Bal {
-    type Error = BytecodeDecodeError;
+    type Error = BalDecodeError;
 
     /// Convert borrowed EIP-7928 [`AlloyAccountChanges`] into a [`Bal`] without consuming
     /// the source.
     ///
     /// # Errors
     ///
-    /// Returns [`BytecodeDecodeError`] if any account code change contains bytecode
-    /// rejected by [`Bytecode::new_raw_checked`](crate::bytecode::Bytecode::new_raw_checked). This
-    /// currently happens for malformed EIP-7702 bytecode, such as bytes with the EIP-7702 magic
-    /// prefix but an invalid length or unsupported version.
+    /// Returns [`BalDecodeError`] if the BAL violates EIP-7928 ordering or uniqueness, contains an
+    /// invalid block access index, or contains malformed bytecode.
     #[inline]
     fn try_from(alloy_bal: &[AlloyAccountChanges]) -> Result<Self, Self::Error> {
         let mut accounts =
             AddressMap::with_capacity_and_hasher(alloy_bal.len(), Default::default());
+        let mut previous = None;
         for alloy_account in alloy_bal {
+            validate_account_order(previous, alloy_account.address)?;
+            previous = Some(alloy_account.address);
             accounts.insert(alloy_account.address, AccountBal::try_from(alloy_account)?);
         }
 
@@ -145,27 +229,44 @@ impl TryFrom<&[AlloyAccountChanges]> for Bal {
 }
 
 impl TryFrom<AlloyBal> for Bal {
-    type Error = BytecodeDecodeError;
+    type Error = BalDecodeError;
 
     /// Convert an EIP-7928 [`AlloyBal`] into a [`Bal`].
     ///
     /// # Errors
     ///
-    /// Returns [`BytecodeDecodeError`] if any account code change contains bytecode
-    /// rejected by [`Bytecode::new_raw_checked`](crate::bytecode::Bytecode::new_raw_checked). This
-    /// currently happens for malformed EIP-7702 bytecode, such as bytes with the EIP-7702 magic
-    /// prefix but an invalid length or unsupported version.
+    /// Returns [`BalDecodeError`] if the BAL violates EIP-7928 ordering or uniqueness, contains an
+    /// invalid block access index, or contains malformed bytecode.
     #[inline]
     fn try_from(alloy_bal: AlloyBal) -> Result<Self, Self::Error> {
         let mut accounts =
             AddressMap::with_capacity_and_hasher(alloy_bal.len(), Default::default());
+        let mut previous = None;
         for alloy_account in alloy_bal {
             let address = alloy_account.address;
+            validate_account_order(previous, address)?;
+            previous = Some(address);
             accounts.insert(address, AccountBal::try_from(alloy_account)?);
         }
 
         Ok(Self { accounts })
     }
+}
+
+#[inline]
+fn validate_account_order(
+    previous: Option<Address>,
+    address: Address,
+) -> Result<(), BalDecodeError> {
+    if let Some(previous) = previous {
+        if previous == address {
+            return Err(BalDecodeError::DuplicateAccount { address });
+        }
+        if previous > address {
+            return Err(BalDecodeError::AccountsOutOfOrder { previous, address });
+        }
+    }
+    Ok(())
 }
 
 impl core::fmt::Display for Bal {
@@ -263,7 +364,7 @@ mod tests {
     use crate::{
         bytecode::Bytecode,
         evm::{
-            bal::{AccountInfoBal, BalChanges, BalCodeChange, StorageBal},
+            bal::{AccountInfoBal, BalChangeKind, BalChanges, BalCodeChange, StorageBal},
             state::{Account, AccountInfo, StorageOverlay, StorageSlot, Tracked},
         },
     };
@@ -531,5 +632,161 @@ mod tests {
         }];
 
         assert!(Bal::try_from(alloy_bal.as_slice()).is_err());
+    }
+
+    fn assert_owned_and_borrowed_error(alloy_bal: AlloyBal, expected: BalDecodeError) {
+        assert_eq!(Bal::try_from(alloy_bal.as_slice()), Err(expected));
+        assert_eq!(Bal::try_from(alloy_bal), Err(expected));
+    }
+
+    #[test]
+    fn try_from_alloy_rejects_duplicate_accounts() {
+        let address = Address::with_last_byte(1);
+        let alloy_bal = vec![
+            AlloyAccountChanges { address, ..Default::default() },
+            AlloyAccountChanges { address, ..Default::default() },
+        ];
+
+        assert_owned_and_borrowed_error(alloy_bal, BalDecodeError::DuplicateAccount { address });
+    }
+
+    #[test]
+    fn try_from_alloy_rejects_out_of_order_accounts() {
+        let low = Address::with_last_byte(1);
+        let high = Address::with_last_byte(2);
+        let alloy_bal = vec![
+            AlloyAccountChanges { address: high, ..Default::default() },
+            AlloyAccountChanges { address: low, ..Default::default() },
+        ];
+
+        assert_owned_and_borrowed_error(
+            alloy_bal,
+            BalDecodeError::AccountsOutOfOrder { previous: high, address: low },
+        );
+    }
+
+    #[test]
+    fn try_from_alloy_rejects_storage_read_write_overlap() {
+        let address = Address::with_last_byte(1);
+        let slot = U256::from(2);
+        let alloy_bal = vec![AlloyAccountChanges {
+            address,
+            storage_changes: vec![AlloySlotChanges::new(
+                slot,
+                vec![AlloyStorageChange::new(idx(1), U256::from(10))],
+            )],
+            storage_reads: vec![slot],
+            ..Default::default()
+        }];
+
+        assert_owned_and_borrowed_error(
+            alloy_bal,
+            BalDecodeError::DuplicateStorageKey { address, slot },
+        );
+    }
+
+    #[test]
+    fn try_from_alloy_rejects_empty_storage_changes() {
+        let address = Address::with_last_byte(1);
+        let slot = U256::from(2);
+        let alloy_bal = vec![AlloyAccountChanges {
+            address,
+            storage_changes: vec![AlloySlotChanges::new(slot, vec![])],
+            ..Default::default()
+        }];
+
+        assert_owned_and_borrowed_error(
+            alloy_bal,
+            BalDecodeError::EmptyStorageChanges { address, slot },
+        );
+    }
+
+    #[test]
+    fn try_from_alloy_rejects_out_of_order_change_indices() {
+        let address = Address::with_last_byte(1);
+        let alloy_bal = vec![AlloyAccountChanges {
+            address,
+            balance_changes: vec![
+                AlloyBalanceChange::new(idx(4), U256::from(40)),
+                AlloyBalanceChange::new(idx(1), U256::from(10)),
+                AlloyBalanceChange::new(idx(2), U256::from(20)),
+                AlloyBalanceChange::new(idx(3), U256::from(30)),
+                AlloyBalanceChange::new(idx(5), U256::from(50)),
+            ],
+            ..Default::default()
+        }];
+
+        assert_owned_and_borrowed_error(
+            alloy_bal,
+            BalDecodeError::ChangeIndicesOutOfOrder {
+                address,
+                kind: BalChangeKind::Balance,
+                previous: idx(4),
+                index: idx(1),
+            },
+        );
+    }
+
+    #[test]
+    fn try_from_alloy_rejects_duplicate_change_indices() {
+        let address = Address::with_last_byte(1);
+        let alloy_bal = vec![AlloyAccountChanges {
+            address,
+            nonce_changes: vec![AlloyNonceChange::new(idx(2), 1), AlloyNonceChange::new(idx(2), 2)],
+            ..Default::default()
+        }];
+
+        assert_owned_and_borrowed_error(
+            alloy_bal,
+            BalDecodeError::DuplicateBlockAccessIndex {
+                address,
+                kind: BalChangeKind::Nonce,
+                index: idx(2),
+            },
+        );
+    }
+
+    #[test]
+    fn try_from_alloy_rejects_non_uint32_change_index() {
+        let address = Address::with_last_byte(1);
+        let index = idx(u32::MAX as u64 + 1);
+        let alloy_bal = vec![AlloyAccountChanges {
+            address,
+            code_changes: vec![AlloyCodeChange::new(index, Bytes::new())],
+            ..Default::default()
+        }];
+
+        assert_owned_and_borrowed_error(
+            alloy_bal,
+            BalDecodeError::BlockAccessIndexOutOfRange {
+                address,
+                kind: BalChangeKind::Code,
+                index,
+            },
+        );
+    }
+
+    #[test]
+    fn try_from_alloy_with_transaction_count_rejects_index_after_post_execution() {
+        let address = Address::with_last_byte(1);
+        let index = idx(4);
+        let max = idx(3);
+        let alloy_bal = vec![AlloyAccountChanges {
+            address,
+            balance_changes: vec![AlloyBalanceChange::new(index, U256::from(10))],
+            ..Default::default()
+        }];
+        let expected = BalDecodeError::BlockAccessIndexExceedsBlock {
+            address,
+            kind: BalChangeKind::Balance,
+            index,
+            max,
+        };
+
+        assert_eq!(
+            Bal::try_from_alloy_ref_with_transaction_count(alloy_bal.as_slice(), 2),
+            Err(expected)
+        );
+        assert_eq!(Bal::try_from_alloy_with_transaction_count(alloy_bal, 2), Err(expected));
     }
 }

--- a/crates/evm2/src/evm/bal/mod.rs
+++ b/crates/evm2/src/evm/bal/mod.rs
@@ -18,6 +18,7 @@
 mod account;
 mod bal_context;
 mod changes;
+mod decode_error;
 mod error;
 mod list;
 
@@ -25,5 +26,6 @@ pub use account::{AccountBal, AccountInfoBal, StorageBal};
 pub use alloy_eip7928::BlockAccessIndex;
 pub use bal_context::BalContext;
 pub use changes::{BalChange, BalChanges, BalCodeChange};
+pub use decode_error::{BalChangeKind, BalDecodeError};
 pub use error::BalError;
 pub use list::Bal;

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -158,8 +158,8 @@ pub use any::NonStaticAny;
 
 pub mod bal;
 pub use bal::{
-    AccountBal, AccountInfoBal, Bal, BalChange, BalChanges, BalCodeChange, BalContext, BalError,
-    BlockAccessIndex, StorageBal,
+    AccountBal, AccountInfoBal, Bal, BalChange, BalChangeKind, BalChanges, BalCodeChange,
+    BalContext, BalDecodeError, BalError, BlockAccessIndex, StorageBal,
 };
 
 mod db;


### PR DESCRIPTION
## Summary

- validate EIP-7928 ordering and uniqueness while converting Alloy BAL types
- reject duplicate accounts, storage overlap, empty slot changes, and invalid change indices
- consume owned code changes without cloning bytecode

## Testing

- `cargo test -p evm2 --lib evm::bal --no-default-features --features std,map-foldhash,sha3-keccak`
- `cargo clippy -p evm2 --lib --tests --no-default-features --features std,map-foldhash,sha3-keccak -- -D warnings`

ZELLIC_232