### PR TITLE
perf(js): avoid per-step allocations and copies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,7 @@ auto_impl = "1.3"
 bitvec = { version = "1", default-features = false }
 boa_engine = { version = "0.21", default-features = false }
 boa_gc = { version = "0.21", default-features = false }
+num-bigint = { version = "0.4", default-features = false }
 cfg-if = { version = "1.0", default-features = false }
 derive-where = { version = "1.6", default-features = false }
 colorchoice = { version = "1.0", default-features = false }

--- a/crates/evm2/src/interpreter/runtime.rs
+++ b/crates/evm2/src/interpreter/runtime.rs
@@ -276,6 +276,15 @@ impl<'frame, 'host, T: EvmTypesHost> Interpreter<'frame, 'host, T> {
         &mut self.return_data
     }
 
+    /// Borrows the operand stack, linear memory, and host independently for inspection.
+    #[inline]
+    pub const fn stack_memory_host(&mut self) -> (StackRef<'_>, &[u8], &mut T::Host<'host>) {
+        // SAFETY: As in `host`, the host pointer is initialized during execution and points
+        // outside the interpreter's owned stack and memory.
+        let host = unsafe { self.host.unwrap_unchecked().as_mut() };
+        (self.stack(), self.memory.as_slice(), host)
+    }
+
     /// Returns the host implementation.
     #[inline]
     pub const fn host(&mut self) -> &mut T::Host<'host> {

--- a/crates/inspectors/Cargo.toml
+++ b/crates/inspectors/Cargo.toml
@@ -34,6 +34,7 @@ serde_json = { workspace = true, features = ["alloc"] }
 # js-tracer
 boa_engine = { workspace = true, optional = true }
 boa_gc = { workspace = true, optional = true }
+num-bigint = { workspace = true, optional = true }
 
 [dev-dependencies]
 alloy-eips.workspace = true
@@ -62,4 +63,4 @@ serde = [
     "alloy-rpc-types-eth/serde",
     "evm2/serde",
 ]
-js-tracer = ["std", "dep:boa_engine", "dep:boa_gc"]
+js-tracer = ["std", "dep:boa_engine", "dep:boa_gc", "dep:num-bigint"]

--- a/crates/inspectors/Cargo.toml
+++ b/crates/inspectors/Cargo.toml
@@ -35,6 +35,7 @@ serde_json = { workspace = true, features = ["alloc"] }
 boa_engine = { workspace = true, optional = true }
 boa_gc = { workspace = true, optional = true }
 num-bigint = { workspace = true, optional = true }
+ruint = { workspace = true, optional = true, features = ["num-bigint"] }
 
 [dev-dependencies]
 alloy-eips.workspace = true
@@ -55,14 +56,16 @@ std = [
     "evm2/std",
     "thiserror/std",
     "num-bigint?/std",
+    "ruint?/std",
 ]
 serde = [
     "dep:serde",
     "num-bigint?/serde",
+    "ruint?/serde",
     "alloy-primitives/serde",
     "alloy-consensus/serde",
     "alloy-eip2930/serde",
     "alloy-rpc-types-eth/serde",
     "evm2/serde",
 ]
-js-tracer = ["std", "dep:boa_engine", "dep:boa_gc", "dep:num-bigint"]
+js-tracer = ["std", "dep:boa_engine", "dep:boa_gc", "dep:num-bigint", "dep:ruint"]

--- a/crates/inspectors/Cargo.toml
+++ b/crates/inspectors/Cargo.toml
@@ -54,9 +54,11 @@ std = [
     "serde_json/std",
     "evm2/std",
     "thiserror/std",
+    "num-bigint?/std",
 ]
 serde = [
     "dep:serde",
+    "num-bigint?/serde",
     "alloy-primitives/serde",
     "alloy-consensus/serde",
     "alloy-eip2930/serde",

--- a/crates/inspectors/src/tracing/js/bindings.rs
+++ b/crates/inspectors/src/tracing/js/bindings.rs
@@ -3,8 +3,9 @@
 use crate::tracing::{
     TransactionContext,
     js::builtins::{
-        address_to_uint8_array, address_to_uint8_array_value, bytes_from_value, bytes_to_address,
-        bytes_to_b256, to_bigint, to_uint8_array, to_uint8_array_value,
+        address_from_value, address_to_uint8_array, address_to_uint8_array_value, b256_from_value,
+        call_kind_js_string, to_bigint, to_uint8_array, to_uint8_array_value,
+        uint8_array_from_block,
     },
     tx_state::TxState,
     types::CallKind,
@@ -18,32 +19,52 @@ use alloc::{
 };
 use alloy_primitives::{Address, B256, Bytes, KECCAK256_EMPTY, U256};
 use boa_engine::{
-    Context, JsArgs, JsError, JsNativeError, JsObject, JsResult, JsValue, js_string,
+    Context, JsArgs, JsError, JsNativeError, JsObject, JsResult, JsString, JsValue, js_string,
     native_function::NativeFunction,
-    object::{FunctionObjectBuilder, builtins::JsUint8Array},
+    object::{
+        FunctionObjectBuilder,
+        builtins::{AlignedVec, JsFunction},
+    },
 };
 use boa_gc::{Finalize, Trace, empty_trace};
-use core::cell::RefCell;
+use core::{
+    cell::{OnceCell, Ref, RefCell, RefMut},
+    marker::PhantomData,
+    ops::Range,
+};
 use evm2::{
     bytecode::Bytecode,
     evm::{AccountInfo, DbResult, DynDatabase, State},
     interpreter::{
-        Memory, Word,
-        opcode::{OpCode, op},
+        Word,
+        opcode::{
+            OpCode, op as opcode,
+            op::{PUSH0, PUSH32},
+        },
     },
 };
 
 /// Shared mutable state captured by JS native functions.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 struct Shared<T>(Rc<RefCell<T>>);
+
+impl<T> Clone for Shared<T> {
+    fn clone(&self) -> Self {
+        Self(Rc::clone(&self.0))
+    }
+}
 
 impl<T> Shared<T> {
     fn new(value: T) -> Self {
         Self(Rc::new(RefCell::new(value)))
     }
 
-    fn replace(&self, value: T) {
-        *self.0.borrow_mut() = value;
+    fn borrow(&self) -> Ref<'_, T> {
+        self.0.borrow()
+    }
+
+    fn borrow_mut(&self) -> RefMut<'_, T> {
+        self.0.borrow_mut()
     }
 }
 
@@ -53,7 +74,57 @@ unsafe impl<T> Trace for Shared<T> {
     empty_trace!();
 }
 
+/// A native function body that operates on the shared state of the object it belongs to.
+type StateFnPtr<T> = fn(&Shared<T>, &[JsValue], &mut Context) -> JsResult<JsValue>;
+
+/// Wrapper so a function pointer can be captured by a boa native function.
+struct StateFn<T>(StateFnPtr<T>);
+
+impl<T> Clone for StateFn<T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<T> Copy for StateFn<T> {}
+
+impl<T> Finalize for StateFn<T> {}
+
+unsafe impl<T> Trace for StateFn<T> {
+    empty_trace!();
+}
+
+/// Builds a native JS function with access to the given shared state.
+fn state_fn<T: 'static>(
+    ctx: &mut Context,
+    state: Shared<T>,
+    length: usize,
+    f: StateFnPtr<T>,
+) -> JsFunction {
+    FunctionObjectBuilder::new(
+        ctx.realm(),
+        NativeFunction::from_copy_closure_with_captures(
+            move |_this, args, (state, f), ctx| (f.0)(state, args, ctx),
+            (state, StateFn(f)),
+        ),
+    )
+    .length(length)
+    .build()
+}
+
+fn type_error(message: String) -> JsError {
+    JsError::from_native(JsNativeError::typ().with_message(message))
+}
+
 /// Reusable JS log object for opcode steps.
