### PR TITLE
fix(ci): grant required Cyclops workflow permissions

### DIFF
--- a/.github/workflows/cyclops-audit.yml
+++ b/.github/workflows/cyclops-audit.yml
@@ -19,6 +19,8 @@ jobs:
       )
     permissions:
       contents: read
+      pull-requests: read
+      statuses: write
     uses: tempoxyz/gh-actions/.github/workflows/pr-audit.yml@7741a8658354abd422dd1b941d07f809682ca96d # tempoxyz/gh-actions#99
     with:
       required-labels: |


### PR DESCRIPTION
The Cyclops workflow fails validation before any job starts because the pinned reusable workflow requests `pull-requests: read` and `statuses: write`, while the caller grants only `contents: read`. This also blocks comment-triggered runs, even though the audit gate jobs are disabled.

Grant the two required permissions on the reusable-workflow calling job to resolve the [startup failure](https://github.com/alloy-rs/evm2/actions/runs/33968995637). GitHub validates the nested jobs' permissions regardless of their runtime conditions.

Validation: parsed both workflows and checked every nested job's requested permissions against the caller; reproduced the original three permission mismatches and confirmed all are resolved. `git diff --check` passes. Live comment-triggered execution requires the fix to land on the default branch.

Prompted by: @DaniPopes
