### PR TITLE
feat(cli): pair mainnet replay bench with revm

### DIFF
--- a/crates/cli/benches/evm.rs
+++ b/crates/cli/benches/evm.rs
@@ -1,6 +1,8 @@
 #![allow(missing_docs, unexpected_cfgs, clippy::missing_const_for_fn)]
 
-use criterion::{Criterion, criterion_group, criterion_main};
+use criterion::{
+    BenchmarkGroup, Criterion, criterion_group, criterion_main, measurement::WallTime,
+};
 use evm2_cli::evm_bench::{self, BenchCase, BenchCaseKind, BenchKind};
 use std::{env, time::Duration};
 
@@ -11,16 +13,28 @@ mod fixture;
 mod jit;
 #[path = "evm/mainnet.rs"]
 mod mainnet;
+#[path = "evm/mainnet_revm.rs"]
+mod mainnet_revm;
 #[path = "evm/revm.rs"]
 mod revm;
 #[path = "evm/support.rs"]
 mod support;
 
+const WARM_UP: Duration = Duration::from_secs(1);
+const MEASUREMENT: Duration = Duration::from_secs(2);
+const SAMPLE_SIZE: usize = 10;
+
+/// Blockchain-replay cases run ~110 ms per iteration, so the default budget
+/// collects 10 samples from 20 iterations -- too thin to compare two engines.
+/// Replay cases therefore get their own budget, overridable through
+/// `EVM2_BENCH_REPLAY_MEASUREMENT_SECS` and `EVM2_BENCH_REPLAY_SAMPLES`.
+const REPLAY_WARM_UP: Duration = Duration::from_secs(3);
+const REPLAY_MEASUREMENT_SECS: u64 = 15;
+const REPLAY_SAMPLE_SIZE: usize = 20;
+
 fn evm(c: &mut Criterion) {
     let mut group = c.benchmark_group("evm");
-    group.warm_up_time(Duration::from_secs(1));
-    group.measurement_time(Duration::from_secs(2));
-    group.sample_size(10);
+    apply_default_budget(&mut group);
 
     let benches = evm_bench::BENCHES;
     let suites =
@@ -55,12 +69,44 @@ fn evm(c: &mut Criterion) {
             BenchCaseKind::BlockchainReplay => {
                 let prepared = mainnet::PreparedBench::load(bench);
                 prepared.sanity_check();
+
+                let revm_prepared = bench_revm.then(|| {
+                    let prepared = mainnet_revm::PreparedBench::load(bench);
+                    prepared.sanity_check();
+                    prepared
+                });
+
+                apply_replay_budget(&mut group);
                 prepared.bench(&mut group);
+                if let Some(revm_prepared) = &revm_prepared {
+                    revm_prepared.bench(&mut group);
+                    revm_prepared.bench_setup(&mut group);
+                }
+                apply_default_budget(&mut group);
             }
         }
     }
 
     group.finish();
