### PR TITLE
refactor(inspectors): cache spec ID during execution

### DIFF
--- a/crates/inspectors/src/tracing/mod.rs
+++ b/crates/inspectors/src/tracing/mod.rs
@@ -599,7 +599,9 @@ impl TracingInspector {
 impl<T: EvmTypes> Inspector<T> for TracingInspector {
     #[inline]
     fn initialize_interp(&mut self, interp: &mut Interpreter<'_, '_, T>) {
-        self.spec_id = Some(interp.spec());
+        if self.spec_id.is_none() {
+            self.spec_id = Some(interp.spec());
+        }
         self.features = interp.version().features;
     }
 
@@ -637,7 +639,9 @@ impl<T: EvmTypes> Inspector<T> for TracingInspector {
         interp: &mut Interpreter<'_, '_, T>,
         message: &mut Message<T>,
     ) -> Option<MessageResult<T>> {
-        self.spec_id = Some(interp.spec());
+        if self.spec_id.is_none() {
+            self.spec_id = Some(interp.spec());
+        }
         self.features = interp.version().features;
 
         // determine correct `from` and `to` based on the call scheme
@@ -688,7 +692,9 @@ impl<T: EvmTypes> Inspector<T> for TracingInspector {
         interp: &mut Interpreter<'_, '_, T>,
         message: &mut Message<T>,
     ) -> Option<MessageResult<T>> {
-        self.spec_id = Some(interp.spec());
+        if self.spec_id.is_none() {
+            self.spec_id = Some(interp.spec());
+        }
         self.features = interp.version().features;
 
         self.start_trace_on_call(


### PR DESCRIPTION
Mirror [revm-inspectors #482](https://github.com/paradigmxyz/revm-inspectors/pull/482): capture the spec ID only when it is unset in `initialize_interp`, `call`, and `create`, avoiding repeated assignments for nested frames. `fuse()` already clears the cache between executions; evm2's separate feature tracking remains intact.

This is the only remaining merged inspector change from the August 8–September 7 upstream audit. The other 14 merged inspector changes are already present on evm2 main.

Validation:

- `cargo test -p evm2-inspectors --all-features --quiet`: 81 unit tests and 49 integration tests passed.
- `cargo +nightly clippy -p evm2-inspectors --all-features --all-targets --quiet`: passed.
- `cargo +nightly fmt --all --check`: passed.
- `git diff --check`: passed.

Prompted by: @DaniPopes
