### PR TITLE
fix: enforce StackMut invariants

### DIFF
--- a/crates/evm2/src/interpreter/stack.rs
+++ b/crates/evm2/src/interpreter/stack.rs
@@ -236,8 +236,13 @@ impl<'a> StackMut<'a> {
     }
 
     /// Consumes this borrowed stack and returns its raw word pointer and length.
+    ///
+    /// # Safety
+    ///
+    /// The caller must keep the length at or below [`STACK_LIMIT`] and ensure the first `len`
+    /// words are initialized before creating another stack view.
     #[inline]
-    pub const fn into_raw_parts(self) -> (*mut Word, &'a mut usize) {
+    pub const unsafe fn into_raw_parts(self) -> (*mut Word, &'a mut usize) {
         (self.stack.as_mut_ptr().cast(), self.len)
     }
 
@@ -419,9 +424,13 @@ impl<'a> StackMut<'a> {
     }
 
     /// Duplicates the `n`th stack word from the top.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `n` is zero.
     #[inline]
     pub fn dup(&mut self, n: usize) -> Result {
-        debug_assert!(n > 0, "attempted to dup 0");
+        assert!(n > 0, "attempted to dup 0");
         let len = self.len();
         if (len < n) | (len == Self::CAPACITY) {
             cold_path();
@@ -441,15 +450,23 @@ impl<'a> StackMut<'a> {
     }
 
     /// Swaps the top word with the `n`th word below it.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `n` is zero.
     #[inline(always)]
     pub fn swap(&mut self, n: usize) -> Result {
         self.exchange(0, n)
     }
 
     /// Exchanges the `n`th and `m`th words below the top.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `n` and `m` are equal.
     #[inline]
     pub fn exchange(&mut self, n: usize, m: usize) -> Result {
-        debug_assert!(n != m, "overlapping exchange");
+        assert!(n != m, "overlapping exchange");
         let len = self.len();
         if n >= len || m >= len {
             cold_path();
@@ -680,6 +697,30 @@ mod tests {
 
         run_with_len(StackMut::CAPACITY, |stack| {
             assert_matches!(stack.dup(1), Err(InstrStop::StackOverflow));
+        });
+    }
+
+    #[test]
+    #[should_panic(expected = "attempted to dup 0")]
+    fn dup_zero_panics() {
+        run(|stack| {
+            let _ = stack.dup(0);
+        });
+    }
+
+    #[test]
+    #[should_panic(expected = "overlapping exchange")]
+    fn swap_zero_panics() {
+        run_with_len(1, |stack| {
+            let _ = stack.swap(0);
+        });
+    }
+
+    #[test]
+    #[should_panic(expected = "overlapping exchange")]
+    fn overlapping_exchange_panics() {
+        run_with_len(2, |stack| {
+            let _ = stack.exchange(1, 1);
         });
     }
 

--- a/crates/jit/builtins/src/lib.rs
+++ b/crates/jit/builtins/src/lib.rs
@@ -1136,7 +1136,8 @@ mod tests {
         );
         let config = Box::leak(Box::new(config));
         interpreter.prepare_run(config.base_spec_id(), config.version(), host);
-        let (ecx, stack, _stack_len) = EvmContext::from_interpreter_with_stack(interpreter);
+        let (ecx, stack, _stack_len) =
+            unsafe { EvmContext::from_interpreter_with_stack(interpreter) };
         PreparedJitFrame { ecx, stack }
     }
 

--- a/crates/jit/codegen/src/tests/runner.rs
+++ b/crates/jit/codegen/src/tests/runner.rs
@@ -400,7 +400,8 @@ fn with_evm_context_and_host_mut<
     let mut interpreter = Interpreter::<BaseEvmTypes>::new(&tx_env, &message);
     interpreter.prepare_run(config.base_spec_id(), config.version(), host);
 
-    let (mut ecx, stack, stack_len) = EvmContext::from_interpreter_with_stack(&mut interpreter);
+    let (mut ecx, stack, stack_len) =
+        unsafe { EvmContext::from_interpreter_with_stack(&mut interpreter) };
     f(&mut ecx, stack, stack_len)
 }
 

--- a/crates/jit/context/src/lib.rs
+++ b/crates/jit/context/src/lib.rs
@@ -72,12 +72,17 @@ impl<'ctx, 'frame, 'host> EvmContext<'ctx, 'frame, 'host> {
     pub fn from_interpreter(
         interpreter: &'ctx mut Interpreter<'frame, 'host, BaseEvmTypes>,
     ) -> Self {
-        Self::from_interpreter_with_stack(interpreter).0
+        unsafe { Self::from_interpreter_with_stack(interpreter).0 }
     }
 
     /// Creates a new context from an interpreter and returns the borrowed stack.
+    ///
+    /// # Safety
+    ///
+    /// The caller must keep the returned stack length at or below the stack capacity and ensure
+    /// the first `stack_len` words are initialized before accessing the interpreter stack.
     #[inline]
-    pub fn from_interpreter_with_stack(
+    pub unsafe fn from_interpreter_with_stack(
         interpreter: &'ctx mut Interpreter<'frame, 'host, BaseEvmTypes>,
     ) -> (Self, &'ctx mut EvmStack, &'ctx mut usize) {
         let interpreter_ptr = ptr::from_mut(&mut *interpreter);
@@ -86,7 +91,7 @@ impl<'ctx, 'frame, 'host> EvmContext<'ctx, 'frame, 'host> {
         let gas = interpreter.gas();
         let calldatasize = message.input.len();
         let return_data_len = interpreter.return_data().len();
-        let (stack_ptr, stack_len) = interpreter.stack_mut().into_raw_parts();
+        let (stack_ptr, stack_len) = unsafe { interpreter.stack_mut().into_raw_parts() };
         let stack = unsafe { EvmStack::from_mut_ptr(stack_ptr.cast()) };
         let mut this = Self {
             interpreter: interpreter_ptr,
@@ -325,7 +330,8 @@ impl EvmCompilerFn {
         self,
         interpreter: &'ctx mut Interpreter<'frame, 'host, BaseEvmTypes>,
     ) -> InstrStop {
-        let (mut ecx, stack, stack_len) = EvmContext::from_interpreter_with_stack(interpreter);
+        let (mut ecx, stack, stack_len) =
+            unsafe { EvmContext::from_interpreter_with_stack(interpreter) };
         let result = unsafe { self.call(&mut ecx, stack, stack_len) };
         if result == InstrStop::OutOfGas {
             ecx.gas.spend_all();


### PR DESCRIPTION
This fixes ZELLIC-236 by preventing safe `StackMut` calls from violating the invariants used by its unchecked length and pointer operations.

Raw access to the stack length now requires an unsafe call with documented capacity and initialization requirements. The JIT context helper that re-exposes this access is also unsafe. Zero-depth duplication and overlapping exchanges now panic in all builds before reaching unchecked pointer operations, with regression coverage for `dup(0)`, `swap(0)`, and equal-index `exchange`.