### PR TITLE
perf(bal): size storage vectors by partition

### DIFF
--- a/crates/evm2/src/evm/bal/account.rs
+++ b/crates/evm2/src/evm/bal/account.rs
@@ -353,8 +353,9 @@ impl StorageBal {
     /// Convert the storage into a vector of reads and writes, each sorted by slot key.
     pub fn into_vecs(self) -> (Vec<U256>, Vec<(U256, BalChanges<StorageChange>)>) {
         let len = self.storage.len();
-        let mut reads = Vec::with_capacity(len);
-        let mut writes = Vec::with_capacity(len);
+        let read_len = self.storage.values().filter(|value| value.is_empty()).count();
+        let mut reads = Vec::with_capacity(read_len);
+        let mut writes = Vec::with_capacity(len - read_len);
 
         for (key, value) in self.storage {
             if value.is_empty() {


### PR DESCRIPTION
Reserve BAL storage read/write vectors for their actual partition sizes instead of reserving the full slot count for both. This adds a counting pass, removes unused capacity, and avoids allocating for empty partitions without changing the output.

Mirrors https://github.com/bluealloy/revm/pull/3898: across 30 validated Reth 300M fixtures, the revm change removes about 640 KB of unused vector capacity and 558 allocation calls per block; lazy growth adds reallocations and requests more bytes overall. Its six-pair benchmark is neutral on server latency (102.53 → 102.68 ms, +0.15% ±0.58%); these are upstream results, with no evm2 benchmark or demonstrated end-to-end speedup.