+///
+/// The object graph (`log.op`, `log.stack`, `log.memory`, `log.contract` and the getters) is built
+/// once, all callbacks read from a shared state that is refreshed for every step.
+///
+/// The stack and memory are not copied per step. [`StepSnapshot::record`] saves the parts an
+/// opcode can overwrite (its stack inputs and the memory range it writes) before it executes, and
+/// [`Self::with_scope`] combines them with the post-execution stack and memory into the
+/// pre-execution view that geth exposes to `step`.
 #[derive(Debug)]
 pub(crate) struct ReusableStepLog {
     state: Shared<StepLogState>,
@@ -61,8 +132,8 @@ pub(crate) struct ReusableStepLog {
 }
 
 impl ReusableStepLog {
-    pub(crate) fn new(ctx: &mut Context) -> JsResult<Self> {
-        let state = Shared::new(StepLogState::default());
+    pub(crate) fn new(ctx: &mut Context, op_names: OpcodeNames) -> JsResult<Self> {
+        let state = Shared::new(StepLogState::new(op_names));
         let object = JsObject::with_object_proto(ctx.intrinsics());
 
         object.set(js_string!("op"), build_step_op_object(state.clone(), ctx)?, false, ctx)?;
@@ -85,68 +156,23 @@ impl ReusableStepLog {
             ctx,
         )?;
 
-        let get_pc = FunctionObjectBuilder::new(
-            ctx.realm(),
-            NativeFunction::from_copy_closure_with_captures(
-                move |_this, _args, state, _ctx| Ok(JsValue::from(state.0.borrow().pc)),
-                state.clone(),
-            ),
-        )
-        .length(0)
-        .build();
-        let get_gas = FunctionObjectBuilder::new(
-            ctx.realm(),
-            NativeFunction::from_copy_closure_with_captures(
-                move |_this, _args, state, _ctx| Ok(JsValue::from(state.0.borrow().gas_remaining)),
-                state.clone(),
-            ),
-        )
-        .length(0)
-        .build();
-        let get_cost = FunctionObjectBuilder::new(
-            ctx.realm(),
-            NativeFunction::from_copy_closure_with_captures(
-                move |_this, _args, state, _ctx| Ok(JsValue::from(state.0.borrow().cost)),
-                state.clone(),
-            ),
-        )
-        .length(0)
-        .build();
-        let get_depth = FunctionObjectBuilder::new(
-            ctx.realm(),
-            NativeFunction::from_copy_closure_with_captures(
-                move |_this, _args, state, _ctx| Ok(JsValue::from(state.0.borrow().depth)),
-                state.clone(),
-            ),
-        )
-        .length(0)
-        .build();
-        let get_refund = FunctionObjectBuilder::new(
-            ctx.realm(),
-            NativeFunction::from_copy_closure_with_captures(
-                move |_this, _args, state, _ctx| Ok(JsValue::from(state.0.borrow().refund)),
-                state.clone(),
-            ),
-        )
-        .length(0)
-        .build();
-        let get_error = FunctionObjectBuilder::new(
-            ctx.realm(),
-            NativeFunction::from_copy_closure_with_captures(
-                move |_this, _args, state, _ctx| {
-                    Ok(state
-                        .0
-                        .borrow()
-                        .error
-                        .as_ref()
-                        .map(|error| JsValue::from(js_string!(error.as_str())))
-                        .unwrap_or_else(JsValue::undefined))
-                },
-                state.clone(),
-            ),
-        )
-        .length(0)
-        .build();
+        let get_pc = state_fn(ctx, state.clone(), 0, |state, _, _| Ok(state.borrow().pc.into()));
+        let get_gas =
+            state_fn(ctx, state.clone(), 0, |state, _, _| Ok(state.borrow().gas_remaining.into()));
+        let get_cost =
+            state_fn(ctx, state.clone(), 0, |state, _, _| Ok(state.borrow().cost.into()));
+        let get_depth =
+            state_fn(ctx, state.clone(), 0, |state, _, _| Ok(state.borrow().depth.into()));
+        let get_refund =
+            state_fn(ctx, state.clone(), 0, |state, _, _| Ok(state.borrow().refund.into()));
+        let get_error = state_fn(ctx, state.clone(), 0, |state, _, _| {
+            Ok(state
+                .borrow()
+                .error
+                .as_ref()
+                .map(|error| JsValue::from(js_string!(error.as_str())))
+                .unwrap_or_else(JsValue::undefined))
+        });
 
         object.set(js_string!("getPC"), get_pc, false, ctx)?;
         object.set(js_string!("getError"), get_error, false, ctx)?;
@@ -158,12 +184,118 @@ impl ReusableStepLog {
         Ok(Self { state, object })
     }
 
-    pub(crate) fn update(&self, step: StepLog) {
-        self.state.replace(step.into());
+    /// Makes the post-execution `stack` and `memory` available to the JS object, so it can serve
+    /// the pre-execution view recorded by [`StepSnapshot::record`], and fills in the
+    /// remaining step data.
+    ///
+    /// Access is revoked before returning, including during unwinding. The guard stays internal
+    /// so callers cannot leak it, and the input borrows remain live throughout the callback.
+    pub(crate) fn with_scope<'a, R>(
+        &'a self,
+        snapshot: &'a mut StepSnapshot,
+        stack: &'a [U256],
+        memory: &'a [u8],
+        info: StepInfo<'_>,
+        f: impl FnOnce() -> R,
+    ) -> R {
+        assert!(self.state.borrow().stack.post.is_none(), "step scope is already active");
+        // SAFETY: boa requires 'static values, the guard removes the references from the shared
+        // state when it is dropped and JS code only runs while the guard is alive.
+        let stack: &'static [U256] =
+            unsafe { core::mem::transmute::<&[U256], &'static [U256]>(stack) };
+        let memory_slice: &'static [u8] =
+            unsafe { core::mem::transmute::<&[u8], &'static [u8]>(memory) };
+
+        {
+            let mut state = self.state.borrow_mut();
+            core::mem::swap(&mut state.snapshot, snapshot);
+            state.stack.post = Some(stack);
+            state.memory.post = Some(memory_slice);
+            state.cost = info.cost;
+            state.depth = info.depth;
+            state.error = info.error;
+            if let Some(op) = info.op {
+                state.op = op;
+            }
+            state.contract.caller = info.caller;
+            state.contract.contract = info.contract;
+            state.contract.value = info.value;
+            // the input only changes with the call, so it is only cloned once per call
+            if state.call_id != info.call_id {
+                state.call_id = info.call_id;
+                state.contract.input = info.input.clone();
+            }
+        }
+
+        let _scope = StepScope { state: &self.state, snapshot };
+        f()
     }
 
     pub(crate) fn value(&self) -> JsValue {
         self.object.clone().into()
+    }
+}
+
+/// Pre-execution data of a step, see [`StepSnapshot::record`].
+#[derive(Debug)]
+pub(crate) struct PreStep<'a> {
+    /// Program counter before step execution
+    pub(crate) pc: u64,
+    /// Opcode to be executed
+    pub(crate) op: u8,
+    /// Remaining gas before step execution
+    pub(crate) gas_remaining: u64,
+    /// Gas refund counter before step execution
+    pub(crate) refund: u64,
+    /// Stack before step execution
+    pub(crate) stack: &'a [U256],
+    /// Memory before step execution
+    pub(crate) memory: &'a [u8],
+}
+
+/// Post-execution data of a step, see [`ReusableStepLog::with_scope`].
+#[derive(Debug)]
+pub(crate) struct StepInfo<'a> {
+    /// Gas cost of step execution
+    pub(crate) cost: u64,
+    /// Call depth
+    pub(crate) depth: u64,
+    /// Information about the error if one occurred
+    pub(crate) error: Option<String>,
+    /// Overrides the recorded opcode, faults are reported as `REVERT`.
+    pub(crate) op: Option<u8>,
+    /// Caller of the current call
+    pub(crate) caller: Address,
+    /// Address of the current call
+    pub(crate) contract: Address,
+    /// Value of the current call
+    pub(crate) value: U256,
+    /// Input of the current call
+    pub(crate) input: &'a Bytes,
+    /// Id of the current call, see `CallStackItem::id`
+    pub(crate) call_id: u64,
+}
+
+/// Revokes the JS log object's access to the interpreter's stack and memory when dropped.
+#[derive(Debug)]
+#[must_use]
+struct StepScope<'a> {
+    state: &'a Shared<StepLogState>,
+    snapshot: &'a mut StepSnapshot,
+}
+
+impl Drop for StepScope<'_> {
+    fn drop(&mut self) {
+        let mut state = self.state.borrow_mut();
+        state.stack.post = None;
+        state.memory.post = None;
+        // Keep the last scalar fields available through retained log objects, while returning
+        // the reusable stack/memory buffers to their call depth.
+        self.snapshot.pc = state.pc;
+        self.snapshot.op = state.op;
+        self.snapshot.gas_remaining = state.gas_remaining;
+        self.snapshot.refund = state.refund;
+        core::mem::swap(&mut state.snapshot, self.snapshot);
     }
 }
 
@@ -179,68 +311,21 @@ impl ReusableCallFrame {
         let state = Shared::new(CallFrameState::default());
         let object = JsObject::with_object_proto(ctx.intrinsics());
 
-        let get_from = FunctionObjectBuilder::new(
-            ctx.realm(),
-            NativeFunction::from_copy_closure_with_captures(
-                move |_this, _args, state, ctx| {
-                    address_to_uint8_array_value(state.0.borrow().caller, ctx)
-                },
-                state.clone(),
-            ),
-        )
-        .length(0)
-        .build();
-        let get_to = FunctionObjectBuilder::new(
-            ctx.realm(),
-            NativeFunction::from_copy_closure_with_captures(
-                move |_this, _args, state, ctx| {
-                    address_to_uint8_array_value(state.0.borrow().contract, ctx)
-                },
-                state.clone(),
-            ),
-        )
-        .length(0)
-        .build();
-        let get_value = FunctionObjectBuilder::new(
-            ctx.realm(),
-            NativeFunction::from_copy_closure_with_captures(
-                move |_this, _args, state, _ctx| to_bigint(state.0.borrow().value),
-                state.clone(),
-            ),
-        )
-        .length(0)
-        .build();
-        let get_input = FunctionObjectBuilder::new(
-            ctx.realm(),
-            NativeFunction::from_copy_closure_with_captures(
-                move |_this, _args, state, ctx| {
-                    to_uint8_array_value(state.0.borrow().input.clone(), ctx)
-                },
-                state.clone(),
-            ),
-        )
-        .length(0)
-        .build();
-        let get_gas = FunctionObjectBuilder::new(
-            ctx.realm(),
-            NativeFunction::from_copy_closure_with_captures(
-                move |_this, _args, state, _ctx| Ok(JsValue::from(state.0.borrow().gas)),
-                state.clone(),
-            ),
-        )
-        .length(0)
-        .build();
-        let get_type = FunctionObjectBuilder::new(
-            ctx.realm(),
-            NativeFunction::from_copy_closure_with_captures(
-                move |_this, _args, state, _ctx| {
-                    Ok(JsValue::from(js_string!(state.0.borrow().kind.as_str())))
-                },
-                state.clone(),
-            ),
-        )
-        .length(0)
-        .build();
+        let get_from = state_fn(ctx, state.clone(), 0, |state, _, ctx| {
+            address_to_uint8_array_value(state.borrow().caller, ctx)
+        });
+        let get_to = state_fn(ctx, state.clone(), 0, |state, _, ctx| {
+            address_to_uint8_array_value(state.borrow().contract, ctx)
+        });
+        let get_value =
+            state_fn(ctx, state.clone(), 0, |state, _, _| Ok(to_bigint(state.borrow().value)));
+        let get_input = state_fn(ctx, state.clone(), 0, |state, _, ctx| {
+            to_uint8_array_value(state.borrow().input.clone(), ctx)
+        });
+        let get_gas = state_fn(ctx, state.clone(), 0, |state, _, _| Ok(state.borrow().gas.into()));
+        let get_type = state_fn(ctx, state.clone(), 0, |state, _, _| {
+            Ok(call_kind_js_string(state.borrow().kind).into())
+        });
 
         object.set(js_string!("getFrom"), get_from, false, ctx)?;
         object.set(js_string!("getTo"), get_to, false, ctx)?;
@@ -253,7 +338,14 @@ impl ReusableCallFrame {
     }
 
     pub(crate) fn update(&self, frame: CallFrame) {
-        self.state.replace(frame.into());
+        let CallFrame { contract, kind, gas } = frame;
+        let mut state = self.state.borrow_mut();
+        state.caller = contract.caller;
+        state.contract = contract.contract;
+        state.value = contract.value;
+        state.input = contract.input;
+        state.gas = gas;
+        state.kind = kind;
     }
 
     pub(crate) fn value(&self) -> JsValue {
@@ -273,43 +365,19 @@ impl ReusableFrameResult {
         let state = Shared::new(FrameResultState::default());
         let object = JsObject::with_object_proto(ctx.intrinsics());
 
-        let get_gas_used = FunctionObjectBuilder::new(
-            ctx.realm(),
-            NativeFunction::from_copy_closure_with_captures(
-                move |_this, _args, state, _ctx| Ok(JsValue::from(state.0.borrow().gas_used)),
-                state.clone(),
-            ),
-        )
-        .length(0)
-        .build();
-        let get_output = FunctionObjectBuilder::new(
-            ctx.realm(),
-            NativeFunction::from_copy_closure_with_captures(
-                move |_this, _args, state, ctx| {
-                    to_uint8_array_value(state.0.borrow().output.clone(), ctx)
-                },
-                state.clone(),
-            ),
-        )
-        .length(0)
-        .build();
-        let get_error = FunctionObjectBuilder::new(
-            ctx.realm(),
-            NativeFunction::from_copy_closure_with_captures(
-                move |_this, _args, state, _ctx| {
-                    Ok(state
-                        .0
-                        .borrow()
-                        .error
-                        .as_ref()
-                        .map(|error| JsValue::from(js_string!(error.as_str())))
-                        .unwrap_or_else(JsValue::undefined))
-                },
-                state.clone(),
-            ),
-        )
-        .length(0)
-        .build();
+        let get_gas_used =
+            state_fn(ctx, state.clone(), 0, |state, _, _| Ok(state.borrow().gas_used.into()));
+        let get_output = state_fn(ctx, state.clone(), 0, |state, _, ctx| {
+            to_uint8_array_value(state.borrow().output.clone(), ctx)
+        });
+        let get_error = state_fn(ctx, state.clone(), 0, |state, _, _| {
+            Ok(state
+                .borrow()
+                .error
+                .as_ref()
+                .map(|error| JsValue::from(js_string!(error.as_str())))
+                .unwrap_or_else(JsValue::undefined))
+        });
 
         object.set(js_string!("getGasUsed"), get_gas_used, false, ctx)?;
         object.set(js_string!("getOutput"), get_output, false, ctx)?;
@@ -319,7 +387,11 @@ impl ReusableFrameResult {
     }
 
     pub(crate) fn update(&self, frame: FrameResult) {
-        self.state.replace(frame.into());
+        let FrameResult { gas_used, output, error } = frame;
+        let mut state = self.state.borrow_mut();
+        state.gas_used = gas_used;
+        state.output = output;
+        state.error = error;
     }
 
     pub(crate) fn value(&self) -> JsValue {
@@ -327,7 +399,10 @@ impl ReusableFrameResult {
     }
 }
 
-/// Reusable JS database object for step and fault callbacks.
+/// Reusable JS database object for step, fault and result callbacks.
+///
+/// The object is built once, [`Self::with_scope`] points it at the state and database of the
+/// current transaction for the duration of a callback.
 #[derive(Debug)]
 pub(crate) struct ReusableEvmDb {
     state: Shared<EvmDbState>,
@@ -339,81 +414,34 @@ impl ReusableEvmDb {
         let state = Shared::new(EvmDbState::default());
         let object = JsObject::with_object_proto(ctx.intrinsics());
 
-        let exists = FunctionObjectBuilder::new(
-            ctx.realm(),
-            NativeFunction::from_copy_closure_with_captures(
-                move |_this, args, state, ctx| {
-                    let db = current_db(state)?;
-                    let acc = db.read_basic(args.get_or_undefined(0).clone(), ctx)?;
-                    Ok(JsValue::from(acc.is_some()))
-                },
-                state.clone(),
-            ),
-        )
-        .length(1)
-        .build();
-        let get_balance = FunctionObjectBuilder::new(
-            ctx.realm(),
-            NativeFunction::from_copy_closure_with_captures(
-                move |_this, args, state, ctx| {
-                    let db = current_db(state)?;
-                    let balance = db
-                        .read_basic(args.get_or_undefined(0).clone(), ctx)?
-                        .map(|acc| acc.balance)
-                        .unwrap_or_default();
-                    to_bigint(balance)
-                },
-                state.clone(),
-            ),
-        )
-        .length(1)
-        .build();
-        let get_nonce = FunctionObjectBuilder::new(
-            ctx.realm(),
-            NativeFunction::from_copy_closure_with_captures(
-                move |_this, args, state, ctx| {
-                    let db = current_db(state)?;
-                    let nonce = db
-                        .read_basic(args.get_or_undefined(0).clone(), ctx)?
-                        .map(|acc| acc.nonce)
-                        .unwrap_or_default();
-                    Ok(JsValue::from(nonce))
-                },
-                state.clone(),
-            ),
-        )
-        .length(1)
-        .build();
-        let get_code = FunctionObjectBuilder::new(
-            ctx.realm(),
-            NativeFunction::from_copy_closure_with_captures(
-                move |_this, args, state, ctx| {
-                    let db = current_db(state)?;
-                    Ok(db.read_code(args.get_or_undefined(0).clone(), ctx)?.into())
-                },
-                state.clone(),
-            ),
-        )
-        .length(1)
-        .build();
-        let get_state = FunctionObjectBuilder::new(
-            ctx.realm(),
-            NativeFunction::from_copy_closure_with_captures(
-                move |_this, args, state, ctx| {
-                    let db = current_db(state)?;
-                    Ok(db
-                        .read_state(
-                            args.get_or_undefined(0).clone(),
-                            args.get_or_undefined(1).clone(),
-                            ctx,
-                        )?
-                        .into())
-                },
-                state.clone(),
-            ),
-        )
-        .length(2)
-        .build();
+        // Note: the arguments are converted before the state is borrowed mutably, since
+        // converting a value may run JS code.
+        let exists = state_fn(ctx, state.clone(), 1, |state, args, ctx| {
+            let address = address_from_value(args.get_or_undefined(0).clone(), ctx)?;
+            let acc = state.borrow_mut().read_basic(address)?;
+            Ok(JsValue::from(acc.is_some()))
+        });
+        let get_balance = state_fn(ctx, state.clone(), 1, |state, args, ctx| {
+            let address = address_from_value(args.get_or_undefined(0).clone(), ctx)?;
+            let acc = state.borrow_mut().read_basic(address)?;
+            Ok(to_bigint(acc.map(|acc| acc.balance).unwrap_or_default()))
+        });
+        let get_nonce = state_fn(ctx, state.clone(), 1, |state, args, ctx| {
+            let address = address_from_value(args.get_or_undefined(0).clone(), ctx)?;
+            let acc = state.borrow_mut().read_basic(address)?;
+            Ok(JsValue::from(acc.map(|acc| acc.nonce).unwrap_or_default()))
+        });
+        let get_code = state_fn(ctx, state.clone(), 1, |state, args, ctx| {
+            let address = address_from_value(args.get_or_undefined(0).clone(), ctx)?;
+            let code = state.borrow_mut().read_code(address)?;
+            to_uint8_array_value(code, ctx)
+        });
+        let get_state = state_fn(ctx, state.clone(), 2, |state, args, ctx| {
+            let address = address_from_value(args.get_or_undefined(0).clone(), ctx)?;
+            let slot = b256_from_value(args.get_or_undefined(1).clone(), ctx)?;
+            let value = state.borrow_mut().read_state(address, slot)?;
+            to_uint8_array_value(B256::from(value), ctx)
+        });
 
         object.set(js_string!("getBalance"), get_balance, false, ctx)?;
         object.set(js_string!("getNonce"), get_nonce, false, ctx)?;
@@ -424,8 +452,35 @@ impl ReusableEvmDb {
         Ok(Self { state, object })
     }
 
-    pub(crate) fn update(&self, db: EvmDbRef) {
-        self.state.replace(EvmDbState { current: Some(db) });
+    /// Borrows the in-flight state only for the duration of a callback.
+    pub(crate) fn with_state_scope<R>(&self, state: &mut State<'_>, f: impl FnOnce() -> R) -> R {
+        self.with_scope(&mut StateDbReader { state }, f)
+    }
+
+    /// Borrows a transaction's materialized changes and backing database during a callback.
+    pub(crate) fn with_changes_scope<R>(
+        &self,
+        changes: &TxState,
+        db: &mut dyn DynDatabase,
+        f: impl FnOnce() -> R,
+    ) -> R {
+        self.with_scope(&mut ChangesDbReader { changes, db }, f)
+    }
+
+    /// Access is revoked on return or unwind; callers cannot retain or forget the guard.
+    fn with_scope<'a, R>(&'a self, reader: &'a mut dyn EvmDbReader, f: impl FnOnce() -> R) -> R {
+        assert!(self.state.borrow().reader.is_none(), "database scope is already active");
+        // SAFETY: The reader is borrowed throughout f, and DbScope clears the reference on
+        // return or unwind before the reader or any of its borrowed inputs can be dropped.
+        let reader = unsafe {
+            core::mem::transmute::<
+                &mut (dyn EvmDbReader + '_),
+                &'static mut (dyn EvmDbReader + 'static),
+            >(reader)
+        };
+        self.state.borrow_mut().reader = Some(reader);
+        let _scope = DbScope { state: &self.state, _borrow: PhantomData };
+        f()
     }
 
     pub(crate) fn value(&self) -> JsValue {
@@ -433,265 +488,425 @@ impl ReusableEvmDb {
     }
 }
 
-#[derive(Clone, Debug, Default)]
+/// Revokes the JS database object's access to the state and database when dropped.
+#[derive(Debug)]
+#[must_use]
+struct DbScope<'a> {
+    state: &'a Shared<EvmDbState>,
+    _borrow: PhantomData<&'a mut dyn EvmDbReader>,
+}
+
+impl Drop for DbScope<'_> {
+    fn drop(&mut self) {
+        let mut state = self.state.borrow_mut();
+        state.reader = None;
+    }
+}
+
+/// DB reader used by the JS context.
+pub(crate) trait EvmDbReader {
+    fn read_basic(&mut self, address: &Address) -> DbResult<Option<AccountInfo>>;
+
+    fn read_code(&mut self, address: &Address) -> DbResult<Bytecode>;
+
+    fn read_state(&mut self, address: &Address, slot: &Word) -> DbResult<Word>;
+}
+
+impl core::fmt::Debug for dyn EvmDbReader {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str("EvmDbReader")
+    }
+}
+
+struct StateDbReader<'a, 'db> {
+    state: &'a mut State<'db>,
+}
+
+impl EvmDbReader for StateDbReader<'_, '_> {
+    fn read_basic(&mut self, address: &Address) -> DbResult<Option<AccountInfo>> {
+        self.state.account_info_untracked(address)
+    }
+
+    fn read_code(&mut self, address: &Address) -> DbResult<Bytecode> {
+        self.state.account(address, false)?.load_code()
+    }
+
+    fn read_state(&mut self, address: &Address, slot: &Word) -> DbResult<Word> {
+        self.state.read_committed_storage(address, slot)
+    }
+}
+
+struct ChangesDbReader<'a> {
+    changes: &'a TxState,
+    db: &'a mut dyn DynDatabase,
+}
+
+impl ChangesDbReader<'_> {
+    fn code_from_info(&mut self, info: AccountInfo) -> DbResult<Bytecode> {
+        // Note: the changed account from the state output always holds the code.
+        if let Some(code) = info.code
+            && !code.is_empty()
+        {
+            return Ok(code);
+        }
+        let code_hash = info.code_hash;
+        if code_hash == KECCAK256_EMPTY {
+            return Ok(Bytecode::default());
+        }
+        self.db.get_code_by_hash(&code_hash)
+    }
+}
+
+impl EvmDbReader for ChangesDbReader<'_> {
+    fn read_basic(&mut self, address: &Address) -> DbResult<Option<AccountInfo>> {
+        if let Some(account) = self.changes.accounts.get(address) {
+            return Ok(account.current.clone());
+        }
+        self.db.get_account(address)
+    }
+
+    fn read_code(&mut self, address: &Address) -> DbResult<Bytecode> {
+        let Some(info) = self.read_basic(address)? else {
+            return Ok(Bytecode::default());
+        };
+        self.code_from_info(info)
+    }
+
+    fn read_state(&mut self, address: &Address, slot: &Word) -> DbResult<Word> {
+        // Storage is always read from the backing database, not the transaction changes.
+        self.db.get_storage(address, slot)
+    }
+}
+
+#[derive(Default, Debug)]
 struct EvmDbState {
-    current: Option<EvmDbRef>,
+    reader: Option<&'static mut dyn EvmDbReader>,
 }
 
