### PR TITLE
fix: preserve BAL code and selfdestruct reads

### DIFF
--- a/crates/evm2/src/evm/bal/account.rs
+++ b/crates/evm2/src/evm/bal/account.rs
@@ -6,7 +6,7 @@ use super::{
 };
 use crate::{
     bytecode::Bytecode,
-    evm::state::{AccountInfo, StorageSlot},
+    evm::state::{AccountInfo, StorageOverlay},
 };
 use alloc::vec::Vec;
 use alloy_eip7928::{
@@ -464,17 +464,31 @@ impl StorageBal {
         }
     }
 
-    /// Update storage from an account's pending [`StorageSlot`] overlay: a changed slot records a
-    /// write at `bal_index`, a loaded-but-unchanged slot records a read.
+    /// Update storage from an account's pending [`StorageOverlay`]: a changed slot records a write
+    /// at `bal_index`, and a loaded-but-unchanged slot records a read.
+    ///
+    /// A wipe converts every storage key previously accessed for the account into a read, as
+    /// required for storage within a selfdestructed contract. Wiped slots whose final value is zero
+    /// remain reads; any non-zero post-wipe slot is recorded as a subsequent write.
     #[inline]
-    pub fn update_pending(&mut self, bal_index: BlockAccessIndex, slots: &U256Map<StorageSlot>) {
-        self.storage.reserve(slots.len());
-        for (key, slot) in slots {
-            self.storage.entry(*key).or_default().update(
-                bal_index,
-                &slot.value.original,
-                slot.value.current,
-            );
+    pub fn update_pending(&mut self, bal_index: BlockAccessIndex, overlay: &StorageOverlay) {
+        if overlay.wiped {
+            self.record_wipe();
+        }
+        self.storage.reserve(overlay.slots.len());
+        for (key, slot) in &overlay.slots {
+            let changes = self.storage.entry(*key).or_default();
+            if !overlay.wiped || !slot.value.current.is_zero() {
+                changes.update(bal_index, &slot.value.original, slot.value.current);
+            }
+        }
+    }
+
+    /// Converts all storage keys accumulated so far into reads after a storage wipe.
+    #[inline]
+    pub(crate) fn record_wipe(&mut self) {
+        for changes in self.storage.values_mut() {
+            changes.changes.clear();
         }
     }
 

--- a/crates/evm2/src/evm/bal/bal_context.rs
+++ b/crates/evm2/src/evm/bal/bal_context.rs
@@ -196,7 +196,7 @@ impl BalContext {
             bal.update_account(index, address, entry.original.as_ref(), entry.present.as_ref());
         }
         for (&address, overlay) in storage {
-            bal.accounts.entry(address).or_default().storage.update_pending(index, &overlay.slots);
+            bal.accounts.entry(address).or_default().storage.update_pending(index, overlay);
         }
     }
 
@@ -317,9 +317,9 @@ impl BalContext {
 /// This is the sink shape of the [`Self::commit_pending`] fold: changed accounts and storage
 /// slots are
 /// recorded as writes, loaded-but-unchanged ones -- the read callbacks -- as reads. The bytecode
-/// and storage-wipe callbacks need no BAL action: code changes surface through
-/// [`StateChangeSink::account`], and a wiped account's storage surfaces through the storage
-/// callbacks. Every callback is a no-op when BAL construction is disabled.
+/// Code changes surface through [`StateChangeSink::account`]. A storage wipe converts every slot
+/// previously accumulated for that account into a read; the following storage callbacks add any
+/// post-wipe writes and reads. Every callback is a no-op when BAL construction is disabled.
 impl StateChangeSink for BalContext {
     type Error = Infallible;
 
@@ -350,6 +350,14 @@ impl StateChangeSink for BalContext {
                 .entry(change.key)
                 .or_default()
                 .update(index, &change.original, change.current);
+        }
+        Ok(())
+    }
+
+    #[inline]
+    fn storage_wipe(&mut self, address: Address) -> Result<(), Self::Error> {
+        if let Some(bal) = self.bal_builder.as_mut() {
+            bal.accounts.entry(address).or_default().storage.record_wipe();
         }
         Ok(())
     }

--- a/crates/evm2/src/evm/bal/list.rs
+++ b/crates/evm2/src/evm/bal/list.rs
@@ -112,11 +112,7 @@ impl Bal {
             );
         }
         for (address, overlay) in &pending.storage {
-            self.accounts
-                .entry(*address)
-                .or_default()
-                .storage
-                .update_pending(bal_index, &overlay.slots);
+            self.accounts.entry(*address).or_default().storage.update_pending(bal_index, overlay);
         }
     }
 