+}
+
+fn apply_default_budget(group: &mut BenchmarkGroup<'_, WallTime>) {
+    group.warm_up_time(WARM_UP);
+    group.measurement_time(MEASUREMENT);
+    group.sample_size(SAMPLE_SIZE);
+}
+
+fn apply_replay_budget(group: &mut BenchmarkGroup<'_, WallTime>) {
+    group.warm_up_time(REPLAY_WARM_UP);
+    group.measurement_time(Duration::from_secs(env_or(
+        "EVM2_BENCH_REPLAY_MEASUREMENT_SECS",
+        REPLAY_MEASUREMENT_SECS,
+    )));
+    group.sample_size(env_or("EVM2_BENCH_REPLAY_SAMPLES", REPLAY_SAMPLE_SIZE));
+}
+
+fn env_or<T: std::str::FromStr>(name: &str, fallback: T) -> T {
+    env::var(name).ok().and_then(|value| value.parse().ok()).unwrap_or(fallback)
 }
 
 fn expand_cases(benches: &[evm_bench::Bench], suites: &fixture::Suites) -> Vec<BenchCase> {

--- a/crates/cli/benches/evm.rs
+++ b/crates/cli/benches/evm.rs
@@ -80,7 +80,6 @@ fn evm(c: &mut Criterion) {
                 prepared.bench(&mut group);
                 if let Some(revm_prepared) = &revm_prepared {
                     revm_prepared.bench(&mut group);
-                    revm_prepared.bench_setup(&mut group);
                 }
                 apply_default_budget(&mut group);
             }

--- a/crates/cli/benches/evm/mainnet_revm.rs
+++ b/crates/cli/benches/evm/mainnet_revm.rs
@@ -1,0 +1,69 @@
+use criterion::{BenchmarkGroup, black_box, measurement::WallTime};
+use evm2_cli::{
+    evm_bench::BenchCase,
+    replay_bench::{ReplayFixture, diff},
+};
+use std::{
+    borrow::Cow,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+
+/// revm counterpart of `mainnet::PreparedBench`, plus the harness-only setup
+/// benchmarks that price the work both replay paths repeat every iteration.
+#[derive(Clone)]
+pub(crate) struct PreparedBench {
+    name: Cow<'static, str>,
+    fixture: Arc<ReplayFixture>,
+}
+
+impl PreparedBench {
+    pub(crate) fn load(bench: &BenchCase) -> Self {
+        let path = workspace_path(bench.fixture_path);
+        Self { name: bench.name.clone(), fixture: Arc::new(ReplayFixture::load(&path)) }
+    }
+
+    /// Replays the corpus through both engines once and refuses to benchmark
+    /// unless every transaction agrees on gas used, success and log count.
+    pub(crate) fn sanity_check(&self) {
+        let evm2 = self.fixture.replay_evm2();
+        let revm = self.fixture.replay_revm();
+        for (engine, outcome) in [("evm2", &evm2), ("revm", &revm)] {
+            let mismatches = outcome.header_gas_mismatches();
+            assert!(
+                mismatches.is_empty(),
+                "{} {engine} replay disagrees with the fixture header gas: {mismatches:#?}",
+                self.name
+            );
+        }
+        let mismatches = diff(&evm2, &revm);
+        assert!(
+            mismatches.is_empty(),
+            "{} evm2/revm replay differ on {} entries: {mismatches:#?}",
+            self.name,
+            mismatches.len()
+        );
+    }
+
+    pub(crate) fn bench(&self, group: &mut BenchmarkGroup<'_, WallTime>) {
+        group.bench_function(format!("{}/replay/revm", self.name), |b| {
+            b.iter(|| black_box(self.fixture.replay_revm()));
+        });
+    }
+
+    /// Benchmarks the per-iteration harness work only: decoding the fixture's
+    /// pre-state into an in-memory database and building every block's
+    /// transaction environments, with no EVM execution.
+    pub(crate) fn bench_setup(&self, group: &mut BenchmarkGroup<'_, WallTime>) {
+        group.bench_function(format!("{}/replay/setup", self.name), |b| {
+            b.iter(|| black_box(self.fixture.setup_evm2()));
+        });
+        group.bench_function(format!("{}/replay/revm/setup", self.name), |b| {
+            b.iter(|| black_box(self.fixture.setup_revm()));
+        });
+    }
+}
+
+fn workspace_path(path: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../..").join(path)
+}

--- a/crates/cli/benches/evm/mainnet_revm.rs
+++ b/crates/cli/benches/evm/mainnet_revm.rs
@@ -1,16 +1,16 @@
-use criterion::{BenchmarkGroup, black_box, measurement::WallTime};
+use criterion::{BenchmarkGroup, measurement::WallTime};
 use evm2_cli::{
     evm_bench::BenchCase,
     replay_bench::{ReplayFixture, diff},
 };
+use evm2_eest::BlockchainTestNoopHook;
 use std::{
     borrow::Cow,
     path::{Path, PathBuf},
     sync::Arc,
 };
 
-/// revm counterpart of `mainnet::PreparedBench`, plus the harness-only setup
-/// benchmarks that price the work both replay paths repeat every iteration.
+/// revm counterpart of `mainnet::PreparedBench`.
 #[derive(Clone)]
 pub(crate) struct PreparedBench {
     name: Cow<'static, str>,
@@ -30,6 +30,8 @@ impl PreparedBench {
         let evm2 = self.fixture.replay_evm2();
         let revm = self.fixture.replay_revm();
         for (engine, outcome) in [("evm2", &evm2), ("revm", &revm)] {
+            assert_eq!(outcome.blocks.len(), self.fixture.blocks());
+            assert_eq!(outcome.transactions(), self.fixture.transactions());
             let mismatches = outcome.header_gas_mismatches();
             assert!(
                 mismatches.is_empty(),
@@ -48,19 +50,7 @@ impl PreparedBench {
 
     pub(crate) fn bench(&self, group: &mut BenchmarkGroup<'_, WallTime>) {
         group.bench_function(format!("{}/replay/revm", self.name), |b| {
-            b.iter(|| black_box(self.fixture.replay_revm()));
-        });
-    }
-
-    /// Benchmarks the per-iteration harness work only: decoding the fixture's
-    /// pre-state into an in-memory database and building every block's
-    /// transaction environments, with no EVM execution.
-    pub(crate) fn bench_setup(&self, group: &mut BenchmarkGroup<'_, WallTime>) {
-        group.bench_function(format!("{}/replay/setup", self.name), |b| {
-            b.iter(|| black_box(self.fixture.setup_evm2()));
-        });
-        group.bench_function(format!("{}/replay/revm/setup", self.name), |b| {
-            b.iter(|| black_box(self.fixture.setup_revm()));
+            b.iter(|| self.fixture.execute_revm(&mut BlockchainTestNoopHook));
         });
     }
 }

--- a/crates/cli/benches/evm/mainnet_revm.rs
+++ b/crates/cli/benches/evm/mainnet_revm.rs
@@ -24,7 +24,8 @@ impl PreparedBench {
     }
 
     /// Replays the corpus through both engines once and refuses to benchmark
-    /// unless every transaction agrees on gas used, success and log count.
+    /// unless every transaction agrees on gas used, success and logs, every
+    /// block agrees on its EIP-8037 gas split, and both reproduce the header gas.
     pub(crate) fn sanity_check(&self) {
         let evm2 = self.fixture.replay_evm2();
         let revm = self.fixture.replay_revm();

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -2,3 +2,4 @@
 
 #[allow(missing_docs)]
 pub mod evm_bench;
+pub mod replay_bench;

--- a/crates/cli/src/replay/mod.rs
+++ b/crates/cli/src/replay/mod.rs
@@ -356,7 +356,7 @@ impl BlockchainTestHook for ReplayProgressHook {
 
     fn transaction_started(&mut self, _event: BlockchainTestTransactionStarted) {}
 
-    fn transaction_finished(&mut self, event: BlockchainTestTransactionFinished) {
+    fn transaction_finished(&mut self, event: BlockchainTestTransactionFinished<'_>) {
         if event.total_transactions >= 1_000
             && ((event.transaction_index + 1).is_multiple_of(500)
                 || event.transaction_index + 1 == event.total_transactions)

--- a/crates/cli/src/replay_bench.rs
+++ b/crates/cli/src/replay_bench.rs
@@ -1,0 +1,939 @@
+//! Paired evm2/revm drivers for the mainnet block-replay benchmark.
+//!
+//! The benchmark's evm2 timing path stays on `evm2_eest`'s blockchain-test
+//! executor (`crates/cli/benches/evm/mainnet.rs`). This module adds the missing
+//! revm counterpart plus an evm2 mirror of the same block loop, so that the two
+//! engines can be diffed transaction by transaction and the harness-side setup
+//! cost can be measured on either side with the same code shape.
+//!
+//! The evm2 mirror follows `crates/eest/src/blockchaintest/execute.rs`
+//! (`execute_case`/`execute_block`) step for step; the revm driver follows
+//! `bins/revme/src/cmd/blockchaintest.rs` of the pinned revm 42 checkout, with
+//! the block/commit cadence bent to match the evm2 side rather than revme's.
+
+use alloy_consensus::{TypedTransaction, transaction::Recovered};
+use alloy_eips::{eip7702::SignedAuthorization, eip7840::BlobParams};
+use alloy_primitives::{Address, B256, Bytes, KECCAK256_EMPTY, TxKind, U256};
+use alloy_rpc_types_eth::{
+    AccessList as RpcAccessList, AccessListItem as RpcAccessListItem, TransactionInput,
+    TransactionRequest,
+};
+use evm2::{
+    BaseEvmTypes, Evm, Precompiles, SpecId,
+    bytecode::Bytecode,
+    env::{BlockEnv, BlockEnvExt},
+    ethereum::{RecoveredTxEnvelope, TxEnvelope, ethereum_tx_registry},
+    evm::{
+        AccountChangeRef, AccountInfo, BEACON_ROOTS_ADDRESS, BlockStateAccumulator,
+        CONSOLIDATION_REQUEST_ADDRESS, HISTORY_STORAGE_ADDRESS, InMemoryDB, StateChangeSink,
+        StateChangeSource, SystemTx, Tee, WITHDRAWAL_REQUEST_ADDRESS,
+    },
+};
+use evm2_eest::blockchaintest::{
+    Block, BlockHeader, BlockchainTest, BlockchainTestCase, ForkSpec, Transaction, Withdrawal,
+};
+use revm::{
+    Context, DatabaseCommit, ExecuteEvm, MainBuilder, MainContext, SystemCallEvm,
+    context::{BlockEnv as RevmBlockEnv, CfgEnv, ContextTr, JournalTr, TxEnv},
+    context_interface::{block::BlobExcessGasAndPrice, either::Either},
+    database::{CacheDB, EmptyDB, InMemoryDB as RevmInMemoryDB},
+    handler::EvmTr,
+    primitives::hardfork::SpecId as RevmSpecId,
+    state::{AccountInfo as RevmAccountInfo, Bytecode as RevmBytecode},
+};
+use std::{mem, path::Path};
+
+const ONE_GWEI: u64 = 1_000_000_000;
+
+/// Per-transaction outcome recorded identically by both engines.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct TxOutcome {
+    /// Gas charged to the transaction (refunds applied).
+    pub gas_used: u64,
+    /// Whether execution finished successfully.
+    pub success: bool,
+    /// Number of logs emitted by the transaction.
+    pub logs: usize,
+}
+
+/// Per-block outcome recorded identically by both engines.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BlockOutcome {
+    /// Block number taken from the fixture header.
+    pub number: u64,
+    /// `gasUsed` declared by the fixture header.
+    pub header_gas_used: u64,
+    /// Cumulative transaction gas used, as observed during execution.
+    pub gas_used: u64,
+    /// Per-transaction outcomes, in block order.
+    pub txs: Vec<TxOutcome>,
+}
+
+/// Outcome of replaying every block of a fixture case.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct ReplayOutcome {
+    /// Per-block outcomes, in fixture order.
+    pub blocks: Vec<BlockOutcome>,
+}
+
+impl ReplayOutcome {
+    /// Returns the total number of executed transactions.
+    pub fn transactions(&self) -> usize {
+        self.blocks.iter().map(|block| block.txs.len()).sum()
+    }
+
+    /// Returns the total transaction gas used across every block.
+    pub fn gas_used(&self) -> u128 {
+        self.blocks.iter().map(|block| u128::from(block.gas_used)).sum()
+    }
+
+    /// Returns the blocks whose observed gas used disagrees with the fixture header.
+    pub fn header_gas_mismatches(&self) -> Vec<&BlockOutcome> {
+        self.blocks.iter().filter(|block| block.gas_used != block.header_gas_used).collect()
+    }
+}
+
+/// One disagreement between the two engines.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Mismatch {
+    /// Block number the disagreement was found in.
+    pub block: u64,
+    /// Transaction index inside the block, or `None` for block-level fields.
+    pub transaction: Option<usize>,
+    /// Name of the compared field.
+    pub field: &'static str,
+    /// Value observed on the evm2 side.
+    pub evm2: String,
+    /// Value observed on the revm side.
+    pub revm: String,
+}
+
+/// Compares two replay outcomes transaction by transaction.
+pub fn diff(evm2: &ReplayOutcome, revm: &ReplayOutcome) -> Vec<Mismatch> {
+    let mut mismatches = Vec::new();
+    if evm2.blocks.len() != revm.blocks.len() {
+        mismatches.push(Mismatch {
+            block: 0,
+            transaction: None,
+            field: "block_count",
+            evm2: evm2.blocks.len().to_string(),
+            revm: revm.blocks.len().to_string(),
+        });
+        return mismatches;
+    }
+    for (left, right) in evm2.blocks.iter().zip(&revm.blocks) {
+        let block = left.number;
+        if left.number != right.number {
+            mismatches.push(Mismatch {
+                block,
+                transaction: None,
+                field: "block_number",
+                evm2: left.number.to_string(),
+                revm: right.number.to_string(),
+            });
+        }
+        if left.txs.len() != right.txs.len() {
+            mismatches.push(Mismatch {
+                block,
+                transaction: None,
+                field: "transaction_count",
+                evm2: left.txs.len().to_string(),
+                revm: right.txs.len().to_string(),
+            });
+            continue;
+        }
+        if left.gas_used != right.gas_used {
+            mismatches.push(Mismatch {
+                block,
+                transaction: None,
+                field: "block_gas_used",
+                evm2: left.gas_used.to_string(),
+                revm: right.gas_used.to_string(),
+            });
+        }
+        for (index, (left, right)) in left.txs.iter().zip(&right.txs).enumerate() {
+            if left.gas_used != right.gas_used {
+                mismatches.push(Mismatch {
+                    block,
+                    transaction: Some(index),
+                    field: "gas_used",
+                    evm2: left.gas_used.to_string(),
+                    revm: right.gas_used.to_string(),
+                });
+            }
+            if left.success != right.success {
+                mismatches.push(Mismatch {
+                    block,
+                    transaction: Some(index),
+                    field: "success",
+                    evm2: left.success.to_string(),
+                    revm: right.success.to_string(),
+                });
+            }
+            if left.logs != right.logs {
+                mismatches.push(Mismatch {
+                    block,
+                    transaction: Some(index),
+                    field: "logs",
+                    evm2: left.logs.to_string(),
+                    revm: right.logs.to_string(),
+                });
+            }
+        }
+    }
+    mismatches
+}
+
+/// A decoded blockchain-replay fixture holding exactly one test case.
+#[derive(Debug)]
+pub struct ReplayFixture {
+    name: String,
+    spec: SpecId,
+    case: BlockchainTestCase,
+}
+
+impl ReplayFixture {
+    /// Decodes the fixture at `path` and selects its single test case.
+    ///
+    /// # Panics
+    ///
+    /// Panics when the fixture cannot be read or does not contain exactly one case.
+    pub fn load(path: &Path) -> Self {
+        let suite: BlockchainTest = evm2_eest::read_blockchain_fixture(path)
+            .unwrap_or_else(|err| panic!("failed to read fixture {}: {err}", path.display()));
+        assert_eq!(
+            suite.0.len(),
+            1,
+            "replay fixture {} must contain exactly one case",
+            path.display()
+        );
+        let (name, case) = suite.0.into_iter().next().expect("fixture must contain a case");
+        let spec = fork_to_spec_id(case.network);
+        Self { name, spec, case }
+    }
+
+    /// Returns the case name.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Returns the fork the case runs under.
+    pub const fn spec(&self) -> SpecId {
+        self.spec
+    }
+
+    /// Returns the number of blocks in the case.
+    pub const fn blocks(&self) -> usize {
+        self.case.blocks.len()
+    }
+
+    /// Returns the total number of transactions across every block.
+    pub fn transactions(&self) -> usize {
+        self.case.blocks.iter().map(|block| block_transactions(block).len()).sum()
+    }
+
+    /// Builds the evm2 pre-state database and every block's transaction list.
+    ///
+    /// This is the harness-side work the timed replay repeats on each iteration;
+    /// it is exposed so the benchmark can price it separately.
+    pub fn setup_evm2(&self) -> (InMemoryDB, Vec<Vec<RecoveredTxEnvelope>>) {
+        let mut database = evm2_pre_state(&self.case);
+        evm2_seed_block_hashes(&mut database, &self.case);
+        let txs = self
+            .case
+            .blocks
+            .iter()
+            .map(|block| block_transactions(block).iter().map(evm2_tx).collect())
+            .collect();
+        (database, txs)
+    }
+
+    /// Builds the revm pre-state database and every block's transaction list.
+    pub fn setup_revm(&self) -> (RevmInMemoryDB, Vec<Vec<TxEnv>>) {
+        let mut database = revm_pre_state(&self.case);
+        revm_seed_block_hashes(&mut database, &self.case);
+        let txs = self
+            .case
+            .blocks
+            .iter()
+            .map(|block| block_transactions(block).iter().map(revm_tx).collect())
+            .collect();
+        (database, txs)
+    }
+
+    /// Replays every block through evm2, mirroring the EEST blockchain executor.
+    pub fn replay_evm2(&self) -> ReplayOutcome {
+        let case = &self.case;
+        let spec = self.spec;
+        let mut database = evm2_pre_state(case);
+        evm2_seed_block_hashes(&mut database, case);
+
+        let mut parent_block_hash = Some(case.genesis_block_header.hash);
+        let mut parent_excess_blob_gas =
+            case.genesis_block_header.excess_blob_gas.unwrap_or_default().saturating_to::<u64>();
+        let mut outcome = ReplayOutcome::default();
+
+        for block in &case.blocks {
+            let header = block_header(block).expect("replay fixture block must carry a header");
+            let block_env = evm2_block_env(header, parent_excess_blob_gas, spec);
+
+            let mut evm = Evm::<BaseEvmTypes>::new(
+                spec,
+                block_env,
+                ethereum_tx_registry(spec),
+                mem::take(&mut database),
+                Precompiles::base(spec),
+            );
+            let mut block_state = BlockStateAccumulator::new();
+
+            evm2_pre_block(&mut evm, &mut block_state, spec, block_env, parent_block_hash, header);
+
+            let mut txs = Vec::with_capacity(block_transactions(block).len());
+            let mut gas_used = 0u64;
+            for raw in block_transactions(block) {
+                let tx = evm2_tx(raw);
+                let result = evm
+                    .transact(&tx)
+                    .unwrap_or_else(|err| panic!("evm2 replay transaction must execute: {err:?}"))
+                    .commit_to(&mut block_state);
+                gas_used = gas_used.saturating_add(result.tx_gas_used());
+                txs.push(TxOutcome {
+                    gas_used: result.tx_gas_used(),
+                    success: result.status,
+                    logs: result.logs.len(),
+                });
+            }
+
+            evm2_post_block(&mut evm, &mut block_state, spec, block_withdrawals(block));
+
+            let mut restored = mem::take(
+                evm.database_as_mut::<InMemoryDB>().expect("block EVM database must be InMemoryDB"),
+            );
+            drop(evm);
+            restored.commit_source(&block_state);
+            restored.insert_block_hash(&header.number, &header.hash);
+            database = restored;
+
+            parent_block_hash = Some(header.hash);
+            if let Some(excess) = header.excess_blob_gas {
+                parent_excess_blob_gas = excess.saturating_to::<u64>();
+            }
+
+            outcome.blocks.push(BlockOutcome {
+                number: header.number.saturating_to::<u64>(),
+                header_gas_used: header.gas_used.saturating_to::<u64>(),
+                gas_used,
+                txs,
+            });
+        }
+
+        outcome
+    }
+
+    /// Replays every block through revm using the same block sequence and cadence.
+    pub fn replay_revm(&self) -> ReplayOutcome {
+        let case = &self.case;
+        let spec = self.spec;
+        let revm_spec = revm_spec_id(spec);
+        let mut database = revm_pre_state(case);
+        revm_seed_block_hashes(&mut database, case);
+
+        let mut cfg = CfgEnv::new();
+        cfg.set_spec_and_mainnet_gas_params(revm_spec);
+
+        let mut parent_block_hash = Some(case.genesis_block_header.hash);
+        let mut parent_excess_blob_gas =
+            case.genesis_block_header.excess_blob_gas.unwrap_or_default().saturating_to::<u64>();
+        let mut outcome = ReplayOutcome::default();
+
+        for block in &case.blocks {
+            let header = block_header(block).expect("replay fixture block must carry a header");
+            let block_env = revm_block_env(header, parent_excess_blob_gas, spec);
+            let block_number = header.number.saturating_to::<u64>();
+
+            let mut txs = Vec::with_capacity(block_transactions(block).len());
+            let mut gas_used = 0u64;
+            {
+                let mut evm = Context::mainnet()
+                    .with_cfg(cfg.clone())
+                    .with_block(block_env)
+                    .with_db(&mut database)
+                    .build_mainnet();
+
+                revm_pre_block(&mut evm, spec, block_number, parent_block_hash, header);
+
+                for raw in block_transactions(block) {
+                    let result = evm.transact_one(revm_tx(raw)).unwrap_or_else(|err| {
+                        panic!("revm replay transaction must execute: {err:?}")
+                    });
+                    gas_used = gas_used.saturating_add(result.tx_gas_used());
+                    txs.push(TxOutcome {
+                        gas_used: result.tx_gas_used(),
+                        success: result.is_success(),
+                        logs: result.logs().len(),
+                    });
+                }
+
+                revm_post_block(&mut evm, spec, block_withdrawals(block));
+
+                let state = evm.finalize();
+                evm.ctx_mut().db_mut().commit(state);
+            }
+            database.cache.block_hashes.insert(header.number, header.hash);
+
+            parent_block_hash = Some(header.hash);
+            if let Some(excess) = header.excess_blob_gas {
+                parent_excess_blob_gas = excess.saturating_to::<u64>();
+            }
+
+            outcome.blocks.push(BlockOutcome {
+                number: block_number,
+                header_gas_used: header.gas_used.saturating_to::<u64>(),
+                gas_used,
+                txs,
+            });
+        }
+
+        outcome
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Fixture accessors, mirroring `crates/eest/src/blockchaintest/execute.rs`.
+// ---------------------------------------------------------------------------
+
+fn block_header(block: &Block) -> Option<&BlockHeader> {
+    block
+        .block_header
+        .as_ref()
+        .or_else(|| block.rlp_decoded.as_ref().and_then(|decoded| decoded.block_header.as_ref()))
+}
+
+fn block_transactions(block: &Block) -> &[Transaction] {
+    if let Some(transactions) = &block.transactions
+        && !transactions.is_empty()
+    {
+        return transactions;
+    }
+    block.rlp_decoded.as_ref().map(|decoded| decoded.transactions.as_slice()).unwrap_or_default()
+}
+
+fn block_withdrawals(block: &Block) -> &[Withdrawal] {
+    if let Some(withdrawals) = &block.withdrawals
+        && !withdrawals.is_empty()
+    {
+        return withdrawals;
+    }
+    block.rlp_decoded.as_ref().map(|decoded| decoded.withdrawals.as_slice()).unwrap_or_default()
+}
+
+fn blob_params_for_timestamp(timestamp: U256, spec: SpecId) -> BlobParams {
+    const MAINNET_BPO1_TIMESTAMP: u64 = 1_765_290_071;
+    const MAINNET_BPO2_TIMESTAMP: u64 = 1_767_747_671;
+
+    if spec.enables(SpecId::AMSTERDAM) || timestamp.saturating_to::<u64>() >= MAINNET_BPO2_TIMESTAMP
+    {
+        BlobParams::bpo2()
+    } else if timestamp.saturating_to::<u64>() >= MAINNET_BPO1_TIMESTAMP {
+        BlobParams::bpo1()
+    } else if spec.enables(SpecId::OSAKA) {
+        BlobParams::osaka()
+    } else if spec.enables(SpecId::PRAGUE) {
+        BlobParams::prague()
+    } else {
+        BlobParams::cancun()
+    }
+}
+
+fn fork_to_spec_id(fork: ForkSpec) -> SpecId {
+    match fork {
+        ForkSpec::Frontier => SpecId::FRONTIER,
+        ForkSpec::Homestead => SpecId::HOMESTEAD,
+        ForkSpec::EIP150 => SpecId::TANGERINE,
+        ForkSpec::EIP158 => SpecId::SPURIOUS_DRAGON,
+        ForkSpec::Byzantium => SpecId::BYZANTIUM,
+        ForkSpec::Constantinople | ForkSpec::ConstantinopleFix => SpecId::PETERSBURG,
+        ForkSpec::Istanbul => SpecId::ISTANBUL,
+        ForkSpec::Berlin => SpecId::BERLIN,
+        ForkSpec::London => SpecId::LONDON,
+        ForkSpec::Paris
+        | ForkSpec::MergeEOF
+        | ForkSpec::MergeMeterInitCode
+        | ForkSpec::MergePush0 => SpecId::MERGE,
+        ForkSpec::Shanghai => SpecId::SHANGHAI,
+        ForkSpec::Cancun => SpecId::CANCUN,
+        ForkSpec::Prague => SpecId::PRAGUE,
+        ForkSpec::Osaka => SpecId::OSAKA,
+        ForkSpec::Amsterdam => SpecId::AMSTERDAM,
+        other => panic!("replay fixture fork {other:?} is not supported"),
+    }
+}
+
+fn revm_spec_id(spec: SpecId) -> RevmSpecId {
+    match spec {
+        SpecId::FRONTIER => RevmSpecId::FRONTIER,
+        SpecId::HOMESTEAD => RevmSpecId::HOMESTEAD,
+        SpecId::TANGERINE => RevmSpecId::TANGERINE,
+        SpecId::SPURIOUS_DRAGON => RevmSpecId::SPURIOUS_DRAGON,
+        SpecId::BYZANTIUM => RevmSpecId::BYZANTIUM,
+        SpecId::PETERSBURG => RevmSpecId::PETERSBURG,
+        SpecId::ISTANBUL => RevmSpecId::ISTANBUL,
+        SpecId::BERLIN => RevmSpecId::BERLIN,
+        SpecId::LONDON => RevmSpecId::LONDON,
+        SpecId::MERGE => RevmSpecId::MERGE,
+        SpecId::SHANGHAI => RevmSpecId::SHANGHAI,
+        SpecId::CANCUN => RevmSpecId::CANCUN,
+        SpecId::PRAGUE => RevmSpecId::PRAGUE,
+        SpecId::OSAKA => RevmSpecId::OSAKA,
+        SpecId::AMSTERDAM => RevmSpecId::AMSTERDAM,
+        other => panic!("unsupported replay spec: {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// evm2 side.
+// ---------------------------------------------------------------------------
+
+fn evm2_pre_state(case: &BlockchainTestCase) -> InMemoryDB {
+    let mut database = InMemoryDB::default();
+    for (address, account) in &case.pre.0 {
+        let info = AccountInfo::default()
+            .with_balance(account.balance)
+            .with_nonce(account.nonce.saturating_to::<u64>())
+            .with_code(
+                Bytecode::new_raw_checked(account.code.clone())
+                    .unwrap_or_else(|_| Bytecode::new_legacy(account.code.clone())),
+            );
+        database.insert_account_info(address, info);
+        for (key, value) in &account.storage {
+            database.insert_account_storage(address, key, value);
+        }
+    }
+    database
+}
+
+fn evm2_seed_block_hashes(database: &mut InMemoryDB, case: &BlockchainTestCase) {
+    for block_hash in &case.block_hashes {
+        database.insert_block_hash(&block_hash.number, &block_hash.hash);
+    }
+    database.insert_block_hash(&case.genesis_block_header.number, &case.genesis_block_header.hash);
+}
+
+fn evm2_block_env(header: &BlockHeader, parent_excess_blob_gas: u64, spec: SpecId) -> BlockEnv {
+    let excess_blob_gas = header
+        .excess_blob_gas
+        .map(|gas| gas.saturating_to::<u64>())
+        .unwrap_or(parent_excess_blob_gas);
+    BlockEnvExt {
+        number: header.number,
+        beneficiary: header.coinbase,
+        timestamp: header.timestamp,
+        gas_limit: header.gas_limit,
+        basefee: header.base_fee_per_gas.unwrap_or_default(),
+        difficulty: header.difficulty,
+        prevrandao: if header.difficulty.is_zero() {
+            U256::from_be_slice(header.mix_hash.as_slice())
+        } else {
+            U256::ZERO
+        },
+        blob_basefee: U256::from(
+            blob_params_for_timestamp(header.timestamp, spec).calc_blob_fee(excess_blob_gas),
+        ),
+        slot_num: header.slot_number.unwrap_or_default(),
+        ext: (),
+        _non_exhaustive: (),
+    }
+}
+
+fn evm2_pre_block(
+    evm: &mut Evm<'_, BaseEvmTypes>,
+    block_state: &mut BlockStateAccumulator,
+    spec: SpecId,
+    block: BlockEnv,
+    parent_block_hash: Option<B256>,
+    header: &BlockHeader,
+) {
+    if block.number.is_zero() {
+        return;
+    }
+    if spec.enables(SpecId::PRAGUE)
+        && let Some(hash) = parent_block_hash
+    {
+        evm2_system_call(
+            evm,
+            block_state,
+            HISTORY_STORAGE_ADDRESS,
+            Bytes::copy_from_slice(hash.as_slice()),
+            "eip2935",
+        );
+    }
+    if spec.enables(SpecId::CANCUN)
+        && let Some(root) = header.parent_beacon_block_root
+    {
+        evm2_system_call(
+            evm,
+            block_state,
+            BEACON_ROOTS_ADDRESS,
+            Bytes::copy_from_slice(root.as_slice()),
+            "eip4788",
+        );
+    }
+}
+
+/// Mirrors `post_block_transition`, minus the pre-merge block and ommer rewards:
+/// the replay corpus is post-merge, so `block_reward` is always zero.
+fn evm2_post_block(
+    evm: &mut Evm<'_, BaseEvmTypes>,
+    block_state: &mut BlockStateAccumulator,
+    spec: SpecId,
+    withdrawals: &[Withdrawal],
+) {
+    assert!(spec.enables(SpecId::MERGE), "replay corpus must be post-merge");
+
+    if spec.enables(SpecId::SHANGHAI) {
+        for withdrawal in withdrawals {
+            evm2_increment_balance(
+                evm,
+                block_state,
+                withdrawal.address,
+                withdrawal.amount.saturating_mul(U256::from(ONE_GWEI)),
+            );
+        }
+    }
+
+    if spec.enables(SpecId::PRAGUE) {
+        evm2_system_call(evm, block_state, WITHDRAWAL_REQUEST_ADDRESS, Bytes::new(), "eip7002");
+        evm2_system_call(evm, block_state, CONSOLIDATION_REQUEST_ADDRESS, Bytes::new(), "eip7251");
+    }
+
+    if spec.enables(SpecId::AMSTERDAM) {
+        evm2_system_call(
+            evm,
+            block_state,
+            evm2::evm::BUILDER_DEPOSIT_REQUEST_ADDRESS,
+            Bytes::new(),
+            "eip8282_deposit",
+        );
+        evm2_system_call(
+            evm,
+            block_state,
+            evm2::evm::BUILDER_EXIT_REQUEST_ADDRESS,
+            Bytes::new(),
+            "eip8282_exit",
+        );
+    }
+}
+
+fn evm2_system_call(
+    evm: &mut Evm<'_, BaseEvmTypes>,
+    block_state: &mut BlockStateAccumulator,
+    address: Address,
+    data: Bytes,
+    label: &'static str,
+) {
+    let executed = evm
+        .system_call(SystemTx::new(address, data))
+        .unwrap_or_else(|err| panic!("evm2 {label} system call must execute: {err:?}"));
+    assert!(executed.result().status, "evm2 {label} system call must succeed");
+    let _ = executed.commit_to(block_state);
+}
+
+struct AccountStateChange {
+    address: Address,
+    original: Option<AccountInfo>,
+    current: Option<AccountInfo>,
+}
+
+impl StateChangeSource for AccountStateChange {
+    fn visit<S: StateChangeSink>(&self, sink: &mut S) -> Result<(), S::Error> {
+        sink.account(AccountChangeRef {
+            address: self.address,
+            original: self.original.as_ref(),
+            current: self.current.as_ref(),
+            created: false,
+            selfdestructed: false,
+        })
+    }
+}
+
+fn evm2_increment_balance(
+    evm: &mut Evm<'_, BaseEvmTypes>,
+    block_state: &mut BlockStateAccumulator,
+    address: Address,
+    amount: U256,
+) {
+    let original = evm
+        .read_account_info(&address)
+        .unwrap_or_else(|code| panic!("evm2 withdrawal account read must succeed: {code:?}"));
+    let mut current = original.clone().unwrap_or_default();
+    current.balance = current.balance.saturating_add(amount);
+    if current.code_hash.is_zero() {
+        current.code_hash = KECCAK256_EMPTY;
+    }
+    let current = (!current.is_empty()).then_some(current);
+
+    let change = AccountStateChange { address, original, current };
+    let mut sink = Tee::new(evm.overlay_db_mut(), block_state);
+    let Ok(()) = change.visit(&mut sink);
+}
+
+fn evm2_tx(raw: &Transaction) -> RecoveredTxEnvelope {
+    let caller = raw.sender.expect("replay transaction must carry a sender");
+    let tx_type = raw.transaction_type.map(|ty| ty.saturating_to::<u8>()).unwrap_or(0);
+
+    let mut request = TransactionRequest::default()
+        .from(caller)
+        .gas_limit(raw.gas_limit.saturating_to::<u64>())
+        .nonce(raw.nonce.saturating_to::<u64>())
+        .value(raw.value)
+        .input(TransactionInput::from(raw.data.clone()));
+    request.to = Some(raw.to.map_or(TxKind::Create, TxKind::Call));
+    request.transaction_type = Some(tx_type);
+    request.chain_id = raw.chain_id.map(|id| id.saturating_to::<u64>());
+    if !matches!(tx_type, 2..=4) {
+        request.gas_price = raw.gas_price.map(|price| price.saturating_to::<u128>());
+        if request.gas_price.is_none()
+            && (matches!(tx_type, 0 | 1)
+                || (raw.max_fee_per_gas.is_none() && raw.max_priority_fee_per_gas.is_none()))
+        {
+            request.gas_price = Some(0);
+        }
+    }
+    request.max_fee_per_gas = raw.max_fee_per_gas.map(|fee| fee.saturating_to::<u128>());
+    request.max_priority_fee_per_gas =
+        if raw.max_fee_per_gas.is_some() && raw.max_priority_fee_per_gas.is_none() {
+            Some(0)
+        } else {
+            raw.max_priority_fee_per_gas.map(|fee| fee.saturating_to::<u128>())
+        };
+    request.max_fee_per_blob_gas = raw.max_fee_per_blob_gas.map(|fee| fee.saturating_to::<u128>());
+    request.access_list = evm2_access_list(raw, tx_type);
+    request.authorization_list = authorization_list(raw);
+    if raw.max_fee_per_blob_gas.is_some() || tx_type == 3 || !raw.blob_versioned_hashes.is_empty() {
+        request.blob_versioned_hashes = Some(raw.blob_versioned_hashes.clone());
+    }
+
+    let tx = request
+        .build_consensus_tx()
+        .unwrap_or_else(|err| panic!("replay transaction must build: {}", err.error));
+    match tx {
+        TypedTransaction::Legacy(tx) => Recovered::new_unchecked(TxEnvelope::Legacy(tx), caller),
+        TypedTransaction::Eip2930(tx) => Recovered::new_unchecked(TxEnvelope::Eip2930(tx), caller),
+        TypedTransaction::Eip1559(tx) => Recovered::new_unchecked(TxEnvelope::Eip1559(tx), caller),
+        TypedTransaction::Eip4844(tx) => Recovered::new_unchecked(TxEnvelope::Eip4844(tx), caller),
+        TypedTransaction::Eip7702(tx) => Recovered::new_unchecked(tx.into(), caller),
+    }
+}
+
+fn evm2_access_list(raw: &Transaction, tx_type: u8) -> Option<RpcAccessList> {
+    if tx_type == 0 {
+        return None;
+    }
+    let Some(access_list) = &raw.access_list else {
+        return (tx_type == 1).then(RpcAccessList::default);
+    };
+    Some(RpcAccessList(
+        access_list
+            .iter()
+            .map(|item| RpcAccessListItem {
+                address: item.address,
+                storage_keys: item.storage_keys.clone(),
+            })
+            .collect(),
+    ))
+}
+
+fn authorization_list(raw: &Transaction) -> Option<Vec<SignedAuthorization>> {
+    let authorizations = raw.authorization_list.as_deref()?;
+    Some(
+        authorizations
+            .iter()
+            .map(|authorization| {
+                serde_json::from_value(authorization.value.clone())
+                    .expect("replay authorization must decode")
+            })
+            .collect(),
+    )
+}
+
+// ---------------------------------------------------------------------------
+// revm side.
+// ---------------------------------------------------------------------------
+
+type RevmEvm<'a> = revm::MainnetEvm<revm::handler::MainnetContext<&'a mut RevmInMemoryDB>>;
+
+fn revm_pre_state(case: &BlockchainTestCase) -> RevmInMemoryDB {
+    let mut database = CacheDB::new(EmptyDB::new());
+    for (address, account) in &case.pre.0 {
+        let code = RevmBytecode::new_raw_checked(account.code.clone())
+            .unwrap_or_else(|_| RevmBytecode::new_legacy(account.code.clone()));
+        let mut info = RevmAccountInfo {
+            balance: account.balance,
+            nonce: account.nonce.saturating_to::<u64>(),
+            code: Some(code),
+            ..Default::default()
+        };
+        // Mirrors evm2's `CacheDB::insert_account_info`: the bytecode lands in
+        // the shared contract map and the account keeps only its code hash, so
+        // execution has to resolve code through `code_by_hash`.
+        database.insert_contract(&mut info);
+        info.code = None;
+        database.insert_account_info(*address, info);
+        for (key, value) in &account.storage {
+            database
+                .insert_account_storage(*address, *key, *value)
+                .expect("revm replay storage must insert");
+        }
+    }
+    database
+}
+
+fn revm_seed_block_hashes(database: &mut RevmInMemoryDB, case: &BlockchainTestCase) {
+    for block_hash in &case.block_hashes {
+        database.cache.block_hashes.insert(block_hash.number, block_hash.hash);
+    }
+    database
+        .cache
+        .block_hashes
+        .insert(case.genesis_block_header.number, case.genesis_block_header.hash);
+}
+
+fn revm_block_env(header: &BlockHeader, parent_excess_blob_gas: u64, spec: SpecId) -> RevmBlockEnv {
+    let excess_blob_gas = header
+        .excess_blob_gas
+        .map(|gas| gas.saturating_to::<u64>())
+        .unwrap_or(parent_excess_blob_gas);
+    // The blob gas price is computed with the same `BlobParams` selection the
+    // evm2 side uses, so both engines see an identical blob base fee.
+    let blob_gasprice =
+        blob_params_for_timestamp(header.timestamp, spec).calc_blob_fee(excess_blob_gas);
+    RevmBlockEnv {
+        number: header.number,
+        beneficiary: header.coinbase,
+        timestamp: header.timestamp,
+        gas_limit: header.gas_limit.saturating_to::<u64>(),
+        basefee: header.base_fee_per_gas.unwrap_or_default().saturating_to::<u64>(),
+        difficulty: header.difficulty,
+        prevrandao: header.difficulty.is_zero().then_some(header.mix_hash),
+        blob_excess_gas_and_price: Some(BlobExcessGasAndPrice { excess_blob_gas, blob_gasprice }),
+        slot_num: header.slot_number.unwrap_or_default().saturating_to::<u64>(),
+    }
+}
+
+fn revm_pre_block(
+    evm: &mut RevmEvm<'_>,
+    spec: SpecId,
+    block_number: u64,
+    parent_block_hash: Option<B256>,
+    header: &BlockHeader,
+) {
+    if block_number == 0 {
+        return;
+    }
+    if spec.enables(SpecId::PRAGUE)
+        && let Some(hash) = parent_block_hash
+    {
+        revm_system_call(evm, HISTORY_STORAGE_ADDRESS, hash.0.into(), "eip2935");
+    }
+    if spec.enables(SpecId::CANCUN)
+        && let Some(root) = header.parent_beacon_block_root
+    {
+        revm_system_call(evm, BEACON_ROOTS_ADDRESS, root.0.into(), "eip4788");
+    }
+}
+
+/// Mirrors the evm2 post-block transition: post-merge, so no block reward.
+fn revm_post_block(evm: &mut RevmEvm<'_>, spec: SpecId, withdrawals: &[Withdrawal]) {
+    assert!(spec.enables(SpecId::MERGE), "replay corpus must be post-merge");
+
+    if spec.enables(SpecId::SHANGHAI) {
+        for withdrawal in withdrawals {
+            evm.ctx_mut()
+                .journal_mut()
+                .balance_incr(
+                    withdrawal.address,
+                    withdrawal.amount.saturating_mul(U256::from(ONE_GWEI)),
+                )
+                .expect("revm withdrawal credit must succeed");
+        }
+    }
+
+    if spec.enables(SpecId::PRAGUE) {
+        revm_system_call(evm, WITHDRAWAL_REQUEST_ADDRESS, Bytes::new(), "eip7002");
+        revm_system_call(evm, CONSOLIDATION_REQUEST_ADDRESS, Bytes::new(), "eip7251");
+    }
+
+    if spec.enables(SpecId::AMSTERDAM) {
+        revm_system_call(
+            evm,
+            evm2::evm::BUILDER_DEPOSIT_REQUEST_ADDRESS,
+            Bytes::new(),
+            "eip8282_deposit",
+        );
+        revm_system_call(
+            evm,
+            evm2::evm::BUILDER_EXIT_REQUEST_ADDRESS,
+            Bytes::new(),
+            "eip8282_exit",
+        );
+    }
+}
+
+fn revm_system_call(evm: &mut RevmEvm<'_>, address: Address, data: Bytes, label: &'static str) {
+    let result = evm
+        .system_call_one(address, data)
+        .unwrap_or_else(|err| panic!("revm {label} system call must execute: {err:?}"));
+    assert!(result.is_success(), "revm {label} system call must succeed");
+}
+
+fn revm_tx(raw: &Transaction) -> TxEnv {
+    let caller = raw.sender.expect("replay transaction must carry a sender");
+    let tx_type = raw.transaction_type.map(|ty| ty.saturating_to::<u8>()).unwrap_or(0);
+
+    let mut builder = TxEnv::builder()
+        .tx_type(Some(tx_type))
+        .caller(caller)
+        .gas_limit(raw.gas_limit.saturating_to::<u64>())
+        .nonce(raw.nonce.saturating_to::<u64>())
+        .value(raw.value)
+        .data(raw.data.clone())
+        .kind(raw.to.map_or(TxKind::Create, TxKind::Call))
+        .chain_id(raw.chain_id.map(|id| id.saturating_to::<u64>()))
+        .blob_hashes(raw.blob_versioned_hashes.clone())
+        .max_fee_per_blob_gas(raw.max_fee_per_blob_gas.unwrap_or_default().saturating_to::<u128>())
+        .authorization_list(
+            authorization_list(raw).unwrap_or_default().into_iter().map(Either::Left).collect(),
+        );
+    if let Some(access_list) = revm_access_list(raw, tx_type) {
+        builder = builder.access_list(access_list);
+    }
+    builder = if matches!(tx_type, 2..=4) {
+        builder
+            .gas_price(raw.max_fee_per_gas.unwrap_or_default().saturating_to::<u128>())
+            .gas_priority_fee(Some(
+                raw.max_priority_fee_per_gas.unwrap_or_default().saturating_to::<u128>(),
+            ))
+    } else {
+        builder.gas_price(raw.gas_price.unwrap_or_default().saturating_to::<u128>())
+    };
+
+    builder.build().unwrap_or_else(|err| panic!("revm replay transaction must build: {err:?}"))
+}
+
+fn revm_access_list(raw: &Transaction, tx_type: u8) -> Option<RpcAccessList> {
+    if tx_type == 0 {
+        return None;
+    }
+    let Some(access_list) = &raw.access_list else {
+        return (tx_type == 1).then(RpcAccessList::default);
+    };
+    Some(RpcAccessList(
+        access_list
+            .iter()
+            .map(|item| RpcAccessListItem {
+                address: item.address,
+                storage_keys: item.storage_keys.clone(),
+            })
+            .collect(),
+    ))
+}

--- a/crates/cli/src/replay_bench.rs
+++ b/crates/cli/src/replay_bench.rs
@@ -13,7 +13,7 @@
 
 use alloy_consensus::{TypedTransaction, transaction::Recovered};
 use alloy_eips::{eip7702::SignedAuthorization, eip7840::BlobParams};
-use alloy_primitives::{Address, B256, Bytes, KECCAK256_EMPTY, TxKind, U256};
+use alloy_primitives::{Address, B256, Bytes, KECCAK256_EMPTY, Log, TxKind, U256, keccak256};
 use alloy_rpc_types_eth::{
     AccessList as RpcAccessList, AccessListItem as RpcAccessListItem, TransactionInput,
     TransactionRequest,
@@ -54,6 +54,8 @@ pub struct TxOutcome {
     pub success: bool,
     /// Number of logs emitted by the transaction.
     pub logs: usize,
+    /// Digest of every emitted log's address, topics and data, in emission order.
+    pub logs_digest: B256,
 }
 
 /// Per-block outcome recorded identically by both engines.
@@ -63,8 +65,16 @@ pub struct BlockOutcome {
     pub number: u64,
     /// `gasUsed` declared by the fixture header.
     pub header_gas_used: u64,
-    /// Cumulative transaction gas used, as observed during execution.
+    /// Cumulative receipt gas used by the block's transactions (refunds applied).
     pub gas_used: u64,
+    /// Cumulative EIP-8037 execution gas (pre-refund, EIP-7623 floor applied).
+    pub execution_gas_used: u64,
+    /// Cumulative EIP-8037 state gas.
+    pub state_gas_used: u64,
+    /// Gas the header must record under the fixture's fork: [`Self::gas_used`] before
+    /// Amsterdam, `max(execution_gas_used, state_gas_used)` from Amsterdam on, mirroring
+    /// the EEST executor's block validation.
+    pub block_gas_used: u64,
     /// Per-transaction outcomes, in block order.
     pub txs: Vec<TxOutcome>,
 }
@@ -87,9 +97,9 @@ impl ReplayOutcome {
         self.blocks.iter().map(|block| u128::from(block.gas_used)).sum()
     }
 
-    /// Returns the blocks whose observed gas used disagrees with the fixture header.
+    /// Returns the blocks whose fork-rule block gas disagrees with the fixture header.
     pub fn header_gas_mismatches(&self) -> Vec<&BlockOutcome> {
-        self.blocks.iter().filter(|block| block.gas_used != block.header_gas_used).collect()
+        self.blocks.iter().filter(|block| block.block_gas_used != block.header_gas_used).collect()
     }
 }
 
@@ -142,14 +152,20 @@ pub fn diff(evm2: &ReplayOutcome, revm: &ReplayOutcome) -> Vec<Mismatch> {
             });
             continue;
         }
-        if left.gas_used != right.gas_used {
-            mismatches.push(Mismatch {
-                block,
-                transaction: None,
-                field: "block_gas_used",
-                evm2: left.gas_used.to_string(),
-                revm: right.gas_used.to_string(),
-            });
+        for (field, lhs, rhs) in [
+            ("block_gas_used", left.gas_used, right.gas_used),
+            ("block_execution_gas_used", left.execution_gas_used, right.execution_gas_used),
+            ("block_state_gas_used", left.state_gas_used, right.state_gas_used),
+        ] {
+            if lhs != rhs {
+                mismatches.push(Mismatch {
+                    block,
+                    transaction: None,
+                    field,
+                    evm2: lhs.to_string(),
+                    revm: rhs.to_string(),
+                });
+            }
         }
         for (index, (left, right)) in left.txs.iter().zip(&right.txs).enumerate() {
             if left.gas_used != right.gas_used {
@@ -179,6 +195,15 @@ pub fn diff(evm2: &ReplayOutcome, revm: &ReplayOutcome) -> Vec<Mismatch> {
                     revm: right.logs.to_string(),
                 });
             }
+            if left.logs_digest != right.logs_digest {
+                mismatches.push(Mismatch {
+                    block,
+                    transaction: Some(index),
+                    field: "logs_digest",
+                    evm2: left.logs_digest.to_string(),
+                    revm: right.logs_digest.to_string(),
+                });
+            }
         }
     }
     mismatches
@@ -197,7 +222,8 @@ impl ReplayFixture {
     ///
     /// # Panics
     ///
-    /// Panics when the fixture cannot be read or does not contain exactly one case.
+    /// Panics when the fixture cannot be read or does not contain exactly one case, or
+    /// when the case fails the checks in [`Self::from_case`].
     pub fn load(path: &Path) -> Self {
         let suite: BlockchainTest = evm2_eest::read_blockchain_fixture(path)
             .unwrap_or_else(|err| panic!("failed to read fixture {}: {err}", path.display()));
@@ -208,6 +234,23 @@ impl ReplayFixture {
             path.display()
         );
         let (name, case) = suite.0.into_iter().next().expect("fixture must contain a case");
+        Self::from_case(name, case)
+    }
+
+    /// Wraps a decoded test case after checking that it is a canonical chain.
+    ///
+    /// The replay loops execute and commit every block unconditionally; they do not
+    /// mirror the EEST executor's handling of blocks that expect an exception. A
+    /// fixture relying on that handling would silently replay its invalid blocks, so
+    /// such fixtures are rejected here instead.
+    ///
+    /// # Panics
+    ///
+    /// Panics when the case has no blocks, when a block expects an exception, lacks a
+    /// header or does not extend the previous block, or when `lastblockhash` is not the
+    /// final block's hash.
+    pub fn from_case(name: String, case: BlockchainTestCase) -> Self {
+        assert_canonical(&name, &case);
         let spec = fork_to_spec_id(case.network);
         Self { name, spec, case }
     }
@@ -290,6 +333,8 @@ impl ReplayFixture {
 
             let mut txs = Vec::with_capacity(block_transactions(block).len());
             let mut gas_used = 0u64;
+            let mut execution_gas_used = 0u64;
+            let mut state_gas_used = 0u64;
             for raw in block_transactions(block) {
                 let tx = evm2_tx(raw);
                 let result = evm
@@ -297,10 +342,14 @@ impl ReplayFixture {
                     .unwrap_or_else(|err| panic!("evm2 replay transaction must execute: {err:?}"))
                     .commit_to(&mut block_state);
                 gas_used = gas_used.saturating_add(result.tx_gas_used());
+                execution_gas_used =
+                    execution_gas_used.saturating_add(result.execution_gas_spent());
+                state_gas_used = state_gas_used.saturating_add(result.state_gas_spent());
                 txs.push(TxOutcome {
                     gas_used: result.tx_gas_used(),
                     success: result.status,
                     logs: result.logs.len(),
+                    logs_digest: logs_digest(&result.logs),
                 });
             }
 
@@ -323,6 +372,9 @@ impl ReplayFixture {
                 number: header.number.saturating_to::<u64>(),
                 header_gas_used: header.gas_used.saturating_to::<u64>(),
                 gas_used,
+                execution_gas_used,
+                state_gas_used,
+                block_gas_used: block_gas_used(spec, gas_used, execution_gas_used, state_gas_used),
                 txs,
             });
         }
@@ -353,6 +405,8 @@ impl ReplayFixture {
 
             let mut txs = Vec::with_capacity(block_transactions(block).len());
             let mut gas_used = 0u64;
+            let mut execution_gas_used = 0u64;
+            let mut state_gas_used = 0u64;
             {
                 let mut evm = Context::mainnet()
                     .with_cfg(cfg.clone())
@@ -367,10 +421,15 @@ impl ReplayFixture {
                         panic!("revm replay transaction must execute: {err:?}")
                     });
                     gas_used = gas_used.saturating_add(result.tx_gas_used());
+                    execution_gas_used =
+                        execution_gas_used.saturating_add(result.gas().block_regular_gas_used());
+                    state_gas_used =
+                        state_gas_used.saturating_add(result.gas().block_state_gas_used());
                     txs.push(TxOutcome {
                         gas_used: result.tx_gas_used(),
                         success: result.is_success(),
                         logs: result.logs().len(),
+                        logs_digest: logs_digest(result.logs()),
                     });
                 }
 
@@ -390,6 +449,9 @@ impl ReplayFixture {
                 number: block_number,
                 header_gas_used: header.gas_used.saturating_to::<u64>(),
                 gas_used,
+                execution_gas_used,
+                state_gas_used,
+                block_gas_used: block_gas_used(spec, gas_used, execution_gas_used, state_gas_used),
                 txs,
             });
         }
@@ -416,6 +478,58 @@ fn block_transactions(block: &Block) -> &[Transaction] {
         return transactions;
     }
     block.rlp_decoded.as_ref().map(|decoded| decoded.transactions.as_slice()).unwrap_or_default()
+}
+
+/// Checks that `case` is a canonical chain: every block carries a header, expects no
+/// exception and extends the previous block, and `lastblockhash` names the final block.
+fn assert_canonical(name: &str, case: &BlockchainTestCase) {
+    assert!(!case.blocks.is_empty(), "replay fixture {name} has no blocks");
+    let mut parent = &case.genesis_block_header;
+    for (index, block) in case.blocks.iter().enumerate() {
+        assert!(
+            block.expect_exception.is_none(),
+            "replay fixture {name} block {index} expects an exception; replay fixtures must only \
+             contain valid blocks"
+        );
+        let header = block_header(block)
+            .unwrap_or_else(|| panic!("replay fixture {name} block {index} has no header"));
+        assert!(
+            header.parent_hash == parent.hash && header.number == parent.number + U256::ONE,
+            "replay fixture {name} block {index} does not extend the previous block"
+        );
+        parent = header;
+    }
+    assert!(
+        case.lastblockhash == parent.hash,
+        "replay fixture {name} lastblockhash does not match the final block"
+    );
+}
+
+/// Digests a transaction's logs (address, topics and data, in emission order) so the
+/// parity check covers log contents rather than only their count.
+fn logs_digest(logs: &[Log]) -> B256 {
+    let mut bytes = Vec::new();
+    for log in logs {
+        bytes.extend_from_slice(log.address.as_slice());
+        bytes.extend_from_slice(&(log.data.topics().len() as u64).to_be_bytes());
+        for topic in log.data.topics() {
+            bytes.extend_from_slice(topic.as_slice());
+        }
+        bytes.extend_from_slice(&(log.data.data.len() as u64).to_be_bytes());
+        bytes.extend_from_slice(&log.data.data);
+    }
+    keccak256(bytes)
+}
+
+/// Returns the gas a block header must record, mirroring the EEST executor: cumulative
+/// receipt gas before Amsterdam, `max(execution, state)` under EIP-8037 (Amsterdam+).
+fn block_gas_used(
+    spec: SpecId,
+    gas_used: u64,
+    execution_gas_used: u64,
+    state_gas_used: u64,
+) -> u64 {
+    if spec.enables(SpecId::AMSTERDAM) { execution_gas_used.max(state_gas_used) } else { gas_used }
 }
 
 fn block_withdrawals(block: &Block) -> &[Withdrawal] {

--- a/crates/cli/src/replay_bench.rs
+++ b/crates/cli/src/replay_bench.rs
@@ -1,47 +1,38 @@
-//! Paired evm2/revm drivers for the mainnet block-replay benchmark.
+//! Mainnet replay comparison using the EEST executor and revm.
 //!
-//! The benchmark's evm2 timing path stays on `evm2_eest`'s blockchain-test
-//! executor (`crates/cli/benches/evm/mainnet.rs`). This module adds the missing
-//! revm counterpart plus an evm2 mirror of the same block loop, so that the two
-//! engines can be diffed transaction by transaction and the harness-side setup
-//! cost can be measured on either side with the same code shape.
-//!
-//! The evm2 mirror follows `crates/eest/src/blockchaintest/execute.rs`
-//! (`execute_case`/`execute_block`) step for step; the revm driver follows
-//! `bins/revme/src/cmd/blockchaintest.rs` of the pinned revm 42 checkout, with
-//! the block/commit cadence bent to match the evm2 side rather than revme's.
+//! Both engines report results through the EEST hook. Parity checks collect
+//! transaction outcomes; timed runs use a no-op hook and include database setup,
+//! transaction decoding, execution and block commits.
 
-use alloy_consensus::{TypedTransaction, transaction::Recovered};
 use alloy_eips::{eip7702::SignedAuthorization, eip7840::BlobParams};
-use alloy_primitives::{Address, B256, Bytes, KECCAK256_EMPTY, Log, TxKind, U256, keccak256};
-use alloy_rpc_types_eth::{
-    AccessList as RpcAccessList, AccessListItem as RpcAccessListItem, TransactionInput,
-    TransactionRequest,
-};
+use alloy_primitives::{Address, B256, Bytes, Log, TxKind, U256, keccak256};
+use alloy_rpc_types_eth::{AccessList as RpcAccessList, AccessListItem as RpcAccessListItem};
 use evm2::{
-    BaseEvmTypes, Evm, Precompiles, SpecId,
-    bytecode::Bytecode,
-    env::{BlockEnv, BlockEnvExt},
-    ethereum::{RecoveredTxEnvelope, TxEnvelope, ethereum_tx_registry},
+    SpecId,
     evm::{
-        AccountChangeRef, AccountInfo, BEACON_ROOTS_ADDRESS, BlockStateAccumulator,
-        CONSOLIDATION_REQUEST_ADDRESS, HISTORY_STORAGE_ADDRESS, InMemoryDB, StateChangeSink,
-        StateChangeSource, SystemTx, Tee, WITHDRAWAL_REQUEST_ADDRESS,
+        BEACON_ROOTS_ADDRESS, CONSOLIDATION_REQUEST_ADDRESS, HISTORY_STORAGE_ADDRESS,
+        WITHDRAWAL_REQUEST_ADDRESS,
     },
 };
-use evm2_eest::blockchaintest::{
-    Block, BlockHeader, BlockchainTest, BlockchainTestCase, ForkSpec, Transaction, Withdrawal,
+use evm2_eest::{
+    BlockchainTestExecuteConfig, NameFilter,
+    blockchaintest::{
+        Block, BlockFinished, BlockHeader, BlockStarted, BlockchainTest, BlockchainTestCase,
+        CaseStarted, ForkSpec, Hook, Transaction, TransactionFinished, TransactionStarted,
+        Withdrawal,
+    },
+    execute_blockchain_tests_suite,
 };
 use revm::{
     Context, DatabaseCommit, ExecuteEvm, MainBuilder, MainContext, SystemCallEvm,
     context::{BlockEnv as RevmBlockEnv, CfgEnv, ContextTr, JournalTr, TxEnv},
-    context_interface::{block::BlobExcessGasAndPrice, either::Either},
+    context_interface::{Cfg, block::BlobExcessGasAndPrice, either::Either},
     database::{CacheDB, EmptyDB, InMemoryDB as RevmInMemoryDB},
     handler::EvmTr,
     primitives::hardfork::SpecId as RevmSpecId,
     state::{AccountInfo as RevmAccountInfo, Bytecode as RevmBytecode},
 };
-use std::{mem, path::Path};
+use std::path::Path;
 
 const ONE_GWEI: u64 = 1_000_000_000;
 
@@ -214,7 +205,7 @@ pub fn diff(evm2: &ReplayOutcome, revm: &ReplayOutcome) -> Vec<Mismatch> {
 pub struct ReplayFixture {
     name: String,
     spec: SpecId,
-    case: BlockchainTestCase,
+    suite: BlockchainTest,
 }
 
 impl ReplayFixture {
@@ -239,20 +230,18 @@ impl ReplayFixture {
 
     /// Wraps a decoded test case after checking that it is a canonical chain.
     ///
-    /// The replay loops execute and commit every block unconditionally; they do not
-    /// mirror the EEST executor's handling of blocks that expect an exception. A
-    /// fixture relying on that handling would silently replay its invalid blocks, so
-    /// such fixtures are rejected here instead.
+    /// The revm driver supports valid post-merge blocks without block access lists.
     ///
     /// # Panics
     ///
     /// Panics when the case has no blocks, when a block expects an exception, lacks a
     /// header or does not extend the previous block, or when `lastblockhash` is not the
-    /// final block's hash.
+    /// final block's hash. Pre-merge forks and block access lists are unsupported.
     pub fn from_case(name: String, case: BlockchainTestCase) -> Self {
         assert_canonical(&name, &case);
         let spec = fork_to_spec_id(case.network);
-        Self { name, spec, case }
+        assert!(spec.enables(SpecId::MERGE), "replay corpus must be post-merge");
+        Self { name: name.clone(), spec, suite: BlockchainTest([(name, case)].into()) }
     }
 
     /// Returns the case name.
@@ -266,125 +255,45 @@ impl ReplayFixture {
     }
 
     /// Returns the number of blocks in the case.
-    pub const fn blocks(&self) -> usize {
-        self.case.blocks.len()
+    pub fn blocks(&self) -> usize {
+        self.case().blocks.len()
     }
 
     /// Returns the total number of transactions across every block.
     pub fn transactions(&self) -> usize {
-        self.case.blocks.iter().map(|block| block_transactions(block).len()).sum()
+        self.case().blocks.iter().map(|block| block_transactions(block).len()).sum()
     }
 
-    /// Builds the evm2 pre-state database and every block's transaction list.
-    ///
-    /// This is the harness-side work the timed replay repeats on each iteration;
-    /// it is exposed so the benchmark can price it separately.
-    pub fn setup_evm2(&self) -> (InMemoryDB, Vec<Vec<RecoveredTxEnvelope>>) {
-        let mut database = evm2_pre_state(&self.case);
-        evm2_seed_block_hashes(&mut database, &self.case);
-        let txs = self
-            .case
-            .blocks
-            .iter()
-            .map(|block| block_transactions(block).iter().map(evm2_tx).collect())
-            .collect();
-        (database, txs)
+    fn case(&self) -> &BlockchainTestCase {
+        &self.suite.0[&self.name]
     }
 
-    /// Builds the revm pre-state database and every block's transaction list.
-    pub fn setup_revm(&self) -> (RevmInMemoryDB, Vec<Vec<TxEnv>>) {
-        let mut database = revm_pre_state(&self.case);
-        revm_seed_block_hashes(&mut database, &self.case);
-        let txs = self
-            .case
-            .blocks
-            .iter()
-            .map(|block| block_transactions(block).iter().map(revm_tx).collect())
-            .collect();
-        (database, txs)
-    }
-
-    /// Replays every block through evm2, mirroring the EEST blockchain executor.
+    /// Replays through the benchmark's EEST executor and records transaction outcomes.
     pub fn replay_evm2(&self) -> ReplayOutcome {
-        let case = &self.case;
-        let spec = self.spec;
-        let mut database = evm2_pre_state(case);
-        evm2_seed_block_hashes(&mut database, case);
+        let mut recorder = ReplayRecorder { spec: self.spec, outcome: ReplayOutcome::default() };
+        let summary = execute_blockchain_tests_suite(
+            Path::new(&self.name),
+            &self.suite,
+            BlockchainTestExecuteConfig { validate_post_state: false, ..Default::default() },
+            &NameFilter::default(),
+            &mut recorder,
+        )
+        .expect("EEST replay must execute");
+        assert_eq!(summary.executed, 1);
+        assert_eq!(summary.skipped, 0);
+        recorder.outcome
+    }
 
-        let mut parent_block_hash = Some(case.genesis_block_header.hash);
-        let mut parent_excess_blob_gas =
-            case.genesis_block_header.excess_blob_gas.unwrap_or_default().saturating_to::<u64>();
-        let mut outcome = ReplayOutcome::default();
-
-        for block in &case.blocks {
-            let header = block_header(block).expect("replay fixture block must carry a header");
-            let block_env = evm2_block_env(header, parent_excess_blob_gas, spec);
-
-            let mut evm = Evm::<BaseEvmTypes>::new(
-                spec,
-                block_env,
-                ethereum_tx_registry(spec),
-                mem::take(&mut database),
-                Precompiles::base(spec),
-            );
-            let mut block_state = BlockStateAccumulator::new();
-
-            evm2_pre_block(&mut evm, &mut block_state, spec, block_env, parent_block_hash, header);
-
-            let mut txs = Vec::with_capacity(block_transactions(block).len());
-            let mut gas_used = 0u64;
-            let mut execution_gas_used = 0u64;
-            let mut state_gas_used = 0u64;
-            for raw in block_transactions(block) {
-                let tx = evm2_tx(raw);
-                let result = evm
-                    .transact(&tx)
-                    .unwrap_or_else(|err| panic!("evm2 replay transaction must execute: {err:?}"))
-                    .commit_to(&mut block_state);
-                gas_used = gas_used.saturating_add(result.tx_gas_used());
-                execution_gas_used =
-                    execution_gas_used.saturating_add(result.execution_gas_spent());
-                state_gas_used = state_gas_used.saturating_add(result.state_gas_spent());
-                txs.push(TxOutcome {
-                    gas_used: result.tx_gas_used(),
-                    success: result.status,
-                    logs: result.logs.len(),
-                    logs_digest: logs_digest(&result.logs),
-                });
-            }
-
-            evm2_post_block(&mut evm, &mut block_state, spec, block_withdrawals(block));
-
-            let mut restored = mem::take(
-                evm.database_as_mut::<InMemoryDB>().expect("block EVM database must be InMemoryDB"),
-            );
-            drop(evm);
-            restored.commit_source(&block_state);
-            restored.insert_block_hash(&header.number, &header.hash);
-            database = restored;
-
-            parent_block_hash = Some(header.hash);
-            if let Some(excess) = header.excess_blob_gas {
-                parent_excess_blob_gas = excess.saturating_to::<u64>();
-            }
-
-            outcome.blocks.push(BlockOutcome {
-                number: header.number.saturating_to::<u64>(),
-                header_gas_used: header.gas_used.saturating_to::<u64>(),
-                gas_used,
-                execution_gas_used,
-                state_gas_used,
-                block_gas_used: block_gas_used(spec, gas_used, execution_gas_used, state_gas_used),
-                txs,
-            });
-        }
-
-        outcome
+    /// Replays through revm and records transaction outcomes for parity checks.
+    pub fn replay_revm(&self) -> ReplayOutcome {
+        let mut recorder = ReplayRecorder { spec: self.spec, outcome: ReplayOutcome::default() };
+        self.execute_revm(&mut recorder);
+        recorder.outcome
     }
 
     /// Replays every block through revm using the same block sequence and cadence.
-    pub fn replay_revm(&self) -> ReplayOutcome {
-        let case = &self.case;
+    pub fn execute_revm(&self, hook: &mut dyn Hook) {
+        let case = self.case();
         let spec = self.spec;
         let revm_spec = revm_spec_id(spec);
         let mut database = revm_pre_state(case);
@@ -396,14 +305,23 @@ impl ReplayFixture {
         let mut parent_block_hash = Some(case.genesis_block_header.hash);
         let mut parent_excess_blob_gas =
             case.genesis_block_header.excess_blob_gas.unwrap_or_default().saturating_to::<u64>();
-        let mut outcome = ReplayOutcome::default();
+        let total_blocks = case.blocks.len();
+        hook.case_started(CaseStarted { name: &self.name, total_blocks, network: case.network });
 
-        for block in &case.blocks {
+        for (block_index, block) in case.blocks.iter().enumerate() {
             let header = block_header(block).expect("replay fixture block must carry a header");
             let block_env = revm_block_env(header, parent_excess_blob_gas, spec);
             let block_number = header.number.saturating_to::<u64>();
 
-            let mut txs = Vec::with_capacity(block_transactions(block).len());
+            let transactions = block_transactions(block);
+            let total_transactions = transactions.len();
+            hook.block_started(BlockStarted {
+                block_index,
+                total_blocks,
+                block_number: Some(header.number),
+                block_gas_used: Some(header.gas_used),
+                total_transactions,
+            });
             let mut gas_used = 0u64;
             let mut execution_gas_used = 0u64;
             let mut state_gas_used = 0u64;
@@ -416,8 +334,25 @@ impl ReplayFixture {
 
                 revm_pre_block(&mut evm, spec, block_number, parent_block_hash, header);
 
-                for raw in block_transactions(block) {
-                    let result = evm.transact_one(revm_tx(raw)).unwrap_or_else(|err| {
+                for (transaction_index, raw) in transactions.iter().enumerate() {
+                    hook.transaction_started(TransactionStarted {
+                        block_index,
+                        total_blocks,
+                        block_number: Some(header.number),
+                        transaction_index,
+                        total_transactions,
+                    });
+                    let tx = revm_tx(raw);
+                    if spec.enables(SpecId::AMSTERDAM) {
+                        let block_gas_limit = header.gas_limit.saturating_to::<u64>();
+                        assert!(
+                            tx.gas_limit.min(cfg.tx_gas_limit_cap())
+                                <= block_gas_limit.saturating_sub(execution_gas_used)
+                                && tx.gas_limit <= block_gas_limit.saturating_sub(state_gas_used),
+                            "revm transaction gas limit exceeds available block gas",
+                        );
+                    }
+                    let result = evm.transact_one(tx).unwrap_or_else(|err| {
                         panic!("revm replay transaction must execute: {err:?}")
                     });
                     gas_used = gas_used.saturating_add(result.tx_gas_used());
@@ -425,13 +360,25 @@ impl ReplayFixture {
                         execution_gas_used.saturating_add(result.gas().block_regular_gas_used());
                     state_gas_used =
                         state_gas_used.saturating_add(result.gas().block_state_gas_used());
-                    txs.push(TxOutcome {
+                    hook.transaction_finished(TransactionFinished {
+                        block_index,
+                        total_blocks,
+                        block_number: Some(header.number),
+                        transaction_index,
+                        total_transactions,
                         gas_used: result.tx_gas_used(),
+                        execution_gas_used: result.gas().block_regular_gas_used(),
+                        state_gas_used: result.gas().block_state_gas_used(),
                         success: result.is_success(),
-                        logs: result.logs().len(),
-                        logs_digest: logs_digest(result.logs()),
+                        logs: result.logs(),
                     });
                 }
+
+                assert_eq!(
+                    block_gas_used(spec, gas_used, execution_gas_used, state_gas_used),
+                    header.gas_used.saturating_to::<u64>(),
+                    "revm block {block_number} gas must match its header",
+                );
 
                 revm_post_block(&mut evm, spec, block_withdrawals(block));
 
@@ -445,18 +392,59 @@ impl ReplayFixture {
                 parent_excess_blob_gas = excess.saturating_to::<u64>();
             }
 
-            outcome.blocks.push(BlockOutcome {
-                number: block_number,
-                header_gas_used: header.gas_used.saturating_to::<u64>(),
-                gas_used,
-                execution_gas_used,
-                state_gas_used,
-                block_gas_used: block_gas_used(spec, gas_used, execution_gas_used, state_gas_used),
-                txs,
+            hook.block_finished(BlockFinished {
+                block_index,
+                total_blocks,
+                block_number: Some(header.number),
+                block_gas_used: Some(header.gas_used),
             });
         }
+    }
+}
 
-        outcome
+struct ReplayRecorder {
+    spec: SpecId,
+    outcome: ReplayOutcome,
+}
+
+impl Hook for ReplayRecorder {
+    fn block_started(&mut self, event: BlockStarted) {
+        self.outcome.blocks.push(BlockOutcome {
+            number: event.block_number.expect("replay block must have a number").saturating_to(),
+            header_gas_used: event
+                .block_gas_used
+                .expect("replay block must have header gas")
+                .saturating_to(),
+            gas_used: 0,
+            execution_gas_used: 0,
+            state_gas_used: 0,
+            block_gas_used: 0,
+            txs: Vec::with_capacity(event.total_transactions),
+        });
+    }
+
+    fn transaction_finished(&mut self, event: TransactionFinished<'_>) {
+        let block = &mut self.outcome.blocks[event.block_index];
+        block.gas_used = block.gas_used.saturating_add(event.gas_used);
+        block.execution_gas_used =
+            block.execution_gas_used.saturating_add(event.execution_gas_used);
+        block.state_gas_used = block.state_gas_used.saturating_add(event.state_gas_used);
+        block.txs.push(TxOutcome {
+            gas_used: event.gas_used,
+            success: event.success,
+            logs: event.logs.len(),
+            logs_digest: logs_digest(event.logs),
+        });
+    }
+
+    fn block_finished(&mut self, event: BlockFinished) {
+        let block = &mut self.outcome.blocks[event.block_index];
+        block.block_gas_used = block_gas_used(
+            self.spec,
+            block.gas_used,
+            block.execution_gas_used,
+            block.state_gas_used,
+        );
     }
 }
 
@@ -490,6 +478,14 @@ fn assert_canonical(name: &str, case: &BlockchainTestCase) {
             block.expect_exception.is_none(),
             "replay fixture {name} block {index} expects an exception; replay fixtures must only \
              contain valid blocks"
+        );
+        assert!(
+            block.block_access_list.is_none()
+                && block
+                    .rlp_decoded
+                    .as_ref()
+                    .is_none_or(|decoded| decoded.block_access_list.is_none()),
+            "replay fixture {name} block {index}: block access lists are not supported",
         );
         let header = block_header(block)
             .unwrap_or_else(|| panic!("replay fixture {name} block {index} has no header"));
@@ -602,259 +598,6 @@ fn revm_spec_id(spec: SpecId) -> RevmSpecId {
         SpecId::AMSTERDAM => RevmSpecId::AMSTERDAM,
         other => panic!("unsupported replay spec: {other:?}"),
     }
-}
-
-// ---------------------------------------------------------------------------
-// evm2 side.
-// ---------------------------------------------------------------------------
-
-fn evm2_pre_state(case: &BlockchainTestCase) -> InMemoryDB {
-    let mut database = InMemoryDB::default();
-    for (address, account) in &case.pre.0 {
-        let info = AccountInfo::default()
-            .with_balance(account.balance)
-            .with_nonce(account.nonce.saturating_to::<u64>())
-            .with_code(
-                Bytecode::new_raw_checked(account.code.clone())
-                    .unwrap_or_else(|_| Bytecode::new_legacy(account.code.clone())),
-            );
-        database.insert_account_info(address, info);
-        for (key, value) in &account.storage {
-            database.insert_account_storage(address, key, value);
-        }
-    }
-    database
-}
-
-fn evm2_seed_block_hashes(database: &mut InMemoryDB, case: &BlockchainTestCase) {
-    for block_hash in &case.block_hashes {
-        database.insert_block_hash(&block_hash.number, &block_hash.hash);
-    }
-    database.insert_block_hash(&case.genesis_block_header.number, &case.genesis_block_header.hash);
-}
-
-fn evm2_block_env(header: &BlockHeader, parent_excess_blob_gas: u64, spec: SpecId) -> BlockEnv {
-    let excess_blob_gas = header
-        .excess_blob_gas
-        .map(|gas| gas.saturating_to::<u64>())
-        .unwrap_or(parent_excess_blob_gas);
-    BlockEnvExt {
-        number: header.number,
-        beneficiary: header.coinbase,
-        timestamp: header.timestamp,
-        gas_limit: header.gas_limit,
-        basefee: header.base_fee_per_gas.unwrap_or_default(),
-        difficulty: header.difficulty,
-        prevrandao: if header.difficulty.is_zero() {
-            U256::from_be_slice(header.mix_hash.as_slice())
-        } else {
-            U256::ZERO
-        },
-        blob_basefee: U256::from(
-            blob_params_for_timestamp(header.timestamp, spec).calc_blob_fee(excess_blob_gas),
-        ),
-        slot_num: header.slot_number.unwrap_or_default(),
-        ext: (),
-        _non_exhaustive: (),
-    }
-}
-
-fn evm2_pre_block(
-    evm: &mut Evm<'_, BaseEvmTypes>,
-    block_state: &mut BlockStateAccumulator,
-    spec: SpecId,
-    block: BlockEnv,
-    parent_block_hash: Option<B256>,
-    header: &BlockHeader,
-) {
-    if block.number.is_zero() {
-        return;
-    }
-    if spec.enables(SpecId::PRAGUE)
-        && let Some(hash) = parent_block_hash
-    {
-        evm2_system_call(
-            evm,
-            block_state,
-            HISTORY_STORAGE_ADDRESS,
-            Bytes::copy_from_slice(hash.as_slice()),
-            "eip2935",
-        );
-    }
-    if spec.enables(SpecId::CANCUN)
-        && let Some(root) = header.parent_beacon_block_root
-    {
-        evm2_system_call(
-            evm,
-            block_state,
-            BEACON_ROOTS_ADDRESS,
-            Bytes::copy_from_slice(root.as_slice()),
-            "eip4788",
-        );
-    }
-}
-
-/// Mirrors `post_block_transition`, minus the pre-merge block and ommer rewards:
-/// the replay corpus is post-merge, so `block_reward` is always zero.
-fn evm2_post_block(
-    evm: &mut Evm<'_, BaseEvmTypes>,
-    block_state: &mut BlockStateAccumulator,
-    spec: SpecId,
-    withdrawals: &[Withdrawal],
-) {
-    assert!(spec.enables(SpecId::MERGE), "replay corpus must be post-merge");
-
-    if spec.enables(SpecId::SHANGHAI) {
-        for withdrawal in withdrawals {
-            evm2_increment_balance(
-                evm,
-                block_state,
-                withdrawal.address,
-                withdrawal.amount.saturating_mul(U256::from(ONE_GWEI)),
-            );
-        }
-    }
-
-    if spec.enables(SpecId::PRAGUE) {
-        evm2_system_call(evm, block_state, WITHDRAWAL_REQUEST_ADDRESS, Bytes::new(), "eip7002");
-        evm2_system_call(evm, block_state, CONSOLIDATION_REQUEST_ADDRESS, Bytes::new(), "eip7251");
-    }
-
-    if spec.enables(SpecId::AMSTERDAM) {
-        evm2_system_call(
-            evm,
-            block_state,
-            evm2::evm::BUILDER_DEPOSIT_REQUEST_ADDRESS,
-            Bytes::new(),
-            "eip8282_deposit",
-        );
-        evm2_system_call(
-            evm,
-            block_state,
-            evm2::evm::BUILDER_EXIT_REQUEST_ADDRESS,
-            Bytes::new(),
-            "eip8282_exit",
-        );
-    }
-}
-
-fn evm2_system_call(
-    evm: &mut Evm<'_, BaseEvmTypes>,
-    block_state: &mut BlockStateAccumulator,
-    address: Address,
-    data: Bytes,
-    label: &'static str,
-) {
-    let executed = evm
-        .system_call(SystemTx::new(address, data))
-        .unwrap_or_else(|err| panic!("evm2 {label} system call must execute: {err:?}"));
-    assert!(executed.result().status, "evm2 {label} system call must succeed");
-    let _ = executed.commit_to(block_state);
-}
-
-struct AccountStateChange {
-    address: Address,
-    original: Option<AccountInfo>,
-    current: Option<AccountInfo>,
-}
-
-impl StateChangeSource for AccountStateChange {
-    fn visit<S: StateChangeSink>(&self, sink: &mut S) -> Result<(), S::Error> {
-        sink.account(AccountChangeRef {
-            address: self.address,
-            original: self.original.as_ref(),
-            current: self.current.as_ref(),
-            created: false,
-            selfdestructed: false,
-        })
-    }
-}
-
-fn evm2_increment_balance(
-    evm: &mut Evm<'_, BaseEvmTypes>,
-    block_state: &mut BlockStateAccumulator,
-    address: Address,
-    amount: U256,
-) {
-    let original = evm
-        .read_account_info(&address)
-        .unwrap_or_else(|code| panic!("evm2 withdrawal account read must succeed: {code:?}"));
-    let mut current = original.clone().unwrap_or_default();
-    current.balance = current.balance.saturating_add(amount);
-    if current.code_hash.is_zero() {
-        current.code_hash = KECCAK256_EMPTY;
-    }
-    let current = (!current.is_empty()).then_some(current);
-
-    let change = AccountStateChange { address, original, current };
-    let mut sink = Tee::new(evm.overlay_db_mut(), block_state);
-    let Ok(()) = change.visit(&mut sink);
-}
-
-fn evm2_tx(raw: &Transaction) -> RecoveredTxEnvelope {
-    let caller = raw.sender.expect("replay transaction must carry a sender");
-    let tx_type = raw.transaction_type.map(|ty| ty.saturating_to::<u8>()).unwrap_or(0);
-
-    let mut request = TransactionRequest::default()
-        .from(caller)
-        .gas_limit(raw.gas_limit.saturating_to::<u64>())
-        .nonce(raw.nonce.saturating_to::<u64>())
-        .value(raw.value)
-        .input(TransactionInput::from(raw.data.clone()));
-    request.to = Some(raw.to.map_or(TxKind::Create, TxKind::Call));
-    request.transaction_type = Some(tx_type);
-    request.chain_id = raw.chain_id.map(|id| id.saturating_to::<u64>());
-    if !matches!(tx_type, 2..=4) {
-        request.gas_price = raw.gas_price.map(|price| price.saturating_to::<u128>());
-        if request.gas_price.is_none()
-            && (matches!(tx_type, 0 | 1)
-                || (raw.max_fee_per_gas.is_none() && raw.max_priority_fee_per_gas.is_none()))
-        {
-            request.gas_price = Some(0);
-        }
-    }
-    request.max_fee_per_gas = raw.max_fee_per_gas.map(|fee| fee.saturating_to::<u128>());
-    request.max_priority_fee_per_gas =
-        if raw.max_fee_per_gas.is_some() && raw.max_priority_fee_per_gas.is_none() {
-            Some(0)
-        } else {
-            raw.max_priority_fee_per_gas.map(|fee| fee.saturating_to::<u128>())
-        };
-    request.max_fee_per_blob_gas = raw.max_fee_per_blob_gas.map(|fee| fee.saturating_to::<u128>());
-    request.access_list = evm2_access_list(raw, tx_type);
-    request.authorization_list = authorization_list(raw);
-    if raw.max_fee_per_blob_gas.is_some() || tx_type == 3 || !raw.blob_versioned_hashes.is_empty() {
-        request.blob_versioned_hashes = Some(raw.blob_versioned_hashes.clone());
-    }
-
-    let tx = request
-        .build_consensus_tx()
-        .unwrap_or_else(|err| panic!("replay transaction must build: {}", err.error));
-    match tx {
-        TypedTransaction::Legacy(tx) => Recovered::new_unchecked(TxEnvelope::Legacy(tx), caller),
-        TypedTransaction::Eip2930(tx) => Recovered::new_unchecked(TxEnvelope::Eip2930(tx), caller),
-        TypedTransaction::Eip1559(tx) => Recovered::new_unchecked(TxEnvelope::Eip1559(tx), caller),
-        TypedTransaction::Eip4844(tx) => Recovered::new_unchecked(TxEnvelope::Eip4844(tx), caller),
-        TypedTransaction::Eip7702(tx) => Recovered::new_unchecked(tx.into(), caller),
-    }
-}
-
-fn evm2_access_list(raw: &Transaction, tx_type: u8) -> Option<RpcAccessList> {
-    if tx_type == 0 {
-        return None;
-    }
-    let Some(access_list) = &raw.access_list else {
-        return (tx_type == 1).then(RpcAccessList::default);
-    };
-    Some(RpcAccessList(
-        access_list
-            .iter()
-            .map(|item| RpcAccessListItem {
-                address: item.address,
-                storage_keys: item.storage_keys.clone(),
-            })
-            .collect(),
-    ))
 }
 
 fn authorization_list(raw: &Transaction) -> Option<Vec<SignedAuthorization>> {

--- a/crates/cli/tests/replay_parity.rs
+++ b/crates/cli/tests/replay_parity.rs
@@ -1,0 +1,91 @@
+//! Differential check for the mainnet block-replay benchmark.
+//!
+//! Replays the benchmark corpus through evm2 and revm and compares every
+//! transaction's gas used, success flag and log count. The paired benchmark
+//! numbers are only meaningful while this passes.
+
+use evm2_cli::replay_bench::ReplayFixture;
+use evm2_eest::{
+    BlockchainTestExecuteConfig, BlockchainTestNoopHook, NameFilter, execute_blockchain_tests_suite,
+};
+use std::path::{Path, PathBuf};
+
+const FIXTURE: &str = "data/mainnet-25347446-25347455.bin.zst";
+
+fn workspace_path(path: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../..").join(path)
+}
+
+#[test]
+fn mainnet_replay_matches_revm() {
+    let path = workspace_path(FIXTURE);
+    let fixture = ReplayFixture::load(&path);
+    println!(
+        "fixture {} | fork {:?} | blocks {} | transactions {}",
+        fixture.name(),
+        fixture.spec(),
+        fixture.blocks(),
+        fixture.transactions()
+    );
+
+    let evm2 = fixture.replay_evm2();
+    let revm = fixture.replay_revm();
+
+    println!(
+        "{:>10} {:>6} {:>14} {:>14} {:>14}",
+        "block", "txs", "header_gas", "evm2_gas", "revm_gas"
+    );
+    for (left, right) in evm2.blocks.iter().zip(&revm.blocks) {
+        println!(
+            "{:>10} {:>6} {:>14} {:>14} {:>14}",
+            left.number,
+            left.txs.len(),
+            left.header_gas_used,
+            left.gas_used,
+            right.gas_used
+        );
+    }
+    println!(
+        "total: transactions evm2={} revm={} | gas evm2={} revm={}",
+        evm2.transactions(),
+        revm.transactions(),
+        evm2.gas_used(),
+        revm.gas_used()
+    );
+
+    // Both engines must reproduce every block header's `gasUsed`; this is the
+    // same invariant the EEST executor enforces on the benchmark's evm2 path.
+    for (engine, outcome) in [("evm2", &evm2), ("revm", &revm)] {
+        let mismatches = outcome.header_gas_mismatches();
+        assert!(
+            mismatches.is_empty(),
+            "{engine} block gas disagrees with the fixture header: {mismatches:#?}"
+        );
+    }
+
+    let mismatches = evm2_cli::replay_bench::diff(&evm2, &revm);
+    println!("mismatches: {}", mismatches.len());
+    for mismatch in &mismatches {
+        println!("{mismatch:?}");
+    }
+    assert!(mismatches.is_empty(), "evm2 and revm disagree on {} entries", mismatches.len());
+}
+
+/// Guards the mirror against drift from the benchmark's real evm2 path: the
+/// EEST executor must accept the same fixture the mirror replays.
+#[test]
+fn mainnet_replay_eest_path_executes() {
+    let path = workspace_path(FIXTURE);
+    let suite = evm2_eest::read_blockchain_fixture(&path).expect("fixture must decode");
+    let mut hook = BlockchainTestNoopHook;
+    let summary = execute_blockchain_tests_suite(
+        &path,
+        &suite,
+        BlockchainTestExecuteConfig::default(),
+        &NameFilter::default(),
+        &mut hook,
+    )
+    .expect("EEST replay must succeed");
+    assert_eq!(summary.executed, 1);
+    assert_eq!(summary.skipped, 0);
+}

--- a/crates/cli/tests/replay_parity.rs
+++ b/crates/cli/tests/replay_parity.rs
@@ -4,15 +4,45 @@
 //! transaction's gas used, success flag and logs, plus each block's EIP-8037 gas
 //! split. The paired benchmark numbers are only meaningful while this passes.
 
-use alloy_primitives::B256;
+use alloy_primitives::{B256, Log, U256};
 use evm2_cli::replay_bench::ReplayFixture;
 use evm2_eest::{
-    BlockchainTestExecuteConfig, BlockchainTestNoopHook, NameFilter,
-    blockchaintest::BlockchainTestCase, execute_blockchain_tests_suite,
+    BlockchainTestExecuteConfig, BlockchainTestHook, BlockchainTestNoopHook,
+    BlockchainTestTransactionFinished, NameFilter,
+    blockchaintest::{BlockchainTestCase, DecodedBlock, ForkSpec},
+    execute_blockchain_tests_suite,
 };
 use std::path::{Path, PathBuf};
 
 const FIXTURE: &str = "data/mainnet-25347446-25347455.bin.zst";
+
+#[derive(Debug, PartialEq)]
+struct RecordedTransaction {
+    block_index: usize,
+    transaction_index: usize,
+    gas_used: u64,
+    execution_gas_used: u64,
+    state_gas_used: u64,
+    success: bool,
+    logs: Vec<Log>,
+}
+
+#[derive(Default)]
+struct TransactionRecorder(Vec<RecordedTransaction>);
+
+impl BlockchainTestHook for TransactionRecorder {
+    fn transaction_finished(&mut self, event: BlockchainTestTransactionFinished<'_>) {
+        self.0.push(RecordedTransaction {
+            block_index: event.block_index,
+            transaction_index: event.transaction_index,
+            gas_used: event.gas_used,
+            execution_gas_used: event.execution_gas_used,
+            state_gas_used: event.state_gas_used,
+            success: event.success,
+            logs: event.logs.to_vec(),
+        });
+    }
+}
 
 fn workspace_path(path: &str) -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("../..").join(path)
@@ -65,6 +95,8 @@ fn mainnet_replay_matches_revm() {
     // fixture fork's rule; this is the same invariant the EEST executor enforces
     // on the benchmark's evm2 path.
     for (engine, outcome) in [("evm2", &evm2), ("revm", &revm)] {
+        assert_eq!(outcome.blocks.len(), fixture.blocks(), "{engine} block count");
+        assert_eq!(outcome.transactions(), fixture.transactions(), "{engine} transaction count");
         let mismatches = outcome.header_gas_mismatches();
         assert!(
             mismatches.is_empty(),
@@ -80,23 +112,29 @@ fn mainnet_replay_matches_revm() {
     assert!(mismatches.is_empty(), "evm2 and revm disagree on {} entries", mismatches.len());
 }
 
-/// Guards the mirror against drift from the benchmark's real evm2 path: the
-/// EEST executor must accept the same fixture the mirror replays.
+/// Receipt validation must leave transaction outcomes available to hooks.
 #[test]
-fn mainnet_replay_eest_path_executes() {
+fn mainnet_replay_receipt_validation_preserves_hook_outcomes() {
     let path = workspace_path(FIXTURE);
+    let fixture = ReplayFixture::load(&path);
     let suite = evm2_eest::read_blockchain_fixture(&path).expect("fixture must decode");
-    let mut hook = BlockchainTestNoopHook;
+    let mut hook = TransactionRecorder::default();
     let summary = execute_blockchain_tests_suite(
         &path,
         &suite,
-        BlockchainTestExecuteConfig::default(),
+        BlockchainTestExecuteConfig { compare_receipt_root: true, ..Default::default() },
         &NameFilter::default(),
         &mut hook,
     )
     .expect("EEST replay must succeed");
     assert_eq!(summary.executed, 1);
     assert_eq!(summary.skipped, 0);
+    assert_eq!(hook.0.len(), fixture.transactions());
+    assert!(hook.0.iter().any(|transaction| !transaction.logs.is_empty()));
+
+    let mut revm_hook = TransactionRecorder::default();
+    fixture.execute_revm(&mut revm_hook);
+    assert_eq!(hook.0, revm_hook.0);
 }
 
 /// The replay loops commit every block; a fixture that expects an invalid block
@@ -116,4 +154,39 @@ fn replay_rejects_broken_parent_chain() {
     let header = case.blocks[1].block_header.as_mut().expect("captured blocks carry headers");
     header.parent_hash = B256::ZERO;
     let _fixture = ReplayFixture::from_case(name, case);
+}
+
+#[test]
+#[should_panic(expected = "replay corpus must be post-merge")]
+fn replay_rejects_pre_merge_forks() {
+    let (name, mut case) = fixture_case();
+    case.network = ForkSpec::London;
+    let _fixture = ReplayFixture::from_case(name, case);
+}
+
+#[test]
+#[should_panic(expected = "block access lists are not supported")]
+fn replay_rejects_block_access_lists() {
+    let (name, mut case) = fixture_case();
+    case.blocks[0].block_access_list = Some(Default::default());
+    let _fixture = ReplayFixture::from_case(name, case);
+}
+
+#[test]
+#[should_panic(expected = "block access lists are not supported")]
+fn replay_rejects_decoded_block_access_lists() {
+    let (name, mut case) = fixture_case();
+    case.blocks[0].rlp_decoded =
+        Some(DecodedBlock { block_access_list: Some(Default::default()), ..Default::default() });
+    let _fixture = ReplayFixture::from_case(name, case);
+}
+
+#[test]
+#[should_panic(expected = "gas must match its header")]
+fn revm_replay_checks_header_gas_without_recording() {
+    let (name, mut case) = fixture_case();
+    let header = case.blocks[0].block_header.as_mut().expect("captured blocks carry headers");
+    header.gas_used += U256::ONE;
+    let fixture = ReplayFixture::from_case(name, case);
+    fixture.execute_revm(&mut BlockchainTestNoopHook);
 }

--- a/crates/cli/tests/replay_parity.rs
+++ b/crates/cli/tests/replay_parity.rs
@@ -1,12 +1,14 @@
 //! Differential check for the mainnet block-replay benchmark.
 //!
 //! Replays the benchmark corpus through evm2 and revm and compares every
-//! transaction's gas used, success flag and log count. The paired benchmark
-//! numbers are only meaningful while this passes.
+//! transaction's gas used, success flag and logs, plus each block's EIP-8037 gas
+//! split. The paired benchmark numbers are only meaningful while this passes.
 
+use alloy_primitives::B256;
 use evm2_cli::replay_bench::ReplayFixture;
 use evm2_eest::{
-    BlockchainTestExecuteConfig, BlockchainTestNoopHook, NameFilter, execute_blockchain_tests_suite,
+    BlockchainTestExecuteConfig, BlockchainTestNoopHook, NameFilter,
+    blockchaintest::BlockchainTestCase, execute_blockchain_tests_suite,
 };
 use std::path::{Path, PathBuf};
 
@@ -14,6 +16,12 @@ const FIXTURE: &str = "data/mainnet-25347446-25347455.bin.zst";
 
 fn workspace_path(path: &str) -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("../..").join(path)
+}
+
+fn fixture_case() -> (String, BlockchainTestCase) {
+    let suite =
+        evm2_eest::read_blockchain_fixture(&workspace_path(FIXTURE)).expect("fixture must decode");
+    suite.0.into_iter().next().expect("fixture must contain a case")
 }
 
 #[test]
@@ -41,8 +49,8 @@ fn mainnet_replay_matches_revm() {
             left.number,
             left.txs.len(),
             left.header_gas_used,
-            left.gas_used,
-            right.gas_used
+            left.block_gas_used,
+            right.block_gas_used
         );
     }
     println!(
@@ -53,8 +61,9 @@ fn mainnet_replay_matches_revm() {
         revm.gas_used()
     );
 
-    // Both engines must reproduce every block header's `gasUsed`; this is the
-    // same invariant the EEST executor enforces on the benchmark's evm2 path.
+    // Both engines must reproduce every block header's `gasUsed` under the
+    // fixture fork's rule; this is the same invariant the EEST executor enforces
+    // on the benchmark's evm2 path.
     for (engine, outcome) in [("evm2", &evm2), ("revm", &revm)] {
         let mismatches = outcome.header_gas_mismatches();
         assert!(
@@ -88,4 +97,23 @@ fn mainnet_replay_eest_path_executes() {
     .expect("EEST replay must succeed");
     assert_eq!(summary.executed, 1);
     assert_eq!(summary.skipped, 0);
+}
+
+/// The replay loops commit every block; a fixture that expects an invalid block
+/// must be rejected up front rather than replayed as if it were canonical.
+#[test]
+#[should_panic(expected = "expects an exception")]
+fn replay_rejects_expected_invalid_blocks() {
+    let (name, mut case) = fixture_case();
+    case.blocks[0].expect_exception = Some("BlockException.INVALID_BLOCK".to_owned());
+    let _fixture = ReplayFixture::from_case(name, case);
+}
+
+#[test]
+#[should_panic(expected = "does not extend the previous block")]
+fn replay_rejects_broken_parent_chain() {
+    let (name, mut case) = fixture_case();
+    let header = case.blocks[1].block_header.as_mut().expect("captured blocks carry headers");
+    header.parent_hash = B256::ZERO;
+    let _fixture = ReplayFixture::from_case(name, case);
 }

--- a/crates/eest/src/blockchaintest/execute.rs
+++ b/crates/eest/src/blockchaintest/execute.rs
@@ -517,6 +517,18 @@ fn execute_block(
                         block_execution_gas_used.saturating_add(result.execution_gas_spent());
                     block_state_gas_used =
                         block_state_gas_used.saturating_add(result.state_gas_spent());
+                    hook.transaction_finished(TransactionFinished {
+                        block_index,
+                        total_blocks,
+                        block_number,
+                        transaction_index,
+                        total_transactions,
+                        gas_used: result.tx_gas_used(),
+                        execution_gas_used: result.execution_gas_spent(),
+                        state_gas_used: result.state_gas_spent(),
+                        success: result.status,
+                        logs: &result.logs,
+                    });
                     if compare_receipt_root {
                         let status = if spec.enables(SpecId::BYZANTIUM) {
                             Eip658Value::Eip658(result.status)
@@ -538,13 +550,6 @@ fn execute_block(
                             .expect("executor only builds supported Ethereum transaction types");
                         receipts.push(ReceiptEnvelope::from_typed(tx_type, receipt));
                     }
-                    hook.transaction_finished(TransactionFinished {
-                        block_index,
-                        total_blocks,
-                        block_number,
-                        transaction_index,
-                        total_transactions,
-                    });
                 }
                 Err(err) if should_fail => {
                     let _ = err;

--- a/crates/eest/src/blockchaintest/hook.rs
+++ b/crates/eest/src/blockchaintest/hook.rs
@@ -1,5 +1,5 @@
 use super::types::ForkSpec;
-use alloy_primitives::U256;
+use alloy_primitives::{Log, U256};
 use std::fmt;
 
 /// Execution hooks for blockchain test replay.
@@ -20,7 +20,7 @@ pub trait Hook {
     fn transaction_started(&mut self, _event: TransactionStarted) {}
 
     /// Called after a transaction completes.
-    fn transaction_finished(&mut self, _event: TransactionFinished) {}
+    fn transaction_finished(&mut self, _event: TransactionFinished<'_>) {}
 
     /// Called when transaction execution returns an unexpected error.
     fn transaction_failed(&mut self, _event: TransactionFailed<'_>) {}
@@ -115,7 +115,7 @@ pub struct TransactionStarted {
 
 /// Transaction finish event.
 #[derive(Clone, Copy, Debug)]
-pub struct TransactionFinished {
+pub struct TransactionFinished<'a> {
     /// Zero-based block index in the case.
     pub block_index: usize,
     /// Number of blocks in the case.
@@ -126,6 +126,16 @@ pub struct TransactionFinished {
     pub transaction_index: usize,
     /// Number of transactions in the block.
     pub total_transactions: usize,
+    /// Gas charged to the transaction after refunds.
+    pub gas_used: u64,
+    /// Execution gas charged to the block before refunds, with the calldata floor applied.
+    pub execution_gas_used: u64,
+    /// State gas charged to the block.
+    pub state_gas_used: u64,
+    /// Whether execution succeeded.
+    pub success: bool,
+    /// Logs emitted by the transaction.
+    pub logs: &'a [Log],
 }
 
 /// Transaction failure event.


### PR DESCRIPTION
## Summary

- Pair the `mainnet_25347446_25347455/replay` benchmark with revm. It was the only workload without a revm comparison: `BenchCaseKind::BlockchainReplay` never entered the `EVM2_BENCH_REVM=1` path, so the one bench that resembles real-world load had no paired number.
- New `evm2_cli::replay_bench` module drives the same corpus through both engines:
  - an evm2 mirror of the EEST blockchain executor (the EEST hook does not expose per-transaction results, and the timed bench path still uses the unmodified EEST executor);
  - a revm driver aligned step-by-step with the evm2 path: same per-block spec, block env fields, blob base fee via `blob_params_for_timestamp`, pre/post-block system calls (EIP-2935/4788/7002/7251), withdrawals, and commit cadence (journal accumulation per tx, one commit per block onto `CacheDB<EmptyDB>`).
- Parity gate: `tests/replay_parity.rs` plus a bench-time sanity check compare every transaction's gas used, success flag and a digest of its logs, plus each block's EIP-8037 execution/state gas split, and independently anchor both engines to each header's `gasUsed` under the fork's rule (cumulative receipt gas before Amsterdam, `max(execution, state)` from Amsterdam on). Fixtures are validated as canonical chains up front: every block carries a header, expects no exception and extends the previous block, and `lastblockhash` names the final block. The paired numbers only exist while this passes. Current corpus (10 blocks / 2279 txs / 276,625,341 gas): zero mismatches on both dispatch backends.
- Add `…/replay/setup` and `…/replay/revm/setup` benches measuring the engine-neutral harness work (pre-state + tx decoding, ~31 ms per iteration on the corpus) so the EVM-only ratio can be read separately.
- Give the replay group its own criterion budget (3 s warm-up / 15 s measurement / 20 samples, overridable via `EVM2_BENCH_REPLAY_MEASUREMENT_SECS` / `EVM2_BENCH_REPLAY_SAMPLES`). All other benches keep the existing budget and code paths.

Sample numbers on an Apple M5 Pro (nightly): evm2 109.18 ms vs revm 124.71 ms — 1.14x raw, 1.19x after subtracting the shared setup; with `EVM2_DISPATCH_BACKEND=packed`: 115.02 ms vs 125.96 ms (1.10x / 1.13x). All CI widths < 2.5%.

## Test plan

- `cargo test -p evm2-cli --test replay_parity` — zero mismatches across 2279 transactions; also run with `EVM2_DISPATCH_BACKEND=packed`
- `EVM2_BENCH_REVM=1 cargo bench -p evm2-cli --bench evm -- mainnet`
- `cargo fmt --all --check`; `cargo clippy -p evm2-cli -p evm2 --all-targets` and `cargo doc -p evm2-cli --no-deps --document-private-items` with zero warnings; `cargo test -p evm2-cli`

---

**Maintainer edit**

The paired benchmark now uses the EEST executor for evm2, with transaction outcomes exposed through its hook for parity checks. Both timed paths use a no-op hook, so neither collects transaction summaries or hashes logs. Timings include database setup, transaction decoding, execution, block commits, and teardown. The figures below supersede the setup-subtracted comparison above.

Local measurements at 57737070 on an AMD Ryzen 9 7950X, Linux x86_64, rustc 1.100.0-nightly (e7769602a), and revm 42.0.1. The corpus contains 10 mainnet blocks, 2,279 transactions, and 276,625,341 gas. Each run used a 3-second warm-up, a 15-second measurement target, and 20 samples; parity checks passed on both backends.

| Backend | evm2 | revm | revm / evm2 |
| --- | ---: | ---: | ---: |
| Default (TCO) | 145.89 ms | 173.32 ms | 🟢 1.19× |
| Packed | 156.76 ms | 171.81 ms | 🟢 1.10× |