-fn current_db(state: &Shared<EvmDbState>) -> JsResult<EvmDbRef> {
-    state.0.borrow().current.clone().ok_or_else(|| {
-        JsError::from_native(
-            JsNativeError::typ().with_message("tracer accessed db before it was initialized"),
-        )
-    })
+impl EvmDbState {
+    fn active(&mut self) -> JsResult<&mut (dyn EvmDbReader + 'static)> {
+        self.reader
+            .as_deref_mut()
+            .ok_or_else(|| type_error("tracer accessed db outside of a callback".to_string()))
+    }
+
+    fn read_basic(&mut self, address: Address) -> JsResult<Option<AccountInfo>> {
+        self.active()?.read_basic(&address).map_err(|err| {
+            JsNativeError::error().with_message(format!("database read failed: {err:?}")).into()
+        })
+    }
+
+    fn read_code(&mut self, address: Address) -> JsResult<Bytes> {
+        self.active()?.read_code(&address).map(|code| code.original_bytes()).map_err(|err| {
+            JsNativeError::error().with_message(format!("database read failed: {err:?}")).into()
+        })
+    }
+
+    fn read_state(&mut self, address: Address, slot: B256) -> JsResult<U256> {
+        self.active()?.read_state(&address, &slot.into()).map_err(|err| {
+            JsNativeError::error().with_message(format!("database read failed: {err:?}")).into()
+        })
+    }
 }
 
-#[derive(Clone, Debug, Default)]
-struct StepLogState {
-    stack: Option<StackRef>,
+/// Pre-execution data retained independently for each active call depth.
+#[derive(Debug, Default)]
+pub(crate) struct StepSnapshot {
     op: u8,
-    memory: Option<MemoryRef>,
     pc: u64,
     gas_remaining: u64,
-    cost: u64,
-    depth: u64,
     refund: u64,
-    error: Option<String>,
-    contract: Contract,
+    stack: StackView,
+    memory: MemoryView,
 }
 
-impl From<StepLog> for StepLogState {
-    fn from(step: StepLog) -> Self {
+impl StepSnapshot {
+    /// Records everything about a step that must be captured before the opcode executes.
+    pub(crate) fn record(&mut self, step: PreStep<'_>) {
+        let PreStep { pc, op, gas_remaining, refund, stack, memory } = step;
+        let state = self;
+        state.pc = pc;
+        state.op = op;
+        state.gas_remaining = gas_remaining;
+        state.refund = refund;
+        state.stack.record(op, stack);
+        state.memory.record(op, stack, memory);
+    }
+}
+
+#[derive(Debug)]
+struct StepLogState {
+    snapshot: StepSnapshot,
+    cost: u64,
+    depth: u64,
+    error: Option<String>,
+    contract: Contract,
+    call_id: u64,
+    op_names: OpcodeNames,
+}
+
+impl core::ops::Deref for StepLogState {
+    type Target = StepSnapshot;
+    fn deref(&self) -> &Self::Target {
+        &self.snapshot
+    }
+}
+
+impl core::ops::DerefMut for StepLogState {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.snapshot
+    }
+}
+
+impl StepLogState {
+    fn new(op_names: OpcodeNames) -> Self {
         Self {
-            stack: Some(step.stack),
-            op: step.op.0,
-            memory: Some(step.memory),
-            pc: step.pc,
-            gas_remaining: step.gas_remaining,
-            cost: step.cost,
-            depth: step.depth,
-            refund: step.refund,
-            error: step.error,
-            contract: step.contract,
+            snapshot: StepSnapshot::default(),
+            cost: 0,
+            depth: 0,
+            error: None,
+            contract: Contract::default(),
+            call_id: 0,
+            op_names,
         }
     }
 }
 
-#[derive(Clone, Debug, Default)]
+/// Lazily initialized JS strings of all opcode names.
+///
+/// The first `log.op.toString()` call initializes the table; subsequent calls do not allocate.
+/// The table is shared by all step log objects an inspector creates, so rebuilding the objects on
+/// `fuse` does not rebuild the strings.
+#[derive(Clone, Debug)]
+pub(crate) struct OpcodeNames(Rc<OnceCell<Box<[JsString]>>>);
+
+impl OpcodeNames {
+    pub(crate) fn new() -> Self {
+        Self(Rc::new(OnceCell::new()))
+    }
+
+    fn get(&self, op: u8) -> JsString {
+        let names = self.0.get_or_init(|| {
+            (0..=u8::MAX)
+                .map(|op| match OpCode::new(op) {
+                    Some(op) => JsString::from(op.as_str()),
+                    None => JsString::from(format!("opcode {op:x} not defined").as_str()),
+                })
+                .collect()
+        });
+        names[op as usize].clone()
+    }
+}
+
+/// Pre-execution view of the stack, reconstructed from the post-execution stack and the items the
+/// opcode consumed.
+///
+/// An opcode only touches its top `inputs` items, so the pre-execution stack is the post-execution
+/// stack below those items followed by the saved inputs. This holds for halted opcodes too, which
+/// pop at most `inputs` items.
+#[derive(Debug, Default)]
+struct StackView {
+    /// Pre-execution length.
+    len: usize,
+    /// The top `saved.len()` pre-execution items, bottom to top.
+    saved: Vec<U256>,
+    /// Post-execution stack, only set while a callback runs.
+    post: Option<&'static [U256]>,
+}
+
+impl StackView {
+    fn record(&mut self, op: u8, stack: &[U256]) {
+        self.len = stack.len();
+        let inputs = OpCode::new(op).map_or(0, |op| op.inputs() as usize).min(stack.len());
+        self.saved.clear();
+        self.saved.extend_from_slice(&stack[stack.len() - inputs..]);
+    }
+
+    /// Returns the pre-execution length, or 0 outside of a callback.
+    const fn len(&self) -> usize {
+        if self.post.is_some() { self.len } else { 0 }
+    }
+
+    /// Returns the item `idx` positions from the top of the pre-execution stack.
+    fn peek(&self, idx: usize) -> JsResult<U256> {
+        let Some(post) = self.post else {
+            return Err(type_error("tracer accessed stack outside of a callback".to_string()));
+        };
+        let saved = self.saved.len();
+        let item = if idx < saved {
+            Some(self.saved[saved - 1 - idx])
+        } else {
+            (idx < self.len).then(|| post.get(self.len - 1 - idx).copied()).flatten()
+        };
+        item.ok_or_else(|| {
+            type_error(format!(
+                "tracer accessed out of bound stack: size {}, index {idx}",
+                self.len
+            ))
+        })
+    }
+}
+
+/// Pre-execution view of memory, reconstructed from the post-execution memory, the pre-execution
+/// length and the bytes the opcode overwrote.
+///
+/// Opcodes only ever expand memory or overwrite a single range, so restoring that range and
+/// truncating to the pre-execution length yields the pre-execution memory. Call output ranges are
+/// also saved because evm2 reports `step_end` after the child has returned.
+#[derive(Debug, Default)]
+struct MemoryView {
+    /// Pre-execution length.
+    len: usize,
+    /// Offset of `patch` in memory.
+    patch_offset: usize,
+    /// Pre-execution bytes of the range the opcode overwrites.
+    patch: Vec<u8>,
+    /// Post-execution memory, only set while a callback runs.
+    post: Option<&'static [u8]>,
+}
+
+impl MemoryView {
+    fn record(&mut self, op: u8, stack: &[U256], memory: &[u8]) {
+        self.len = memory.len();
+        self.patch.clear();
+        self.patch_offset = 0;
+        if let Some((offset, size)) = memory_write_range(op, stack)
+            && offset < memory.len()
+            && size > 0
+        {
+            let end = offset.saturating_add(size).min(memory.len());
+            self.patch_offset = offset;
+            self.patch.extend_from_slice(&memory[offset..end]);
+        }
+    }
+
+    /// Returns the pre-execution length, or 0 outside of a callback.
+    const fn len(&self) -> usize {
+        if self.post.is_some() { self.len } else { 0 }
+    }
+
+    /// Returns the pre-execution bytes of the given range, which must be within
+    /// [`Self::len`].
+    fn bytes(&self, range: Range<usize>) -> JsResult<AlignedVec<u8>> {
+        let Some(post) = self.post else {
+            return Err(type_error("tracer accessed memory outside of a callback".to_string()));
+        };
+        let patch = self.patch_offset..self.patch_offset + self.patch.len();
+        Ok(AlignedVec::from_iter(
+            0,
+            range.map(|i| {
+                if patch.contains(&i) {
+                    self.patch[i - self.patch_offset]
+                } else {
+                    post.get(i).copied().unwrap_or_default()
+                }
+            }),
+        ))
+    }
+}
+
+/// Returns the memory range `(offset, size)` the opcode overwrites, based on its pre-execution
+/// stack.
+///
+/// Returns `None` for opcodes that don't write to memory, or if the operands are out of range, in
+/// which case the opcode fails without writing.
+fn memory_write_range(op: u8, stack: &[U256]) -> Option<(usize, usize)> {
+    let peek = |n: usize| stack.len().checked_sub(n + 1).map(|i| stack[i]);
+    let (offset, size) = match op {
+        opcode::MSTORE => (peek(0)?, U256::from(32)),
+        opcode::MSTORE8 => (peek(0)?, U256::from(1)),
+        opcode::MCOPY | opcode::CALLDATACOPY | opcode::CODECOPY | opcode::RETURNDATACOPY => {
+            (peek(0)?, peek(2)?)
+        }
+        opcode::EXTCODECOPY => (peek(1)?, peek(3)?),
+        opcode::CALL | opcode::CALLCODE => (peek(5)?, peek(6)?),
+        opcode::DELEGATECALL | opcode::STATICCALL => (peek(4)?, peek(5)?),
+        _ => return None,
+    };
+    Some((usize::try_from(offset).ok()?, usize::try_from(size).ok()?))
+}
+
+#[derive(Debug, Default)]
 struct CallFrameState {
     caller: Address,
     contract: Address,
     value: U256,
     input: Bytes,
     gas: u64,
-    kind: String,
+    kind: CallKind,
 }
 
-impl From<CallFrame> for CallFrameState {
-    fn from(frame: CallFrame) -> Self {
-        Self {
-            caller: frame.contract.caller,
-            contract: frame.contract.contract,
-            value: frame.contract.value,
-            input: frame.contract.input,
-            gas: frame.gas,
-            kind: frame.kind.to_string(),
-        }
-    }
-}
-
-#[derive(Clone, Debug, Default)]
+#[derive(Debug, Default)]
 struct FrameResultState {
     gas_used: u64,
     output: Bytes,
     error: Option<String>,
 }
 
-impl From<FrameResult> for FrameResultState {
-    fn from(frame: FrameResult) -> Self {
-        Self { gas_used: frame.gas_used, output: frame.output, error: frame.error }
-    }
-}
+fn build_step_op_object(state: Shared<StepLogState>, ctx: &mut Context) -> JsResult<JsObject> {
+    let obj = JsObject::with_object_proto(ctx.intrinsics());
+    let to_number = state_fn(ctx, state.clone(), 0, |state, _, _| Ok(state.borrow().op.into()));
+    let is_push = state_fn(ctx, state.clone(), 0, |state, _, _| {
+        Ok(JsValue::from((PUSH0..=PUSH32).contains(&state.borrow().op)))
+    });
+    let to_string = state_fn(ctx, state, 0, |state, _, _| {
+        let state = state.borrow();
+        Ok(state.op_names.get(state.op).into())
+    });
 
-fn build_step_op_object(state: Shared<StepLogState>, context: &mut Context) -> JsResult<JsObject> {
-    let obj = JsObject::with_object_proto(context.intrinsics());
-    let to_number = FunctionObjectBuilder::new(
-        context.realm(),
-        NativeFunction::from_copy_closure_with_captures(
-            move |_this, _args, state, _ctx| Ok(JsValue::from(state.0.borrow().op)),
-            state.clone(),
-        ),
-    )
-    .length(0)
-    .build();
-    let is_push = FunctionObjectBuilder::new(
-        context.realm(),
-        NativeFunction::from_copy_closure_with_captures(
-            move |_this, _args, state, _ctx| {
-                Ok(JsValue::from((op::PUSH0..=op::PUSH32).contains(&state.0.borrow().op)))
-            },
-            state.clone(),
-        ),
-    )
-    .length(0)
-    .build();
-    let to_string = FunctionObjectBuilder::new(
-        context.realm(),
-        NativeFunction::from_copy_closure_with_captures(
-            move |_this, _args, state, _ctx| {
-                let value = state.0.borrow().op;
-                if let Some(op) = OpCode::new(value) {
-                    Ok(JsValue::from(js_string!(op.as_str())))
-                } else {
-                    Ok(JsValue::from(js_string!(format!("opcode {:x} not defined", value))))
-                }
-            },
-            state,
-        ),
-    )
-    .length(0)
-    .build();
-
-    obj.set(js_string!("toNumber"), to_number, false, context)?;
-    obj.set(js_string!("toString"), to_string, false, context)?;
-    obj.set(js_string!("isPush"), is_push, false, context)?;
+    obj.set(js_string!("toNumber"), to_number, false, ctx)?;
+    obj.set(js_string!("toString"), to_string, false, ctx)?;
+    obj.set(js_string!("isPush"), is_push, false, ctx)?;
     Ok(obj)
 }
 
-fn build_step_stack_object(
-    state: Shared<StepLogState>,
-    context: &mut Context,
-) -> JsResult<JsObject> {
-    let obj = JsObject::with_object_proto(context.intrinsics());
-    let length = FunctionObjectBuilder::new(
-        context.realm(),
-        NativeFunction::from_copy_closure_with_captures(
-            move |_this, _args, state, _ctx| {
-                let len = state
-                    .0
-                    .borrow()
-                    .stack
-                    .as_ref()
-                    .and_then(|stack| stack.0.with_inner(Vec::len))
-                    .unwrap_or_default();
-                Ok(JsValue::from(len))
-            },
-            state.clone(),
-        ),
-    )
-    .length(0)
-    .build();
-    let peek = FunctionObjectBuilder::new(
-        context.realm(),
-        NativeFunction::from_copy_closure_with_captures(
-            move |_this, args, state, ctx| {
-                let stack = state.0.borrow().stack.clone().ok_or_else(|| {
-                    JsError::from_native(
-                        JsNativeError::typ()
-                            .with_message("tracer accessed stack before it was initialized"),
-                    )
-                })?;
-                let len = stack.0.with_inner(Vec::len).unwrap_or_default();
-                let idx = StackRef::parse_index(args.get_or_undefined(0), len, ctx)?;
-                if len <= idx {
-                    return Err(JsError::from_native(JsNativeError::typ().with_message(format!(
-                        "tracer accessed out of bound stack: size {len}, index {idx}"
-                    ))));
-                }
-                stack.peek(idx)
-            },
-            state,
-        ),
-    )
-    .length(1)
-    .build();
+fn build_step_stack_object(state: Shared<StepLogState>, ctx: &mut Context) -> JsResult<JsObject> {
+    let obj = JsObject::with_object_proto(ctx.intrinsics());
+    let length = state_fn(ctx, state.clone(), 0, |state, _, _| {
+        Ok(JsValue::from(state.borrow().stack.len()))
+    });
+    let peek = state_fn(ctx, state, 1, |state, args, ctx| {
+        let len = state.borrow().stack.len();
+        let idx = parse_stack_index(args.get_or_undefined(0), len, ctx)?;
+        Ok(to_bigint(state.borrow().stack.peek(idx)?))
+    });
 
-    obj.set(js_string!("length"), length, false, context)?;
-    obj.set(js_string!("peek"), peek, false, context)?;
+    obj.set(js_string!("length"), length, false, ctx)?;
+    obj.set(js_string!("peek"), peek, false, ctx)?;
     Ok(obj)
 }
 
-fn build_step_memory_object(
-    state: Shared<StepLogState>,
-    context: &mut Context,
-) -> JsResult<JsObject> {
-    let obj = JsObject::with_object_proto(context.intrinsics());
-    let length = FunctionObjectBuilder::new(
-        context.realm(),
-        NativeFunction::from_copy_closure_with_captures(
-            move |_this, _args, state, _ctx| {
-                let len = state.0.borrow().memory.as_ref().map(MemoryRef::len).unwrap_or_default();
-                Ok(JsValue::from(len as u64))
-            },
-            state.clone(),
-        ),
-    )
-    .length(0)
-    .build();
-    let slice = FunctionObjectBuilder::new(
-        context.realm(),
-        NativeFunction::from_copy_closure_with_captures(
-            move |_this, args, state, ctx| {
-                let memory = state.0.borrow().memory.clone().ok_or_else(|| {
-                    JsError::from_native(
-                        JsNativeError::typ()
-                            .with_message("tracer accessed memory before it was initialized"),
-                    )
-                })?;
-                let len = memory.len();
-                let start = MemoryRef::parse_index(args.get_or_undefined(0), "start", len, ctx)?;
-                let end = MemoryRef::parse_index(args.get_or_undefined(1), "end", len, ctx)?;
-                if end < start || end > len {
-                    return Err(MemoryRef::out_of_bounds_error(
-                        len,
-                        start,
-                        end.saturating_sub(start),
-                    ));
-                }
-                let slice = memory
-                    .0
-                    .with_inner(|mem| mem.slice_len(start, end - start).to_vec())
-                    .unwrap_or_default();
-                to_uint8_array_value(slice, ctx)
-            },
-            state.clone(),
-        ),
-    )
-    .length(2)
-    .build();
-    let get_uint = FunctionObjectBuilder::new(
-        context.realm(),
-        NativeFunction::from_copy_closure_with_captures(
-            move |_this, args, state, ctx| {
-                let memory = state.0.borrow().memory.clone().ok_or_else(|| {
-                    JsError::from_native(
-                        JsNativeError::typ()
-                            .with_message("tracer accessed memory before it was initialized"),
-                    )
-                })?;
-                let len = memory.len();
-                let offset = MemoryRef::parse_index(args.get_or_undefined(0), "offset", len, ctx)?;
-                let Some(end) = offset.checked_add(32) else {
-                    return Err(MemoryRef::out_of_bounds_error(len, offset, 32));
-                };
-                if end > len {
-                    return Err(MemoryRef::out_of_bounds_error(len, offset, 32));
-                }
-                let slice = memory
-                    .0
-                    .with_inner(|mem| mem.slice_len(offset, 32).to_vec())
-                    .unwrap_or_default();
-                to_uint8_array_value(slice, ctx)
-            },
-            state,
-        ),
-    )
-    .length(1)
-    .build();
+fn build_step_memory_object(state: Shared<StepLogState>, ctx: &mut Context) -> JsResult<JsObject> {
+    let obj = JsObject::with_object_proto(ctx.intrinsics());
+    let length = state_fn(ctx, state.clone(), 0, |state, _, _| {
+        Ok(JsValue::from(state.borrow().memory.len() as u64))
+    });
+    let slice = state_fn(ctx, state.clone(), 2, |state, args, ctx| {
+        let len = state.borrow().memory.len();
+        let start = parse_memory_index(args.get_or_undefined(0), "start", len, ctx)?;
+        let end = parse_memory_index(args.get_or_undefined(1), "end", len, ctx)?;
+        if end < start || end > len {
+            return Err(memory_out_of_bounds_error(len, start, end.saturating_sub(start)));
+        }
+        let bytes = state.borrow().memory.bytes(start..end)?;
+        uint8_array_from_block(bytes, ctx)
+    });
+    let get_uint = state_fn(ctx, state, 1, |state, args, ctx| {
+        let len = state.borrow().memory.len();
+        let offset = parse_memory_index(args.get_or_undefined(0), "offset", len, ctx)?;
+        let Some(end) = offset.checked_add(32) else {
+            return Err(memory_out_of_bounds_error(len, offset, 32));
+        };
+        if end > len {
+            return Err(memory_out_of_bounds_error(len, offset, 32));
+        }
+        let bytes = state.borrow().memory.bytes(offset..end)?;
+        uint8_array_from_block(bytes, ctx)
+    });
 
-    obj.set(js_string!("slice"), slice, false, context)?;
-    obj.set(js_string!("getUint"), get_uint, false, context)?;
-    obj.set(js_string!("length"), length, false, context)?;
+    obj.set(js_string!("slice"), slice, false, ctx)?;
+    obj.set(js_string!("getUint"), get_uint, false, ctx)?;
+    obj.set(js_string!("length"), length, false, ctx)?;
     Ok(obj)
 }
 
@@ -700,48 +915,17 @@ fn build_step_contract_object(
     ctx: &mut Context,
 ) -> JsResult<JsObject> {
     let obj = JsObject::with_object_proto(ctx.intrinsics());
-    let get_caller = FunctionObjectBuilder::new(
-        ctx.realm(),
-        NativeFunction::from_copy_closure_with_captures(
-            move |_this, _args, state, ctx| {
-                address_to_uint8_array_value(state.0.borrow().contract.caller, ctx)
-            },
-            state.clone(),
-        ),
-    )
-    .length(0)
-    .build();
-    let get_address = FunctionObjectBuilder::new(
-        ctx.realm(),
-        NativeFunction::from_copy_closure_with_captures(
-            move |_this, _args, state, ctx| {
-                address_to_uint8_array_value(state.0.borrow().contract.contract, ctx)
-            },
-            state.clone(),
-        ),
-    )
-    .length(0)
-    .build();
-    let get_value = FunctionObjectBuilder::new(
-        ctx.realm(),
-        NativeFunction::from_copy_closure_with_captures(
-            move |_this, _args, state, _ctx| to_bigint(state.0.borrow().contract.value),
-            state.clone(),
-        ),
-    )
-    .length(0)
-    .build();
-    let get_input = FunctionObjectBuilder::new(
-        ctx.realm(),
-        NativeFunction::from_copy_closure_with_captures(
-            move |_this, _args, state, ctx| {
-                to_uint8_array_value(state.0.borrow().contract.input.clone(), ctx)
-            },
-            state,
-        ),
-    )
-    .length(0)
-    .build();
+    let get_caller = state_fn(ctx, state.clone(), 0, |state, _, ctx| {
+        address_to_uint8_array_value(state.borrow().contract.caller, ctx)
+    });
+    let get_address = state_fn(ctx, state.clone(), 0, |state, _, ctx| {
+        address_to_uint8_array_value(state.borrow().contract.contract, ctx)
+    });
+    let get_value =
+        state_fn(ctx, state.clone(), 0, |state, _, _| Ok(to_bigint(state.borrow().contract.value)));
+    let get_input = state_fn(ctx, state, 0, |state, _, ctx| {
+        to_uint8_array_value(state.borrow().contract.input.clone(), ctx)
+    });
 
     obj.set(js_string!("getCaller"), get_caller, false, ctx)?;
     obj.set(js_string!("getAddress"), get_address, false, ctx)?;
@@ -750,281 +934,52 @@ fn build_step_contract_object(
     Ok(obj)
 }
 
-/// A wrapper for a value that can be garbage collected, but will not give access to the value if
-/// it has been dropped via its guard.
-///
-/// This is used to allow the JS tracer functions to access values at a certain point during
-/// inspection by ref without having to clone them and capture them in the js object.
-///
-/// JS tracer functions get access to evm internals via objects or function arguments, for example
-/// `function step(log,evm)` where log has an object `stack` that has a function `peek(number)` that
-/// returns a value from the stack.
-///
-/// These functions could get garbage collected, however the data accessed by the function is
-/// supposed to be ephemeral and only valid for the duration of the function call.
-///
-/// This type supports garbage collection of (rust) references and prevents access to the value if
-/// it has been dropped.
-#[derive(Debug)]
-struct GuardedNullableGc<Val: 'static> {
-    /// The lifetime is a lie to make it possible to use a reference in boa which requires 'static
-    inner: Rc<RefCell<Option<Guarded<'static, Val>>>>,
+fn parse_stack_index(value: &JsValue, len: usize, ctx: &mut Context) -> JsResult<usize> {
+    let index = value.to_numeric_number(ctx)?;
+    if !index.is_finite() || index < 0. || index > usize::MAX as f64 {
+        return Err(type_error(format!(
+            "tracer accessed out of bound stack: size {len}, index {index}"
+        )));
+    }
+    Ok(index as usize)
 }
 
-impl<Val> Clone for GuardedNullableGc<Val> {
-    fn clone(&self) -> Self {
-        Self { inner: Rc::clone(&self.inner) }
-    }
+fn invalid_memory_index_error(name: &str, index: impl core::fmt::Display) -> JsError {
+    type_error(format!("invalid memory {name}: {index}"))
 }
 
-impl<Val: 'static> GuardedNullableGc<Val> {
-    /// Creates a garbage collectible value to the given reference.
-    ///
-    /// # Safety
-    ///
-    /// The caller must ensure that the guard is dropped before the value is dropped.
-    fn new_ref(val: &Val) -> (Self, GcGuard<'_, Val>) {
-        Self::new(Guarded::Ref(val))
+fn memory_out_of_bounds_error(len: usize, offset: usize, size: usize) -> JsError {
+    type_error(format!(
+        "tracer accessed out of bound memory: available {len}, offset {offset}, size {size}"
+    ))
+}
+
+fn parse_memory_index(
+    value: &JsValue,
+    name: &str,
+    len: usize,
+    ctx: &mut Context,
+) -> JsResult<usize> {
+    if value.is_undefined() {
+        return Err(invalid_memory_index_error(name, "undefined"));
     }
-
-    /// Creates a garbage collectible value to the given reference.
-    ///
-    /// # Safety
-    ///
-    /// The caller must ensure that the guard is dropped before the value is dropped.
-    fn new_owned<'a>(val: Val) -> (Self, GcGuard<'a, Val>) {
-        Self::new(Guarded::Owned(val))
-    }
-
-    fn new(val: Guarded<'_, Val>) -> (Self, GcGuard<'_, Val>) {
-        let inner = Rc::new(RefCell::new(Some(val)));
-        let guard = GcGuard { inner: Rc::clone(&inner) };
-
-        // SAFETY: guard enforces that the value is removed from the refcell before it is dropped.
-        #[allow(clippy::missing_transmute_annotations)]
-        let this = Self { inner: unsafe { core::mem::transmute(inner) } };
-
-        (this, guard)
-    }
-
-    /// Executes the given closure with a reference to the inner value if it is still present.
-    fn with_inner<F, R>(&self, f: F) -> Option<R>
-    where
-        F: FnOnce(&Val) -> R,
+    if let Some(index) = value.as_number()
+        && (!index.is_finite() || index < 0.)
     {
-        self.inner.borrow().as_ref().map(|guard| f(guard.as_ref()))
+        return Err(invalid_memory_index_error(name, index));
     }
-}
-
-impl<Val: 'static> Finalize for GuardedNullableGc<Val> {}
-
-unsafe impl<Val: 'static> Trace for GuardedNullableGc<Val> {
-    empty_trace!();
-}
-
-/// A value that is either a reference or an owned value.
-#[derive(Debug)]
-enum Guarded<'a, T> {
-    Ref(&'a T),
-    Owned(T),
-}
-
-impl<T> Guarded<'_, T> {
-    #[inline]
-    const fn as_ref(&self) -> &T {
-        match self {
-            Guarded::Ref(val) => val,
-            Guarded::Owned(val) => val,
-        }
-    }
-}
-
-/// Guard the inner value, once this value is dropped the inner value is also removed.
-///
-/// This type guarantees that it never outlives the wrapped value.
-#[derive(Debug)]
-#[must_use]
-pub(crate) struct GcGuard<'a, Val> {
-    inner: Rc<RefCell<Option<Guarded<'a, Val>>>>,
-}
-
-impl<Val> Drop for GcGuard<'_, Val> {
-    fn drop(&mut self) {
-        self.inner.borrow_mut().take();
-    }
-}
-
-/// The Log object that is passed to the javascript inspector.
-#[derive(Debug)]
-pub(crate) struct StepLog {
-    /// Stack before step execution
-    pub(crate) stack: StackRef,
-    /// Opcode to be executed
-    pub(crate) op: OpObj,
-    /// All allocated memory in a step
-    pub(crate) memory: MemoryRef,
-    /// Program counter before step execution
-    pub(crate) pc: u64,
-    /// Remaining gas before step execution
-    pub(crate) gas_remaining: u64,
-    /// Gas cost of step execution
-    pub(crate) cost: u64,
-    /// Call depth
-    pub(crate) depth: u64,
-    /// Gas refund counter before step execution
-    pub(crate) refund: u64,
-    /// returns information about the error if one occurred, otherwise returns undefined
-    pub(crate) error: Option<String>,
-    /// The contract object available to the js inspector
-    pub(crate) contract: Contract,
-}
-
-/// An owned snapshot of memory contents.
-///
-/// Uses `Rc` internally so cloning is cheap (reference count bump) rather than
-/// copying the entire memory buffer on every step.
-#[derive(Clone, Debug, Default)]
-pub(crate) struct MemorySnapshot(Rc<Vec<u8>>);
-
-impl MemorySnapshot {
-    /// Creates a snapshot by copying the interpreter memory.
-    pub(crate) fn new(mem: &Memory) -> Self {
-        Self(Rc::new(mem.slice(0, mem.len()).to_vec()))
-    }
-
-    fn len(&self) -> usize {
-        self.0.len()
-    }
-
-    fn slice_len(&self, offset: usize, size: usize) -> &[u8] {
-        &self.0[offset..offset + size]
-    }
-}
-
-/// Represents the memory object
-#[derive(Clone, Debug)]
-pub(crate) struct MemoryRef(GuardedNullableGc<MemorySnapshot>);
-
-impl MemoryRef {
-    /// Creates a new memory reference from an owned snapshot.
-    pub(crate) fn new_owned(mem: MemorySnapshot) -> (Self, GcGuard<'static, MemorySnapshot>) {
-        let (inner, guard) = GuardedNullableGc::new_owned(mem);
-        (Self(inner), guard)
-    }
-
-    fn len(&self) -> usize {
-        self.0.with_inner(|mem| mem.len()).unwrap_or_default()
-    }
-
-    fn invalid_index_error(name: &str, index: impl core::fmt::Display) -> JsError {
-        JsError::from_native(
-            JsNativeError::typ().with_message(format!("invalid memory {name}: {index}")),
-        )
-    }
-
-    fn check_index_bounds(index: usize, name: &str, len: usize) -> JsResult<usize> {
-        if index > len {
-            return Err(Self::invalid_index_error(name, index));
-        }
-        Ok(index)
-    }
-
-    fn parse_index(value: &JsValue, name: &str, len: usize, ctx: &mut Context) -> JsResult<usize> {
-        if value.is_undefined() {
-            return Err(Self::invalid_index_error(name, "undefined"));
-        }
-        if let Some(index) = value.as_number()
-            && (!index.is_finite() || index < 0.)
-        {
-            return Err(Self::invalid_index_error(name, index));
-        }
+    let index = if let Some(index) = value.as_bigint() {
         // Boa's `ToIndex` rejects BigInt, but stack-derived tracer values are BigInt.
-        if let Some(index) = value.as_bigint() {
-            let index = index.to_string();
-            let index =
-                index.parse::<usize>().map_err(|_| Self::invalid_index_error(name, &index))?;
-            return Self::check_index_bounds(index, name, len);
-        }
-
+        let index = index.to_string();
+        index.parse::<usize>().map_err(|_| invalid_memory_index_error(name, &index))?
+    } else {
         let index = value.to_index(ctx)?;
-        let index = usize::try_from(index).map_err(|_| Self::invalid_index_error(name, index))?;
-        Self::check_index_bounds(index, name, len)
+        usize::try_from(index).map_err(|_| invalid_memory_index_error(name, index))?
+    };
+    if index > len {
+        return Err(invalid_memory_index_error(name, index));
     }
-
-    fn out_of_bounds_error(len: usize, offset: usize, size: usize) -> JsError {
-        JsError::from_native(JsNativeError::typ().with_message(format!(
-            "tracer accessed out of bound memory: available {len}, offset {offset}, size {size}"
-        )))
-    }
-}
-
-impl Finalize for MemoryRef {}
-
-unsafe impl Trace for MemoryRef {
-    empty_trace!();
-}
-
-/// Represents the opcode object
-#[derive(Debug)]
-pub(crate) struct OpObj(pub(crate) u8);
-
-impl From<u8> for OpObj {
-    fn from(op: u8) -> Self {
-        Self(op)
-    }
-}
-
-/// Represents the stack object
-#[derive(Clone, Debug)]
-pub(crate) struct StackRef(GuardedNullableGc<Vec<Word>>);
-
-impl StackRef {
-    /// Creates a new stack reference from an owned stack.
-    pub(crate) fn new_owned(words: Vec<Word>) -> (Self, GcGuard<'static, Vec<Word>>) {
-        let (inner, guard) = GuardedNullableGc::new_owned(words);
-        (Self(inner), guard)
-    }
-
-    fn parse_index(value: &JsValue, len: usize, ctx: &mut Context) -> JsResult<usize> {
-        let index = value.to_numeric_number(ctx)?;
-        if !index.is_finite() || index < 0. || index > usize::MAX as f64 {
-            return Err(JsError::from_native(JsNativeError::typ().with_message(format!(
-                "tracer accessed out of bound stack: size {len}, index {index}"
-            ))));
-        }
-        Ok(index as usize)
-    }
-
-    fn peek(&self, idx: usize) -> JsResult<JsValue> {
-        self.0
-            .with_inner(|stack| {
-                let Some(value) = idx
-                    .checked_add(1)
-                    .and_then(|idx| stack.len().checked_sub(idx))
-                    .and_then(|idx| stack.get(idx))
-                    .copied()
-                else {
-                    return Err(JsError::from_native(JsNativeError::typ().with_message(format!(
-                        "tracer accessed out of bound stack: size {}, index {}",
-                        stack.len(),
-                        idx
-                    ))));
-                };
-                to_bigint(value)
-            })
-            .ok_or_else(|| {
-                JsError::from_native(
-                    JsNativeError::typ()
-                        .with_message("tracer accessed stack after it was dropped".to_string()),
-                )
-            })?
-    }
-}
-
-impl Finalize for StackRef {}
-
-unsafe impl Trace for StackRef {
-    empty_trace!();
+    Ok(index)
 }
 
 /// Represents the contract object
@@ -1117,7 +1072,7 @@ impl JsEvmContext {
         obj.set(js_string!("gasUsed"), gas_used, false, ctx)?;
         obj.set(js_string!("gasPrice"), gas_price, false, ctx)?;
         obj.set(js_string!("intrinsicGas"), intrinsic_gas, false, ctx)?;
-        obj.set(js_string!("value"), to_bigint(value)?, false, ctx)?;
+        obj.set(js_string!("value"), to_bigint(value), false, ctx)?;
         obj.set(js_string!("block"), block, false, ctx)?;
         obj.set(js_string!("coinbase"), address_to_uint8_array(coinbase, ctx)?, false, ctx)?;
         obj.set(js_string!("output"), to_uint8_array(output, ctx)?, false, ctx)?;
@@ -1139,277 +1094,53 @@ impl JsEvmContext {
     }
 }
 
-/// DB is the object that allows the js inspector to interact with the database.
-#[derive(Clone)]
-pub(crate) struct EvmDbRef {
-    db: GuardedNullableGc<RefCell<Box<dyn EvmDbReader>>>,
-}
-
-impl core::fmt::Debug for EvmDbRef {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("EvmDbRef").finish_non_exhaustive()
-    }
-}
-
-impl EvmDbRef {
-    /// Creates a new evm and db JS object over the in-flight state.
-    pub(crate) fn new_state<'a, 'db>(state: &'a mut State<'db>) -> (Self, EvmDbGuard<'a>) {
-        Self::new_reader(StateDbReader { state })
-    }
-
-    /// Creates a new evm and db JS object over a transaction's materialized state and a backing
-    /// database.
-    pub(crate) fn new_changes<'a>(
-        changes: &'a TxState,
-        db: &'a mut dyn DynDatabase,
-    ) -> (Self, EvmDbGuard<'a>) {
-        Self::new_reader(ChangesDbReader { changes, db })
-    }
-
-    fn new_reader<'a>(reader: impl EvmDbReader + 'a) -> (Self, EvmDbGuard<'a>) {
-        let reader: Box<dyn EvmDbReader + 'a> = Box::new(reader);
-        // SAFETY:
-        //
-        // Boa requires 'static captures for native functions. The returned guard removes the
-        // reader before the borrowed state/database can be dropped.
-        let reader = unsafe {
-            core::mem::transmute::<Box<dyn EvmDbReader + 'a>, Box<dyn EvmDbReader + 'static>>(
-                reader,
-            )
-        };
-        let (db, db_guard) = GuardedNullableGc::new_owned(RefCell::new(reader));
-        (Self { db }, EvmDbGuard { _db_guard: db_guard })
-    }
-
-    fn read_basic(&self, address: JsValue, ctx: &mut Context) -> JsResult<Option<AccountInfo>> {
-        let buf = bytes_from_value(address, ctx)?;
-        let address = bytes_to_address(&buf);
-        match self.db.with_inner(|db| db.borrow_mut().read_basic(&address)) {
-            Some(Ok(acc)) => Ok(acc),
-            _ => Err(JsError::from_native(
-                JsNativeError::error()
-                    .with_message(format!("Failed to read address {address:?} from database")),
-            )),
-        }
-    }
-
-    fn read_code(&self, address: JsValue, ctx: &mut Context) -> JsResult<JsUint8Array> {
-        let buf = bytes_from_value(address, ctx)?;
-        let address = bytes_to_address(&buf);
-        let code = match self.db.with_inner(|db| db.borrow_mut().read_code(&address)) {
-            Some(Ok(code)) => code,
-            _ => {
-                return Err(JsError::from_native(
-                    JsNativeError::error()
-                        .with_message(format!("Failed to read code for {address:?} from database")),
-                ));
-            }
-        };
-        to_uint8_array(code.original_bytes().to_vec(), ctx)
-    }
-
-    fn read_state(
-        &self,
-        address: JsValue,
-        slot: JsValue,
-        ctx: &mut Context,
-    ) -> JsResult<JsUint8Array> {
-        let buf = bytes_from_value(address, ctx)?;
-        let address = bytes_to_address(&buf);
-        let buf = bytes_from_value(slot, ctx)?;
-        let slot: U256 = bytes_to_b256(&buf).into();
-
-        let value = match self.db.with_inner(|db| db.borrow_mut().read_state(&address, &slot)) {
-            Some(Ok(value)) => value,
-            _ => {
-                return Err(JsError::from_native(JsNativeError::error().with_message(format!(
-                    "Failed to read state for {address:?} at {slot:?} from database",
-                ))));
-            }
-        };
-        to_uint8_array(B256::from(value), ctx)
-    }
-
-    pub(crate) fn into_js_object(self, ctx: &mut Context) -> JsResult<JsObject> {
-        let obj = JsObject::with_object_proto(ctx.intrinsics());
-        let exists = FunctionObjectBuilder::new(
-            ctx.realm(),
-            NativeFunction::from_copy_closure_with_captures(
-                move |_this, args, db, ctx| {
-                    let val = args.get_or_undefined(0).clone();
-                    let acc = db.read_basic(val, ctx)?;
-                    let exists = acc.is_some();
-                    Ok(JsValue::from(exists))
-                },
-                self.clone(),
-            ),
-        )
-        .length(1)
-        .build();
-
-        let get_balance = FunctionObjectBuilder::new(
-            ctx.realm(),
-            NativeFunction::from_copy_closure_with_captures(
-                move |_this, args, db, ctx| {
-                    let val = args.get_or_undefined(0).clone();
-                    let acc = db.read_basic(val, ctx)?;
-                    let balance = acc.map(|acc| acc.balance).unwrap_or_default();
-                    to_bigint(balance)
-                },
-                self.clone(),
-            ),
-        )
-        .length(1)
-        .build();
-
-        let get_nonce = FunctionObjectBuilder::new(
-            ctx.realm(),
-            NativeFunction::from_copy_closure_with_captures(
-                move |_this, args, db, ctx| {
-                    let val = args.get_or_undefined(0).clone();
-                    let acc = db.read_basic(val, ctx)?;
-                    let nonce = acc.map(|acc| acc.nonce).unwrap_or_default();
-                    Ok(JsValue::from(nonce))
-                },
-                self.clone(),
-            ),
-        )
-        .length(1)
-        .build();
-
-        let get_code = FunctionObjectBuilder::new(
-            ctx.realm(),
-            NativeFunction::from_copy_closure_with_captures(
-                move |_this, args, db, ctx| {
-                    let val = args.get_or_undefined(0).clone();
-                    Ok(db.read_code(val, ctx)?.into())
-                },
-                self.clone(),
-            ),
-        )
-        .length(1)
-        .build();
-
-        let get_state = FunctionObjectBuilder::new(
-            ctx.realm(),
-            NativeFunction::from_copy_closure_with_captures(
-                move |_this, args, db, ctx| {
-                    let addr = args.get_or_undefined(0).clone();
-                    let slot = args.get_or_undefined(1).clone();
-                    Ok(db.read_state(addr, slot, ctx)?.into())
-                },
-                self,
-            ),
-        )
-        .length(2)
-        .build();
-
-        obj.set(js_string!("getBalance"), get_balance, false, ctx)?;
-        obj.set(js_string!("getNonce"), get_nonce, false, ctx)?;
-        obj.set(js_string!("getCode"), get_code, false, ctx)?;
-        obj.set(js_string!("getState"), get_state, false, ctx)?;
-        obj.set(js_string!("exists"), exists, false, ctx)?;
-        Ok(obj)
-    }
-}
-
-impl Finalize for EvmDbRef {}
-
-unsafe impl Trace for EvmDbRef {
-    empty_trace!();
-}
-
-/// DB reader used by the JS context.
-trait EvmDbReader {
-    fn read_basic(&mut self, address: &Address) -> DbResult<Option<AccountInfo>>;
-
-    fn read_code(&mut self, address: &Address) -> DbResult<Bytecode>;
-
-    fn read_state(&mut self, address: &Address, slot: &Word) -> DbResult<Word>;
-}
-
-impl core::fmt::Debug for dyn EvmDbReader {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.write_str("EvmDbReader")
-    }
-}
-
-struct StateDbReader<'a, 'db> {
-    state: &'a mut State<'db>,
-}
-
-impl EvmDbReader for StateDbReader<'_, '_> {
-    fn read_basic(&mut self, address: &Address) -> DbResult<Option<AccountInfo>> {
-        self.state.account_info_untracked(address)
-    }
-
-    fn read_code(&mut self, address: &Address) -> DbResult<Bytecode> {
-        self.state.account(address, false)?.load_code()
-    }
-
-    fn read_state(&mut self, address: &Address, slot: &Word) -> DbResult<Word> {
-        self.state.read_committed_storage(address, slot)
-    }
-}
-
-struct ChangesDbReader<'a> {
-    changes: &'a TxState,
-    db: &'a mut dyn DynDatabase,
-}
-
-impl ChangesDbReader<'_> {
-    fn code_from_info(&mut self, info: AccountInfo) -> DbResult<Bytecode> {
-        // Note: the changed account from the state output always holds the code.
-        if let Some(code) = info.code
-            && !code.is_empty()
-        {
-            return Ok(code);
-        }
-        let code_hash = info.code_hash;
-        if code_hash == KECCAK256_EMPTY {
-            return Ok(Bytecode::default());
-        }
-        self.db.get_code_by_hash(&code_hash)
-    }
-}
-
-impl EvmDbReader for ChangesDbReader<'_> {
-    fn read_basic(&mut self, address: &Address) -> DbResult<Option<AccountInfo>> {
-        if let Some(account) = self.changes.accounts.get(address) {
-            return Ok(account.current.clone());
-        }
-        self.db.get_account(address)
-    }
-
-    fn read_code(&mut self, address: &Address) -> DbResult<Bytecode> {
-        let Some(info) = self.read_basic(address)? else {
-            return Ok(Bytecode::default());
-        };
-        self.code_from_info(info)
-    }
-
-    fn read_state(&mut self, address: &Address, slot: &Word) -> DbResult<Word> {
-        // Storage is always read from the backing database, not the transaction changes.
-        self.db.get_storage(address, slot)
-    }
-}
-
-/// Guard the inner references, once this value is dropped the inner reference is also removed.
-///
-/// This ensures that the guards are dropped within the lifetime of the borrowed values.
-#[must_use]
-pub(crate) struct EvmDbGuard<'a> {
-    _db_guard: GcGuard<'a, RefCell<Box<dyn EvmDbReader>>>,
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tracing::js::builtins::{json_stringify, register_builtins, to_serde_value};
+    use crate::tracing::js::builtins::{
+        bytes_from_value, json_stringify, register_builtins, to_serde_value,
+    };
     use alloc::vec;
