### PR TITLE
fix: skip failed ERC-7562 keccak preimages

### DIFF
--- a/crates/evm2/src/interpreter/mod.rs
+++ b/crates/evm2/src/interpreter/mod.rs
@@ -151,6 +151,20 @@ impl InstrStop {
         !self.is_success() && !self.is_revert()
     }
 
+    /// Returns whether execution ran out of gas or exceeded the memory limit.
+    #[inline]
+    pub const fn is_out_of_gas(self) -> bool {
+        matches!(
+            self,
+            Self::OutOfGas
+                | Self::MemoryOOG
+                | Self::MemoryLimitOOG
+                | Self::PrecompileOOG
+                | Self::InvalidOperandOOG
+                | Self::ReentrancySentryOOG
+        )
+    }
+
     /// Returns whether execution hit a fatal host/extension boundary error.
     #[inline]
     pub const fn is_fatal(self) -> bool {

--- a/crates/inspectors/src/tracing/builder/geth.rs
+++ b/crates/inspectors/src/tracing/builder/geth.rs
@@ -18,7 +18,7 @@ use alloy_rpc_types_trace::geth::{
 use evm2::{
     EvmFeatures, EvmTypesHost, TxResultExt, TxResultWithState,
     evm::{DbResult, DynDatabase},
-    interpreter::op,
+    interpreter::{InstrStop, op},
 };
 
 /// A frame awaiting tree assembly, with visibility inherited by children in the forward pass.
@@ -490,10 +490,11 @@ impl<'a> GethTraceBuilder<'a> {
             let mut contract_size = HashMap::default();
             let mut ext_code_access_info = Vec::new();
             let mut keccak = Vec::new();
-            let mut out_of_gas = false;
+            let mut out_of_gas = trace.status.is_some_and(InstrStop::is_out_of_gas);
 
             for step in &trace.steps {
                 let op = step.op.get();
+                out_of_gas |= step.status.is_some_and(InstrStop::is_out_of_gas);
 
                 // Skip if opcode is ignored
                 if opts.ignored_opcodes.contains(&op) {
@@ -548,12 +549,6 @@ impl<'a> GethTraceBuilder<'a> {
                     _ => {}
                 }
 
-                if let Some(status) = &step.status
-                    && *status == evm2::interpreter::InstrStop::OutOfGas
-                {
-                    out_of_gas = true;
-                }
-
                 if matches!(op, op::EXTCODESIZE | op::EXTCODECOPY | op::EXTCODEHASH)
                     && let Some(stack) = &step.stack
                     && let Some(item) = stack.get(stack.len().saturating_sub(1))
@@ -570,7 +565,7 @@ impl<'a> GethTraceBuilder<'a> {
 
                 // KECCAK preimages from returndata
                 if op == op::KECCAK256
-                    && !out_of_gas
+                    && step.status.is_none()
                     && let (Some(stack), Some(memory)) = (&step.stack, &step.memory)
                     && stack.len() >= 2
                 {

--- a/crates/inspectors/src/tracing/builder/geth/steps_tests.rs
+++ b/crates/inspectors/src/tracing/builder/geth/steps_tests.rs
@@ -1,6 +1,11 @@
 use super::*;
-use crate::tracing::types::{CallTrace, CallTraceStep, StorageChange, StorageChangeReason};
-use evm2::interpreter::{InstrStop, opcode::OpCode};
+use crate::tracing::types::{
+    CallTrace, CallTraceStep, RecordedMemory, StorageChange, StorageChangeReason,
+};
+use evm2::{
+    evm::EmptyDB,
+    interpreter::{InstrStop, opcode::OpCode},
+};
 
 fn test_step(pc: usize, op: u8) -> CallTraceStep {
     CallTraceStep {
@@ -28,6 +33,87 @@ fn test_step(pc: usize, op: u8) -> CallTraceStep {
         status: (op == op::REVERT).then_some(InstrStop::Revert),
         immediate_bytes: None,
         decoded: None,
+    }
+}
+
+#[test]
+fn erc7562_keccak_preimages_require_successful_steps() {
+    for status in [
+        None,
+        Some(InstrStop::OutOfGas),
+        Some(InstrStop::MemoryOOG),
+        Some(InstrStop::MemoryLimitOOG),
+        Some(InstrStop::PrecompileOOG),
+        Some(InstrStop::InvalidOperandOOG),
+        Some(InstrStop::ReentrancySentryOOG),
+        Some(InstrStop::StackUnderflow),
+        Some(InstrStop::FatalExternalError),
+    ] {
+        for (offset, len, expected) in
+            [(0, 0, vec![]), (1, 2, vec![2, 3]), (1, 4, vec![2, 3, 0, 0]), (4, 2, vec![0, 0])]
+        {
+            let mut step = test_step(0, op::KECCAK256);
+            step.stack = Some(vec![U256::from(len), U256::from(offset)].into_boxed_slice());
+            step.memory = Some(RecordedMemory::new(&[1, 2, 3]));
+            step.status = status;
+            let builder = GethTraceBuilder::new(vec![CallTraceNode {
+                trace: CallTrace {
+                    steps: vec![step, test_step(1, op::REVERT)],
+                    status: Some(InstrStop::Revert),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }]);
+            let frame = builder
+                .geth_erc7562_traces(Erc7562Config::default(), 0, &mut EmptyDB::default())
+                .unwrap();
+            let expected = if status.is_none() { vec![Bytes::from(expected)] } else { vec![] };
+            assert_eq!(frame.keccak, expected, "status {status:?}, offset {offset}, len {len}");
+        }
+    }
+}
+
+#[test]
+fn erc7562_classifies_all_out_of_gas_statuses() {
+    for (status, expected) in [
+        (None, false),
+        (Some(InstrStop::Stop), false),
+        (Some(InstrStop::Return), false),
+        (Some(InstrStop::Revert), false),
+        (Some(InstrStop::OutOfFunds), false),
+        (Some(InstrStop::InvalidOpcode), false),
+        (Some(InstrStop::OutOfGas), true),
+        (Some(InstrStop::MemoryOOG), true),
+        (Some(InstrStop::MemoryLimitOOG), true),
+        (Some(InstrStop::PrecompileOOG), true),
+        (Some(InstrStop::InvalidOperandOOG), true),
+        (Some(InstrStop::ReentrancySentryOOG), true),
+    ] {
+        assert_eq!(status.is_some_and(InstrStop::is_out_of_gas), expected);
+        for frame_status in [false, true] {
+            let mut step = test_step(0, op::KECCAK256);
+            step.status = status;
+            let builder = GethTraceBuilder::new(vec![CallTraceNode {
+                trace: CallTrace {
+                    status: if frame_status { status } else { None },
+                    steps: if frame_status { vec![] } else { vec![step] },
+                    ..Default::default()
+                },
+                ..Default::default()
+            }]);
+            for ignored in [false, true] {
+                let mut config = Erc7562Config::default();
+                if ignored {
+                    config.ignored_opcodes.push(op::KECCAK256);
+                }
+                let frame =
+                    builder.geth_erc7562_traces(config, 0, &mut EmptyDB::default()).unwrap();
+                assert_eq!(
+                    frame.out_of_gas, expected,
+                    "status {status:?}, frame_status {frame_status}, ignored {ignored}"
+                );
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Failed `KECCAK256` steps could allocate preimage buffers from unchecked stack lengths after memory expansion failed. Require successful execution before reconstructing a preimage. Addresses ZELLIC-243.

Add `InstrStop::is_out_of_gas()` for all six OOG variants and use it for ERC-7562 frame and step statuses, including ignored opcodes and frames without recorded steps.

Closes ZELLIC-243.