### PR TITLE
chore(eest): bump EF fixtures to v8.1.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
         shell: bash
         run: |
           if [[ "${{ matrix.fixture }}" == "devnet" ]]; then
-            export DEVNET_VERSION="tests-glamsterdam-devnet%40v8.1.0"
+            export DEVNET_VERSION="tests-glamsterdam-devnet%40v8.1.4"
             export DEVNET_TAR="fixtures_glamsterdam-devnet.tar.gz"
             export EVM2_STATETEST_DEVNET_ONLY=1
           fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ If fixtures are already available in another worktree, symlink `test-fixtures`
 to that directory instead of re-downloading them.
 By default it downloads the glamsterdam (Amsterdam) devnet fixtures plus legacy
 Cancun/Constantinople state tests. The devnet release defaults to
-`tests-glamsterdam-devnet@v8.1.0` / `fixtures_glamsterdam-devnet.tar.gz`
+`tests-glamsterdam-devnet@v8.1.4` / `fixtures_glamsterdam-devnet.tar.gz`
 (from the `ethereum/execution-specs` repo, base overridable via `DEVNET_BASE_URL`);
 override `DEVNET_VERSION` and `DEVNET_TAR` to select a different devnet release, or
 clear either to disable devnet. The glamsterdam devnet fixtures cover

--- a/scripts/setup_test_fixtures.py
+++ b/scripts/setup_test_fixtures.py
@@ -44,7 +44,7 @@ DEVNET_BASE_URL = os.environ.get(
 # Default fork-specific devnet fixtures: glamsterdam (Amsterdam) devnet-8. Downloaded by default so
 # the Amsterdam tests run without extra configuration; override DEVNET_VERSION/DEVNET_TAR to select a
 # different devnet release. The version is a URL path component, so the `@` is percent-encoded.
-DEFAULT_DEVNET_VERSION = "tests-glamsterdam-devnet%40v8.1.0"
+DEFAULT_DEVNET_VERSION = "tests-glamsterdam-devnet%40v8.1.4"
 DEFAULT_DEVNET_TAR = "fixtures_glamsterdam-devnet.tar.gz"
 LEGACY_URL = (
     f"https://github.com/ethereum/tests/archive/refs/tags/{LEGACY_VERSION}.tar.gz"


### PR DESCRIPTION
Bump the default EF/EEST fixtures from `tests-glamsterdam-devnet@v8.1.0` to [v8.1.4](https://github.com/ethereum/execution-specs/releases/tag/tests-glamsterdam-devnet%40v8.1.4). Update the downloader default, CI override, and documented version together.

Validation: verified the release asset exists, executed the downloader's fixture-plan construction and checked the generated URL, and ran `git diff --check`. The full EEST suite was not run locally; existing CI jobs cover it.

Prompted by: @rakita
