### PR TITLE
perf(geth): skip storage lookups for unrelated opcodes

### DIFF
--- a/crates/inspectors/src/tracing/builder/geth.rs
+++ b/crates/inspectors/src/tracing/builder/geth.rs
@@ -97,8 +97,11 @@ impl<'a> GethTraceBuilder<'a> {
             // have depth 1.
             let mut log = step.convert_to_geth_struct_log(opts, trace_node.trace.depth as u64 + 1);
 
-            // Fill in memory and storage depending on the options
-            if opts.is_storage_enabled() {
+            // Only touch the storage cache when updating it or emitting a storage snapshot.
+            if opts.is_storage_enabled()
+                && (step.storage_change.is_some()
+                    || matches!(step.op.get(), op::SLOAD | op::SSTORE))
+            {
                 let contract_storage = storage.entry(trace_node.execution_address()).or_default();
                 if let Some(change) = &step.storage_change {
                     contract_storage.insert(change.key.into(), change.value.into());

--- a/crates/inspectors/src/tracing/builder/geth/steps_tests.rs
+++ b/crates/inspectors/src/tracing/builder/geth/steps_tests.rs
@@ -161,3 +161,40 @@ fn opcode_trace_resumes_parents_after_nested_and_empty_calls() {
             .is_empty()
     );
 }
+
+#[test]
+fn storage_snapshots_keep_empty_reads_and_custom_changes() {
+    let mut custom_change = test_step(2, op::SSTORE);
+    // Public trace nodes can carry a storage change on a different opcode.
+    custom_change.op = OpCode::new_or_unknown(op::ADD);
+    let builder = GethTraceBuilder::new(vec![CallTraceNode {
+        trace: CallTrace {
+            steps: vec![
+                test_step(0, op::PUSH0),
+                test_step(1, op::SLOAD),
+                custom_change,
+                test_step(3, op::SLOAD),
+            ],
+            ..Default::default()
+        },
+        ..Default::default()
+    }]);
+    for disable_storage in [false, true] {
+        let frame = builder.geth_traces(
+            0,
+            Bytes::new(),
+            GethDefaultTracingOptions {
+                disable_storage: Some(disable_storage),
+                ..Default::default()
+            },
+        );
+        assert_eq!(frame.struct_logs.len(), 4);
+        assert!(frame.struct_logs[0].storage.is_none());
+        assert_eq!(frame.struct_logs[1].storage, (!disable_storage).then(BTreeMap::new));
+        assert!(frame.struct_logs[2].storage.is_none());
+        assert_eq!(
+            frame.struct_logs[3].storage,
+            (!disable_storage).then(|| { BTreeMap::from([(B256::ZERO, U256::from(2).into())]) })
+        );
+    }
+}


### PR DESCRIPTION
With storage capture enabled, the geth opcode trace builder currently looks up the execution address for every opcode and creates unused cache entries for contracts without storage access. Access the cache only for recorded storage changes or SLOAD/SSTORE steps.

Preserves empty SLOAD/SSTORE snapshots and custom storage-change metadata on other opcodes. Mirrors paradigmxyz/revm-inspectors#496, including its regression coverage, on top of the streaming traversal change.
