### PR TITLE
fix(evm): allow transaction hooks to adjust floor gas

### DIFF
--- a/crates/evm2/src/ethereum/eip1559.rs
+++ b/crates/evm2/src/ethereum/eip1559.rs
@@ -54,9 +54,7 @@ pub fn handle_with_hooks<T: EvmTypes, H: TxHandlerHooks<T>>(
     );
     // EIP-2780: state-dependent gas is charged at the runtime gas phase, not the intrinsic phase.
     let mut initial_state_gas = 0;
-    H::adjust_intrinsic_gas(req.host, req.envelope, &mut intrinsic, &mut initial_state_gas)?;
-    validate_intrinsic_gas(tx.gas_limit, intrinsic, initial_state_gas)?;
-    let floor_gas = floor_gas(
+    let mut floor_gas = floor_gas(
         req.host.version(),
         caller,
         tx.to,
@@ -65,6 +63,14 @@ pub fn handle_with_hooks<T: EvmTypes, H: TxHandlerHooks<T>>(
         access_list_storage_keys,
         tx.value,
     );
+    H::adjust_intrinsic_gas(
+        req.host,
+        req.envelope,
+        &mut intrinsic,
+        &mut initial_state_gas,
+        &mut floor_gas,
+    )?;
+    validate_intrinsic_gas(tx.gas_limit, intrinsic, initial_state_gas)?;
     validate_floor_gas(tx.gas_limit, floor_gas)?;
     validate_execution_gas_limit_cap(req.host.version(), tx.gas_limit, intrinsic, floor_gas)?;
 

--- a/crates/evm2/src/ethereum/eip2930.rs
+++ b/crates/evm2/src/ethereum/eip2930.rs
@@ -49,9 +49,7 @@ pub fn handle_with_hooks<T: EvmTypes, H: TxHandlerHooks<T>>(
     );
     // EIP-2780: state-dependent gas is charged at the runtime gas phase, not the intrinsic phase.
     let mut initial_state_gas = 0;
-    H::adjust_intrinsic_gas(req.host, req.envelope, &mut intrinsic, &mut initial_state_gas)?;
-    validate_intrinsic_gas(tx.gas_limit, intrinsic, initial_state_gas)?;
-    let floor_gas = floor_gas(
+    let mut floor_gas = floor_gas(
         req.host.version(),
         caller,
         tx.to,
@@ -60,6 +58,14 @@ pub fn handle_with_hooks<T: EvmTypes, H: TxHandlerHooks<T>>(
         access_list_storage_keys,
         tx.value,
     );
+    H::adjust_intrinsic_gas(
+        req.host,
+        req.envelope,
+        &mut intrinsic,
+        &mut initial_state_gas,
+        &mut floor_gas,
+    )?;
+    validate_intrinsic_gas(tx.gas_limit, intrinsic, initial_state_gas)?;
     validate_floor_gas(tx.gas_limit, floor_gas)?;
     validate_execution_gas_limit_cap(req.host.version(), tx.gas_limit, intrinsic, floor_gas)?;
 

--- a/crates/evm2/src/ethereum/eip4844.rs
+++ b/crates/evm2/src/ethereum/eip4844.rs
@@ -62,9 +62,7 @@ pub fn handle_with_hooks<T: EvmTypes, H: TxHandlerHooks<T>>(
     // Blob transactions are always calls; EIP-2780 charges any state-dependent gas at the runtime
     // gas phase, so no state gas is charged at the intrinsic phase.
     let mut initial_state_gas = 0;
-    H::adjust_intrinsic_gas(req.host, req.envelope, &mut intrinsic, &mut initial_state_gas)?;
-    validate_intrinsic_gas(tx.gas_limit, intrinsic, initial_state_gas)?;
-    let floor_gas = floor_gas(
+    let mut floor_gas = floor_gas(
         req.host.version(),
         caller,
         tx.to.into(),
@@ -73,6 +71,14 @@ pub fn handle_with_hooks<T: EvmTypes, H: TxHandlerHooks<T>>(
         access_list_storage_keys,
         tx.value,
     );
+    H::adjust_intrinsic_gas(
+        req.host,
+        req.envelope,
+        &mut intrinsic,
+        &mut initial_state_gas,
+        &mut floor_gas,
+    )?;
+    validate_intrinsic_gas(tx.gas_limit, intrinsic, initial_state_gas)?;
     validate_floor_gas(tx.gas_limit, floor_gas)?;
     validate_execution_gas_limit_cap(req.host.version(), tx.gas_limit, intrinsic, floor_gas)?;
 

--- a/crates/evm2/src/ethereum/eip7702.rs
+++ b/crates/evm2/src/ethereum/eip7702.rs
@@ -64,9 +64,7 @@ pub fn handle_with_hooks<T: EvmTypes, H: TxHandlerHooks<T>>(
     // none either). A transaction that passes the intrinsic check but cannot afford the runtime
     // charges is included as an out-of-gas halt rather than rejected.
     let mut initial_state_gas = 0;
-    H::adjust_intrinsic_gas(req.host, envelope, &mut intrinsic, &mut initial_state_gas)?;
-    validate_intrinsic_gas(tx.gas_limit, intrinsic, initial_state_gas)?;
-    let floor_gas = floor_gas(
+    let mut floor_gas = floor_gas(
         req.host.version(),
         caller,
         tx.to.into(),
@@ -75,6 +73,14 @@ pub fn handle_with_hooks<T: EvmTypes, H: TxHandlerHooks<T>>(
         access_list_storage_keys,
         tx.value,
     );
+    H::adjust_intrinsic_gas(
+        req.host,
+        envelope,
+        &mut intrinsic,
+        &mut initial_state_gas,
+        &mut floor_gas,
+    )?;
+    validate_intrinsic_gas(tx.gas_limit, intrinsic, initial_state_gas)?;
     validate_floor_gas(tx.gas_limit, floor_gas)?;
     validate_execution_gas_limit_cap(req.host.version(), tx.gas_limit, intrinsic, floor_gas)?;
 

--- a/crates/evm2/src/ethereum/legacy.rs
+++ b/crates/evm2/src/ethereum/legacy.rs
@@ -41,9 +41,15 @@ pub fn handle_with_hooks<T: EvmTypes, H: TxHandlerHooks<T>>(
     // EIP-2780: create-transaction and EIP-7702 state gas is charged at the runtime gas phase, so
     // no state gas is charged at the intrinsic phase.
     let mut initial_state_gas = 0;
-    H::adjust_intrinsic_gas(req.host, req.envelope, &mut intrinsic, &mut initial_state_gas)?;
+    let mut floor_gas = floor_gas(req.host.version(), caller, tx.to, &tx.input, 0, 0, tx.value);
+    H::adjust_intrinsic_gas(
+        req.host,
+        req.envelope,
+        &mut intrinsic,
+        &mut initial_state_gas,
+        &mut floor_gas,
+    )?;
     validate_intrinsic_gas(tx.gas_limit, intrinsic, initial_state_gas)?;
-    let floor_gas = floor_gas(req.host.version(), caller, tx.to, &tx.input, 0, 0, tx.value);
     validate_floor_gas(tx.gas_limit, floor_gas)?;
     validate_execution_gas_limit_cap(req.host.version(), tx.gas_limit, intrinsic, floor_gas)?;
 

--- a/crates/evm2/src/ethereum/mod.rs
+++ b/crates/evm2/src/ethereum/mod.rs
@@ -915,6 +915,69 @@ mod tests {
     use alloy_consensus::{TxEip2930, transaction::Recovered};
     use alloy_eips::eip2930::AccessList;
 
+    #[rstest::rstest]
+    fn adjusted_floor_gas_controls_validation_and_settlement(
+        #[values(31_049, 31_050)] gas_limit: u64,
+    ) {
+        use crate::evm::handler::TxHandlerHooks;
+
+        struct CalldataSurcharge;
+
+        impl TxHandlerHooks<BaseEvmTypes> for CalldataSurcharge {
+            fn adjust_intrinsic_gas(
+                _host: &mut Evm<'_, BaseEvmTypes>,
+                _envelope: &TxEnvelope,
+                intrinsic: &mut u64,
+                initial_state_gas: &mut u64,
+                floor_gas: &mut u64,
+            ) -> HandlerResult<()> {
+                assert_eq!(*intrinsic, 21_020);
+                assert_eq!(*initial_state_gas, 0);
+                assert_eq!(*floor_gas, 21_050);
+                *intrinsic += 10_000;
+                *floor_gas += 10_000;
+                Ok(())
+            }
+        }
+
+        let caller = Address::with_last_byte(0xaa);
+        let tx = Recovered::new_unchecked(
+            TxEnvelope::Legacy(TxLegacy {
+                gas_limit,
+                to: TxKind::Call(Address::with_last_byte(0xbb)),
+                input: Bytes::from_static(&[0, 1]),
+                ..TxLegacy::default()
+            }),
+            caller,
+        );
+        let registry = TxRegistry::new().with_handler(
+            0,
+            TxEnvelope::as_legacy,
+            legacy::handle_with_hooks::<BaseEvmTypes, CalldataSurcharge>,
+        );
+        let mut evm = Evm::<BaseEvmTypes>::new(
+            SpecId::PRAGUE,
+            BlockEnvExt::default(),
+            registry,
+            InMemoryDB::default(),
+            Precompiles::base(SpecId::PRAGUE),
+        );
+
+        let result = evm.transact(&tx).map(crate::evm::ExecutedTx::discard);
+        if gas_limit < 31_050 {
+            assert_eq!(
+                result,
+                Err(HandlerError::IntrinsicGasTooLow { required: 31_050, got: gas_limit })
+            );
+        } else {
+            let result = result.unwrap();
+            assert!(result.status);
+            assert_eq!(result.total_gas_spent, 31_020);
+            assert_eq!(result.floor_gas, 31_050);
+            assert_eq!(result.tx_gas_used(), 31_050);
+        }
+    }
+
     #[test]
     fn intrinsic_gas_charges_shanghai_create_initcode_words() {
         let input = Bytes::from(vec![1; 74]);

--- a/crates/evm2/src/evm/handler.rs
+++ b/crates/evm2/src/evm/handler.rs
@@ -26,12 +26,14 @@ pub struct GasSettlement<T: EvmTypes> {
 
 /// Static extension points shared by transaction handlers.
 pub trait TxHandlerHooks<T: EvmTypes>: Sized {
-    /// Adjusts the intrinsic execution and state gas calculated by the standard handler.
+    /// Adjusts the intrinsic execution gas, state gas, and floor gas calculated by the standard
+    /// handler before gas-limit validation. The adjusted floor gas is also used during settlement.
     fn adjust_intrinsic_gas(
         _host: &mut Evm<'_, T>,
         _envelope: &T::Tx,
         _intrinsic: &mut u64,
         _initial_state_gas: &mut u64,
+        _floor_gas: &mut u64,
     ) -> HandlerResult<()> {
         Ok(())
     }


### PR DESCRIPTION
Custom transaction hooks can adjust intrinsic gas but cannot change the EIP-7623 floor. Add `&mut floor_gas` to `TxHandlerHooks::adjust_intrinsic_gas` and calculate the floor before calling the hook in all five Ethereum transaction handlers. Gas-limit validation and settlement then use the adjusted floor.

Add a regression test for a calldata surcharge, covering rejection below the adjusted floor and receipt gas usage at the floor.

Fixes https://github.com/alloy-rs/evm2/issues/388.

Validation:
- `cargo +nightly fmt --all --check`
- `cargo test -p evm2 --lib --no-default-features --features std,parse` — 489 tests passed.
- `cargo +nightly clippy -p evm2 --all-targets --no-default-features --features std,parse`

Prompted by: @DaniPopes