@@ -124,9 +120,10 @@ impl Bal {
     /// against its present info. An absent side is the non-existent (default) account, so an
     /// account removed by the transaction records zeroed writes.
     ///
-    /// A selfdestructed account needs no special-casing: transaction finalization already resolved
-    /// its present info to the EIP-8246 balance-only remnant or to a removed account, and its
-    /// destroyed storage writes surface as reads (execution-specs `destroy_storage`).
+    /// A selfdestructed account needs no account-info special-casing: transaction finalization
+    /// already resolved its present info to the EIP-8246 balance-only remnant or to a removed
+    /// account. [`StorageBal::update_pending`](super::StorageBal::update_pending) uses the storage
+    /// wipe marker to convert its destroyed storage writes into reads.
     #[inline]
     pub(crate) fn update_account(
         &mut self,
@@ -364,8 +361,12 @@ mod tests {
     use crate::{
         bytecode::Bytecode,
         evm::{
-            bal::{AccountInfoBal, BalChangeKind, BalChanges, BalCodeChange, StorageBal},
-            state::{Account, AccountInfo, StorageOverlay, StorageSlot, Tracked},
+            bal::{
+                AccountInfoBal, BalChangeKind, BalChanges, BalCodeChange, BalContext, StorageBal,
+            },
+            state::{
+                Account, AccountInfo, StateChangeSource, StorageOverlay, StorageSlot, Tracked,
+            },
         },
     };
     use alloc::{vec, vec::Vec};
@@ -543,16 +544,16 @@ mod tests {
         let address = Address::with_last_byte(1);
 
         // Transaction finalization already resolved the selfdestructed account: removed
-        // (`present: None`), storage overlay wiped with the prior writes turned into
-        // loaded-but-unchanged slots surfacing as reads. The BAL derives from that overlay
-        // without special-casing.
+        // (`present: None`) with its storage overlay marked as wiped.
         let account = Account {
             original: Some(AccountInfo::default().with_balance(U256::from(100))),
             present: None,
             ..Default::default()
         };
         let mut overlay = StorageOverlay { wiped: true, ..Default::default() };
-        overlay.slots.insert(U256::from(5), slot(U256::from(42), U256::from(42)));
+        // Wiping preserves the transaction-boundary original for state accounting while setting
+        // the current value to zero. BAL construction must classify this destroyed slot as a read.
+        overlay.slots.insert(U256::from(5), slot(U256::from(42), U256::ZERO));
         let pending = PendingState {
             accounts: AddressMap::from_iter([(address, account)]),
             storage: AddressMap::from_iter([(address, overlay)]),
@@ -568,8 +569,48 @@ mod tests {
             account.account_info.balance.changes,
             vec![AlloyBalanceChange::new(idx(2), U256::ZERO)]
         );
-        // The loaded-but-unchanged slot stays a read (empty writes).
+        // The changed-to-zero slot becomes a read because the overlay is wiped.
         assert!(account.storage.storage.get(&U256::from(5)).unwrap().is_empty());
+    }
+
+    #[test]
+    fn storage_wipe_converts_prior_writes_to_reads_in_both_fold_paths() {
+        let address = Address::with_last_byte(1);
+        let key = U256::from(5);
+
+        let mut written = StorageOverlay::default();
+        written.slots.insert(key, slot(U256::ZERO, U256::from(42)));
+        let first = PendingState {
+            accounts: AddressMap::default(),
+            storage: AddressMap::from_iter([(address, written)]),
+            selfdestructs: AddressSet::default(),
+        };
+
+        let mut wiped = StorageOverlay { wiped: true, ..Default::default() };
+        wiped.slots.insert(key, slot(U256::from(42), U256::ZERO));
+        let second = PendingState {
+            accounts: AddressMap::default(),
+            storage: AddressMap::from_iter([(address, wiped)]),
+            selfdestructs: AddressSet::from_iter([address]),
+        };
+
+        let mut direct = Bal::new();
+        direct.commit(idx(1), first.clone());
+        direct.commit(idx(2), second.clone());
+
+        let mut streamed = BalContext::new().with_bal_builder();
+        streamed.set_bal_index(idx(1));
+        first.visit(&mut streamed).unwrap();
+        streamed.set_bal_index(idx(2));
+        second.visit(&mut streamed).unwrap();
+        let streamed = streamed.take_bal_builder().unwrap();
+
+        assert_eq!(direct, streamed);
+        assert!(direct.accounts[&address].storage.storage[&key].is_empty());
+
+        let alloy = AlloyBal::from(direct);
+        assert_eq!(alloy[0].storage_reads, vec![key]);
+        assert!(alloy[0].storage_changes.is_empty());
     }
 
     #[test]

--- a/crates/evm2/src/evm/db/cache.rs
+++ b/crates/evm2/src/evm/db/cache.rs
@@ -161,7 +161,7 @@ impl<ExtDB> CacheDB<ExtDB> {
                 continue;
             }
             match entry.present.as_ref() {
-                Some(account) => self.insert_account_info(&address, account.clone_no_code()),
+                Some(account) => self.insert_account_info(&address, account.clone()),
                 None => {
                     self.cache.accounts.insert(address, None);
                     self.cache.storage.entry(address).or_default().wipe();
@@ -314,6 +314,12 @@ impl<ExtDB: DynDatabase> DynDatabase for CacheDB<ExtDB> {
         if let Some(bal_account) = bal_account {
             self.bal_context.populate_bal_account(bal_account, &mut account);
         }
+        // BAL code changes carry the bytecode inline. Register it before returning the account so
+        // a subsequent code-by-hash lookup cannot fall through to a backing database that never
+        // saw the BAL-provided code.
+        if let Some(info) = account.as_mut() {
+            Self::insert_contract_inner(&mut self.cache.contracts, info);
+        }
         Ok(account)
     }
 
@@ -419,7 +425,7 @@ mod typed {
 mod tests {
     use super::*;
     use crate::{
-        evm::bal::{AccountBal, Bal, BalChanges, BlockAccessIndex},
+        evm::bal::{AccountBal, Bal, BalChanges, BalCodeChange, BlockAccessIndex},
         interpreter::op,
     };
     use alloc::{string::ToString, sync::Arc, vec};
@@ -558,6 +564,26 @@ mod tests {
         assert_eq!(cache.db.inner().account_loads, 1);
     }
 
+    #[test]
+    fn commit_caches_present_code_when_its_hash_is_unchanged() {
+        let address = Address::with_last_byte(1);
+        let code = Bytecode::new_legacy(Bytes::from_static(&[op::STOP]));
+        let code_hash = code.hash_slow();
+        let original = AccountInfo::default().with_code(code.clone());
+        let current = original.clone().with_balance(Word::from(1));
+        let mut cache = CacheDB::new(crate::evm::Db::new(CountingDB::default()));
+
+        // The account changes, but the code hash does not, so `changed_code` does not emit the
+        // bytecode separately. Committing the present account must still register its inline code.
+        let mut pending = PendingState::default();
+        pending.insert_account(address, Some(original), Some(current));
+        cache.commit_pending(&pending);
+
+        assert_eq!(cache.account_info(&address).unwrap().code_hash, code_hash);
+        assert_eq!(cache.get_code_by_hash(&code_hash).unwrap(), code);
+        assert_eq!(cache.db.inner().code_loads, 0);
+    }
+
     /// A counting cache with an attached read BAL positioned at index 2.
     fn cache_with_read_bal(
         address: Address,
@@ -605,6 +631,32 @@ mod tests {
 
         // Storage slot 7 is served from the BAL, shadowing the database value (9).
         assert_eq!(cache.get_storage(&address, &Word::from(7)).unwrap(), Word::from(42));
+    }
+
+    #[test]
+    fn attached_bal_registers_supplied_bytecode_by_hash() {
+        let address = Address::with_last_byte(1);
+        let code = Bytecode::new_legacy(Bytes::from_static(&[op::STOP]));
+        let code_hash = code.hash_slow();
+        let mut account = AccountBal::default();
+        account.account_info.code = BalChanges::new(vec![BalCodeChange::new(
+            BlockAccessIndex::new(1),
+            (code_hash, code.clone()),
+        )]);
+
+        let mut cache = counting_cache();
+        cache.bal_context.set_bal(Arc::new(Bal::from_iter([(address, account)])));
+        cache.bal_context.set_bal_index(BlockAccessIndex::new(2));
+
+        let loaded = cache.get_account(&address).unwrap().unwrap();
+        assert_eq!(loaded.code_hash, code_hash);
+        assert_eq!(loaded.code.as_ref(), Some(&code));
+
+        // The backing database never knew this code. Once the BAL is detached, the normal
+        // code-by-hash path must still find the bytecode registered by the BAL account read.
+        cache.bal_context.clear_bal();
+        assert_eq!(cache.get_code_by_hash(&code_hash).unwrap(), code);
+        assert_eq!(cache.db.inner().code_loads, 0);
     }
 
     #[test]

--- a/crates/evm2/src/evm/mod.rs
+++ b/crates/evm2/src/evm/mod.rs
@@ -1999,6 +1999,28 @@ mod tests {
         Ok(TxResultExt { status: true, total_gas_spent: req.tx.nonce, ..TxResultExt::default() })
     }
 
+    fn handle_storage_wipe_tx(
+        req: TxRequest<'_, '_, BaseEvmTypes, TxLegacy>,
+    ) -> HandlerResult<TxResult> {
+        {
+            let slot = req
+                .host
+                .state
+                .storage(&LIFECYCLE_ACCOUNT)
+                .into_slot(LIFECYCLE_STORAGE_KEY, false)
+                .map_err(registry::HandlerError::Fatal)?;
+            assert_eq!(slot.current(), Word::from(1));
+        }
+
+        req.host
+            .state
+            .account(&LIFECYCLE_ACCOUNT, false)
+            .map_err(registry::HandlerError::Fatal)?
+            .mark_destructed();
+
+        Ok(TxResultExt { status: true, ..TxResultExt::default() })
+    }
+
     fn empty_precompiles() -> Precompiles<BaseEvmTypes> {
         Precompiles::new(Cow::Owned(PrecompileMap::new()))
     }
@@ -2086,6 +2108,27 @@ mod tests {
         database.insert_account_info(
             &LIFECYCLE_ACCOUNT,
             AccountInfo::default().with_balance(Word::from(1)),
+        );
+        database.insert_account_storage(&LIFECYCLE_ACCOUNT, &LIFECYCLE_STORAGE_KEY, &Word::from(1));
+        Evm::<BaseEvmTypes>::new(
+            SpecId::OSAKA,
+            BlockEnvExt::default(),
+            registry,
+            database,
+            Precompiles::base(SpecId::OSAKA),
+        )
+    }
+
+    fn storage_wipe_evm() -> Evm<'static, BaseEvmTypes> {
+        let registry = TxRegistry::new().with_handler(
+            TEST_TX_TYPE,
+            TxEnvelope::as_legacy,
+            handle_storage_wipe_tx,
+        );
+        let mut database = InMemoryDB::default();
+        database.insert_account_info(
+            &LIFECYCLE_ACCOUNT,
+            AccountInfo::default().with_code(Bytecode::new_legacy(Bytes::from_static(&[op::STOP]))),
         );
         database.insert_account_storage(&LIFECYCLE_ACCOUNT, &LIFECYCLE_STORAGE_KEY, &Word::from(1));
         Evm::<BaseEvmTypes>::new(
@@ -2920,6 +2963,63 @@ mod tests {
             evm.state.storage_slot_untracked(&LIFECYCLE_ACCOUNT, &LIFECYCLE_STORAGE_KEY).unwrap(),
             Word::from(1)
         );
+    }
+
+    #[test]
+    fn selfdestruct_storage_read_matches_all_commit_paths() {
+        let index = BlockAccessIndex::new(1);
+        let tx = test_tx(0);
+
+        let mut evm = storage_wipe_evm();
+        evm.state.enable_bal_builder();
+        evm.state.set_bal_index(index);
+        let _ = evm.transact(&tx).expect("selfdestruct transaction should execute").commit();
+        let committed = BlockAccessList::from(
+            evm.state.take_bal_builder().expect("commit BAL builder was enabled"),
+        );
+
+        let mut evm = storage_wipe_evm();
+        let mut streamed = BalContext::new().with_bal_builder();
+        streamed.set_bal_index(index);
+        let _ = evm
+            .transact(&tx)
+            .expect("selfdestruct transaction should execute")
+            .commit_with(&mut streamed)
+            .expect("BAL sink is infallible");
+        let streamed = BlockAccessList::from(
+            streamed.take_bal_builder().expect("streamed BAL builder was enabled"),
+        );
+
+        let mut evm = storage_wipe_evm();
+        let detached = evm
+            .transact(&tx)
+            .expect("selfdestruct transaction should execute")
+            .detach()
+            .pending_state;
+        let mut pending = BalContext::new().with_bal_builder();
+        pending.set_bal_index(index);
+        pending.commit_pending(&detached);
+        let pending = BlockAccessList::from(
+            pending.take_bal_builder().expect("pending BAL builder was enabled"),
+        );
+
+        assert_eq!(streamed, committed);
+        assert_eq!(pending, committed);
+        assert_eq!(
+            alloy_eip7928::compute_block_access_list_hash(&streamed),
+            alloy_eip7928::compute_block_access_list_hash(&committed)
+        );
+        assert_eq!(
+            alloy_eip7928::compute_block_access_list_hash(&pending),
+            alloy_eip7928::compute_block_access_list_hash(&committed)
+        );
+
+        let account = committed
+            .iter()
+            .find(|account| account.address == LIFECYCLE_ACCOUNT)
+            .expect("selfdestructed account is in the BAL");
+        assert_eq!(account.storage_reads, vec![LIFECYCLE_STORAGE_KEY]);
+        assert!(account.storage_changes.is_empty());
     }
 
     #[test]

--- a/crates/evm2/src/evm/state/mod.rs
+++ b/crates/evm2/src/evm/state/mod.rs
@@ -776,10 +776,10 @@ impl<'a> State<'a> {
         Ok(())
     }
 
-    /// Visits transaction state changes in database application order.
+    /// Visits transaction state accesses in database application order.
     ///
-    /// This borrows changes directly from the transaction layer without detaching it and does not
-    /// mutate the accepted overlay.
+    /// This borrows changes and loaded-but-unchanged reads directly from the transaction layer
+    /// without detaching it and does not mutate the accepted overlay.
     pub(crate) fn visit_transaction_changes<S: StateChangeSink>(
         &self,
         sink: &mut S,
@@ -794,25 +794,33 @@ impl<'a> State<'a> {
             if storage.wiped {
                 sink.storage_wipe(address)?;
             }
-            for (&key, slot) in storage.changed_slots() {
-                sink.storage(StorageChange {
-                    address,
-                    key,
-                    original: slot.original,
-                    current: slot.current,
-                })?;
+            for (&key, slot) in &storage.slots {
+                let value = &slot.value;
+                if value.is_changed() && (!storage.wiped || !value.current.is_zero()) {
+                    sink.storage(StorageChange {
+                        address,
+                        key,
+                        original: value.original,
+                        current: value.current,
+                    })?;
+                } else {
+                    sink.storage_read(address, key, value.current)?;
+                }
             }
         }
 
         for (&address, entry) in self.accounts.iter() {
-            if entry.is_changed() {
+            let selfdestructed = self.selfdestructs.contains(&address);
+            if entry.is_changed() || entry.is_created() || selfdestructed {
                 sink.account(AccountChangeRef {
                     address,
                     original: entry.original.as_ref(),
                     current: entry.present.as_ref(),
                     created: entry.is_created(),
-                    selfdestructed: self.selfdestructs.contains(&address),
+                    selfdestructed,
                 })?;
+            } else {
+                sink.account_read(address, entry.present.as_ref())?;
             }
         }
 

--- a/crates/evm2/src/evm/state/storage.rs
+++ b/crates/evm2/src/evm/state/storage.rs
@@ -186,10 +186,10 @@ impl<'a, 'db> StorageHandle<'a, 'db> {
     ///
     /// Only called during transaction finalization (selfdestruct and EIP-161 dead-account
     /// deletion), after the last revertible scope, so the wipe is not journaled. Loaded slot
-    /// entries are kept with their values reset to zero: wiped slots resolve to zero on re-load,
-    /// and resetting `original` alongside `current` turns the transaction's prior writes into
-    /// unchanged reads, which keeps a destroyed account's storage accesses visible to the EIP-7928
-    /// block access list (execution-specs `destroy_storage` converts writes to reads).
+    /// entries are kept with their current values reset to zero, while transaction-boundary
+    /// originals remain intact for EVM state accounting. Wiped slots resolve to zero on re-load;
+    /// EIP-7928 BAL construction uses the overlay's wipe marker to classify destroyed slots as
+    /// reads.
     #[inline]
     pub fn wipe(&mut self) {
         self.storage.wiped = true;
@@ -394,6 +394,10 @@ mod tests {
         assert!(!state.storage_slot(&account, cold_key, false).unwrap().is_warm());
         assert_eq!(state.storage_slot(&account, warm_key, false).unwrap().current(), Word::ZERO);
         assert_eq!(state.storage_slot(&account, cold_key, false).unwrap().current(), Word::ZERO);
+        assert_eq!(
+            state.storage_slot(&account, cold_key, false).unwrap().original(),
+            Word::from(4)
+        );
 
         let pending = state.take_pending_state();
         let overlay = pending.storage.get(&account).expect("wipe must be emitted");


### PR DESCRIPTION
## Summary

- register BAL-provided bytecode in the contract cache during account reads and commits
- convert storage writes to reads when a later selfdestruct wipes the account, consistently across direct and streamed BAL construction
- preserve transaction-boundary storage originals and add regressions for both findings

## Testing

- `cargo test -p evm2 --no-default-features --features std,map-foldhash,parse,asm-keccak`
- `cargo clippy -p evm2 --all-targets --no-default-features --features std,map-foldhash,parse,asm-keccak -- -D warnings`
- `cargo check -p evm2-eest`
- `cargo fmt --all -- --check`

EEST all-target clippy remains unavailable in this environment because `cmake` is not installed for the `mcl_rust` build.