### PR TITLE
fix(state): stream transaction reads to sinks

### DIFF
--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -2002,6 +2002,28 @@ mod tests {
         Ok(TxResultExt { status: true, total_gas_spent: req.tx.nonce, ..TxResultExt::default() })
     }
 
+    fn handle_read_only_tx(
+        req: TxRequest<'_, '_, BaseEvmTypes, TxLegacy>,
+    ) -> HandlerResult<TxResult> {
+        let account = req
+            .host
+            .state
+            .account(&LIFECYCLE_ACCOUNT, false)
+            .map_err(registry::HandlerError::Fatal)?;
+        assert_eq!(account.balance(), Word::from(1));
+        drop(account);
+
+        let slot = req
+            .host
+            .state
+            .storage(&LIFECYCLE_ACCOUNT)
+            .into_slot(LIFECYCLE_STORAGE_KEY, false)
+            .map_err(registry::HandlerError::Fatal)?;
+        assert_eq!(slot.current(), Word::from(1));
+
+        Ok(TxResultExt { status: true, ..TxResultExt::default() })
+    }
+
     fn empty_precompiles() -> Precompiles<BaseEvmTypes> {
         Precompiles::new(Cow::Owned(PrecompileMap::new()))
     }
@@ -2125,6 +2147,27 @@ mod tests {
             TEST_TX_TYPE,
             TxEnvelope::as_legacy,
             handle_lifecycle_tx,
+        );
+        let mut database = InMemoryDB::default();
+        database.insert_account_info(
+            &LIFECYCLE_ACCOUNT,
+            AccountInfo::default().with_balance(Word::from(1)),
+        );
+        database.insert_account_storage(&LIFECYCLE_ACCOUNT, &LIFECYCLE_STORAGE_KEY, &Word::from(1));
+        Evm::<BaseEvmTypes>::new(
+            SpecId::OSAKA,
+            BlockEnvExt::default(),
+            registry,
+            database,
+            Precompiles::base(SpecId::OSAKA),
+        )
+    }
+
+    fn read_only_evm() -> Evm<'static, BaseEvmTypes> {
+        let registry = TxRegistry::new().with_handler(
+            TEST_TX_TYPE,
+            TxEnvelope::as_legacy,
+            handle_read_only_tx,
         );
         let mut database = InMemoryDB::default();
         database.insert_account_info(
@@ -2916,6 +2959,32 @@ mod tests {
         assert_eq!(
             evm.state.storage_slot_untracked(&LIFECYCLE_ACCOUNT, &LIFECYCLE_STORAGE_KEY).unwrap(),
             Word::from(1)
+        );
+    }
+
+    #[test]
+    fn executed_transaction_discard_with_streams_bal_reads() {
+        let mut evm = read_only_evm();
+        let mut sink = InMemoryDB::default();
+        sink.bal_context.enable_bal_builder();
+
+        let _ = evm
+            .transact(&test_tx(0))
+            .expect("read-only transaction should execute")
+            .discard_with(&mut sink)
+            .expect("cache sink is infallible");
+
+        let bal = sink.bal_context.take_bal_builder().expect("builder was enabled");
+        let account = bal.accounts.get(&LIFECYCLE_ACCOUNT).expect("read account is in the bal");
+        assert!(account.account_info.balance.is_empty());
+        assert!(account.account_info.nonce.is_empty());
+        assert!(
+            account
+                .storage
+                .storage
+                .get(&LIFECYCLE_STORAGE_KEY)
+                .expect("read slot is in the bal")
+                .is_empty()
         );
     }
 

--- a/crates/evm2/src/evm/state/mod.rs
+++ b/crates/evm2/src/evm/state/mod.rs
@@ -794,25 +794,33 @@ impl<'a> State<'a> {
             if storage.wiped {
                 sink.storage_wipe(address)?;
             }
-            for (&key, slot) in storage.changed_slots() {
-                sink.storage(StorageChange {
-                    address,
-                    key,
-                    original: slot.original,
-                    current: slot.current,
-                })?;
+            for (&key, slot) in &storage.slots {
+                let value = &slot.value;
+                if value.is_changed() && (!storage.wiped || !value.current.is_zero()) {
+                    sink.storage(StorageChange {
+                        address,
+                        key,
+                        original: value.original,
+                        current: value.current,
+                    })?;
+                } else {
+                    sink.storage_read(address, key, value.current)?;
+                }
             }
         }
 
         for (&address, entry) in self.accounts.iter() {
-            if entry.is_changed() {
+            let selfdestructed = self.selfdestructs.contains(&address);
+            if entry.is_changed() || entry.is_created() || selfdestructed {
                 sink.account(AccountChangeRef {
                     address,
                     original: entry.original.as_ref(),
                     current: entry.present.as_ref(),
                     created: entry.is_created(),
-                    selfdestructed: self.selfdestructs.contains(&address),
+                    selfdestructed,
                 })?;
+            } else {
+                sink.account_read(address, entry.present.as_ref())?;
             }
         }
 


### PR DESCRIPTION
Reports loaded-but-unchanged accounts and storage slots through `StateChangeSink` read callbacks when streaming an `ExecutedTx`. This keeps `commit_with`, `commit_to`, and `discard_with` BAL construction aligned with `PendingState` folding.

Linear: https://linear.app/tempoxyz/issue/ZELLIC-240

Prompted by: @rakita