-    use boa_engine::Source;
+    use boa_engine::{Source, object::builtins::JsUint8Array};
     use core::convert::Infallible;
     use evm2::evm::{CacheDB, Database, Db, EmptyDB};
+
+    /// Records and enters a step with the given pre- and post-execution stack.
+    fn with_step<'a, R>(
+        log: &'a ReusableStepLog,
+        op: u8,
+        stack: &'a [U256],
+        memory: &'a RefCell<Vec<u8>>,
+        contract: &'a Contract,
+        f: impl FnOnce() -> R,
+    ) -> R {
+        let mut snapshot = StepSnapshot::default();
+        snapshot.record(PreStep {
+            pc: 0,
+            op,
+            gas_remaining: 0,
+            refund: 0,
+            stack,
+            memory: &memory.borrow(),
+        });
+        log.with_scope(
+            &mut snapshot,
+            stack,
+            &memory.borrow(),
+            StepInfo {
+                cost: 0,
+                depth: 0,
+                error: None,
+                op: None,
+                caller: contract.caller,
+                contract: contract.contract,
+                value: contract.value,
+                input: &contract.input,
+                call_id: 1,
+            },
+            f,
+        )
+    }
 
     #[test]
     fn test_contract() {
@@ -1422,73 +1153,62 @@ mod tests {
         };
         register_builtins(&mut ctx).unwrap();
 
-        let (stack_ref, _stack_guard) = StackRef::new_owned(Vec::new());
-        let mem = MemorySnapshot::default();
-        let (mem_ref, _mem_guard) = MemoryRef::new_owned(mem);
-        let step = StepLog {
-            stack: stack_ref,
-            op: OpObj(0),
-            memory: mem_ref,
-            pc: 0,
-            gas_remaining: 0,
-            cost: 0,
-            depth: 0,
-            refund: 0,
-            error: None,
-            contract: contract.clone(),
-        };
-        let reusable_step = ReusableStepLog::new(&mut ctx).unwrap();
-        reusable_step.update(step);
-
-        let s = "({
+        let memory = RefCell::new(Vec::new());
+        let reusable_step = ReusableStepLog::new(&mut ctx, OpcodeNames::new()).unwrap();
+        with_step(&reusable_step, 0, &[], &memory, &contract, || {
+            let s = "({
                 caller: function(log) { return log.contract.getCaller(); },
                 value: function(log) { return log.contract.getValue(); },
                 address: function(log) { return log.contract.getAddress(); },
                 input: function(log) { return log.contract.getInput(); }
         })";
 
-        let log_arg = reusable_step.value();
-        let eval_obj = ctx.eval(Source::from_bytes(s)).unwrap();
-        let call = eval_obj.as_object().unwrap().get(js_string!("caller"), &mut ctx).unwrap();
-        let res = call
-            .as_callable()
-            .unwrap()
-            .call(&JsValue::undefined(), core::slice::from_ref(&log_arg), &mut ctx)
-            .unwrap();
-        assert!(res.is_object());
-        let obj = res.as_object().unwrap();
-        let array_buf = JsUint8Array::from_object(obj);
-        assert!(array_buf.is_ok());
+            let log_arg = reusable_step.value();
+            let eval_obj = ctx.eval(Source::from_bytes(s)).unwrap();
+            let call = eval_obj.as_object().unwrap().get(js_string!("caller"), &mut ctx).unwrap();
+            let res = call
+                .as_callable()
+                .unwrap()
+                .call(&JsValue::undefined(), core::slice::from_ref(&log_arg), &mut ctx)
+                .unwrap();
+            assert!(res.is_object());
+            let obj = res.as_object().unwrap();
+            let array_buf = JsUint8Array::from_object(obj);
+            assert!(array_buf.is_ok());
 
-        let get_address =
-            eval_obj.as_object().unwrap().get(js_string!("address"), &mut ctx).unwrap();
-        let res = get_address
-            .as_callable()
-            .unwrap()
-            .call(&JsValue::undefined(), core::slice::from_ref(&log_arg), &mut ctx)
-            .unwrap();
-        assert!(res.is_object());
+            let get_address =
+                eval_obj.as_object().unwrap().get(js_string!("address"), &mut ctx).unwrap();
+            let res = get_address
+                .as_callable()
+                .unwrap()
+                .call(&JsValue::undefined(), core::slice::from_ref(&log_arg), &mut ctx)
+                .unwrap();
+            assert!(res.is_object());
 
-        let buf = bytes_from_value(res, &mut ctx).unwrap();
-        assert_eq!(buf, contract.contract.as_slice());
+            let buf = bytes_from_value(res, &mut ctx).unwrap();
+            assert_eq!(buf, contract.contract.as_slice());
 
-        let call = eval_obj.as_object().unwrap().get(js_string!("value"), &mut ctx).unwrap();
-        let res = call
-            .as_callable()
-            .unwrap()
-            .call(&JsValue::undefined(), core::slice::from_ref(&log_arg), &mut ctx)
-            .unwrap();
-        assert_eq!(
-            res.to_string(&mut ctx).unwrap().to_std_string().unwrap(),
-            contract.value.to_string()
-        );
+            let call = eval_obj.as_object().unwrap().get(js_string!("value"), &mut ctx).unwrap();
+            let res = call
+                .as_callable()
+                .unwrap()
+                .call(&JsValue::undefined(), core::slice::from_ref(&log_arg), &mut ctx)
+                .unwrap();
+            assert_eq!(
+                res.to_string(&mut ctx).unwrap().to_std_string().unwrap(),
+                contract.value.to_string()
+            );
 
-        let call = eval_obj.as_object().unwrap().get(js_string!("input"), &mut ctx).unwrap();
-        let res =
-            call.as_callable().unwrap().call(&JsValue::undefined(), &[log_arg], &mut ctx).unwrap();
+            let call = eval_obj.as_object().unwrap().get(js_string!("input"), &mut ctx).unwrap();
+            let res = call
+                .as_callable()
+                .unwrap()
+                .call(&JsValue::undefined(), &[log_arg], &mut ctx)
+                .unwrap();
 
-        let buf = bytes_from_value(res, &mut ctx).unwrap();
-        assert_eq!(buf, contract.input);
+            let buf = bytes_from_value(res, &mut ctx).unwrap();
+            assert_eq!(buf, contract.input);
+        });
     }
 
     #[test]
