### PR TITLE
fix: reconcile sibling state gas refills

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
         shell: bash
         run: |
           if [[ "${{ matrix.fixture }}" == "devnet" ]]; then
-            export DEVNET_VERSION="tests-glamsterdam-devnet%40v8.1.0"
+            export DEVNET_VERSION="tests-glamsterdam-devnet%40v8.1.4"
             export DEVNET_TAR="fixtures_glamsterdam-devnet.tar.gz"
             export EVM2_STATETEST_DEVNET_ONLY=1
           fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ If fixtures are already available in another worktree, symlink `test-fixtures`
 to that directory instead of re-downloading them.
 By default it downloads the glamsterdam (Amsterdam) devnet fixtures plus legacy
 Cancun/Constantinople state tests. The devnet release defaults to
-`tests-glamsterdam-devnet@v8.1.0` / `fixtures_glamsterdam-devnet.tar.gz`
+`tests-glamsterdam-devnet@v8.1.4` / `fixtures_glamsterdam-devnet.tar.gz`
 (from the `ethereum/execution-specs` repo, base overridable via `DEVNET_BASE_URL`);
 override `DEVNET_VERSION` and `DEVNET_TAR` to select a different devnet release, or
 clear either to disable devnet. The glamsterdam devnet fixtures cover

--- a/crates/evm2/src/interpreter/gas.rs
+++ b/crates/evm2/src/interpreter/gas.rs
@@ -230,6 +230,22 @@ impl GasTracker {
         self.reservoir = val;
     }
 
