### PR TITLE
feat: add BAL builder capacity configuration

### DIFF
--- a/crates/evm2/src/evm/bal/bal_context.rs
+++ b/crates/evm2/src/evm/bal/bal_context.rs
@@ -120,6 +120,17 @@ impl BalContext {
         self
     }
 
+    /// Enables BAL construction with capacity for at least `capacity` accounts.
+    ///
+    /// Installs an empty builder, replacing any existing builder.
+    #[inline]
+    pub fn with_bal_builder_capacity(mut self, capacity: usize) -> Self {
+        let mut bal = Bal::new();
+        bal.accounts.reserve(capacity);
+        self.bal_builder = Some(bal);
+        self
+    }
+
     /// Enables EIP-7928 BAL construction in place, installing an empty builder.
     #[inline]
     pub fn enable_bal_builder(&mut self) {


### PR DESCRIPTION
Adds `BalContext::with_bal_builder_capacity(capacity)` to enable BAL construction with reserved account capacity. Callers that know the expected account count can preallocate an empty builder without reaching into its internals.

Motivated by https://github.com/paradigmxyz/reth/pull/27079.
