### PR TITLE
chore(ci): update Cyclops action pins

### DIFF
--- a/.github/workflows/cyclops-audit.yml
+++ b/.github/workflows/cyclops-audit.yml
@@ -19,7 +19,7 @@ jobs:
       )
     permissions:
       contents: read
-    uses: tempoxyz/gh-actions/.github/workflows/pr-audit.yml@af809bfc35e4dd023bd52f6cc45e09809612a8cf # tempoxyz/gh-actions#40
+    uses: tempoxyz/gh-actions/.github/workflows/pr-audit.yml@7741a8658354abd422dd1b941d07f809682ca96d # tempoxyz/gh-actions#99
     with:
       required-labels: |
         cyclops
@@ -44,7 +44,7 @@ jobs:
       issues: write
       pull-requests: read
     steps:
-      - uses: tempoxyz/gh-actions/actions/pr-audit-comment@af809bfc35e4dd023bd52f6cc45e09809612a8cf # tempoxyz/gh-actions#40
+      - uses: tempoxyz/gh-actions/actions/pr-audit-comment@7741a8658354abd422dd1b941d07f809682ca96d # tempoxyz/gh-actions#99
         with:
           command-regex: '^(?:@decofe\s+)?(?:cyclops\s+audit|derek\s+audit)\b'
           permission-check-mode: association


### PR DESCRIPTION
## Summary

- update the reusable Cyclops audit workflow pin to `tempoxyz/gh-actions#99`
- update the Cyclops audit comment action pin to the same merged commit

## Validation

- `git diff --check`
- verified the pinned commit is signed and valid on GitHub

Prompted by: @DaniPopes