@@ -1508,41 +1228,35 @@ mod tests {
         assert!(result.is_callable());
 
         let f = result.as_callable().unwrap();
+
+        let mut db = CacheDB::new(EmptyDB::default());
+        let state = TxState::default();
         let reusable_db = ReusableEvmDb::new(&mut context).unwrap();
-
         {
-            let mut state = State::new(CacheDB::new(EmptyDB::default()));
-            let (db, guard) = EvmDbRef::new_state(&mut state);
-            let addr = Address::default();
-            let addr = JsValue::from(js_string!(addr.to_string()));
-            reusable_db.update(db);
-            let db = reusable_db.value();
-            let res = f.call(&result, &[db.clone(), addr.clone()], &mut context).unwrap();
-            assert!(!res.as_boolean().unwrap());
-
-            // drop the db which also drops any GC values
-            drop(guard);
-            let res = f.call(&result, &[db, addr], &mut context);
+            let addr = JsValue::from(js_string!(Address::default().to_string()));
+            let db_value = reusable_db.value();
+            reusable_db.with_changes_scope(&state, &mut db, || {
+                let res = f.call(&result, &[db_value.clone(), addr.clone()], &mut context).unwrap();
+                assert!(!res.as_boolean().unwrap());
+            });
+            // Leaving the callback revokes access through retained JS objects.
+            let res = f.call(&result, &[db_value.clone(), addr.clone()], &mut context);
             assert!(res.is_err());
         }
         let addr = Address::default();
-        let mut db = CacheDB::new(EmptyDB::default());
         db.insert_account_info(&addr, Default::default());
 
         {
-            let mut state = State::new(db);
-            let (db, guard) = EvmDbRef::new_state(&mut state);
             let addr = JsValue::from(js_string!(addr.to_string()));
-            reusable_db.update(db);
-            let db = reusable_db.value();
-            let res = f.call(&result, &[db.clone(), addr.clone()], &mut context).unwrap();
+            let db_value = reusable_db.value();
+            reusable_db.with_changes_scope(&state, &mut db, || {
+                let res = f.call(&result, &[db_value.clone(), addr.clone()], &mut context).unwrap();
 
-            // account exists
-            assert!(res.as_boolean().unwrap());
-
-            // drop the db which also drops any GC values
-            drop(guard);
-            let res = f.call(&result, &[db, addr], &mut context);
+                // account exists
+                assert!(res.as_boolean().unwrap());
+            });
+            // Leaving the callback revokes access through retained JS objects.
+            let res = f.call(&result, &[db_value.clone(), addr.clone()], &mut context);
             assert!(res.is_err());
         }
     }
