### PR TITLE
docs: fix benchmark command

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ See [`crates/evm2/examples/custom_evm`](crates/evm2/examples/custom_evm) for the
 ## Benchmarks
 
 ```sh
-cargo bench -p evm2 --bench evm
-EVM2_BENCH_REVM=1 cargo bench -p evm2 --bench evm
+cargo bench -p evm2-cli --bench evm
+EVM2_BENCH_REVM=1 cargo bench -p evm2-cli --bench evm
 ```
 
 ## Development


### PR DESCRIPTION
## Summary

- fix the benchmark command to use the `evm2-cli` package, which owns the `evm` bench target
- keep the root README focused on the command correction

Split from #385.

## Test plan

- documentation-only change
- verified the diff only changes the benchmark package name

Prompted by: @DaniPopes
