### PR TITLE
feat(interpreter): expose base opcode implementations

### DIFF
--- a/crates/evm2/src/interpreter/instructions/arithmetic.rs
+++ b/crates/evm2/src/interpreter/instructions/arithmetic.rs
@@ -3,58 +3,58 @@ use crate::interpreter::Word;
 use evm2_macros::instruction;
 
 #[instruction]
-pub(crate) fn add([a, b]: [Word]) -> out {
+pub fn add([a, b]: [Word]) -> out {
     *out = a.wrapping_add(*b);
 }
 
 #[instruction]
-pub(crate) fn mul([a, b]: [Word]) -> out {
+pub fn mul([a, b]: [Word]) -> out {
     *out = a.wrapping_mul(*b);
 }
 
 #[instruction]
-pub(crate) fn sub([a, b]: [Word]) -> out {
+pub fn sub([a, b]: [Word]) -> out {
     *out = a.wrapping_sub(*b);
 }
 
 #[instruction]
-pub(crate) fn div([a, b]: [Word]) -> out {
+pub fn div([a, b]: [Word]) -> out {
     *out = if b.is_zero() { Word::ZERO } else { a.wrapping_div(*b) };
 }
 
 #[instruction]
-pub(crate) fn sdiv([a, b]: [Word]) -> out {
+pub fn sdiv([a, b]: [Word]) -> out {
     *out = i256_div(*a, *b);
 }
 
 #[instruction]
-pub(crate) fn rem([a, b]: [Word]) -> out {
+pub fn rem([a, b]: [Word]) -> out {
     *out = if b.is_zero() { Word::ZERO } else { a.wrapping_rem(*b) };
 }
 
 #[instruction]
-pub(crate) fn smod([a, b]: [Word]) -> out {
+pub fn smod([a, b]: [Word]) -> out {
     *out = i256_mod(*a, *b);
 }
 
 #[instruction]
-pub(crate) fn addmod([a, b, n]: [Word]) -> out {
+pub fn addmod([a, b, n]: [Word]) -> out {
     *out = a.add_mod(*b, *n);
 }
 
 #[instruction]
-pub(crate) fn mulmod([a, b, n]: [Word]) -> out {
+pub fn mulmod([a, b, n]: [Word]) -> out {
     *out = a.mul_mod(*b, *n);
 }
 
 #[instruction(dynamic_gas)]
-pub(crate) fn exp(cx: _, [a, b]: [Word]) -> Result<out> {
+pub fn exp(cx: _, [a, b]: [Word]) -> Result<out> {
     cx.gas.spend(cx.state.gas_params().exp_cost(*b))?;
     *out = a.wrapping_pow(*b);
 }
 
 #[instruction]
-pub(crate) fn signextend([ext, value]: [Word]) -> out {
+pub fn signextend([ext, value]: [Word]) -> out {
     if *ext < 31 {
         let bit_index = (8 * ext.as_limbs()[0] + 7) as usize;
         let mask = (Word::ONE << bit_index) - Word::ONE;

--- a/crates/evm2/src/interpreter/instructions/bitwise.rs
+++ b/crates/evm2/src/interpreter/instructions/bitwise.rs
@@ -4,75 +4,75 @@ use core::cmp::Ordering;
 use evm2_macros::instruction;
 
 #[instruction]
-pub(crate) fn lt([a, b]: [Word]) -> out {
+pub fn lt([a, b]: [Word]) -> out {
     *out = Word::from(a < b);
 }
 
 #[instruction]
-pub(crate) fn gt([a, b]: [Word]) -> out {
+pub fn gt([a, b]: [Word]) -> out {
     *out = Word::from(a > b);
 }
 
 #[instruction]
-pub(crate) fn slt([a, b]: [Word]) -> out {
+pub fn slt([a, b]: [Word]) -> out {
     *out = Word::from(i256_cmp(a, b) == Ordering::Less);
 }
 
 #[instruction]
-pub(crate) fn sgt([a, b]: [Word]) -> out {
+pub fn sgt([a, b]: [Word]) -> out {
     *out = Word::from(i256_cmp(a, b) == Ordering::Greater);
 }
 
 #[instruction]
-pub(crate) fn eq([a, b]: [Word]) -> out {
+pub fn eq([a, b]: [Word]) -> out {
     *out = Word::from(a == b);
 }
 
 #[instruction]
-pub(crate) fn iszero([value]: [Word]) -> out {
+pub fn iszero([value]: [Word]) -> out {
     *out = Word::from(value.is_zero());
 }
 
 #[instruction]
-pub(crate) fn bitand([a, b]: [Word]) -> out {
+pub fn bitand([a, b]: [Word]) -> out {
     *out = *a & *b;
 }
 
 #[instruction]
-pub(crate) fn bitor([a, b]: [Word]) -> out {
+pub fn bitor([a, b]: [Word]) -> out {
     *out = *a | *b;
 }
 
 #[instruction]
-pub(crate) fn bitxor([a, b]: [Word]) -> out {
+pub fn bitxor([a, b]: [Word]) -> out {
     *out = *a ^ *b;
 }
 
 #[instruction]
-pub(crate) fn not([value]: [Word]) -> out {
+pub fn not([value]: [Word]) -> out {
     *out = !*value;
 }
 
 #[instruction]
-pub(crate) fn byte([index, value]: [Word]) -> out {
+pub fn byte([index, value]: [Word]) -> out {
     let index = word_to_usize_saturated(*index);
     *out = if index < 32 { Word::from(value.byte(31 - index)) } else { Word::ZERO };
 }
 
 #[instruction]
-pub(crate) fn shl([shift, value]: [Word]) -> out {
+pub fn shl([shift, value]: [Word]) -> out {
     let shift = word_to_usize_saturated(*shift);
     *out = if shift < 256 { *value << shift } else { Word::ZERO };
 }
 
 #[instruction]
-pub(crate) fn shr([shift, value]: [Word]) -> out {
+pub fn shr([shift, value]: [Word]) -> out {
     let shift = word_to_usize_saturated(*shift);
     *out = if shift < 256 { *value >> shift } else { Word::ZERO };
 }
 
 #[instruction]
-pub(crate) fn sar([shift, value]: [Word]) -> out {
+pub fn sar([shift, value]: [Word]) -> out {
     let shift = word_to_usize_saturated(*shift);
     *out = if shift < 256 {
         value.arithmetic_shr(shift)
@@ -84,7 +84,7 @@ pub(crate) fn sar([shift, value]: [Word]) -> out {
 }
 
 #[instruction]
-pub(crate) fn clz([value]: [Word]) -> out {
+pub fn clz([value]: [Word]) -> out {
     *out = Word::from(value.leading_zeros());
 }
 

--- a/crates/evm2/src/interpreter/instructions/block.rs
+++ b/crates/evm2/src/interpreter/instructions/block.rs
@@ -7,7 +7,7 @@ use crate::{
 use evm2_macros::instruction;
 
 #[instruction]
-pub(crate) fn blockhash(cx: _, [number]: [Word]) -> Result<out> {
+pub fn blockhash(cx: _, [number]: [Word]) -> Result<out> {
     *out = if let Some(diff) = cx.state.host().block_env().number.checked_sub(*number) {
         if diff == 0 || diff > BLOCK_HASH_HISTORY {
             Word::ZERO
@@ -20,22 +20,22 @@ pub(crate) fn blockhash(cx: _, [number]: [Word]) -> Result<out> {
 }
 
 #[instruction]
-pub(crate) fn coinbase(cx: _) -> out {
+pub fn coinbase(cx: _) -> out {
     *out = address_to_word(&cx.state.host().block_env().beneficiary);
 }
 
 #[instruction]
-pub(crate) fn timestamp(cx: _) -> out {
+pub fn timestamp(cx: _) -> out {
     *out = cx.state.host().block_env().timestamp;
 }
 
 #[instruction]
-pub(crate) fn block_number(cx: _) -> out {
+pub fn block_number(cx: _) -> out {
     *out = cx.state.host().block_env().number;
 }
 
 #[instruction]
-pub(crate) fn difficulty(cx: _) -> out {
+pub fn difficulty(cx: _) -> out {
     *out = if cx.state.feature(EvmFeatures::EIP4399) {
         cx.state.host().block_env().prevrandao
     } else {
@@ -44,39 +44,39 @@ pub(crate) fn difficulty(cx: _) -> out {
 }
 
 #[instruction]
-pub(crate) fn gaslimit(cx: _) -> out {
+pub fn gaslimit(cx: _) -> out {
     *out = cx.state.host().block_env().gas_limit;
 }
 
 #[instruction]
-pub(crate) fn chainid(cx: _) -> Result<out> {
+pub fn chainid(cx: _) -> Result<out> {
     *out = cx.state.tx().chain_id;
 }
 
 #[instruction]
-pub(crate) fn selfbalance(cx: _) -> Result<out> {
+pub fn selfbalance(cx: _) -> Result<out> {
     let destination = &cx.state.message().destination;
     *out = cx.state.host().load_account(destination, false, false)?.balance;
 }
 
 #[instruction]
-pub(crate) fn basefee(cx: _) -> Result<out> {
+pub fn basefee(cx: _) -> Result<out> {
     *out = cx.state.host().block_env().basefee;
 }
 
 #[instruction]
-pub(crate) fn blobhash(cx: _, [index]: [Word]) -> Result<out> {
+pub fn blobhash(cx: _, [index]: [Word]) -> Result<out> {
     let index = word_to_usize_saturated(*index);
     *out = cx.state.tx().blob_hashes.get(index).copied().unwrap_or_default();
 }
 
 #[instruction]
-pub(crate) fn blobbasefee(cx: _) -> Result<out> {
+pub fn blobbasefee(cx: _) -> Result<out> {
     *out = cx.state.host().block_env().blob_basefee;
 }
 
 #[instruction]
-pub(crate) fn slotnum(cx: _) -> Result<out> {
+pub fn slotnum(cx: _) -> Result<out> {
     *out = cx.state.host().block_env().slot_num;
 }
 

--- a/crates/evm2/src/interpreter/instructions/control.rs
+++ b/crates/evm2/src/interpreter/instructions/control.rs
@@ -10,18 +10,18 @@ use core::hint::cold_path;
 use evm2_macros::instruction;
 
 #[instruction]
-pub(crate) fn stop() -> Result {
+pub fn stop() -> Result {
     cold_path();
     Err(InstrStop::Stop)
 }
 
 #[instruction]
-pub(crate) fn jump(cx: _, [target]: [Word]) -> Result {
+pub fn jump(cx: _, [target]: [Word]) -> Result {
     jump_inner(*target, &mut cx)
 }
 
 #[instruction]
-pub(crate) fn jumpi(cx: _, [target, cond]: [Word]) -> Result {
+pub fn jumpi(cx: _, [target, cond]: [Word]) -> Result {
     if !cond.is_zero() {
         jump_inner(*target, &mut cx)?;
     } else {
@@ -41,25 +41,25 @@ fn jump_inner<T: EvmTypesHost>(target: Word, cx: &mut InstructionCx<'_, '_, '_, 
 }
 
 #[instruction]
-pub(crate) fn pc(cx: _) -> out {
+pub fn pc(cx: _) -> out {
     *out = Word::from(cx.state.bytecode().pc_offset(*cx.pc));
 }
 
 #[instruction(dynamic_gas)]
-pub(crate) fn gas(cx: _) -> out {
+pub fn gas(cx: _) -> out {
     *out = Word::from(cx.gas.remaining());
 }
 
 #[instruction]
-pub(crate) fn jumpdest() {}
+pub fn jumpdest() {}
 
 #[instruction(dynamic_gas)]
-pub(crate) fn r#return(cx: _, [offset, len]: [Word]) -> Result {
+pub fn r#return(cx: _, [offset, len]: [Word]) -> Result {
     return_inner(cx, offset, len, InstrStop::Return)
 }
 
 #[instruction(dynamic_gas)]
-pub(crate) fn revert(cx: _, [offset, len]: [Word]) -> Result {
+pub fn revert(cx: _, [offset, len]: [Word]) -> Result {
     return_inner(cx, offset, len, InstrStop::Revert)
 }
 
@@ -89,7 +89,7 @@ fn return_inner<T: EvmTypesHost>(
 }
 
 #[instruction]
-pub(crate) fn invalid() -> Result {
+pub fn invalid() -> Result {
     cold_path();
     Err(InstrStop::InvalidOpcode)
 }

--- a/crates/evm2/src/interpreter/instructions/crypto.rs
+++ b/crates/evm2/src/interpreter/instructions/crypto.rs
@@ -3,7 +3,7 @@ use alloy_primitives::{KECCAK256_EMPTY, keccak256 as keccak256_hash};
 use evm2_macros::instruction;
 
 #[instruction(dynamic_gas)]
-pub(crate) fn keccak256(cx: _, [offset, len]: [Word]) -> Result<out> {
+pub fn keccak256(cx: _, [offset, len]: [Word]) -> Result<out> {
     let len = word_to_usize(*len)?;
     cx.gas.spend(cx.state.gas_params().keccak256_word_cost(len))?;
     let hash = if len == 0 {

--- a/crates/evm2/src/interpreter/instructions/env.rs
+++ b/crates/evm2/src/interpreter/instructions/env.rs
@@ -44,32 +44,32 @@ fn copy_data(
 }
 
 #[instruction]
-pub(crate) fn address(cx: _) -> out {
+pub fn address(cx: _) -> out {
     *out = address_to_word(&cx.state.message().destination);
 }
 
 #[instruction(dynamic_gas)]
-pub(crate) fn balance(cx: _, [addr]: [Word]) -> Result<out> {
+pub fn balance(cx: _, [addr]: [Word]) -> Result<out> {
     *out = load_account(&mut cx, *addr, false)?.balance;
 }
 
 #[instruction]
-pub(crate) fn origin(cx: _) -> out {
+pub fn origin(cx: _) -> out {
     *out = address_to_word(&cx.state.tx().origin);
 }
 
 #[instruction]
-pub(crate) fn caller(cx: _) -> out {
+pub fn caller(cx: _) -> out {
     *out = address_to_word(&cx.state.message().caller);
 }
 
 #[instruction]
-pub(crate) fn callvalue(cx: _) -> out {
+pub fn callvalue(cx: _) -> out {
     *out = cx.state.message().value;
 }
 
 #[instruction]
-pub(crate) fn calldataload(cx: _, [offset]: [Word]) -> out {
+pub fn calldataload(cx: _, [offset]: [Word]) -> out {
     let offset = word_to_usize_saturated(*offset);
     let input = cx.state.message().input.as_ref();
     let mut word = B256::ZERO;
@@ -81,12 +81,12 @@ pub(crate) fn calldataload(cx: _, [offset]: [Word]) -> out {
 }
 
 #[instruction]
-pub(crate) fn calldatasize(cx: _) -> out {
+pub fn calldatasize(cx: _) -> out {
     *out = Word::from(cx.state.message().input.len());
 }
 
 #[instruction(dynamic_gas)]
-pub(crate) fn calldatacopy(cx: _, [memory_offset, data_offset, len]: [Word]) -> Result {
+pub fn calldatacopy(cx: _, [memory_offset, data_offset, len]: [Word]) -> Result {
     let len = word_to_usize(*len)?;
     cx.gas.spend(cx.state.gas_params().copy_cost(len))?;
     let input = cx.state.message().input.as_ref();
@@ -95,12 +95,12 @@ pub(crate) fn calldatacopy(cx: _, [memory_offset, data_offset, len]: [Word]) -> 
 }
 
 #[instruction]
-pub(crate) fn codesize(cx: _) -> out {
+pub fn codesize(cx: _) -> out {
     *out = Word::from(cx.state.bytecode().len());
 }
 
 #[instruction(dynamic_gas)]
-pub(crate) fn codecopy(cx: _, [memory_offset, code_offset, len]: [Word]) -> Result {
+pub fn codecopy(cx: _, [memory_offset, code_offset, len]: [Word]) -> Result {
     let len = word_to_usize(*len)?;
     cx.gas.spend(cx.state.gas_params().copy_cost(len))?;
     let data = cx.state.0.bytecode.original_byte_slice();
@@ -109,23 +109,23 @@ pub(crate) fn codecopy(cx: _, [memory_offset, code_offset, len]: [Word]) -> Resu
 }
 
 #[instruction]
-pub(crate) fn gasprice(cx: _) -> out {
+pub fn gasprice(cx: _) -> out {
     *out = cx.state.tx().gas_price;
 }
 
 #[instruction(dynamic_gas)]
-pub(crate) fn extcodesize(cx: _, [addr]: [Word]) -> Result<out> {
+pub fn extcodesize(cx: _, [addr]: [Word]) -> Result<out> {
     *out = Word::from(load_account(&mut cx, *addr, true)?.code.len());
 }
 
 #[instruction(dynamic_gas)]
-pub(crate) fn extcodehash(cx: _, [addr]: [Word]) -> Result<out> {
+pub fn extcodehash(cx: _, [addr]: [Word]) -> Result<out> {
     let account = load_account(&mut cx, *addr, false)?;
     *out = if account.is_empty { Word::ZERO } else { b256_to_word(account.code_hash) };
 }
 
 #[instruction(dynamic_gas)]
-pub(crate) fn extcodecopy(cx: _, [addr, memory_offset, code_offset, len]: [Word]) -> Result {
+pub fn extcodecopy(cx: _, [addr, memory_offset, code_offset, len]: [Word]) -> Result {
     let len = word_to_usize(*len)?;
     cx.gas.spend(cx.state.gas_params().extcodecopy_cost(len))?;
     let memory_offset = if len != 0 {
@@ -146,12 +146,12 @@ pub(crate) fn extcodecopy(cx: _, [addr, memory_offset, code_offset, len]: [Word]
 }
 
 #[instruction]
-pub(crate) fn returndatasize(cx: _) -> Result<out> {
+pub fn returndatasize(cx: _) -> Result<out> {
     *out = Word::from(cx.state.return_data().len());
 }
 
 #[instruction(dynamic_gas)]
-pub(crate) fn returndatacopy(cx: _, [memory_offset, data_offset, len]: [Word]) -> Result {
+pub fn returndatacopy(cx: _, [memory_offset, data_offset, len]: [Word]) -> Result {
     let len = word_to_usize(*len)?;
     let data_offset = word_to_usize_saturated(*data_offset);
     if data_offset.saturating_add(len) > cx.state.return_data().len() {

--- a/crates/evm2/src/interpreter/instructions/host.rs
+++ b/crates/evm2/src/interpreter/instructions/host.rs
@@ -16,7 +16,7 @@ const fn require_non_staticcall<T: EvmTypesHost>(state: &InterpreterState<'_, '_
 }
 
 #[instruction(dynamic_gas)]
-pub(crate) fn sload(cx: _, [key]: [Word]) -> Result<out> {
+pub fn sload(cx: _, [key]: [Word]) -> Result<out> {
     // EIP-2929: SLOAD pays the warm read cost as static opcode gas, then only
     // charges the additional cold cost when the slot was not already warm. Avoid
     // touching the host/database if the frame cannot afford that cold surcharge.
@@ -32,7 +32,7 @@ pub(crate) fn sload(cx: _, [key]: [Word]) -> Result<out> {
 }
 
 #[instruction(dynamic_gas)]
-pub(crate) fn sstore(cx: _, [key, value]: [Word]) -> Result {
+pub fn sstore(cx: _, [key, value]: [Word]) -> Result {
     require_non_staticcall(cx.state)?;
     let is_eip2200 = cx.state.feature(EvmFeatures::EIP2200);
 
@@ -80,20 +80,20 @@ pub(crate) fn sstore(cx: _, [key, value]: [Word]) -> Result {
 }
 
 #[instruction]
-pub(crate) fn tload(cx: _, [key]: [Word]) -> out {
+pub fn tload(cx: _, [key]: [Word]) -> out {
     let destination = &cx.state.message().destination;
     *out = cx.state.host().tload(destination, key);
 }
 
 #[instruction]
-pub(crate) fn tstore(cx: _, [key, value]: [Word]) -> Result {
+pub fn tstore(cx: _, [key, value]: [Word]) -> Result {
     require_non_staticcall(cx.state)?;
     let destination = &cx.state.message().destination;
     cx.state.host().tstore(destination, key, value);
 }
 
 #[instruction(no_stack_preamble, dynamic_gas)]
-pub(crate) fn log<const N: usize>(cx: _) -> Result {
+pub fn log<const N: usize>(cx: _) -> Result {
     log_common(cx, stack, N)
 }
 

--- a/crates/evm2/src/interpreter/instructions/memory.rs
+++ b/crates/evm2/src/interpreter/instructions/memory.rs
@@ -2,33 +2,33 @@ use crate::{interpreter::Word, utils::word_to_usize};
 use evm2_macros::instruction;
 
 #[instruction(dynamic_gas)]
-pub(crate) fn mload(cx: _, [offset]: [Word]) -> Result<out> {
+pub fn mload(cx: _, [offset]: [Word]) -> Result<out> {
     let offset = word_to_usize(*offset)?;
     cx.state.resize_memory(cx.gas, offset, 32)?;
     *out = cx.state.memory().get_word(offset);
 }
 
 #[instruction(dynamic_gas)]
-pub(crate) fn mstore(cx: _, [offset, value]: [Word]) -> Result {
+pub fn mstore(cx: _, [offset, value]: [Word]) -> Result {
     let offset = word_to_usize(*offset)?;
     cx.state.resize_memory(cx.gas, offset, 32)?;
     cx.state.memory().set(offset, &value.to_be_bytes::<32>());
 }
 
 #[instruction(dynamic_gas)]
-pub(crate) fn mstore8(cx: _, [offset, value]: [Word]) -> Result {
+pub fn mstore8(cx: _, [offset, value]: [Word]) -> Result {
     let offset = word_to_usize(*offset)?;
     cx.state.resize_memory(cx.gas, offset, 1)?;
     cx.state.memory().set(offset, &[value.byte(0)]);
 }
 
 #[instruction]
-pub(crate) fn msize(cx: _) -> out {
+pub fn msize(cx: _) -> out {
     *out = Word::from(cx.state.memory().len());
 }
 
 #[instruction(dynamic_gas)]
-pub(crate) fn mcopy(cx: _, [dst, src, len]: [Word]) -> Result {
+pub fn mcopy(cx: _, [dst, src, len]: [Word]) -> Result {
     let len = word_to_usize(*len)?;
     cx.gas.spend(cx.state.gas_params().mcopy_cost(len))?;
     if len != 0 {

--- a/crates/evm2/src/interpreter/instructions/mod.rs
+++ b/crates/evm2/src/interpreter/instructions/mod.rs
@@ -1,32 +1,32 @@
 mod arithmetic;
-pub(crate) use arithmetic::*;
+pub use arithmetic::*;
 
 mod bitwise;
-pub(crate) use bitwise::*;
+pub use bitwise::*;
 
 mod block;
-pub(crate) use block::*;
+pub use block::*;
 
 mod control;
-pub(crate) use control::*;
+pub use control::*;
 
 mod crypto;
-pub(crate) use crypto::*;
+pub use crypto::*;
 
 mod env;
-pub(crate) use env::*;
+pub use env::*;
 
 mod host;
-pub(crate) use host::*;
+pub use host::*;
 
 mod memory;
-pub(crate) use memory::*;
+pub use memory::*;
 
 mod stack;
-pub(crate) use stack::*;
+pub use stack::*;
 
 mod system;
-pub(crate) use system::*;
+pub use system::*;
 
 pub mod i256;
 

--- a/crates/evm2/src/interpreter/instructions/stack.rs
+++ b/crates/evm2/src/interpreter/instructions/stack.rs
@@ -2,10 +2,10 @@ use crate::interpreter::{InstrStop, Word};
 use evm2_macros::instruction;
 
 #[instruction]
-pub(crate) fn pop([_value]: [Word]) -> Result {}
+pub fn pop([_value]: [Word]) -> Result {}
 
 #[instruction(no_stack_preamble)]
-pub(crate) fn push<const N: usize>(cx: _) -> Result {
+pub fn push<const N: usize>(cx: _) -> Result {
     if N == 0 {
         return stack.push(Word::ZERO);
     }
@@ -14,31 +14,31 @@ pub(crate) fn push<const N: usize>(cx: _) -> Result {
 }
 
 #[instruction(no_stack_preamble)]
-pub(crate) fn dup<const N: usize>() -> Result {
+pub fn dup<const N: usize>() -> Result {
     stack.dup(N)
 }
 
 #[instruction(no_stack_preamble)]
-pub(crate) fn swap<const N: usize>() -> Result {
+pub fn swap<const N: usize>() -> Result {
     stack.swap(N)
 }
 
 #[instruction(no_stack_preamble)]
-pub(crate) fn dupn(cx: _) -> Result {
+pub fn dupn(cx: _) -> Result {
     let n = decode_single(unsafe { cx.pc.read_bytes_offset_unchecked(1, 1)[0] })
         .ok_or(InstrStop::InvalidImmediateEncoding)?;
     stack.dup(n)
 }
 
 #[instruction(no_stack_preamble)]
-pub(crate) fn swapn(cx: _) -> Result {
+pub fn swapn(cx: _) -> Result {
     let n = decode_single(unsafe { cx.pc.read_bytes_offset_unchecked(1, 1)[0] })
         .ok_or(InstrStop::InvalidImmediateEncoding)?;
     stack.exchange(0, n)
 }
 
 #[instruction(no_stack_preamble)]
-pub(crate) fn exchange(cx: _) -> Result {
+pub fn exchange(cx: _) -> Result {
     let (n, m) = decode_pair(unsafe { cx.pc.read_bytes_offset_unchecked(1, 1)[0] })
         .ok_or(InstrStop::InvalidImmediateEncoding)?;
     stack.exchange(n, m)

--- a/crates/evm2/src/interpreter/instructions/system.rs
+++ b/crates/evm2/src/interpreter/instructions/system.rs
@@ -257,27 +257,27 @@ fn call_inner<T: EvmTypesHost>(
 }
 
 #[instruction(no_stack_preamble, dynamic_gas)]
-pub(crate) fn call(cx: _) -> Result {
+pub fn call(cx: _) -> Result {
     call_inner(stack, cx.gas, cx.state, MessageKind::Call)
 }
 
 #[instruction(no_stack_preamble, dynamic_gas)]
-pub(crate) fn callcode(cx: _) -> Result {
+pub fn callcode(cx: _) -> Result {
     call_inner(stack, cx.gas, cx.state, MessageKind::CallCode)
 }
 
 #[instruction(no_stack_preamble, dynamic_gas)]
-pub(crate) fn delegatecall(cx: _) -> Result {
+pub fn delegatecall(cx: _) -> Result {
     call_inner(stack, cx.gas, cx.state, MessageKind::DelegateCall)
 }
 
 #[instruction(no_stack_preamble, dynamic_gas)]
-pub(crate) fn staticcall(cx: _) -> Result {
+pub fn staticcall(cx: _) -> Result {
     call_inner(stack, cx.gas, cx.state, MessageKind::StaticCall)
 }
 
 #[instruction(no_stack_preamble, dynamic_gas)]
-pub(crate) fn create<const IS_CREATE2: bool>(cx: _) -> Result {
+pub fn create<const IS_CREATE2: bool>(cx: _) -> Result {
     create_inner(stack, cx.gas, cx.state, IS_CREATE2)
 }
 
@@ -410,7 +410,7 @@ fn create_inner<T: EvmTypesHost>(
 }
 
 #[instruction(dynamic_gas)]
-pub(crate) fn selfdestruct(cx: _, [target]: [Word]) -> Result {
+pub fn selfdestruct(cx: _, [target]: [Word]) -> Result {
     require_non_staticcall(cx.state)?;
     let target = word_to_address(*target);
     let cold_load_gas = cx.state.gas_params().selfdestruct_cold_cost();

--- a/crates/evm2/src/interpreter/mod.rs
+++ b/crates/evm2/src/interpreter/mod.rs
@@ -6,7 +6,11 @@ pub use gas::{Gas, GasTracker, MemoryGas};
 #[macro_use]
 mod utils;
 
-pub(crate) mod instructions;
+/// Base EVM instruction implementations.
+///
+/// This module is not part of the stable API and has no stability guarantees.
+#[doc(hidden)]
+pub mod instructions;
 pub use instructions::i256;
 
 pub(crate) mod dispatch;


### PR DESCRIPTION
## Summary

- expose the generated base opcode instruction types for downstream custom instruction tables
- keep the instruction module hidden from generated documentation
- explicitly document that the module has no stability guarantees

## Testing

- `cargo +nightly fmt --all -- --check`
- `cargo +nightly clippy -p evm2 --no-default-features --features std,map-foldhash,parse,asm-keccak -- -D warnings`
- `cargo check -p evm2 --no-default-features --features std,map-foldhash,parse,asm-keccak`
- `cargo test -p evm2 --lib --no-default-features --features std,map-foldhash,parse,asm-keccak` (487 passed)

Closes #387

Prompted by: @DaniPopes