### PR TITLE
perf(geth): stream opcode steps during trace construction

### DIFF
--- a/crates/inspectors/src/tracing/builder/geth.rs
+++ b/crates/inspectors/src/tracing/builder/geth.rs
@@ -5,12 +5,7 @@ use crate::tracing::{
     types::{CallKind, CallTraceNode, CallTraceStepStackItem},
     utils::load_account_code,
 };
-use alloc::{
-    borrow::Cow,
-    collections::{BTreeMap, VecDeque},
-    format, vec,
-    vec::Vec,
-};
+use alloc::{borrow::Cow, collections::BTreeMap, format, vec, vec::Vec};
 use alloy_primitives::{
     Address, B256, Bytes, U256,
     map::{Entry, HashMap},
@@ -25,6 +20,9 @@ use evm2::{
     evm::{DbResult, DynDatabase},
     interpreter::op,
 };
+
+#[cfg(test)]
+mod steps_tests;
 
 /// A type for creating geth style traces
 #[derive(Clone, Debug)]
@@ -78,23 +76,21 @@ impl<'a> GethTraceBuilder<'a> {
         storage: &mut HashMap<Address, BTreeMap<B256, B256>>,
         struct_logs: &mut Vec<StructLog>,
     ) {
-        // A stack with all the steps of the trace and all its children's steps.
-        // This is used to process the steps in the order they appear in the transactions.
-        // Steps are grouped by their Call Trace Node, in order to process them all in the order
-        // they appear in the transaction, we need to process steps of call nodes when they appear.
-        // When we find a call step, we push all the steps of the child trace on the stack, so they
-        // are processed next. The very next step is the last item on the stack
-        let mut step_stack = VecDeque::with_capacity(main_trace_node.trace.steps.len());
+        // Suspend only the parent iterator when entering a child. Scratch space scales with
+        // call depth rather than step count, and a trace without subcalls needs no allocation.
+        let mut steps = main_trace_node.steps_with_children();
+        let mut parents = Vec::new();
 
-        main_trace_node.push_steps_on_stack(&mut step_stack);
-
-        // Iterate over the steps inside the given trace
-        while let Some(CallTraceStepStackItem { trace_node, step, call_child_id }) =
-            step_stack.pop_back()
-        {
+        loop {
             if opts.limit.is_some_and(|limit| struct_logs.len() as u64 >= limit) {
                 break;
             }
+            let Some(CallTraceStepStackItem { trace_node, step, call_child_id }) = steps.next()
+            else {
+                let Some(parent) = parents.pop() else { break };
+                steps = parent;
+                continue;
+            };
 
             // We increment the depth by one because steps that are part of call at depth N should
             // have depth N + 1. For example, steps inside of a top-level call should
@@ -120,11 +116,10 @@ impl<'a> GethTraceBuilder<'a> {
             // Add step to geth trace
             struct_logs.push(log);
 
-            // If the step is a call, we first push all the steps of the child trace on the stack,
-            // so they are processed next
+            // Visit the child immediately after its call opcode, then resume the parent.
             if let Some(call_child_id) = call_child_id {
-                let child_trace = &self.nodes[call_child_id];
-                child_trace.push_steps_on_stack(&mut step_stack);
+                parents.push(steps);
+                steps = self.nodes[call_child_id].steps_with_children();
             }
         }
     }

--- a/crates/inspectors/src/tracing/builder/geth/steps_tests.rs
+++ b/crates/inspectors/src/tracing/builder/geth/steps_tests.rs
@@ -1,0 +1,163 @@
+use super::*;
+use crate::tracing::types::{CallTrace, CallTraceStep, StorageChange, StorageChangeReason};
+use evm2::interpreter::{InstrStop, opcode::OpCode};
+
+fn test_step(pc: usize, op: u8) -> CallTraceStep {
+    CallTraceStep {
+        pc,
+        op: OpCode::new_or_unknown(op),
+        stack: Some(vec![U256::from(pc)].into_boxed_slice()),
+        push_stack: None,
+        memory: None,
+        returndata: Bytes::from(vec![pc as u8]),
+        gas_remaining: 1000 - pc as u64,
+        gas_refund_counter: 0,
+        gas_used: pc as u64,
+        gas_cost: 1,
+        state_gas_cost: None,
+        state_gas_reservoir: None,
+        state_gas_spent: 0,
+        storage_change: (op == op::SSTORE).then(|| {
+            alloc::boxed::Box::new(StorageChange {
+                key: U256::ZERO,
+                value: U256::from(pc),
+                had_value: None,
+                reason: StorageChangeReason::SSTORE,
+            })
+        }),
+        status: (op == op::REVERT).then_some(InstrStop::Revert),
+        immediate_bytes: None,
+        decoded: None,
+    }
+}
+
+#[test]
+fn opcode_trace_resumes_parents_after_nested_and_empty_calls() {
+    // Cover all call-like opcodes, a precompile with no steps, an empty creation,
+    // a reverting grandchild, and a final call opcode that failed before recording a child.
+    type Fixture = (Option<usize>, usize, &'static [usize], &'static [u8]);
+    let fixtures: &[Fixture] = &[
+        (
+            None,
+            0,
+            &[1, 2, 4, 5, 6],
+            &[
+                op::SSTORE,
+                op::CALL,
+                op::CALLCODE,
+                op::STATICCALL,
+                op::CREATE,
+                op::CREATE2,
+                op::CALL,
+            ],
+        ),
+        (Some(0), 1, &[], &[]),
+        (Some(0), 1, &[3], &[op::SSTORE, op::DELEGATECALL, op::SLOAD, op::STOP]),
+        (Some(2), 2, &[], &[op::SSTORE, op::REVERT]),
+        (Some(0), 1, &[], &[op::RETURN]),
+        (Some(0), 1, &[], &[]),
+        (Some(0), 1, &[], &[op::STOP]),
+    ];
+    let mut nodes: Vec<_> = fixtures
+        .iter()
+        .enumerate()
+        .map(|(idx, &(parent, depth, children, ops))| {
+            CallTraceNode {
+                idx,
+                parent,
+                children: children.to_vec(),
+                trace: CallTrace {
+                    depth,
+                    maybe_precompile: Some(idx == 1),
+                    address: Address::with_last_byte(idx as u8),
+                    // The grandchild executes in its parent's storage context.
+                    caller: Address::with_last_byte(2),
+                    kind: if idx == 3 { CallKind::DelegateCall } else { CallKind::Call },
+                    steps: ops
+                        .iter()
+                        .enumerate()
+                        .map(|(pc, &op)| test_step(idx * 10 + pc, op))
+                        .collect(),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }
+        })
+        .collect();
+    nodes[0].trace.steps.last_mut().unwrap().status = Some(InstrStop::OutOfGas);
+    let builder = GethTraceBuilder::new(nodes);
+    let expected = [
+        (0, 1),
+        (1, 1),
+        (2, 1),
+        (20, 2),
+        (21, 2),
+        (30, 3),
+        (31, 3),
+        (22, 2),
+        (23, 2),
+        (3, 1),
+        (40, 2),
+        (4, 1),
+        (5, 1),
+        (60, 2),
+        (6, 1),
+    ];
+    for disable_storage in [false, true] {
+        let opts = GethDefaultTracingOptions {
+            disable_storage: Some(disable_storage),
+            enable_return_data: Some(true),
+            ..Default::default()
+        };
+        let frame = builder.geth_traces(123, Bytes::new(), opts);
+        assert_eq!(frame.gas, 123);
+        assert_eq!(
+            frame.struct_logs.iter().map(|log| (log.pc, log.depth)).collect::<Vec<_>>(),
+            expected
+        );
+        for log in &frame.struct_logs {
+            assert_eq!(log.stack, Some(vec![U256::from(log.pc)]));
+            assert_eq!(log.return_data, Some(Bytes::from(vec![log.pc as u8])));
+            assert_eq!(log.gas, 1000 - log.pc);
+            let value = match log.pc {
+                0 => Some(0),
+                20 => Some(20),
+                30 | 22 => Some(30),
+                _ => None,
+            };
+            assert_eq!(
+                log.storage,
+                value
+                    .filter(|_| !disable_storage)
+                    .map(|value| { BTreeMap::from([(B256::ZERO, U256::from(value).into())]) })
+            );
+        }
+        for limit in [0, 1, 3, 6, 9, 99] {
+            let limited = builder.geth_traces(
+                123,
+                Bytes::new(),
+                GethDefaultTracingOptions {
+                    limit: Some(limit),
+                    disable_storage: Some(disable_storage),
+                    enable_return_data: Some(true),
+                    ..Default::default()
+                },
+            );
+            let len =
+                if limit == 0 { expected.len() } else { (limit as usize).min(expected.len()) };
+            assert_eq!(limited.struct_logs, frame.struct_logs[..len]);
+        }
+    }
+    assert!(
+        GethTraceBuilder::new(vec![])
+            .geth_traces(0, Bytes::new(), Default::default())
+            .struct_logs
+            .is_empty()
+    );
+    assert!(
+        GethTraceBuilder::new(vec![CallTraceNode::default()])
+            .geth_traces(0, Bytes::new(), Default::default())
+            .struct_logs
+            .is_empty()
+    );
+}

--- a/crates/inspectors/src/tracing/types.rs
+++ b/crates/inspectors/src/tracing/types.rs
@@ -3,7 +3,6 @@
 use crate::tracing::{config::TraceStyle, utils, utils::convert_memory};
 use alloc::{
     boxed::Box,
-    collections::VecDeque,
     format,
     string::{String, ToString},
     vec::Vec,
@@ -259,38 +258,16 @@ impl CallTraceNode {
         if self.trace.kind.is_delegate() { self.trace.caller } else { self.trace.address }
     }
 
-    /// Pushes all steps onto the stack in reverse order
-    /// so that the first step is on top of the stack
-    pub(crate) fn push_steps_on_stack<'a>(
-        &'a self,
-        stack: &mut VecDeque<CallTraceStepStackItem<'a>>,
-    ) {
-        let initial_len = stack.len();
-
-        // First, extend the stack with all steps in reverse order
-        stack.extend(self.trace.steps.iter().rev().map(|step| CallTraceStepStackItem {
-            trace_node: self,
-            step,
-            call_child_id: None,
-        }));
-
-        // Then, iterate over the inserted range in reverse to set call_child_id values
-        // Since we inserted in reverse order, we need to process from the end to maintain
-        // the correct child_id assignment order
-        let mut child_id = 0;
-        for i in (initial_len..stack.len()).rev() {
-            let item = &mut stack[i];
-
-            // If the opcode is a call, set the child trace id
-            if item.step.is_call_like_op() {
-                // The opcode of this step is a call but it's possible that this step resulted
-                // in a revert or out of gas error in which case there's no actual child call executed and recorded: <https://github.com/paradigmxyz/reth/issues/3915>
-                if let Some(call_id) = self.children.get(child_id).copied() {
-                    item.call_child_id = Some(call_id);
-                    child_id += 1;
-                }
-            }
-        }
+    /// Iterates over steps in execution order, matching call opcodes to recorded children.
+    pub(crate) fn steps_with_children(&self) -> impl Iterator<Item = CallTraceStepStackItem<'_>> {
+        let mut children = self.children.iter();
+        self.trace.steps.iter().map(move |step| {
+            // A call opcode can fail before a child is recorded, e.g. due to out of gas:
+            // <https://github.com/paradigmxyz/reth/issues/3915>.
+            let call_child_id =
+                if step.is_call_like_op() { children.next().copied() } else { None };
+            CallTraceStepStackItem { trace_node: self, step, call_child_id }
+        })
     }
 
     /// Returns true if this is a call to a precompile


### PR DESCRIPTION
The geth opcode trace builder currently copies every step reference into a temporary queue and scans that queue again to associate child calls. Walk each call’s steps directly and suspend its iterator while visiting a child, so traversal scratch space scales with active call depth instead of total step count. Flat traces need no traversal allocation.

Preserves execution order, opcode limits, and delegate-call storage snapshots. Mirrors paradigmxyz/revm-inspectors#495, including its regression coverage, adapted to evm2’s interpreter types.