+    /// Adopts a child's returned reservoir, first restoring any state gas spilled
+    /// into this frame's execution gas in last-in-first-out order.
+    ///
+    /// A child can refill state gas charged by an ancestor or sibling without
+    /// inheriting its spill counter. Only the excess refill stays in the reservoir.
+    /// This reconciles the funding pools; the child's signed state-gas spend is
+    /// merged separately by [`Self::merge_child_gas`].
+    #[inline]
+    pub const fn absorb_returned_reservoir(&mut self, reservoir: u64) {
+        let to_remaining =
+            if reservoir < self.state_gas_spilled { reservoir } else { self.state_gas_spilled };
+        self.remaining = self.remaining.saturating_add(to_remaining);
+        self.state_gas_spilled -= to_remaining;
+        self.reservoir = reservoir - to_remaining;
+    }
+
     /// Returns spent state gas. May be negative within a frame (see field docs).
     #[inline]
     pub const fn state_gas_spent(&self) -> i64 {
@@ -412,7 +428,8 @@ impl GasTracker {
     ///   the child's execution gas (already zeroed when settled).
     /// - **The reservoir** is a shared state-gas pool the child inherited at call time, so the
     ///   parent always adopts the child's value — which settling restored to the inherited amount
-    ///   on revert/halt, leaving it untouched.
+    ///   on revert/halt. Any returned reservoir first unwinds the parent's outstanding spilled
+    ///   state gas in LIFO order.
     /// - **Net state gas, its spilled portion, and the refund counter** persist only on success; on
     ///   revert/halt the child's state changes roll back, so it contributes none.
     #[inline]
@@ -420,12 +437,12 @@ impl GasTracker {
         if stop.is_success() || stop.is_revert() {
             self.erase_cost(child.remaining);
         }
-        self.set_reservoir(child.reservoir);
         if stop.is_success() {
             self.add_state_gas_spent(child.state_gas_spent);
             self.add_state_gas_spilled(child.state_gas_spilled);
             self.record_refund(child.refunded);
         }
+        self.absorb_returned_reservoir(child.reservoir);
     }
 
     /// Spends all remaining execution gas.
@@ -858,6 +875,57 @@ mod tests {
             (gas.reservoir(), gas.remaining(), gas.state_gas_spent(), gas.state_gas_spilled()),
             (200, 1000, 0, 0)
         );
+    }
+
+    #[test]
+    fn returned_reservoir_restores_spilled_state_gas_first() {
+        let mut gas = GasTracker::from_parts(1_000, 600, 0);
+        gas.spend_state(400).unwrap();
+
+        gas.absorb_returned_reservoir(250);
+        assert_eq!(gas.remaining(), 450);
+        assert_eq!(gas.reservoir(), 0);
+        assert_eq!(gas.state_gas_spilled(), 150);
+        assert_eq!(gas.state_gas_spent(), 400);
+
+        gas.absorb_returned_reservoir(200);
+        assert_eq!(gas.remaining(), 600);
+        assert_eq!(gas.reservoir(), 50);
+        assert_eq!(gas.state_gas_spilled(), 0);
+        assert_eq!(gas.state_gas_spent(), 400);
+    }
+
+    #[test]
+    fn sibling_refill_restores_parent_regular_gas() {
+        const STATE_GAS: u64 = 200;
+        const CHILD_GAS: u64 = 500;
+        let mut parent = GasTracker::from_parts(1_000, 1_000, 0);
+
+        // A's state creation spills into execution gas and is merged into P.
+        parent.spend(CHILD_GAS).unwrap();
+        let mut child_a = GasTracker::from_parts(CHILD_GAS, CHILD_GAS, 0);
+        child_a.spend_state(STATE_GAS).unwrap();
+        child_a.settle_gas(InstrStop::Stop);
+        parent.merge_child_gas(child_a, InstrStop::Stop);
+        assert_eq!(parent.remaining(), 800);
+        assert_eq!(parent.reservoir(), 0);
+        assert_eq!(parent.state_gas_spent(), STATE_GAS as i64);
+        assert_eq!(parent.state_gas_spilled(), STATE_GAS);
+
+        // B clears A's slot, with no local spill counter to restore.
+        parent.spend(CHILD_GAS).unwrap();
+        let mut child_b = GasTracker::from_parts(CHILD_GAS, CHILD_GAS, parent.reservoir());
+        child_b.refill_reservoir(STATE_GAS);
+        assert_eq!(child_b.reservoir(), STATE_GAS);
+        assert_eq!(child_b.state_gas_spilled(), 0);
+
+        // P absorbs B's reservoir to restore the execution gas spent by A.
+        child_b.settle_gas(InstrStop::Stop);
+        parent.merge_child_gas(child_b, InstrStop::Stop);
+        assert_eq!(parent.remaining(), 1_000);
+        assert_eq!(parent.reservoir(), 0);
+        assert_eq!(parent.state_gas_spent(), 0);
+        assert_eq!(parent.state_gas_spilled(), 0);
     }
 
     #[test]

--- a/crates/evm2/src/tests.rs
+++ b/crates/evm2/src/tests.rs
@@ -160,3 +160,86 @@ fn evm_reports_invalid_transaction_execution() {
 
     assert_eq!(result.stop, InstrStop::StackUnderflow);
 }
+
+#[test]
+fn eip8037_sibling_refill_restores_parent_gas_left() {
+    use crate::{
+        EvmFeatures, ExecutionConfig, Version,
+        ethereum::{TxEnvelope, ethereum_tx_registry},
+        version::GasId,
+    };
+    use alloy_consensus::{TxLegacy, transaction::Recovered};
+    use alloy_primitives::{TxKind, U256};
+
+    let parent = Address::from([0x11; 20]);
+    let setter = Address::from([0xa1; 20]);
+    let clearer = Address::from([0xb2; 20]);
+    let caller = Address::from([0xcc; 20]);
+    let mut parent_code = Vec::new();
+    for target in [setter, clearer] {
+        // DELEGATECALL(gas, target, 0, 0, 0, 0).
+        for _ in 0..4 {
+            parent_code.extend([op::PUSH1, 0]);
+        }
+        parent_code.push(op::PUSH20);
+        parent_code.extend_from_slice(target.as_slice());
+        parent_code.extend([op::GAS, op::DELEGATECALL, op::POP]);
+    }
+    // Return the gas visible to the parent after both siblings finish.
+    parent_code.extend([
+        op::GAS,
+        op::PUSH1,
+        0,
+        op::MSTORE,
+        op::PUSH1,
+        32,
+        op::PUSH1,
+        0,
+        op::RETURN,
+    ]);
+
+    let mut database = InMemoryDB::default();
+    for (address, code) in [
+        (parent, legacy_bytecode(parent_code)),
+        (setter, legacy_bytecode([op::PUSH1, 1, op::PUSH1, 0, op::SSTORE, op::STOP])),
+        (clearer, legacy_bytecode([op::PUSH1, 0, op::PUSH1, 0, op::SSTORE, op::STOP])),
+    ] {
+        database
+            .insert_account_info(&address, AccountInfo::default().with_nonce(1).with_code(code));
+    }
+    database.insert_account_info(
+        &caller,
+        AccountInfo { balance: U256::from(u64::MAX), ..Default::default() },
+    );
+    let tx = Recovered::new_unchecked(
+        TxEnvelope::Legacy(TxLegacy {
+            gas_limit: 1_000_000,
+            to: TxKind::Call(parent),
+            ..Default::default()
+        }),
+        caller,
+    );
+    let run = |enabled| {
+        let mut version = Version::new(SpecId::AMSTERDAM);
+        version.features.remove(EvmFeatures::EIP2780);
+        version.features.set(EvmFeatures::EIP8037, enabled);
+        version.gas_params.set(GasId::SstoreSetState, 200_000);
+        let mut evm = TestEvm::new_with_execution_config(
+            ExecutionConfig::for_spec_and_version(SpecId::AMSTERDAM, version),
+            SpecId::AMSTERDAM,
+            BlockEnvExt::default(),
+            ethereum_tx_registry(SpecId::AMSTERDAM),
+            database.clone(),
+            Precompiles::base(SpecId::AMSTERDAM),
+        );
+        evm.transact(&tx).unwrap().discard()
+    };
+
+    let baseline = run(false);
+    let result = run(true);
+    assert!(baseline.status);
+    assert!(result.status);
+    assert_eq!(result.state_gas_spent, 0);
+    assert_eq!(result.output.len(), 32);
+    assert_eq!(result.output, baseline.output);
+}

--- a/scripts/setup_test_fixtures.py
+++ b/scripts/setup_test_fixtures.py
@@ -44,7 +44,7 @@ DEVNET_BASE_URL = os.environ.get(
 # Default fork-specific devnet fixtures: glamsterdam (Amsterdam) devnet-8. Downloaded by default so
 # the Amsterdam tests run without extra configuration; override DEVNET_VERSION/DEVNET_TAR to select a
 # different devnet release. The version is a URL path component, so the `@` is percent-encoded.
-DEFAULT_DEVNET_VERSION = "tests-glamsterdam-devnet%40v8.1.0"
+DEFAULT_DEVNET_VERSION = "tests-glamsterdam-devnet%40v8.1.4"
 DEFAULT_DEVNET_TAR = "fixtures_glamsterdam-devnet.tar.gz"
 LEGACY_URL = (
     f"https://github.com/ethereum/tests/archive/refs/tags/{LEGACY_VERSION}.tar.gz"


### PR DESCRIPTION
Ports [bluealloy/revm#3893](https://github.com/bluealloy/revm/pull/3893) to evm2. When one child creates storage using execution gas and a sibling clears it, the returned reservoir now restores the parent's spilled execution gas before retaining any excess. Reconciliation happens after merging the successful child's counters and does not double-adjust signed state-gas spend.

Adds the upstream partial/excess reservoir and sibling-frame regressions, plus a full transaction test comparing the parent's returned `GAS` value with EIP-8037 enabled and disabled. Both sibling regressions were confirmed to fail with the old merge behavior and pass with the fix.

Also includes the fixture bump from [alloy-rs/evm2#414](https://github.com/alloy-rs/evm2/pull/414): the downloader default, CI override, and documented EF/EEST fixture version now use `tests-glamsterdam-devnet@v8.1.4`.

Validation:

- `cargo test -p evm2 --lib`: 490 passed.
- `cargo test -p evm2 --lib --no-default-features --features std,parse`: 490 passed.
- `cargo +nightly clippy -p evm2 --all-targets --all-features`: passed.
- `cargo +nightly fmt --all --check`: passed.
- Fixture bump: verified the v8.1.4 release asset, executed the downloader's fixture-plan construction, checked its generated URL, and ran `git diff --check`. The full EEST suite was not run locally.

Prompted by: @rakita