@@ -1568,30 +1282,30 @@ mod tests {
         let result_fn = obj.get(js_string!("result"), &mut context).unwrap().as_object().unwrap();
         let setup_fn = obj.get(js_string!("setup"), &mut context).unwrap().as_object().unwrap();
 
+        let mut db = CacheDB::new(EmptyDB::default());
+        let state = TxState::default();
         {
-            let mut state = State::new(CacheDB::new(EmptyDB::default()));
-            let (db_ref, guard) = EvmDbRef::new_state(&mut state);
             let reusable_db = ReusableEvmDb::new(&mut context).unwrap();
-            reusable_db.update(db_ref);
-            let _res =
-                setup_fn.call(&(obj.clone().into()), &[reusable_db.value()], &mut context).unwrap();
-            assert!(obj.get(js_string!("db"), &mut context).unwrap().is_object());
+            let addr = JsValue::from(js_string!(Address::default().to_string()));
+            reusable_db.with_changes_scope(&state, &mut db, || {
+                let _res = setup_fn
+                    .call(&(obj.clone().into()), &[reusable_db.value()], &mut context)
+                    .unwrap();
+                assert!(obj.get(js_string!("db"), &mut context).unwrap().is_object());
 
-            let addr = Address::default();
-            let addr = JsValue::from(js_string!(addr.to_string()));
-            let res = result_fn
-                .call(&(obj.clone().into()), core::slice::from_ref(&addr), &mut context)
-                .unwrap();
-            assert!(!res.as_boolean().unwrap());
-
-            // drop the guard which also drops any GC values
-            drop(guard);
+                let addr = Address::default();
+                let addr = JsValue::from(js_string!(addr.to_string()));
+                let res = result_fn
+                    .call(&(obj.clone().into()), core::slice::from_ref(&addr), &mut context)
+                    .unwrap();
+                assert!(!res.as_boolean().unwrap());
+            });
+            // Leaving the callback revokes access through retained JS objects.
             let res = result_fn.call(&(obj.clone().into()), &[addr], &mut context);
             assert!(res.is_err());
         }
     }
 
-    #[derive(Debug)]
     struct BackingDb {
         address: Address,
         account: AccountInfo,
@@ -1631,65 +1345,70 @@ mod tests {
         let address = Address::repeat_byte(0x42);
         let slot = Word::from(7);
         let value = Word::from(0xfeed);
-        let code = Bytecode::new_legacy(vec![op::PUSH1, 0x01, op::STOP].into());
+        let code = Bytecode::new_legacy(vec![opcode::PUSH1, 0x01, opcode::STOP].into());
         let account = AccountInfo::default()
             .with_balance(Word::from(1234))
             .with_nonce(9)
             .with_code(code.clone());
         let mut db = Db::new(BackingDb { address, account, slot, value });
         let changes = TxState::default();
-        let (db_ref, _guard) = EvmDbRef::new_changes(&changes, &mut db);
-        let js_db = db_ref.into_js_object(&mut context).unwrap();
-        let js_addr = JsValue::from(js_string!(address.to_string()));
-        let js_slot = JsValue::from(js_string!(B256::from(slot).to_string()));
+        let reusable_db = ReusableEvmDb::new(&mut context).unwrap();
+        reusable_db.with_changes_scope(&changes, &mut db, || {
+            let js_db = reusable_db.value().as_object().unwrap();
+            let js_addr = JsValue::from(js_string!(address.to_string()));
+            let js_slot = JsValue::from(js_string!(B256::from(slot).to_string()));
 
-        let exists = js_db
-            .get(js_string!("exists"), &mut context)
-            .unwrap()
-            .as_callable()
-            .unwrap()
-            .call(&JsValue::undefined(), core::slice::from_ref(&js_addr), &mut context)
-            .unwrap();
-        assert!(exists.as_boolean().unwrap());
+            let exists = js_db
+                .get(js_string!("exists"), &mut context)
+                .unwrap()
+                .as_callable()
+                .unwrap()
+                .call(&JsValue::undefined(), core::slice::from_ref(&js_addr), &mut context)
+                .unwrap();
+            assert!(exists.as_boolean().unwrap());
 
-        let balance_to_string = context
-            .eval(Source::from_bytes(
-                "(function(db, addr) { return db.getBalance(addr).toString(); })",
-            ))
-            .unwrap();
-        let balance = balance_to_string
-            .as_callable()
-            .unwrap()
-            .call(&JsValue::undefined(), &[js_db.clone().into(), js_addr.clone()], &mut context)
-            .unwrap();
-        assert_eq!(balance.to_string(&mut context).unwrap().to_std_string().unwrap(), "1234");
+            let balance_to_string = context
+                .eval(Source::from_bytes(
+                    "(function(db, addr) { return db.getBalance(addr).toString(); })",
+                ))
+                .unwrap();
+            let balance = balance_to_string
+                .as_callable()
+                .unwrap()
+                .call(&JsValue::undefined(), &[js_db.clone().into(), js_addr.clone()], &mut context)
+                .unwrap();
+            assert_eq!(balance.to_string(&mut context).unwrap().to_std_string().unwrap(), "1234");
 
-        let nonce = js_db
-            .get(js_string!("getNonce"), &mut context)
-            .unwrap()
-            .as_callable()
-            .unwrap()
-            .call(&JsValue::undefined(), core::slice::from_ref(&js_addr), &mut context)
-            .unwrap();
-        assert_eq!(nonce.as_number().unwrap(), 9.0);
+            let nonce = js_db
+                .get(js_string!("getNonce"), &mut context)
+                .unwrap()
+                .as_callable()
+                .unwrap()
+                .call(&JsValue::undefined(), core::slice::from_ref(&js_addr), &mut context)
+                .unwrap();
+            assert_eq!(nonce.as_number().unwrap(), 9.0);
 
-        let code_res = js_db
-            .get(js_string!("getCode"), &mut context)
-            .unwrap()
-            .as_callable()
-            .unwrap()
-            .call(&JsValue::undefined(), core::slice::from_ref(&js_addr), &mut context)
-            .unwrap();
-        assert_eq!(bytes_from_value(code_res, &mut context).unwrap(), code.original_bytes());
+            let code_res = js_db
+                .get(js_string!("getCode"), &mut context)
+                .unwrap()
+                .as_callable()
+                .unwrap()
+                .call(&JsValue::undefined(), core::slice::from_ref(&js_addr), &mut context)
+                .unwrap();
+            assert_eq!(bytes_from_value(code_res, &mut context).unwrap(), code.original_bytes());
 
-        let state = js_db
-            .get(js_string!("getState"), &mut context)
-            .unwrap()
-            .as_callable()
-            .unwrap()
-            .call(&JsValue::undefined(), &[js_addr, js_slot], &mut context)
-            .unwrap();
-        assert_eq!(bytes_from_value(state, &mut context).unwrap(), B256::from(value).as_slice());
+            let state = js_db
+                .get(js_string!("getState"), &mut context)
+                .unwrap()
+                .as_callable()
+                .unwrap()
+                .call(&JsValue::undefined(), &[js_addr, js_slot], &mut context)
+                .unwrap();
+            assert_eq!(
+                bytes_from_value(state, &mut context).unwrap(),
+                B256::from(value).as_slice()
+            );
+        });
     }
 
     #[test]
@@ -1710,28 +1429,13 @@ mod tests {
         let result_fn = obj.get(js_string!("result"), &mut context).unwrap().as_object().unwrap();
         let step_fn = obj.get(js_string!("step"), &mut context).unwrap().as_object().unwrap();
 
-        let (stack_ref, _stack_guard) =
-            StackRef::new_owned(vec![U256::from(35000), U256::from(35000), U256::from(35000)]);
-        let mem = MemorySnapshot::default();
-        let (mem_ref, _mem_guard) = MemoryRef::new_owned(mem);
-
-        let step = StepLog {
-            stack: stack_ref,
-            op: OpObj(0),
-            memory: mem_ref,
-            pc: 0,
-            gas_remaining: 0,
-            cost: 0,
-            depth: 0,
-            refund: 0,
-            error: None,
-            contract: Default::default(),
-        };
-
-        let reusable_step = ReusableStepLog::new(&mut context).unwrap();
-        reusable_step.update(step);
-
-        let _ = step_fn.call(&eval, &[reusable_step.value()], &mut context).unwrap();
+        let stack = [U256::from(35000); 3];
+        let memory = RefCell::new(Vec::new());
+        let contract = Contract::default();
+        let reusable_step = ReusableStepLog::new(&mut context, OpcodeNames::new()).unwrap();
+        with_step(&reusable_step, 0, &stack, &memory, &contract, || {
+            step_fn.call(&eval, &[reusable_step.value()], &mut context).unwrap();
+        });
 
         let res = result_fn.call(&eval, &[], &mut context).unwrap();
         let val = json_stringify(res.clone(), &mut context).unwrap().to_std_string().unwrap();
@@ -1798,31 +1502,145 @@ mod tests {
         let result_fn = obj.get(js_string!("result"), &mut context).unwrap().as_object().unwrap();
         let step_fn = obj.get(js_string!("step"), &mut context).unwrap().as_object().unwrap();
 
-        let (stack_ref, _stack_guard) =
-            StackRef::new_owned(vec![U256::from(35000), U256::from(35000), U256::from(35000)]);
-        let mem = MemorySnapshot::default();
-        let (mem_ref, _mem_guard) = MemoryRef::new_owned(mem);
-
-        let step = StepLog {
-            stack: stack_ref,
-            op: OpObj(85),
-            memory: mem_ref,
-            pc: 0,
-            gas_remaining: 0,
-            cost: 0,
-            depth: 0,
-            refund: 0,
-            error: None,
-            contract: Default::default(),
-        };
-
-        let reusable_step = ReusableStepLog::new(&mut context).unwrap();
-        reusable_step.update(step);
-
-        let _ = step_fn.call(&eval, &[reusable_step.value()], &mut context).unwrap();
+        let stack = [U256::from(35000); 3];
+        let memory = RefCell::new(Vec::new());
+        let contract = Contract::default();
+        let reusable_step = ReusableStepLog::new(&mut context, OpcodeNames::new()).unwrap();
+        with_step(&reusable_step, 85, &stack, &memory, &contract, || {
+            step_fn.call(&eval, &[reusable_step.value()], &mut context).unwrap();
+        });
 
         let res = result_fn.call(&eval, &[], &mut context).unwrap();
         let val = json_stringify(res, &mut context).unwrap().to_std_string().unwrap();
         assert_eq!(val, r#"["0000000000000000000000000000000000000000:88b8;88b8"]"#);
+    }
+
+    #[test]
+    fn test_scopes_revoke_access_on_return_error_and_unwind() {
+        use std::panic::{AssertUnwindSafe, catch_unwind};
+
+        let mut ctx = Context::default();
+        register_builtins(&mut ctx).unwrap();
+        let log = ReusableStepLog::new(&mut ctx, OpcodeNames::new()).unwrap();
+        let db = ReusableEvmDb::new(&mut ctx).unwrap();
+        ctx.global_object().set(js_string!("savedLog"), log.value(), false, &mut ctx).unwrap();
+        ctx.global_object().set(js_string!("savedDb"), db.value(), false, &mut ctx).unwrap();
+
+        for outcome in 0..3 {
+            let stack = vec![U256::from(42)];
+            let memory = RefCell::new(vec![7u8; 32]);
+            let contract = Contract::default();
+            let state = TxState::default();
+            let mut database = CacheDB::new(EmptyDB::default());
+            let result = catch_unwind(AssertUnwindSafe(|| {
+                db.with_changes_scope(&state, &mut database, || {
+                    with_step(&log, opcode::STOP, &stack, &memory, &contract, || {
+                        assert!(ctx.eval(Source::from_bytes(
+                            "savedLog.stack.peek(0) === 42n && savedLog.memory.getUint(0)[0] === 7 && savedDb.getBalance('00') === 0n"
+                        )).unwrap().as_boolean().unwrap());
+                        match outcome {
+                            0 => Ok(JsValue::undefined()),
+                            1 => ctx.eval(Source::from_bytes("throw new Error('callback failed')")),
+                            _ => panic!("native callback panicked"),
+                        }
+                    })
+                })
+            }));
+            match outcome {
+                0 => assert!(result.unwrap().is_ok()),
+                1 => assert!(result.unwrap().is_err()),
+                _ => assert!(result.is_err()),
+            }
+            assert!(memory.try_borrow_mut().is_ok());
+            drop((stack, memory, state, database));
+            // Retained JS objects must not access the now-dropped backing storage.
+            for expression in
+                ["savedLog.stack.peek(0)", "savedLog.memory.getUint(0)", "savedDb.getBalance('00')"]
+            {
+                assert!(ctx.eval(Source::from_bytes(expression)).is_err(), "{expression}");
+            }
+            assert!(
+                ctx.eval(Source::from_bytes(
+                    "savedLog.stack.length() === 0 && savedLog.memory.length() === 0"
+                ))
+                .unwrap()
+                .as_boolean()
+                .unwrap()
+            );
+        }
+    }
+
+    #[test]
+    fn test_stack_view_reconstructs_pre_execution_stack() {
+        // SWAP1 touches the top two items, DUP1 one item, ADD two items
+        let pre = [U256::from(1), U256::from(2), U256::from(3)];
+        for (op, post) in [
+            (opcode::SWAP1, vec![U256::from(1), U256::from(3), U256::from(2)]),
+            (opcode::DUP1, vec![U256::from(1), U256::from(2), U256::from(3), U256::from(3)]),
+            (opcode::ADD, vec![U256::from(1), U256::from(5)]),
+            (opcode::POP, vec![U256::from(1), U256::from(2)]),
+            // halted before pushing, e.g. out of gas after popping the inputs
+            (opcode::MSTORE, vec![U256::from(1)]),
+            (opcode::STOP, pre.to_vec()),
+        ] {
+            let mut view = StackView::default();
+            view.record(op, &pre);
+            let post: &'static [U256] = post.leak();
+            view.post = Some(post);
+            assert_eq!(view.len(), 3);
+            for (idx, expected) in pre.iter().rev().enumerate() {
+                assert_eq!(view.peek(idx).unwrap(), *expected, "op {op:#x} idx {idx}");
+            }
+            assert!(view.peek(3).is_err());
+        }
+    }
+
+    #[test]
+    fn test_memory_view_reconstructs_pre_execution_memory() {
+        let pre: Vec<u8> = (0..64).collect();
+        // MSTORE at offset 16, expanding memory to 96 bytes
+        let mut post = pre.clone();
+        post[16..48].copy_from_slice(&[0xff; 32]);
+        post.resize(96, 0);
+        let stack = [U256::from(16)];
+
+        let mut view = MemoryView::default();
+        view.record(opcode::MSTORE, &stack, &pre);
+        assert_eq!(view.patch_offset, 16);
+        assert_eq!(view.patch, pre[16..48]);
+        view.post = Some(post.leak());
+
+        assert_eq!(view.len(), 64);
+        assert_eq!(view.bytes(0..64).unwrap().as_slice(), pre.as_slice());
+        assert_eq!(view.bytes(10..20).unwrap().as_slice(), &pre[10..20]);
+
+        // writes beyond the pre-execution length only expand memory
+        let mut view = MemoryView::default();
+        view.record(opcode::MSTORE, &[U256::from(64)], &pre);
+        assert!(view.patch.is_empty());
+
+        // MCOPY: dst = 0, src = 32, len = 8, operands are popped top first
+        let mut view = MemoryView::default();
+        view.record(opcode::MCOPY, &[U256::from(8), U256::from(32), U256::ZERO], &pre);
+        assert_eq!(view.patch_offset, 0);
+        assert_eq!(view.patch, pre[..8]);
+
+        // EXTCODECOPY: address, dst = 4, src = 0, len = 2
+        let mut view = MemoryView::default();
+        view.record(
+            opcode::EXTCODECOPY,
+            &[U256::from(2), U256::ZERO, U256::from(4), U256::from(1)],
+            &pre,
+        );
+        assert_eq!(view.patch_offset, 4);
+        assert_eq!(view.patch, pre[4..6]);
+
+        // out of range operands fail without writing
+        let mut view = MemoryView::default();
+        view.record(opcode::MSTORE, &[U256::MAX], &pre);
+        assert!(view.patch.is_empty());
+        let mut view = MemoryView::default();
+        view.record(opcode::MSTORE, &[], &pre);
+        assert!(view.patch.is_empty());
     }
 }

--- a/crates/inspectors/src/tracing/js/builtins.rs
+++ b/crates/inspectors/src/tracing/js/builtins.rs
@@ -275,19 +275,13 @@ pub(crate) fn bytes_to_fb<const N: usize>(mut bytes: &[u8]) -> FixedBytes<N> {
 
 /// Converts a U256 to a Boa bigint value.
 pub(crate) fn to_bigint(value: U256) -> JsValue {
-    let limbs = value.as_limbs();
-    // Most values fit into a machine integer, for which `num-bigint` has cheap constructors.
-    // Larger values (e.g. addresses and hashes) are constructed from their big endian bytes,
-    // avoiding a decimal round trip through strings.
-    let big = if limbs[1] | limbs[2] | limbs[3] == 0 {
-        JsBigInt::from(limbs[0])
-    } else if limbs[2] | limbs[3] == 0 {
-        JsBigInt::from(((limbs[1] as u128) << 64) | limbs[0] as u128)
+    // Keep the cheap machine-integer constructors for common small values.
+    let big = if let Ok(value) = u64::try_from(value) {
+        JsBigInt::from(value)
+    } else if let Ok(value) = u128::try_from(value) {
+        JsBigInt::from(value)
     } else {
-        JsBigInt::from(num_bigint::BigInt::from_bytes_be(
-            num_bigint::Sign::Plus,
-            &value.to_be_bytes::<32>(),
-        ))
+        JsBigInt::from(num_bigint::BigInt::from(value))
     };
     big.into()
 }
@@ -497,7 +491,18 @@ mod tests {
         }
 
         // Values above 64 and 128 bits take different construction paths
-        for value in [U256::from(u128::MAX), U256::from(u128::MAX) + U256::from(1), U256::MAX] {
+        for value in [
+            U256::from(u64::MAX) + U256::from(1),
+            U256::from(u128::MAX),
+            U256::from(u128::MAX) + U256::from(1),
+            U256::from_limbs([
+                0x0123456789abcdef,
+                0xfedcba9876543210,
+                0x13579bdf2468ace0,
+                0xabcdef0123456789,
+            ]),
+            U256::MAX,
+        ] {
             let result = to_bigint(value);
             let result_str = result.to_string(&mut ctx).unwrap().to_std_string().unwrap();
             assert_eq!(result_str, value.to_string(), "BigInt conversion failed for {value}");

--- a/crates/inspectors/src/tracing/js/builtins.rs
+++ b/crates/inspectors/src/tracing/js/builtins.rs
@@ -1,13 +1,17 @@
 //! Builtin functions
 
-use alloc::{borrow::Cow, format, string::ToString, vec::Vec};
+use crate::tracing::types::CallKind;
+use alloc::{borrow::Cow, format, vec::Vec};
 use alloy_primitives::{Address, B256, FixedBytes, U256, hex, map::HashSet};
 use boa_engine::{
     Context, JsArgs, JsBigInt, JsError, JsNativeError, JsResult, JsString, JsValue, NativeFunction,
     Source,
-    builtins::{array_buffer::ArrayBuffer, typed_array::TypedArray},
+    builtins::{
+        array_buffer::ArrayBuffer,
+        typed_array::{TypedArray, TypedArrayKind},
+    },
     js_string,
-    object::builtins::{JsArray, JsArrayBuffer, JsTypedArray, JsUint8Array},
+    object::builtins::{AlignedVec, JsArray, JsArrayBuffer, JsTypedArray, JsUint8Array},
     property::Attribute,
 };
 use boa_gc::{Finalize, Trace, empty_trace};
@@ -120,6 +124,11 @@ pub(crate) fn bytes_from_value(val: JsValue, context: &mut Context) -> JsResult<
     if let Some(obj) = val.as_object() {
         if obj.is::<TypedArray>() {
             let array: JsTypedArray = JsTypedArray::from_object(obj)?;
+            if array.kind() == Some(TypedArrayKind::Uint8)
+                && let Some(bytes) = uint8_array_bytes(&array, context)?
+            {
+                return Ok(bytes);
+            }
             let len = array.length(context)?;
             let mut buf = Vec::with_capacity(len);
             for i in 0..len {
@@ -157,6 +166,35 @@ pub(crate) fn bytes_from_value(val: JsValue, context: &mut Context) -> JsResult<
     ))
 }
 
+/// Copies the viewed bytes of a `Uint8Array` directly out of its buffer.
+///
+/// Returns `None` if the buffer is not a plain, attached `ArrayBuffer`, in which case the caller
+/// falls back to reading the elements one by one.
+fn uint8_array_bytes(array: &JsTypedArray, context: &mut Context) -> JsResult<Option<Vec<u8>>> {
+    let Some(buffer) = array.buffer(context)?.as_object() else {
+        return Ok(None);
+    };
+    let Ok(buffer) = JsArrayBuffer::from_object(buffer) else {
+        return Ok(None);
+    };
+    let offset = array.byte_offset(context)?;
+    let len = array.byte_length(context)?;
+    let Some(data) = buffer.data() else {
+        return Ok(None);
+    };
+    Ok(data.get(offset..offset + len).map(<[u8]>::to_vec))
+}
+
+/// Converts a buffer type value to an address, see [`bytes_from_value`] and [`bytes_to_address`].
+pub(crate) fn address_from_value(val: JsValue, context: &mut Context) -> JsResult<Address> {
+    Ok(bytes_to_address(&bytes_from_value(val, context)?))
+}
+
+/// Converts a buffer type value to a word, see [`bytes_from_value`] and [`bytes_to_b256`].
+pub(crate) fn b256_from_value(val: JsValue, context: &mut Context) -> JsResult<B256> {
+    Ok(bytes_to_b256(&bytes_from_value(val, context)?))
+}
+
 /// Create a new [JsUint8Array] array buffer from the address' bytes.
 pub(crate) fn address_to_uint8_array(
     addr: Address,
@@ -189,6 +227,28 @@ where
     to_uint8_array(bytes, context).map(Into::into)
 }
 
+/// Create a new [JsUint8Array] object that takes ownership of an already collected byte block.
+pub(crate) fn uint8_array_from_block(
+    bytes: AlignedVec<u8>,
+    context: &mut Context,
+) -> JsResult<JsValue> {
+    let buffer = JsArrayBuffer::from_byte_block(bytes, context)?;
+    JsUint8Array::from_array_buffer(buffer, context).map(Into::into)
+}
+
+/// Returns the JS string of the given call kind without allocating.
+pub(crate) const fn call_kind_js_string(kind: CallKind) -> JsString {
+    match kind {
+        CallKind::Call => js_string!("CALL"),
+        CallKind::StaticCall => js_string!("STATICCALL"),
+        CallKind::CallCode => js_string!("CALLCODE"),
+        CallKind::DelegateCall => js_string!("DELEGATECALL"),
+        CallKind::AuthCall => js_string!("AUTHCALL"),
+        CallKind::Create => js_string!("CREATE"),
+        CallKind::Create2 => js_string!("CREATE2"),
+    }
+}
+
 /// Converts a slice of bytes to an address.
 ///
 /// See [`bytes_to_fb`] for more information.
@@ -214,12 +274,22 @@ pub(crate) fn bytes_to_fb<const N: usize>(mut bytes: &[u8]) -> FixedBytes<N> {
 }
 
 /// Converts a U256 to a Boa bigint value.
-pub(crate) fn to_bigint(value: U256) -> JsResult<JsValue> {
-    JsBigInt::from_string(&value.to_string()).map(Into::into).ok_or_else(|| {
-        JsError::from_native(
-            JsNativeError::error().with_message("failed to convert U256 to BigInt"),
-        )
-    })
+pub(crate) fn to_bigint(value: U256) -> JsValue {
+    let limbs = value.as_limbs();
+    // Most values fit into a machine integer, for which `num-bigint` has cheap constructors.
+    // Larger values (e.g. addresses and hashes) are constructed from their big endian bytes,
+    // avoiding a decimal round trip through strings.
+    let big = if limbs[1] | limbs[2] | limbs[3] == 0 {
+        JsBigInt::from(limbs[0])
+    } else if limbs[2] | limbs[3] == 0 {
+        JsBigInt::from(((limbs[1] as u128) << 64) | limbs[0] as u128)
+    } else {
+        JsBigInt::from(num_bigint::BigInt::from_bytes_be(
+            num_bigint::Sign::Plus,
+            &value.to_be_bytes::<32>(),
+        ))
+    };
+    big.into()
 }
 
 /// Compute the address of a contract created using CREATE2.
@@ -385,7 +455,6 @@ unsafe impl Trace for PrecompileList {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloc::vec;
 
     #[test]
     fn test_install_bigint() {
@@ -421,15 +490,22 @@ mod tests {
         ];
 
         for (value, expected) in test_cases {
-            let result = to_bigint(value).unwrap();
+            let result = to_bigint(value);
             assert!(result.is_bigint(), "Result should be a bigint for value {value}");
             let result_str = result.to_string(&mut ctx).unwrap().to_std_string().unwrap();
             assert_eq!(result_str, expected, "BigInt conversion failed for {value}");
         }
 
+        // Values above 64 and 128 bits take different construction paths
+        for value in [U256::from(u128::MAX), U256::from(u128::MAX) + U256::from(1), U256::MAX] {
+            let result = to_bigint(value);
+            let result_str = result.to_string(&mut ctx).unwrap().to_std_string().unwrap();
+            assert_eq!(result_str, value.to_string(), "BigInt conversion failed for {value}");
+        }
+
         // Test that the result can be used in JavaScript operations
         let big_value = U256::from(999u64);
-        let bigint_result = to_bigint(big_value).unwrap();
+        let bigint_result = to_bigint(big_value);
 
         // Set it as a global variable
         ctx.global_object().set(js_string!("testBigInt"), bigint_result, false, &mut ctx).unwrap();

--- a/crates/inspectors/src/tracing/js/mod.rs
+++ b/crates/inspectors/src/tracing/js/mod.rs
@@ -5,9 +5,9 @@ use crate::tracing::{
     config::TraceStyle,
     js::{
         bindings::{
-            CallFrame, Contract, EvmDbRef, FrameResult, JsEvmContext, MemoryRef, MemorySnapshot,
-            ReusableCallFrame, ReusableEvmDb, ReusableFrameResult, ReusableStepLog, StackRef,
-            StepLog,
+            CallFrame, Contract, FrameResult, JsEvmContext, OpcodeNames, PreStep,
+            ReusableCallFrame, ReusableEvmDb, ReusableFrameResult, ReusableStepLog, StepInfo,
+            StepSnapshot,
         },
         builtins::{PrecompileList, register_builtins, to_serde_value},
     },
@@ -30,12 +30,15 @@ use evm2::{
     evm::DynDatabase,
     interpreter::{
         GasTracker, InstrStop, Interpreter, Message, MessageKind, MessageResult, MessageResultExt,
-        Word, opcode::OpCode,
+        opcode::op,
     },
 };
 
 pub(crate) mod bindings;
 pub(crate) mod builtins;
+
+#[cfg(test)]
+mod snapshot_tests;
 
 /// The maximum number of iterations in a loop.
 ///
@@ -48,31 +51,12 @@ pub const LOOP_ITERATION_LIMIT: u64 = 200_000;
 /// Once exceeded, the function will throw an error.
 pub const RECURSION_LIMIT: usize = 10_000;
 
-/// Pre-execution state captured in `step()` to be used in `step_end()`.
-///
-/// The JS step callback needs the pre-execution stack/memory state but the post-execution gas
-/// cost. This struct holds the snapshot from `step()` so `step_end()` can invoke the callback
-/// with the correct gas cost.
-#[derive(Debug)]
+/// Reused pre-execution data for one call depth. Parents remain pending during child execution.
+#[derive(Debug, Default)]
 struct PendingStep {
-    /// Cloned stack from before opcode execution
-    stack: Vec<Word>,
-    /// Program counter
-    pc: u64,
-    /// Opcode being executed
-    op: u8,
-    /// Gas remaining before execution
-    gas_remaining: u64,
-    /// Call depth
-    depth: u64,
-    /// Gas refund counter
-    refund: u64,
-    /// Contract info
-    contract: Contract,
-    /// Memory before opcode execution.
-    memory: MemorySnapshot,
-    /// Total gas spent before this opcode (to compute delta in step_end)
+    snapshot: StepSnapshot,
     gas_spent_before: u64,
+    active: bool,
 }
 
 /// A javascript inspector that will delegate inspector functions to javascript functions
@@ -88,6 +72,8 @@ pub struct JsInspector {
     config: serde_json::Value,
     /// The evaluated object that contains the inspector functions.
     obj: JsObject,
+    /// Cached `this` value for callbacks.
+    this: JsValue,
     /// The context of the transaction that is being inspected.
     transaction_context: TransactionContext,
 
@@ -108,6 +94,8 @@ pub struct JsInspector {
     exit_fn: Option<JsObject>,
     /// Executed before each instruction is executed.
     step_fn: Option<JsObject>,
+    /// Lazily initialized opcode names shared across transaction resets.
+    op_names: OpcodeNames,
     /// Reused step wrapper to avoid rebuilding the JS object graph per opcode.
     reusable_step_log: ReusableStepLog,
     /// Reused frame wrapper to avoid rebuilding the JS object graph per enter callback.
@@ -118,16 +106,12 @@ pub struct JsInspector {
     reusable_db: ReusableEvmDb,
     /// Keeps track of the current call stack.
     call_stack: Vec<CallStackItem>,
+    /// Monotonically increasing ID used to refresh callback contract input.
+    next_call_id: u64,
     /// Marker to track whether the precompiles have been registered.
     precompiles_registered: bool,
     /// Pre-execution states captured in `step()` to be processed in `step_end()`.
     pending_steps: Vec<PendingStep>,
-    /// Cached memory snapshot, only updated when the previous opcode modifies memory.
-    cached_memory: MemorySnapshot,
-    /// The opcode from the previous step, used to decide whether to re-snapshot memory.
-    prev_op: Option<OpCode>,
-    /// The call depth from the previous step, used to refresh memory across frames.
-    prev_depth: Option<u16>,
 }
 
 impl core::fmt::Debug for JsInspector {
@@ -188,8 +172,9 @@ impl JsInspector {
         let JsTracerObject { obj, result_fn, fault_fn, enter_fn, exit_fn, step_fn } =
             JsTracerObject::evaluate(&script, &config, &mut ctx)?;
 
+        let op_names = OpcodeNames::new();
         let reusable_step_log =
-            ReusableStepLog::new(&mut ctx).map_err(JsInspectorError::EvalCode)?;
+            ReusableStepLog::new(&mut ctx, op_names.clone()).map_err(JsInspectorError::EvalCode)?;
         let reusable_call_frame =
             ReusableCallFrame::new(&mut ctx).map_err(JsInspectorError::EvalCode)?;
         let reusable_frame_result =
@@ -201,6 +186,7 @@ impl JsInspector {
             code,
             script,
             config,
+            this: obj.clone().into(),
             obj,
             transaction_context,
             result_fn,
@@ -208,16 +194,15 @@ impl JsInspector {
             enter_fn,
             exit_fn,
             step_fn,
+            op_names,
             reusable_step_log,
             reusable_call_frame,
             reusable_frame_result,
             reusable_db,
             call_stack: Default::default(),
+            next_call_id: 1,
             precompiles_registered: false,
             pending_steps: Vec::new(),
-            cached_memory: MemorySnapshot::default(),
-            prev_op: None,
-            prev_depth: None,
         })
     }
 
@@ -243,8 +228,8 @@ impl JsInspector {
         // Callback objects are mutable JS objects: replacing their Rust state does not remove
         // user-defined properties or restore overwritten methods. Rebuild them once per
         // transaction, while retaining the parsed script and reusing wrappers within a transaction.
-        let reusable_step_log =
-            ReusableStepLog::new(&mut self.ctx).map_err(JsInspectorError::EvalCode)?;
+        let reusable_step_log = ReusableStepLog::new(&mut self.ctx, self.op_names.clone())
+            .map_err(JsInspectorError::EvalCode)?;
         let reusable_call_frame =
             ReusableCallFrame::new(&mut self.ctx).map_err(JsInspectorError::EvalCode)?;
         let reusable_frame_result =
@@ -255,6 +240,7 @@ impl JsInspector {
         self.reusable_call_frame = reusable_call_frame;
         self.reusable_frame_result = reusable_frame_result;
         self.reusable_db = reusable_db;
+        self.this = obj.clone().into();
         self.obj = obj;
         self.result_fn = result_fn;
         self.fault_fn = fault_fn;
@@ -264,9 +250,7 @@ impl JsInspector {
         self.call_stack.clear();
         self.precompiles_registered = false;
         self.pending_steps.clear();
-        self.cached_memory = MemorySnapshot::default();
-        self.prev_op = None;
-        self.prev_depth = None;
+
         Ok(())
     }
 
@@ -311,7 +295,6 @@ impl JsInspector {
     ) -> Result<JsValue, JsInspectorError> {
         let TxResultWithState { result, pending_state, .. } = res;
         let state = TxState::from_pending(pending_state);
-        let (db, _db_guard) = EvmDbRef::new_changes(&state, db);
 
         let mut to = None;
         let mut output_bytes = None;
@@ -356,42 +339,15 @@ impl JsInspector {
             error,
         };
         let ctx = ctx.into_js_object(&mut self.ctx)?;
-        let db = db.into_js_object(&mut self.ctx)?;
-        Ok(self.result_fn.call(
-            &(self.obj.clone().into()),
-            &[ctx.into(), db.into()],
-            &mut self.ctx,
-        )?)
-    }
-
-    fn try_fault(&mut self, step: StepLog, db: EvmDbRef) -> JsResult<()> {
-        self.reusable_step_log.update(step);
-        self.reusable_db.update(db);
-        let step = self.reusable_step_log.value();
-        let db = self.reusable_db.value();
-        self.fault_fn.call(&(self.obj.clone().into()), &[step, db], &mut self.ctx)?;
-        Ok(())
-    }
-
-    fn try_step(&mut self, step: StepLog, db: EvmDbRef) -> JsResult<()> {
-        if let Some(step_fn) = &self.step_fn {
-            self.reusable_step_log.update(step);
-            self.reusable_db.update(db);
-            let step = self.reusable_step_log.value();
-            let db = self.reusable_db.value();
-            step_fn.call(&(self.obj.clone().into()), &[step, db], &mut self.ctx)?;
-        }
-        Ok(())
+        Ok(self.reusable_db.with_changes_scope(&state, db, || {
+            self.result_fn.call(&self.this, &[ctx.into(), self.reusable_db.value()], &mut self.ctx)
+        })?)
     }
 
     fn try_enter(&mut self, frame: CallFrame) -> JsResult<()> {
         if let Some(enter_fn) = &self.enter_fn {
             self.reusable_call_frame.update(frame);
-            enter_fn.call(
-                &(self.obj.clone().into()),
-                &[self.reusable_call_frame.value()],
-                &mut self.ctx,
-            )?;
+            enter_fn.call(&self.this, &[self.reusable_call_frame.value()], &mut self.ctx)?;
         }
         Ok(())
     }
@@ -399,11 +355,7 @@ impl JsInspector {
     fn try_exit(&mut self, frame: FrameResult) -> JsResult<()> {
         if let Some(exit_fn) = &self.exit_fn {
             self.reusable_frame_result.update(frame);
-            exit_fn.call(
-                &(self.obj.clone().into()),
-                &[self.reusable_frame_result.value()],
-                &mut self.ctx,
-            )?;
+            exit_fn.call(&self.this, &[self.reusable_frame_result.value()], &mut self.ctx)?;
         }
         Ok(())
     }
@@ -450,10 +402,12 @@ impl JsInspector {
         gas_limit: u64,
     ) -> &CallStackItem {
         let call = CallStackItem {
+            id: self.next_call_id,
             contract: Contract { caller, contract, value, input },
             kind,
             gas_limit,
         };
+        self.next_call_id += 1;
         self.call_stack.push(call);
         self.active_call()
     }
@@ -476,95 +430,66 @@ impl<T: EvmTypes> Inspector<T> for JsInspector {
         if self.step_fn.is_none() {
             return;
         }
-
-        let message = interp.message();
-
-        // Update the cached memory snapshot only if the previous opcode modified memory or
-        // execution moved to a different frame.
-        // This avoids an expensive Vec<u8> clone on every single step.
-        let should_update_memory = self.prev_op.is_none_or(|prev| prev.modifies_memory())
-            || self.prev_depth != Some(message.depth);
-        if should_update_memory {
-            self.cached_memory = MemorySnapshot::new(interp.memory());
+        let depth = usize::from(interp.message().depth);
+        if self.pending_steps.len() <= depth {
+            self.pending_steps.resize_with(depth + 1, PendingStep::default);
         }
-
-        let op = interp.opcode();
-        self.prev_op = OpCode::new(op);
-        self.prev_depth = Some(message.depth);
-        let active_call = self.active_call();
-        self.pending_steps.push(PendingStep {
-            stack: interp.stack().as_slice().to_vec(),
+        let pending = &mut self.pending_steps[depth];
+        pending.gas_spent_before = interp.gas().spent();
+        pending.active = true;
+        pending.snapshot.record(PreStep {
             pc: interp.pc() as u64,
-            op,
+            op: interp.opcode(),
             gas_remaining: interp.gas().remaining(),
-            depth: u64::from(message.depth),
             refund: interp.gas().refunded() as u64,
-            contract: Contract {
-                caller: message.caller,
-                contract: message.destination,
-                value: active_call.contract.value,
-                input: active_call.contract.input.clone(),
-            },
-            memory: self.cached_memory.clone(),
-            gas_spent_before: interp.gas().spent(),
+            stack: interp.stack().as_slice(),
+            memory: interp.memory().as_slice(),
         });
     }
 
     fn step_end(&mut self, interp: &mut Interpreter<'_, '_, T>) {
-        if self.step_fn.is_none() {
+        let Some(step_fn) = &self.step_fn else {
+            return;
+        };
+        let depth = usize::from(interp.message().depth);
+        let Some(pending) = self.pending_steps.get_mut(depth) else {
+            return;
+        };
+        if !core::mem::take(&mut pending.active) {
             return;
         }
-
-        let Some(pending) = self.pending_steps.pop() else {
-            return;
-        };
-
         let result = interp.result();
         let is_revert = matches!(result, Err(stop) if stop.is_revert());
-        let cost = interp.gas().spent().saturating_sub(pending.gas_spent_before);
-
-        let (db, db_guard) = EvmDbRef::new_state(interp.host().state_mut());
-        let (stack, stack_guard) = StackRef::new_owned(pending.stack);
-        let (memory, memory_guard) = MemoryRef::new_owned(pending.memory);
-
-        let stop = if is_revert {
-            let step = StepLog {
-                stack,
-                op: OpCode::REVERT.get().into(),
-                pc: pending.pc,
-                memory,
-                gas_remaining: pending.gas_remaining,
-                cost,
-                depth: pending.depth,
-                refund: pending.refund,
-                error: result.err().map(|err| format!("{err:?}")),
-                contract: pending.contract,
-            };
-
-            let _ = self.try_fault(step, db);
-            false
-        } else {
-            let step = StepLog {
-                stack,
-                op: pending.op.into(),
-                memory,
-                pc: pending.pc,
-                gas_remaining: pending.gas_remaining,
-                cost,
-                depth: pending.depth,
-                refund: pending.refund,
-                error: None,
-                contract: pending.contract,
-            };
-
-            self.try_step(step, db).is_err() && result.is_ok()
+        let call = self.call_stack.last().expect("call stack is empty");
+        let info = StepInfo {
+            cost: interp.gas().spent().saturating_sub(pending.gas_spent_before),
+            depth: depth as u64,
+            error: if is_revert { result.err().map(|err| format!("{err:?}")) } else { None },
+            op: is_revert.then_some(op::REVERT),
+            caller: interp.message().caller,
+            contract: interp.message().destination,
+            value: call.contract.value,
+            input: &call.contract.input,
+            call_id: call.id,
         };
-
-        drop(memory_guard);
-        drop(stack_guard);
-        drop(db_guard);
-
-        if stop {
+        let (stack, memory, host) = interp.stack_memory_host();
+        let res = self.reusable_db.with_state_scope(host.state_mut(), || {
+            self.reusable_step_log.with_scope(
+                &mut pending.snapshot,
+                stack.as_slice(),
+                memory,
+                info,
+                || {
+                    let f = if is_revert { &self.fault_fn } else { step_fn };
+                    f.call(
+                        &self.this,
+                        &[self.reusable_step_log.value(), self.reusable_db.value()],
+                        &mut self.ctx,
+                    )
+                },
+            )
+        });
+        if !is_revert && res.is_err() && result.is_ok() {
             interp.set_stop(InstrStop::Revert);
         }
     }
@@ -761,6 +686,8 @@ impl JsTracerObject {
 /// Represents an active call
 #[derive(Debug)]
 struct CallStackItem {
+    /// Unique across calls and transaction resets.
+    id: u64,
     contract: Contract,
     kind: CallKind,
     gas_limit: u64,
@@ -1311,6 +1238,52 @@ mod tests {
         }"#;
         let res = run_trace(code, Some(bytes!("0x5F5F52600100")), true);
         assert_eq!(res, json!([json!({}), json!({}), json!({"0": 0})]));
+    }
+
+    #[test]
+    fn test_step_sees_pre_execution_stack() {
+        let code = r#"{
+            res: [],
+            step: function(log) {
+                if (log.op.toString() === 'ADD') {
+                    this.res.push(log.stack.length());
+                    this.res.push(log.stack.peek(0));
+                    this.res.push(log.stack.peek(1));
+                }
+                if (log.op.toString() === 'STOP') {
+                    this.res.push(log.stack.length());
+                    this.res.push(log.stack.peek(0));
+                }
+            },
+            fault: function() {},
+            result: function() { return this.res }
+        }"#;
+        // PUSH1 1, PUSH1 2, ADD, STOP
+        let res = run_trace(code, Some(bytes!("0x600160020100")), true);
+        assert_eq!(res, json!([2, "2", "1", 1, "3"]));
+    }
+
+    #[test]
+    fn test_step_sees_pre_execution_memory() {
+        let code = r#"{
+            res: [],
+            step: function(log) {
+                var op = log.op.toString();
+                if (op === 'MSTORE8' || op === 'STOP') {
+                    this.res.push(log.memory.length());
+                    if (log.memory.length() > 0) {
+                        this.res.push(log.memory.getUint(0)[0]);
+                        this.res.push(log.memory.slice(0, 2)[0]);
+                    }
+                }
+            },
+            fault: function() {},
+            result: function() { return this.res }
+        }"#;
+        // PUSH1 0xff, PUSH1 0, MSTORE8, PUSH1 0xaa, PUSH1 0, MSTORE8, STOP
+        let res = run_trace(code, Some(bytes!("0x60ff60005360aa60005300")), true);
+        // the second MSTORE8 must still see the value written by the first one
+        assert_eq!(res, json!([0, 32, 255, 255, 32, 170, 170]));
     }
 
     #[test]

--- a/crates/inspectors/src/tracing/js/snapshot_tests.rs
+++ b/crates/inspectors/src/tracing/js/snapshot_tests.rs
@@ -1,0 +1,175 @@
+//! Compare reconstructed JS step data with snapshots captured before interpreter execution.
+
+use super::*;
+use alloy_consensus::TxLegacy;
+use alloy_primitives::hex;
+use evm2::{
+    BaseEvmTypes, Precompiles, SpecId,
+    bytecode::Bytecode,
+    ethereum::{TxEnvelope, ethereum_tx_registry},
+    evm::{AccountInfo, CacheDB, EmptyDB},
+    interpreter::Host,
+};
+use serde_json::{Value, json};
+
+struct SnapshotInspector {
+    js: JsInspector,
+    pending: Vec<Value>,
+    expected: Vec<Value>,
+}
+
+impl Inspector<BaseEvmTypes> for SnapshotInspector {
+    fn step(&mut self, interp: &mut Interpreter<'_, '_, BaseEvmTypes>) {
+        self.pending.push(json!([
+            interp.pc(),
+            interp.stack().iter().rev().map(ToString::to_string).collect::<Vec<_>>(),
+            hex::encode(interp.memory().as_slice()),
+            interp.message().depth,
+        ]));
+        self.js.step(interp);
+    }
+
+    fn step_end(&mut self, interp: &mut Interpreter<'_, '_, BaseEvmTypes>) {
+        self.expected.push(self.pending.pop().unwrap());
+        self.js.step_end(interp);
+    }
+
+    fn call(
+        &mut self,
+        interp: &mut Interpreter<'_, '_, BaseEvmTypes>,
+        message: &mut Message<BaseEvmTypes>,
+    ) -> Option<MessageResult<BaseEvmTypes>> {
+        self.js.call(interp, message)
+    }
+
+    fn call_end(
+        &mut self,
+        interp: &mut Interpreter<'_, '_, BaseEvmTypes>,
+        message: &Message<BaseEvmTypes>,
+        result: &mut MessageResult<BaseEvmTypes>,
+    ) {
+        self.js.call_end(interp, message, result);
+    }
+
+    fn create(
+        &mut self,
+        interp: &mut Interpreter<'_, '_, BaseEvmTypes>,
+        message: &mut Message<BaseEvmTypes>,
+    ) -> Option<MessageResult<BaseEvmTypes>> {
+        self.js.create(interp, message)
+    }
+
+    fn create_end(
+        &mut self,
+        interp: &mut Interpreter<'_, '_, BaseEvmTypes>,
+        message: &Message<BaseEvmTypes>,
+        result: &mut MessageResult<BaseEvmTypes>,
+    ) {
+        self.js.create_end(interp, message, result);
+    }
+}
+
+fn compare(code: Bytes, child: Option<Bytes>) -> Vec<Value> {
+    let address = Address::repeat_byte(0x11);
+    let mut db = CacheDB::new(EmptyDB::default());
+    db.insert_account_info(
+        &address,
+        AccountInfo { code: Some(Bytecode::new_legacy(code.clone())), ..Default::default() },
+    );
+    if let Some(child) = child {
+        db.insert_account_info(
+            &Address::repeat_byte(0x22),
+            AccountInfo { code: Some(Bytecode::new_legacy(child)), ..Default::default() },
+        );
+    }
+    let script = r#"{
+        out: [],
+        step: function(log) {
+            var stack = [];
+            for (var i = 0; i < log.stack.length(); i++) stack.push(log.stack.peek(i).toString());
+            this.out.push([log.getPC(), stack, toHex(log.memory.slice(0, log.memory.length())).slice(2), log.getDepth()]);
+        },
+        fault: function(log) { this.step(log); },
+        result: function() { return this.out; }
+    }"#;
+    let inspector = SnapshotInspector {
+        js: JsInspector::new(script.to_string(), Value::Null).unwrap(),
+        pending: Vec::new(),
+        expected: Vec::new(),
+    };
+    let mut evm = Evm::<BaseEvmTypes>::new(
+        SpecId::CANCUN,
+        evm2::env::BlockEnvExt::default(),
+        ethereum_tx_registry(SpecId::CANCUN),
+        db,
+        Precompiles::base(SpecId::CANCUN),
+    );
+    evm.set_inspector(inspector);
+    let tx = Recovered::new_unchecked(
+        TxEnvelope::Legacy(TxLegacy {
+            gas_limit: 1_000_000,
+            to: TxKind::Call(address),
+            ..Default::default()
+        }),
+        Address::ZERO,
+    );
+    let res = evm.transact(&tx).unwrap().detach();
+    let mut inspector = evm.clear_inspector_as::<SnapshotInspector>().unwrap();
+    let block = *evm.block_env();
+    let actual = inspector.js.json_result(&res, &tx, &block, evm.database_mut()).unwrap();
+    assert_eq!(actual, json!(inspector.expected), "bytecode: {code}");
+    inspector.expected
+}
+
+#[test]
+fn reconstructed_steps_match_all_opcode_bytes() {
+    for opcode in 0..=255u8 {
+        // Seed nonzero memory, then enough operands for every opcode (including SWAP16).
+        let mut code = hex!("60ff60005260aa602052").to_vec();
+        for value in 0..20u8 {
+            code.extend_from_slice(&[op::PUSH1, value]);
+        }
+        code.extend_from_slice(&[opcode, op::STOP]);
+        compare(code.into(), None);
+    }
+}
+
+#[test]
+fn parent_snapshot_survives_calls_and_return_data() {
+    for opcode in [op::CALL, op::CALLCODE, op::DELEGATECALL, op::STATICCALL] {
+        for stop in [op::RETURN, op::REVERT] {
+            // The child overwrites the parent's existing output region before CALL's step_end.
+            let mut parent = hex!("60ff600052").to_vec();
+            // Call twice to exercise snapshot reuse at the same depth.
+            for _ in 0..2 {
+                parent.extend_from_slice(&hex!("6020600060006000"));
+                if matches!(opcode, op::CALL | op::CALLCODE) {
+                    parent.extend_from_slice(&hex!("6000"));
+                }
+                parent.push(op::PUSH20);
+                parent.extend_from_slice(Address::repeat_byte(0x22).as_slice());
+                parent.extend_from_slice(&[op::PUSH2, 0xff, 0xff, opcode, op::POP]);
+            }
+            parent.push(op::STOP);
+            let mut child = hex!("60aa60005260206000").to_vec();
+            child.push(stop);
+            let steps = compare(parent.into(), Some(child.into()));
+            assert!(steps.iter().any(|step| step[3] == 1), "child must execute");
+        }
+    }
+}
+
+#[test]
+fn parent_snapshot_survives_create() {
+    for opcode in [op::CREATE, op::CREATE2] {
+        // Store initcode that writes to its own memory before returning empty runtime code.
+        let mut code = hex!("6960aa60005260006000f3600052").to_vec();
+        if opcode == op::CREATE2 {
+            code.extend_from_slice(&hex!("6001"));
+        }
+        code.extend_from_slice(&hex!("600a60166000"));
+        code.extend_from_slice(&[opcode, op::POP, op::STOP]);
+        let steps = compare(code.into(), None);
+        assert!(steps.iter().any(|step| step[3] == 1), "initcode must execute");
+    }
+}


### PR DESCRIPTION
Stacked on #410.

The JS tracer copied the interpreter stack and memory snapshots and allocated database adapters during opcode callbacks. Reconstruct the pre-execution view from borrowed post-execution data, saving only consumed stack operands and overwritten memory. Reuse the callback objects and borrow evm2's state/database readers within scopes that revoke access on return or unwind.

Keep reusable snapshots per call depth: evm2 runs a call opcode's `step_end` after nested execution, so parent snapshots must survive child callbacks. Save call output ranges as well as direct memory writes. A disjoint stack/memory/host accessor lets the tracer borrow interpreter data while reading the host state.

Build BigInts directly, read `Uint8Array` buffers in bulk, and cache call-kind and opcode strings. The opcode-name table initializes on its first lookup and stays shared across `fuse` resets.

Mirrors https://github.com/paradigmxyz/revm-inspectors/pull/493, including scoped borrowing and lazy opcode names, on top of the reset-reuse mirror. Benchmark code is excluded.
